### PR TITLE
servers: always enrich device_info with live tailnet info

### DIFF
--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -106,9 +106,14 @@ pub struct DeviceConnectionData {
 	pub user_agent: Option<String>,
 }
 
-impl From<DeviceWithInfo> for DeviceInfo {
-	fn from(d: DeviceWithInfo) -> Self {
-		Self {
+impl DeviceInfo {
+	/// Build a wire-shape `DeviceInfo` from a `DeviceWithInfo` row plus
+	/// the live tailnet snapshot from the directory (if any). This is
+	/// the **only** way to produce a `DeviceInfo` — every handler that
+	/// returns one should go through here so `tailnet_live` is filled
+	/// consistently across views.
+	pub(super) async fn from_db(d: DeviceWithInfo, state: &AppState) -> Self {
+		let mut info = Self {
 			device: DeviceData {
 				id: d.device.id,
 				created_at: d.device.created_at,
@@ -121,21 +126,14 @@ impl From<DeviceWithInfo> for DeviceInfo {
 			keys: d.keys.into_iter().map(DeviceKeyInfo::from).collect(),
 			latest_connection: d.latest_connection.map(DeviceConnectionData::from),
 			tailnet_live: None,
-		}
-	}
-}
-
-impl DeviceInfo {
-	/// Populate `tailnet_live` from the directory if this device has a
-	/// `tailscale_node_id` and the directory has it cached.
-	pub(super) async fn enrich_with_live(mut self, state: &AppState) -> Self {
-		if let Some(node_id) = self.device.tailscale_node_id.clone()
+		};
+		if let Some(node_id) = info.device.tailscale_node_id.clone()
 			&& let Some(directory) = &state.tailnet_directory
 			&& let Ok(Some(entry)) = directory.find_by_node_id(&node_id).await
 		{
-			self.tailnet_live = Some(entry.into());
+			info.tailnet_live = Some(entry.into());
 		}
-		self
+		info
 	}
 }
 
@@ -236,7 +234,7 @@ pub async fn get_device_by_id(
 ) -> Result<Json<DeviceInfo>> {
 	let mut conn = state.db.get().await?;
 	let device_with_info = Device::get_with_info(&mut conn, args.device_id).await?;
-	let info = DeviceInfo::from(device_with_info).enrich_with_live(&state).await;
+	let info = DeviceInfo::from_db(device_with_info, &state).await;
 	Ok(Json(info))
 }
 
@@ -272,10 +270,10 @@ pub async fn list_untrusted(
 		args.offset.try_into().unwrap_or(0),
 	)
 	.await?;
-	let items = devices_with_info
-		.into_iter()
-		.map(DeviceInfo::from)
-		.collect();
+	let mut items = Vec::with_capacity(devices_with_info.len());
+	for d in devices_with_info {
+		items.push(DeviceInfo::from_db(d, &state).await);
+	}
 	Ok(Json(Page { items, total }))
 }
 
@@ -444,10 +442,10 @@ pub async fn list_trusted(
 		args.offset.try_into().unwrap_or(0),
 	)
 	.await?;
-	let items = devices_with_info
-		.into_iter()
-		.map(DeviceInfo::from)
-		.collect();
+	let mut items = Vec::with_capacity(devices_with_info.len());
+	for d in devices_with_info {
+		items.push(DeviceInfo::from_db(d, &state).await);
+	}
 	Ok(Json(Page { items, total }))
 }
 
@@ -560,10 +558,9 @@ pub async fn search(
 		seen.insert(d.device.id, d);
 	}
 
-	// Enrich each result with live tailnet info.
 	let mut out = Vec::with_capacity(seen.len());
 	for d in seen.into_values() {
-		out.push(DeviceInfo::from(d).enrich_with_live(&state).await);
+		out.push(DeviceInfo::from_db(d, &state).await);
 	}
 	Ok(Json(out))
 }
@@ -646,9 +643,7 @@ pub async fn attach_tailscale(
 	.await?;
 
 	let device_with_info = Device::get_with_info(&mut conn, args.device_id).await?;
-	let info = DeviceInfo::from(device_with_info)
-		.enrich_with_live(&state)
-		.await;
+	let info = DeviceInfo::from_db(device_with_info, &state).await;
 	Ok(Json(info))
 }
 
@@ -671,9 +666,7 @@ pub async fn detach_tailscale(
 	let mut conn = state.db.get().await?;
 	Device::detach_tailscale(&mut conn, args.device_id).await?;
 	let device_with_info = Device::get_with_info(&mut conn, args.device_id).await?;
-	let info = DeviceInfo::from(device_with_info)
-		.enrich_with_live(&state)
-		.await;
+	let info = DeviceInfo::from_db(device_with_info, &state).await;
 	Ok(Json(info))
 }
 
@@ -707,9 +700,7 @@ pub async fn merge_into(
 	let mut conn = state.db.get().await?;
 	Device::merge_into(&mut conn, args.source_id, args.target_id).await?;
 	let device_with_info = Device::get_with_info(&mut conn, args.target_id).await?;
-	let info = DeviceInfo::from(device_with_info)
-		.enrich_with_live(&state)
-		.await;
+	let info = DeviceInfo::from_db(device_with_info, &state).await;
 	Ok(Json(info))
 }
 

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -128,7 +128,7 @@ impl From<DeviceWithInfo> for DeviceInfo {
 impl DeviceInfo {
 	/// Populate `tailnet_live` from the directory if this device has a
 	/// `tailscale_node_id` and the directory has it cached.
-	async fn enrich_with_live(mut self, state: &AppState) -> Self {
+	pub(super) async fn enrich_with_live(mut self, state: &AppState) -> Self {
 		if let Some(node_id) = self.device.tailscale_node_id.clone()
 			&& let Some(directory) = &state.tailnet_directory
 			&& let Ok(Some(entry)) = directory.find_by_node_id(&node_id).await

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -11,7 +11,7 @@ use commons_types::{
 	version::VersionStr,
 };
 use database::{
-	devices::{Device, DeviceConnection, DeviceWithInfo},
+	devices::{Device, DeviceConnection},
 	servers::{PartialServer, Server},
 	statuses::Status,
 	url_field::UrlField,
@@ -368,11 +368,7 @@ pub async fn get_detail(
 
 	let device_info = if let Some(device_id) = device_id {
 		let device_with_info = Device::get_with_info(&mut conn, device_id).await?;
-		Some(
-			convert_device_with_info(device_with_info)
-				.enrich_with_live(&state)
-				.await,
-		)
+		Some(super::devices::DeviceInfo::from_db(device_with_info, &state).await)
 	} else {
 		None
 	};
@@ -680,54 +676,6 @@ pub async fn attach_tailscale_device(
 	.await?;
 
 	Ok(Json(device.id))
-}
-
-fn convert_device_with_info(d: DeviceWithInfo) -> super::devices::DeviceInfo {
-	fn format_key_as_pem(key_data: &[u8]) -> String {
-		use base64::prelude::*;
-		let base64_data = BASE64_STANDARD.encode(key_data);
-		let mut pem = String::with_capacity(base64_data.len() + 100);
-		pem.push_str("-----BEGIN PUBLIC KEY-----\n");
-		for chunk in base64_data.as_bytes().chunks(64) {
-			pem.push_str(&String::from_utf8_lossy(chunk));
-			pem.push('\n');
-		}
-		pem.push_str("-----END PUBLIC KEY-----");
-		pem
-	}
-
-	super::devices::DeviceInfo {
-		device: super::devices::DeviceData {
-			id: d.device.id,
-			created_at: d.device.created_at,
-			updated_at: d.device.updated_at,
-			role: d.device.role,
-			tailscale_node_id: d.device.tailscale_node_id,
-			tailscale_node_name: d.device.tailscale_node_name,
-			tailscale_tailnet: d.device.tailscale_tailnet,
-		},
-		keys: d
-			.keys
-			.into_iter()
-			.map(|key| super::devices::DeviceKeyInfo {
-				id: key.id,
-				device_id: key.device_id,
-				name: key.name,
-				pem_data: format_key_as_pem(&key.key_data),
-				created_at: key.created_at,
-			})
-			.collect(),
-		latest_connection: d
-			.latest_connection
-			.map(|conn| super::devices::DeviceConnectionData {
-				id: conn.id,
-				created_at: conn.created_at,
-				device_id: conn.device_id,
-				ip: conn.ip.addr().to_string(),
-				user_agent: conn.user_agent,
-			}),
-		tailnet_live: None,
-	}
 }
 
 async fn compute_min_chrome_version(

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -368,7 +368,11 @@ pub async fn get_detail(
 
 	let device_info = if let Some(device_id) = device_id {
 		let device_with_info = Device::get_with_info(&mut conn, device_id).await?;
-		Some(convert_device_with_info(device_with_info))
+		Some(
+			convert_device_with_info(device_with_info)
+				.enrich_with_live(&state)
+				.await,
+		)
 	} else {
 		None
 	};

--- a/justfile
+++ b/justfile
@@ -36,8 +36,12 @@ watch-private-build:
 
 # Run the private server's HTTP API, bound to 127.0.0.1:8081, for the private-web Vite frontend.
 # Watches the built binary so it restarts when watch-private-build produces a fresh artefact.
+# CLIENT_IP_SOURCE is overridden to ConnectInfo because the prod default
+# (RightmostXForwardedFor, for behind the Tailscale K8s Operator's ingress)
+# would have the axum-client-ip middleware reject every request — locally
+# there's no proxy in front to set X-Forwarded-For.
 watch-private-api:
-    BIND_ADDRESS=127.0.0.1:8081 watchexec -I -W target/debug -f private-server -- target/debug/private-server
+    CLIENT_IP_SOURCE=ConnectInfo BIND_ADDRESS=127.0.0.1:8081 watchexec -I -W target/debug -f private-server -- target/debug/private-server
 
 # Run the private-web React frontend dev server (Vite proxy expects watch-private-api)
 watch-private-web:

--- a/private-web/e2e/fixture.ts
+++ b/private-web/e2e/fixture.ts
@@ -185,6 +185,12 @@ export async function startStack(opts: StartOptions = {}): Promise<StackHandle> 
 				DATABASE_URL: databaseUrl,
 				BIND_ADDRESS: `127.0.0.1:${apiPort}`,
 				META_LOG: process.env.META_LOG ?? "private_server=info,warn",
+				// The binary defaults to RightmostXForwardedFor for production
+				// (behind the Tailscale K8s Operator's ingress). In e2e there's
+				// no proxy in front, so the axum-client-ip middleware would
+				// reject every request for missing X-Forwarded-For. Fall back
+				// to the raw TCP peer.
+				CLIENT_IP_SOURCE: "ConnectInfo",
 			},
 		});
 		pipeOutput(api, "api", silent);


### PR DESCRIPTION
Otherwise random views are broken for no dang reason.