### PR TITLE
Render markdown/safe-HTML in issue messages with raw toggle

### DIFF
--- a/private-web/package-lock.json
+++ b/private-web/package-lock.json
@@ -18,6 +18,9 @@
 				"react-dom": "^19.2.5",
 				"react-markdown": "^10.1.0",
 				"react-router-dom": "^7.14.2",
+				"rehype-raw": "^7.0.0",
+				"rehype-sanitize": "^6.0.0",
+				"remark-breaks": "^4.0.0",
 				"remark-gfm": "^4.0.1"
 			},
 			"devDependencies": {
@@ -2341,6 +2344,103 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hast-util-from-parse5": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+			"integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"devlop": "^1.0.0",
+				"hastscript": "^9.0.0",
+				"property-information": "^7.0.0",
+				"vfile": "^6.0.0",
+				"vfile-location": "^5.0.0",
+				"web-namespaces": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-parse-selector": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+			"integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-raw": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+			"integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"hast-util-from-parse5": "^8.0.0",
+				"hast-util-to-parse5": "^8.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"parse5": "^7.0.0",
+				"unist-util-position": "^5.0.0",
+				"unist-util-visit": "^5.0.0",
+				"vfile": "^6.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-raw/node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/hast-util-raw/node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/hast-util-sanitize": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+			"integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"unist-util-position": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-to-jsx-runtime": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2368,6 +2468,25 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/hast-util-to-parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+			"integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"devlop": "^1.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"web-namespaces": "^2.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-whitespace": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -2375,6 +2494,23 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hastscript": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+			"integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-parse-selector": "^4.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2417,6 +2553,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -3195,6 +3341,20 @@
 				"devlop": "^1.0.0",
 				"mdast-util-from-markdown": "^2.0.0",
 				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-newline-to-break": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+			"integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-find-and-replace": "^3.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4424,6 +4584,50 @@
 				"react-dom": ">=16.6.0"
 			}
 		},
+		"node_modules/rehype-raw": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+			"integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-raw": "^9.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-sanitize": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+			"integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-sanitize": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-breaks": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+			"integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-newline-to-break": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-gfm": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -5002,6 +5206,20 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/vfile-location": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+			"integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/vfile-message": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -5216,6 +5434,16 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/web-namespaces": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+			"integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/webidl-conversions": {

--- a/private-web/package.json
+++ b/private-web/package.json
@@ -23,6 +23,9 @@
 		"react-dom": "^19.2.5",
 		"react-markdown": "^10.1.0",
 		"react-router-dom": "^7.14.2",
+		"rehype-raw": "^7.0.0",
+		"rehype-sanitize": "^6.0.0",
+		"remark-breaks": "^4.0.0",
 		"remark-gfm": "^4.0.1"
 	},
 	"devDependencies": {

--- a/private-web/src/components/IssueRow.tsx
+++ b/private-web/src/components/IssueRow.tsx
@@ -19,6 +19,7 @@ import { Link as RouterLink } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { humanDuration } from "../lib/humanDuration";
+import MessageView from "./MessageView";
 import NotesList, { AddNoteButton } from "./NotesList";
 import SeverityChip from "./SeverityChip";
 import StatusSnapshotPanel, { StatusSnapshotButton } from "./StatusSnapshot";
@@ -324,18 +325,7 @@ function Body({
 	return (
 		<Box sx={{ mt: 1 }}>
 			<IssueMeta issue={issue} />
-			<Typography
-				variant="body2"
-				component="pre"
-				sx={{
-					m: 0,
-					whiteSpace: "pre-wrap",
-					fontFamily: "monospace",
-					fontSize: "0.85em",
-				}}
-			>
-				{issue.message}
-			</Typography>
+			<MessageView message={issue.message} />
 			{isAdmin && (
 				<IssueActions
 					issue={issue}

--- a/private-web/src/components/Markdown.tsx
+++ b/private-web/src/components/Markdown.tsx
@@ -1,8 +1,27 @@
 import { Box } from "@mui/material";
 import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
-export default function Markdown({ children }: { children: string }) {
+/** Renders markdown with GFM extensions and a sanitised subset of inline
+ * HTML. Sources sometimes wrap their messages in `<b>`, `<a>`, `<code>`
+ * and similar — those pass through; anything dangerous (scripts, inline
+ * event handlers, iframes, etc.) is stripped by `rehype-sanitize`'s
+ * default GitHub-compatible schema. Pass `preserveNewlines` when input
+ * may be plain text with significant line breaks (e.g. log messages),
+ * which converts soft breaks to `<br>`. */
+export default function Markdown({
+	children,
+	preserveNewlines = false,
+}: {
+	children: string;
+	preserveNewlines?: boolean;
+}) {
+	const remarkPlugins = preserveNewlines
+		? [remarkGfm, remarkBreaks]
+		: [remarkGfm];
 	return (
 		<Box
 			sx={{
@@ -47,7 +66,12 @@ export default function Markdown({ children }: { children: string }) {
 				},
 			}}
 		>
-			<ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+			<ReactMarkdown
+				remarkPlugins={remarkPlugins}
+				rehypePlugins={[rehypeRaw, rehypeSanitize]}
+			>
+				{children}
+			</ReactMarkdown>
 		</Box>
 	);
 }

--- a/private-web/src/components/MessageView.tsx
+++ b/private-web/src/components/MessageView.tsx
@@ -1,0 +1,50 @@
+import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import CodeIcon from "@mui/icons-material/Code";
+import NotesIcon from "@mui/icons-material/Notes";
+import { useState } from "react";
+import Markdown from "./Markdown";
+
+/** Renders a message body that may contain markdown or a limited subset of
+ * HTML. The toggle in the top-right switches between the rendered view and
+ * the raw text (monospace, pre-wrap). HTML is sanitised by `Markdown`. */
+export default function MessageView({ message }: { message: string }) {
+	const [raw, setRaw] = useState(false);
+	return (
+		<Box sx={{ position: "relative" }}>
+			<Box sx={{ position: "absolute", top: 0, right: 0 }}>
+				<Tooltip title={raw ? "Show rendered" : "Show raw text"}>
+					<IconButton
+						aria-label={raw ? "Show rendered" : "Show raw text"}
+						size="small"
+						onClick={() => setRaw((v) => !v)}
+					>
+						{raw ? (
+							<NotesIcon fontSize="small" />
+						) : (
+							<CodeIcon fontSize="small" />
+						)}
+					</IconButton>
+				</Tooltip>
+			</Box>
+			{raw ? (
+				<Typography
+					variant="body2"
+					component="pre"
+					sx={{
+						m: 0,
+						pr: 4,
+						whiteSpace: "pre-wrap",
+						fontFamily: "monospace",
+						fontSize: "0.85em",
+					}}
+				>
+					{message}
+				</Typography>
+			) : (
+				<Box sx={{ pr: 4, "& > :first-child": { mt: 0 }, "& > :last-child": { mb: 0 } }}>
+					<Markdown preserveNewlines>{message}</Markdown>
+				</Box>
+			)}
+		</Box>
+	);
+}


### PR DESCRIPTION
## Summary

Some event providers send issue messages formatted with markdown; others with limited HTML. Previously both were rendered as a monospace `<pre>` block, which was robust but looked terrible.

- Extended the `Markdown` component to also accept inline HTML, sanitised against rehype-sanitize's default GitHub-compatible schema. Scripts, inline event handlers, iframes and the like are stripped; `<b>`, `<a>`, `<code>`, lists, etc. pass through. Adds a `preserveNewlines` option that turns soft line breaks into `<br>` for log-like input where newlines are significant.
- New `MessageView` component renders the message through `Markdown` and adds a small icon toggle in the top-right to flip to the raw text (monospace, pre-wrap) for cases where the rendering hides detail that matters.
- `IssueRow`'s expanded body now uses `MessageView` instead of the raw `<pre>` block.

Added deps: `rehype-raw`, `rehype-sanitize`, `remark-breaks`.