### PR TITLE
Fix inverted description/message on canopy-filed events; reject newlines in description

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"c4e4fcfb-b0ff-499d-b1f4-d7481b5c42f3","pid":4065672,"procStart":"28367464","acquiredAt":1778490908236}
+{"sessionId":"f45dee6c-031c-4133-bd17-b9cf58db7361","pid":3133251,"procStart":"44481162","acquiredAt":1778805539209}

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -34,7 +34,9 @@ pub struct Issue {
 	pub r#ref: String,
 	#[diesel(deserialize_as = String, serialize_as = String)]
 	pub severity: Severity,
+	/// Single-line title/subject. See [`NewEvent::description`].
 	pub description: Option<String>,
+	/// Body / long detail. See [`NewEvent::message`].
 	pub message: String,
 	pub active: bool,
 	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
@@ -67,7 +69,9 @@ pub struct Event {
 	pub issue_id: Uuid,
 	#[diesel(deserialize_as = String, serialize_as = String)]
 	pub severity: Severity,
+	/// Single-line title/subject. See [`NewEvent::description`].
 	pub description: Option<String>,
+	/// Body / long detail. See [`NewEvent::message`].
 	pub message: String,
 	pub active: bool,
 	pub hash: Vec<u8>,
@@ -127,8 +131,15 @@ pub struct NewEvent {
 	pub r#ref: String,
 	#[serde(default)]
 	pub severity: Option<Severity>,
+	/// Short single-line title/subject for this event. Rendered as the
+	/// issue's headline in the UI and as the Slack message subject.
+	/// Must not contain newlines — `save()` returns `BadRequest` if it
+	/// does. Use [`Self::message`] for the body / longer detail.
 	#[serde(default)]
 	pub description: Option<String>,
+	/// Body text for this event. Free-form, multi-line OK. Falls back
+	/// to the headline when [`Self::description`] is `None` (the UI
+	/// uses the first line in that case).
 	pub message: String,
 	#[serde(default)]
 	pub active: Option<bool>,
@@ -189,6 +200,17 @@ impl NewEvent {
 		device_id: Option<Uuid>,
 	) -> Result<Issue> {
 		use crate::schema::{events, issues};
+
+		// description is the single-line title; reject multi-line input
+		// up front so the UI never has to fight with a multi-line
+		// "headline".
+		if let Some(d) = self.description.as_deref()
+			&& d.contains('\n')
+		{
+			return Err(AppError::BadRequest(
+				"description must be a single line (no newlines); use `message` for body text".into(),
+			));
+		}
 
 		let severity = self.severity.unwrap_or_default();
 		let active = self.active.unwrap_or(true);

--- a/crates/database/tests/event_validation.rs
+++ b/crates/database/tests/event_validation.rs
@@ -1,0 +1,51 @@
+//! Input validation on `NewEvent::save`: the `description` field is a
+//! single-line title, multi-line content belongs in `message`.
+
+use commons_errors::AppError;
+use commons_types::issue::Severity;
+use database::issues::NewEvent;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn save_rejects_newline_in_description() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let event = NewEvent {
+			source: "test".into(),
+			r#ref: "ref-newline".into(),
+			severity: Some(Severity::Error),
+			description: Some("line one\nline two".into()),
+			message: "body".into(),
+			active: Some(true),
+			occurred_at: None,
+		};
+		let err = event
+			.save(&mut conn, Uuid::nil(), None)
+			.await
+			.expect_err("description with newline must be rejected");
+		match err {
+			AppError::BadRequest(_) => {}
+			other => panic!("expected BadRequest, got {other:?}"),
+		}
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn save_accepts_single_line_description() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let event = NewEvent {
+			source: "test".into(),
+			r#ref: "ref-singleline".into(),
+			severity: Some(Severity::Error),
+			description: Some("a perfectly fine subject line".into()),
+			message: "body".into(),
+			active: Some(true),
+			occurred_at: None,
+		};
+		event
+			.save(&mut conn, Uuid::nil(), None)
+			.await
+			.expect("single-line description saves");
+	})
+	.await
+}

--- a/crates/jobs/src/bin/slacker_outbox.rs
+++ b/crates/jobs/src/bin/slacker_outbox.rs
@@ -235,15 +235,15 @@ async fn file_self_event(
 		source: "canopy".to_string(),
 		r#ref: "slack-delivery-failure".to_string(),
 		severity: Some(Severity::Error),
-		description: Some(format!(
+		description: Some(format!("Slack delivery permanently failed ({})", row.kind)),
+		message: format!(
 			"outbox row {} (kind={}, incident={}): gave up after {attempts} attempts. Last error: {}. Last response: {}",
 			row.id,
 			row.kind,
 			row.incident_id,
 			err.msg,
 			err.body.as_deref().unwrap_or("<none>"),
-		)),
-		message: format!("Slack delivery permanently failed ({})", row.kind),
+		),
 		active: Some(true),
 		occurred_at: None,
 	};

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -870,7 +870,8 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Single-line title/subject. See [`NewEvent::description`]."
           },
           "device_id": {
             "type": [
@@ -892,7 +893,8 @@
             "format": "date-time"
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "Body / long detail. See [`NewEvent::message`]."
           },
           "ref": {
             "type": "string"
@@ -959,10 +961,12 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Short single-line title/subject for this event. Rendered as the\nissue's headline in the UI and as the Slack message subject.\nMust not contain newlines — `save()` returns `BadRequest` if it\ndoes. Use [`Self::message`] for the body / longer detail."
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "Body text for this event. Free-form, multi-line OK. Falls back\nto the headline when [`Self::description`] is `None` (the UI\nuses the first line in that case)."
           },
           "occurredAt": {
             "type": [

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -200,8 +200,8 @@ async fn file_health_events(
 			source: STATUS_SOURCE.into(),
 			r#ref: HEALTH_REF.into(),
 			severity: Some(Severity::Error),
-			description: roll_up_unhealthy_description(&status.health),
-			message: roll_up_unhealthy_message(&curr_failing_checks),
+			description: Some(roll_up_unhealthy_message(&curr_failing_checks)),
+			message: roll_up_unhealthy_description(&status.health).unwrap_or_default(),
 			active: Some(true),
 			occurred_at,
 		}
@@ -216,8 +216,8 @@ async fn file_health_events(
 			source: STATUS_SOURCE.into(),
 			r#ref: format!("{HEALTH_REF}/{check}"),
 			severity: Some(per_check_severity),
-			description: per_check_description(entry),
-			message: format!("Health check '{check}' failed"),
+			description: Some(format!("Health check '{check}' failed")),
+			message: per_check_description(entry).unwrap_or_default(),
 			active: Some(true),
 			occurred_at,
 		}

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -767,13 +767,13 @@ async fn submit_status_warning_check_only() {
 			assert_eq!(per_check.severity, "warning");
 			assert!(per_check.active);
 			assert!(!per_check.is_resolved);
-			assert!(per_check.message.contains("disk"));
 			assert!(
 				per_check
 					.description
 					.as_ref()
-					.is_some_and(|d| d.contains("free_pct"))
+					.is_some_and(|d| d.contains("disk"))
 			);
+			assert!(per_check.message.contains("free_pct"));
 
 			// No roll-up while top-level healthy.
 			assert!(fetch_issue(&mut conn, server_id, "status", "health").await.is_none());
@@ -811,8 +811,9 @@ async fn submit_status_unhealthy_with_checks_opens_incident() {
 				.expect("roll-up issue filed");
 			assert_eq!(roll_up.severity, "error");
 			assert!(roll_up.active);
-			assert!(roll_up.message.contains("database"));
-			assert!(roll_up.message.contains("disk"));
+			let roll_up_headline = roll_up.description.as_deref().unwrap_or_default();
+			assert!(roll_up_headline.contains("database"));
+			assert!(roll_up_headline.contains("disk"));
 
 			for check in ["database", "disk"] {
 				let i = fetch_issue(&mut conn, server_id, "status", &format!("health/{check}"))
@@ -854,7 +855,7 @@ async fn submit_status_unhealthy_no_checks_files_roll_up_only() {
 				.expect("roll-up issue filed");
 			assert_eq!(roll_up.severity, "error");
 			assert!(roll_up.active);
-			assert_eq!(roll_up.message, "Server reports unhealthy");
+			assert_eq!(roll_up.description.as_deref(), Some("Server reports unhealthy"));
 			assert_eq!(count_issues_for_server(&mut conn, server_id).await, 1);
 			assert!(fetch_open_incident(&mut conn, server_id).await.is_some());
 		},


### PR DESCRIPTION
## Summary

The frontend's \`IssueRow\` uses an issue's \`description\` as the headline and falls back to the first line of \`message\` for the body; the Slack integration plumbs \`issue.message\` into the workflow's \`message\` variable, documented as 'issue body'. Two canopy-side filing sites had the two fields swapped:

- \`slacker_outbox::file_self_event\` (\`canopy/slack-delivery-failure\`) was filing the row id / attempt / last-error blob as \`description\` and the one-line summary as \`message\`.
- \`public-server::file_health_events\` (\`status/health\` roll-up + per-check opens) filed the multi-line health detail blob as \`description\` and the short headline as \`message\`.

Both fixed. Close events that previously had \`description = None\` are unchanged — they only carried short text in \`message\`, so the UI's \`headline = description || first_line_of_message\` fallback still picks the right text.

## Doc + validation

- \`NewEvent\` (the wire type) now documents \`description\` as the single-line title/subject and \`message\` as the body. Issue / Event types cross-reference back.
- \`NewEvent::save\` returns \`BadRequest\` if \`description\` contains a newline. Multi-line content belongs in \`message\`; the public \`/events\` endpoint surfaces this as a 400 directly.

## Tests

- Public-server status assertions updated to look at \`description\` (headline) and \`message\` (body) in their new positions.
- New \`event_validation\` tests cover the newline rejection and a happy-path single-line description.