### PR TITLE
issues: surface attaching incident(s) on each issue card

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -812,6 +812,15 @@ impl Issue {
 	}
 }
 
+/// Minimal incident metadata returned alongside an issue so the UI can
+/// link from the issue card to the incident(s) the issue is attached to.
+#[derive(Debug, Clone)]
+pub struct IssueIncidentRef {
+	pub incident_id: Uuid,
+	pub opened_at: Timestamp,
+	pub closed_at: Option<Timestamp>,
+}
+
 /// Aggregate counts displayed against an incident in the UI.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct IncidentStats {
@@ -972,6 +981,50 @@ impl Incident {
 			.load(db)
 			.await
 			.map_err(AppError::from)
+	}
+
+	/// Bulk lookup: for each issue id, the distinct incidents it is or was
+	/// linked to, with their open/close timestamps. Used to surface the
+	/// "attaching incident(s)" pill on each issue card.
+	///
+	/// The same `(issue, incident)` pair can have multiple `incident_issues`
+	/// rows (issue left and rejoined). We dedupe on `incident_id` and order
+	/// by `opened_at desc` so the most recent attachment is first.
+	pub async fn for_issues(
+		db: &mut AsyncPgConnection,
+		issue_ids: &[Uuid],
+	) -> Result<std::collections::HashMap<Uuid, Vec<IssueIncidentRef>>> {
+		use crate::schema::{incident_issues, incidents};
+		use std::collections::HashMap;
+
+		let mut out: HashMap<Uuid, Vec<IssueIncidentRef>> = HashMap::new();
+		if issue_ids.is_empty() {
+			return Ok(out);
+		}
+
+		let rows: Vec<(Uuid, Uuid, jiff_diesel::Timestamp, jiff_diesel::NullableTimestamp)> =
+			incident_issues::table
+				.inner_join(incidents::table.on(incidents::id.eq(incident_issues::incident_id)))
+				.filter(incident_issues::issue_id.eq_any(issue_ids))
+				.select((
+					incident_issues::issue_id,
+					incidents::id,
+					incidents::opened_at,
+					incidents::closed_at,
+				))
+				.distinct()
+				.order(incidents::opened_at.desc())
+				.load(db)
+				.await?;
+
+		for (issue_id, incident_id, opened_at, closed_at) in rows {
+			out.entry(issue_id).or_default().push(IssueIncidentRef {
+				incident_id,
+				opened_at: opened_at.into(),
+				closed_at: Option::<Timestamp>::from(closed_at),
+			});
+		}
+		Ok(out)
 	}
 
 	pub async fn get_with_issues(

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -6,7 +6,9 @@ use commons_types::{
 	Uuid,
 	issue::{ResolvedReason, Severity},
 };
-use database::issues::{Event, Issue, IssueFilter, IssueListFilters, NewEvent};
+use database::issues::{
+	Event, Incident, Issue, IssueFilter, IssueIncidentRef, IssueListFilters, NewEvent,
+};
 use database::notes::IssueNote;
 use database::servers::Server;
 use database::tailscale_users::TailscaleUser as CachedTailscaleUser;
@@ -52,6 +54,28 @@ pub struct IssueData {
 	pub snoozed_until: Option<Timestamp>,
 	pub created_at: Timestamp,
 	pub updated_at: Timestamp,
+	/// Distinct incidents this issue is or was attached to, most recent first.
+	/// Empty for issues that never crossed the threshold to join an incident.
+	pub incidents: Vec<IssueIncidentLink>,
+}
+
+/// Minimal incident reference attached to an issue, enough for the UI to
+/// render a link and indicate open/closed status. See `Incident::for_issues`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct IssueIncidentLink {
+	pub incident_id: Uuid,
+	pub opened_at: Timestamp,
+	pub closed_at: Option<Timestamp>,
+}
+
+impl From<IssueIncidentRef> for IssueIncidentLink {
+	fn from(r: IssueIncidentRef) -> Self {
+		Self {
+			incident_id: r.incident_id,
+			opened_at: r.opened_at,
+			closed_at: r.closed_at,
+		}
+	}
 }
 
 /// All the non-Issue extras we tuck into an `IssueData`.
@@ -59,6 +83,7 @@ struct IssueEnrichment<'a> {
 	server_name: Option<String>,
 	server_host: String,
 	users: &'a std::collections::HashMap<String, CachedTailscaleUser>,
+	incidents: Vec<IssueIncidentLink>,
 }
 
 impl IssueData {
@@ -91,6 +116,7 @@ impl IssueData {
 			snoozed_until: i.snoozed_until,
 			created_at: i.created_at,
 			updated_at: i.updated_at,
+			incidents: e.incidents,
 		}
 	}
 }
@@ -121,8 +147,9 @@ fn collect_user_logins(issues: &[Issue]) -> Vec<&str> {
 	s.into_iter().collect()
 }
 
-/// Enrich a list of issues with their server names/hosts and acker/resolver
-/// display info in two extra batch queries.
+/// Enrich a list of issues with their server names/hosts, acker/resolver
+/// display info, and the incidents each issue is attached to. Three extra
+/// batch queries (servers, users, incidents).
 pub(crate) async fn enrich_issues(
 	conn: &mut database::diesel_async::AsyncPgConnection,
 	issues: Vec<Issue>,
@@ -131,6 +158,8 @@ pub(crate) async fn enrich_issues(
 	let names = Server::names_by_ids(conn, &server_ids).await?;
 	let user_logins = collect_user_logins(&issues);
 	let users = CachedTailscaleUser::by_logins(conn, &user_logins).await?;
+	let issue_ids: Vec<Uuid> = issues.iter().map(|i| i.id).collect();
+	let mut incidents = Incident::for_issues(conn, &issue_ids).await?;
 	Ok(issues
 		.into_iter()
 		.map(|i| {
@@ -138,12 +167,19 @@ pub(crate) async fn enrich_issues(
 				.get(&i.server_id)
 				.cloned()
 				.unwrap_or((None, String::new()));
+			let links = incidents
+				.remove(&i.id)
+				.unwrap_or_default()
+				.into_iter()
+				.map(IssueIncidentLink::from)
+				.collect();
 			IssueData::from_with(
 				i,
 				IssueEnrichment {
 					server_name: name,
 					server_host: host,
 					users: &users,
+					incidents: links,
 				},
 			)
 		})
@@ -161,12 +197,20 @@ pub(crate) async fn enrich_issue(
 		.unwrap_or((None, String::new()));
 	let user_logins = collect_user_logins(std::slice::from_ref(&issue));
 	let users = CachedTailscaleUser::by_logins(conn, &user_logins).await?;
+	let mut incidents = Incident::for_issues(conn, &[issue.id]).await?;
+	let links = incidents
+		.remove(&issue.id)
+		.unwrap_or_default()
+		.into_iter()
+		.map(IssueIncidentLink::from)
+		.collect();
 	Ok(IssueData::from_with(
 		issue,
 		IssueEnrichment {
 			server_name: name,
 			server_host: host,
 			users: &users,
+			incidents: links,
 		},
 	))
 }

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -3794,7 +3794,8 @@
           "first_seen",
           "last_seen",
           "created_at",
-          "updated_at"
+          "updated_at",
+          "incidents"
         ],
         "properties": {
           "acknowledged_at": {
@@ -3851,6 +3852,13 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "incidents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IssueIncidentLink"
+            },
+            "description": "Distinct incidents this issue is or was attached to, most recent first.\nEmpty for issues that never crossed the threshold to join an incident."
           },
           "last_seen": {
             "type": "string",
@@ -3936,6 +3944,31 @@
           "issue_id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "IssueIncidentLink": {
+        "type": "object",
+        "description": "Minimal incident reference attached to an issue, enough for the UI to\nrender a link and indicate open/closed status. See `Incident::for_issues`.",
+        "required": [
+          "incident_id",
+          "opened_at"
+        ],
+        "properties": {
+          "closed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "incident_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "opened_at": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1506,6 +1506,11 @@ export interface components {
             first_seen: string;
             /** Format: uuid */
             id: string;
+            /**
+             * @description Distinct incidents this issue is or was attached to, most recent first.
+             *     Empty for issues that never crossed the threshold to join an incident.
+             */
+            incidents: components["schemas"]["IssueIncidentLink"][];
             /** Format: date-time */
             last_seen: string;
             message: string;
@@ -1535,6 +1540,18 @@ export interface components {
         IssueIdArgs: {
             /** Format: uuid */
             issue_id: string;
+        };
+        /**
+         * @description Minimal incident reference attached to an issue, enough for the UI to
+         *     render a link and indicate open/closed status. See `Incident::for_issues`.
+         */
+        IssueIncidentLink: {
+            /** Format: date-time */
+            closed_at?: string | null;
+            /** Format: uuid */
+            incident_id: string;
+            /** Format: date-time */
+            opened_at: string;
         };
         IssueNoteData: {
             author: string;

--- a/private-web/src/components/IssueRow.tsx
+++ b/private-web/src/components/IssueRow.tsx
@@ -2,6 +2,7 @@ import {
 	Alert as MuiAlert,
 	Box,
 	Button,
+	Chip,
 	IconButton,
 	Link as MuiLink,
 	MenuItem,
@@ -13,7 +14,9 @@ import {
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import HistoryIcon from "@mui/icons-material/History";
 import SnoozeIcon from "@mui/icons-material/Snooze";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
@@ -28,6 +31,7 @@ import {
 	RESOLVED_REASONS,
 	RESOLVED_REASON_LABEL,
 	type IssueData,
+	type IssueIncidentLink,
 	type ResolvedReason,
 } from "../types";
 
@@ -179,6 +183,7 @@ function Header({
 					snoozed
 				</Typography>
 			)}
+			<IncidentLinks incidents={issue.incidents} />
 			<HeaderActor issue={issue} isAdmin={isAdmin} onChanged={onChanged} />
 			<Box sx={{ flexShrink: 0 }}>
 				<SourceChip source={issue.source} refValue={issue.ref} />
@@ -522,6 +527,39 @@ function IssueActions({
 				</MuiAlert>
 			)}
 		</Box>
+	);
+}
+
+/** One small chip per attaching incident, each linking to its detail page.
+ * Open incidents are warning-coloured with a warning icon; closed ones use a
+ * history icon and a neutral tone. Without these, there's no way to navigate
+ * from an issue back to the incident(s) it joined. */
+function IncidentLinks({ incidents }: { incidents: IssueIncidentLink[] }) {
+	if (incidents.length === 0) return null;
+	return (
+		<Stack direction="row" spacing={0.5} sx={{ flexShrink: 0, flexWrap: "wrap" }}>
+			{incidents.map((inc) => {
+				const open = inc.closed_at == null;
+				const opened = new Date(inc.opened_at).toLocaleString();
+				const tooltip = open
+					? `Open incident, opened ${opened}`
+					: `Closed incident, opened ${opened}`;
+				return (
+					<Tooltip key={inc.incident_id} title={tooltip}>
+						<Chip
+							component={RouterLink}
+							to={`/incidents/${inc.incident_id}`}
+							size="small"
+							variant="outlined"
+							color={open ? "error" : "default"}
+							icon={open ? <WarningAmberIcon /> : <HistoryIcon />}
+							label="incident"
+							clickable
+						/>
+					</Tooltip>
+				);
+			})}
+		</Stack>
 	);
 }
 

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -103,6 +103,7 @@ export type DeviceInfo = Solidify<Schemas["DeviceInfo"]>;
 export type TailnetLiveInfo = Solidify<Schemas["TailnetLiveInfo"]>;
 
 export type IssueData = Solidify<Schemas["IssueData"]>;
+export type IssueIncidentLink = Solidify<Schemas["IssueIncidentLink"]>;
 export type EventData = Solidify<Schemas["EventData"]>;
 export type IncidentData = Solidify<Schemas["IncidentData"]>;
 export type IncidentIssueData = Solidify<Schemas["IncidentIssueData"]>;


### PR DESCRIPTION
IssueData gains an 'incidents' field (distinct (incident, opened_at, closed_at) tuples, most recent first), populated via a bulk join in Incident::for_issues. IssueRow renders one small chip per attaching incident in the header, click-through to the incident detail page; open incidents get the error colour, closed get a history icon. Without this there was no way to navigate from an issue back to past incidents.