### PR TITLE
feat: sort servers by rank and name in api

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,24 @@ $ cargo test
 ```
 
 We recommend using [Rust Analyzer](https://rust-analyzer.github.io/) or [Rust Rover](https://www.jetbrains.com/rust/) for development.
+
+### Migrations
+
+1. Install the diesel CLI tool: <https://diesel.rs/guides/getting-started.html#installing-diesel-cli>
+
+2. Create a migration
+```console
+$ diesel migration generate some_name_here
+```
+
+3. Write the migration's `up.sql` and `down.sql`
+
+4. Run the pending migrations:
+```console
+$ diesel migration run
+```
+
+5. Test your down:
+```console
+$ diesel migration redo
+```

--- a/README.md
+++ b/README.md
@@ -157,3 +157,8 @@ $ diesel migration run
 ```console
 $ diesel migration redo
 ```
+
+6. Run formatter:
+```console
+$ cargo fmt
+```

--- a/migrations/2024-09-05-092619_servers_view_order/down.sql
+++ b/migrations/2024-09-05-092619_servers_view_order/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW ordered_servers;

--- a/migrations/2024-09-05-092619_servers_view_order/up.sql
+++ b/migrations/2024-09-05-092619_servers_view_order/up.sql
@@ -1,0 +1,13 @@
+CREATE VIEW ordered_servers AS (
+	select * from servers
+	order by (CASE
+		WHEN (servers.rank = 'live') THEN 0
+		WHEN (servers.rank = 'prod') THEN 0
+		WHEN (servers.rank = 'production') THEN 0
+		WHEN (servers.rank = 'clone') THEN 1
+		WHEN (servers.rank = 'demo') THEN 2
+		WHEN (servers.rank = 'test') THEN 3
+		WHEN (servers.rank = 'dev') THEN 4
+		ELSE 5
+	END), servers.name
+);

--- a/src/app/servers.rs
+++ b/src/app/servers.rs
@@ -23,7 +23,7 @@ pub async fn create(
 	let input = input.into_inner();
 	let server = Server::from(input);
 
-	diesel::insert_into(crate::schema::servers::table)
+	diesel::insert_into(crate::views::ordered_servers::table)
 		.values(server.clone())
 		.execute(&mut db)
 		.await
@@ -38,12 +38,12 @@ pub async fn edit(
 	mut db: Connection<Db>,
 	input: Json<PartialServer>,
 ) -> TamanuHeaders<Json<Server>> {
-	use crate::schema::servers::dsl::*;
+	use crate::views::ordered_servers::dsl::*;
 
 	let input = input.into_inner();
 	let input_id = input.id;
 
-	diesel::update(servers)
+	diesel::update(ordered_servers)
 		.filter(id.eq(input_id))
 		.set(input)
 		.execute(&mut db)
@@ -51,7 +51,7 @@ pub async fn edit(
 		.expect("Error updating server");
 
 	TamanuHeaders::new(Json(
-		servers
+		ordered_servers
 			.filter(id.eq(input_id))
 			.select(Server::as_select())
 			.first(&mut db)

--- a/src/db/servers.rs
+++ b/src/db/servers.rs
@@ -6,7 +6,7 @@ use super::server_rank::ServerRank;
 use super::url_field::UrlField;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable)]
-#[diesel(table_name = crate::schema::servers)]
+#[diesel(table_name = crate::views::ordered_servers)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct Server {
 	pub id: Uuid,
@@ -22,7 +22,7 @@ pub struct Server {
 
 impl Server {
 	pub async fn get_all(db: &mut AsyncPgConnection) -> Vec<Self> {
-		crate::schema::servers::table
+		crate::views::ordered_servers::table
 			.select(Server::as_select())
 			.load(db)
 			.await
@@ -49,7 +49,7 @@ impl From<NewServer> for Server {
 }
 
 #[derive(Debug, Deserialize, AsChangeset)]
-#[diesel(table_name = crate::schema::servers)]
+#[diesel(table_name = crate::views::ordered_servers)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct PartialServer {
 	pub id: Uuid,

--- a/src/views.rs
+++ b/src/views.rs
@@ -21,3 +21,14 @@ diesel::table! {
 		latest_error_message -> Nullable<Text>,
 	}
 }
+
+diesel::table! {
+	ordered_servers (id) {
+		id -> Uuid,
+		created_at -> Timestamptz,
+		updated_at -> Timestamptz,
+		name -> Text,
+		rank -> Text,
+		host -> Text,
+	}
+}


### PR DESCRIPTION
This is compatibility behaviour, so that production servers appear at the top of the list.
