### PR TITLE
feat: add root timesync server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,6 +1498,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jiff"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2089,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,7 +2116,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.9.0",
+ "rand 0.9.1",
  "sha2",
  "stringprep",
 ]
@@ -2215,13 +2271,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.2",
- "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -3004,6 +3059,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "time",
+ "timesimp",
  "url",
  "uuid",
  "x509-parser 0.17.0",
@@ -3127,6 +3183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "timesimp"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1336a0fe2406385517aabf4e0dbcd8808c56ad3c4be9c3d9cb132c9a6de67920"
+dependencies = [
+ "jiff",
+ "rand 0.9.1",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,7 +3266,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.0",
+ "rand 0.9.1",
  "socket2",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ time = "0.3.41"
 url = { version = "2.5.4", features = ["serde"] }
 uuid = { version = "1.16.0", features = ["serde", "v4"] }
 x509-parser = "0.17.0"
+timesimp = "1.0.0"
 
 [features]
 default = ["migrations-with-tokio-postgres", "tls-host-roots"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ pub mod server_type;
 pub mod servers;
 pub mod statuses;
 pub mod tamanu_headers;
+pub mod timesync;
 pub mod version;
 pub mod versions;
 
@@ -37,6 +38,7 @@ pub fn rocket() -> Rocket<Build> {
 				statuses::view,
 				statuses::reload,
 				statuses::create,
+				timesync::endpoint,
 				versions::list,
 				versions::view,
 				versions::create,

--- a/src/app/timesync.rs
+++ b/src/app/timesync.rs
@@ -1,0 +1,41 @@
+use timesimp::{Request, SignedDuration, Timesimp};
+
+use crate::{
+	app::TamanuHeaders,
+	error::{AppError, Result},
+};
+
+#[post("/timesync", data = "<request>")]
+pub async fn endpoint(request: Vec<u8>) -> Result<TamanuHeaders<Vec<u8>>> {
+	let response = ServerSimp
+		.answer_client(Request::try_from(request.as_ref())?)
+		.await?;
+	Ok(TamanuHeaders::new(response.to_bytes().to_vec()))
+}
+
+struct ServerSimp;
+impl Timesimp for ServerSimp {
+	type Err = AppError;
+
+	async fn load_offset(&self) -> Result<Option<SignedDuration>, Self::Err> {
+		// server time is correct
+		Ok(Some(SignedDuration::ZERO))
+	}
+
+	async fn store_offset(&mut self, _offset: SignedDuration) -> Result<(), Self::Err> {
+		// as time is correct, no need to store offset
+		unimplemented!()
+	}
+
+	async fn query_server(
+		&self,
+		_request: timesimp::Request,
+	) -> Result<timesimp::Response, Self::Err> {
+		// server has no upstream timesimp
+		unimplemented!()
+	}
+
+	async fn sleep(duration: std::time::Duration) {
+		rocket::tokio::time::sleep(duration).await;
+	}
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,10 @@ pub enum AppError {
 
 	#[error("version range is not usable")]
 	UnusableRange,
+
+	#[error("timesync: {0}")]
+	#[serde(serialize_with = "serialize_timesimp_error")]
+	Timesync(#[from] timesimp::ParseError),
 }
 
 impl AppError {
@@ -61,4 +65,14 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for AppError {
 			.sized_body(json.len(), Cursor::new(json))
 			.finalize())
 	}
+}
+
+pub fn serialize_timesimp_error<S>(
+	value: &timesimp::ParseError,
+	serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+	S: serde::Serializer,
+{
+	value.to_string().serialize(serializer)
 }


### PR DESCRIPTION
With this, we can timesync servers to a central source. For example Tamanu central servers could all timesync to the meta server, and then carry that down to their facilities.