### PR TITLE
Accept gzip/br/zstd request bodies

### DIFF
--- a/crates/commons-servers/Cargo.toml
+++ b/crates/commons-servers/Cargo.toml
@@ -37,6 +37,7 @@ time = "0.3.47"
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 tower-http = { version = "0.6.8", features = [
 	"compression-full",
+	"decompression-full",
 	"fs",
 	"trace",
 ] }

--- a/crates/commons-servers/src/lib.rs
+++ b/crates/commons-servers/src/lib.rs
@@ -7,7 +7,9 @@ use axum::{Router, middleware};
 use axum_client_ip::{ClientIp, ClientIpSource};
 use axum_server_timing::ServerTimingLayer;
 use tokio::net::TcpListener;
-use tower_http::{compression::CompressionLayer, trace::TraceLayer};
+use tower_http::{
+	compression::CompressionLayer, decompression::RequestDecompressionLayer, trace::TraceLayer,
+};
 use tracing::Span;
 
 pub mod device_auth;
@@ -53,6 +55,7 @@ pub fn router(routes: Router<()>, client_ip_source: ClientIpSource) -> Router<()
 				),
 		)
 		.layer(CompressionLayer::new())
+		.layer(RequestDecompressionLayer::new())
 		.layer(ServerTimingLayer::new("srv"))
 }
 


### PR DESCRIPTION
## Summary
- Add `RequestDecompressionLayer` alongside the existing `CompressionLayer` in `commons_servers::router`, so both public and private servers transparently decompress incoming request bodies.
- Enables the `decompression-full` feature on `tower-http`.