### PR TITLE
Paginate the event log on the issue card

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -959,6 +959,7 @@ impl Event {
 	pub async fn list_for_issue(
 		db: &mut AsyncPgConnection,
 		issue_id: Uuid,
+		offset: i64,
 		limit: i64,
 	) -> Result<Vec<Self>> {
 		use crate::schema::events::dsl;
@@ -967,8 +968,20 @@ impl Event {
 			.select(Self::as_select())
 			.filter(dsl::issue_id.eq(issue_id))
 			.order(dsl::created_at.desc())
+			.offset(offset)
 			.limit(limit)
 			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	pub async fn count_for_issue(db: &mut AsyncPgConnection, issue_id: Uuid) -> Result<i64> {
+		use crate::schema::events::dsl;
+
+		dsl::events
+			.filter(dsl::issue_id.eq(issue_id))
+			.count()
+			.get_result(db)
 			.await
 			.map_err(AppError::from)
 	}

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
+use crate::fns::Page;
 use crate::state::AppState;
 
 const DEFAULT_LIMIT: i64 = 100;
@@ -393,6 +394,8 @@ pub async fn list_for_server(
 pub struct ListEventsArgs {
 	pub issue_id: Uuid,
 	#[serde(default)]
+	pub offset: Option<i64>,
+	#[serde(default)]
 	pub limit: Option<i64>,
 }
 
@@ -403,22 +406,25 @@ pub struct ListEventsArgs {
 	security(("tailscale-user" = [])),
 	request_body = ListEventsArgs,
 	responses(
-		(status = 200, body = Vec<EventData>),
+		(status = 200, body = Page<EventData>),
 	),
 )]
 pub async fn list_events(
 	State(state): State<AppState>,
 	_user: TailscaleUser,
 	Json(args): Json<ListEventsArgs>,
-) -> Result<Json<Vec<EventData>>> {
+) -> Result<Json<Page<EventData>>> {
 	let mut conn = state.db.get().await?;
+	let total = Event::count_for_issue(&mut conn, args.issue_id).await? as u64;
 	let events = Event::list_for_issue(
 		&mut conn,
 		args.issue_id,
+		args.offset.unwrap_or(0),
 		args.limit.unwrap_or(DEFAULT_LIMIT),
 	)
 	.await?;
-	Ok(Json(events.into_iter().map(EventData::from).collect()))
+	let items = events.into_iter().map(EventData::from).collect();
+	Ok(Json(Page { items, total }))
 }
 
 #[derive(Deserialize, ToSchema)]

--- a/crates/private-server/tests/issues.rs
+++ b/crates/private-server/tests/issues.rs
@@ -403,8 +403,29 @@ async fn list_events_returns_event_log() {
 			.json(&serde_json::json!({ "issue_id": issue_id }))
 			.await;
 		events.assert_status_ok();
-		let evs: Vec<serde_json::Value> = events.json();
-		assert_eq!(evs.len(), 3, "each distinct push is its own event row");
+		let page: serde_json::Value = events.json();
+		let items = page.get("items").and_then(|v| v.as_array()).unwrap();
+		assert_eq!(items.len(), 3, "each distinct push is its own event row");
+		assert_eq!(page.get("total").and_then(|v| v.as_u64()), Some(3));
+
+		// Pagination: limit=2 returns 2 items but total still reflects 3.
+		let page1 = private
+			.post("/api/issues/list_events")
+			.json(&serde_json::json!({ "issue_id": issue_id, "offset": 0, "limit": 2 }))
+			.await;
+		page1.assert_status_ok();
+		let page1: serde_json::Value = page1.json();
+		assert_eq!(page1.get("items").and_then(|v| v.as_array()).unwrap().len(), 2);
+		assert_eq!(page1.get("total").and_then(|v| v.as_u64()), Some(3));
+
+		let page2 = private
+			.post("/api/issues/list_events")
+			.json(&serde_json::json!({ "issue_id": issue_id, "offset": 2, "limit": 2 }))
+			.await;
+		page2.assert_status_ok();
+		let page2: serde_json::Value = page2.json();
+		assert_eq!(page2.get("items").and_then(|v| v.as_array()).unwrap().len(), 1);
+		assert_eq!(page2.get("total").and_then(|v| v.as_u64()), Some(3));
 	})
 	.await;
 }

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1640,10 +1640,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/EventData"
-                  }
+                  "$ref": "#/components/schemas/Page_EventData"
                 }
               }
             }
@@ -4120,6 +4117,13 @@
               "null"
             ],
             "format": "int64"
+          },
+          "offset": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
           }
         }
       },
@@ -4356,6 +4360,81 @@
                       "description": "Live snapshot from the Tailscale control plane for a device\nthat's currently attached by `tailscale_node_id`. `None` if the\ndevice has no tailnet attachment, the directory isn't\nconfigured, or the node id isn't in the directory's cache."
                     }
                   ]
+                }
+              }
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
+      "Page_EventData": {
+        "type": "object",
+        "description": "Standard wrapper for paginated list responses. The total reflects the full\nrow count (not just the current page) so the frontend can render page\ncounts without a separate count fetch.",
+        "required": [
+          "items",
+          "total"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "issue_id",
+                "created_at",
+                "severity",
+                "message",
+                "active",
+                "occurrences",
+                "last_seen"
+              ],
+              "properties": {
+                "active": {
+                  "type": "boolean"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "issue_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "last_seen": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "occurred_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "occurrences": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "severity": {
+                  "$ref": "#/components/schemas/Severity"
                 }
               }
             }

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1607,6 +1607,8 @@ export interface components {
             issue_id: string;
             /** Format: int64 */
             limit?: number | null;
+            /** Format: int64 */
+            offset?: number | null;
         };
         ListForDeviceArgs: {
             active_only?: boolean | null;
@@ -1686,6 +1688,33 @@ export interface components {
                 keys: components["schemas"]["DeviceKeyInfo"][];
                 latest_connection?: null | components["schemas"]["DeviceConnectionData"];
                 tailnet_live?: null | components["schemas"]["TailnetLiveInfo"];
+            }[];
+            /** Format: int64 */
+            total: number;
+        };
+        /**
+         * @description Standard wrapper for paginated list responses. The total reflects the full
+         *     row count (not just the current page) so the frontend can render page
+         *     counts without a separate count fetch.
+         */
+        Page_EventData: {
+            items: {
+                active: boolean;
+                /** Format: date-time */
+                created_at: string;
+                description?: string | null;
+                /** Format: uuid */
+                id: string;
+                /** Format: uuid */
+                issue_id: string;
+                /** Format: date-time */
+                last_seen: string;
+                message: string;
+                /** Format: date-time */
+                occurred_at?: string | null;
+                /** Format: int32 */
+                occurrences: number;
+                severity: components["schemas"]["Severity"];
             }[];
             /** Format: int64 */
             total: number;
@@ -3255,7 +3284,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["EventData"][];
+                    "application/json": components["schemas"]["Page_EventData"];
                 };
             };
         };

--- a/private-web/src/components/IssueRow.tsx
+++ b/private-web/src/components/IssueRow.tsx
@@ -5,6 +5,7 @@ import {
 	IconButton,
 	Link as MuiLink,
 	MenuItem,
+	Pagination,
 	Stack,
 	TextField,
 	Tooltip,
@@ -567,6 +568,9 @@ function IssueMeta({ issue }: { issue: IssueData }) {
 	);
 }
 
+const COLLAPSED_EVENT_COUNT = 3;
+const EXPANDED_PAGE_SIZE = 10;
+
 function EventLog({
 	issueId,
 	serverId,
@@ -574,11 +578,15 @@ function EventLog({
 	issueId: string;
 	serverId: string;
 }) {
+	const [expanded, setExpanded] = useState(false);
+	const [page, setPage] = useState(0);
+	const limit = expanded ? EXPANDED_PAGE_SIZE : COLLAPSED_EVENT_COUNT;
+	const offset = expanded ? page * EXPANDED_PAGE_SIZE : 0;
 	const result = useApi(
 		"issues",
 		"list_events",
-		{ issue_id: issueId },
-		[issueId],
+		{ issue_id: issueId, offset, limit },
+		[issueId, offset, limit],
 	);
 	const [snapshotOpen, setSnapshotOpen] = useState<ReadonlySet<string>>(
 		() => new Set(),
@@ -606,16 +614,20 @@ function EventLog({
 		);
 	if (result.status === "error")
 		return <MuiAlert severity="error">{result.error.message}</MuiAlert>;
-	if (result.data.length === 0)
+	const { items, total } = result.data;
+	if (total === 0)
 		return (
 			<Typography variant="caption" color="text.secondary">
 				No events recorded.
 			</Typography>
 		);
 
+	const pageCount = Math.max(1, Math.ceil(total / EXPANDED_PAGE_SIZE));
+	const hiddenCount = Math.max(0, total - COLLAPSED_EVENT_COUNT);
+
 	return (
 		<Stack spacing={0.5}>
-			{result.data.map((e) => {
+			{items.map((e) => {
 				const at = e.occurred_at ?? e.created_at;
 				const open = snapshotOpen.has(e.id);
 				return (
@@ -686,6 +698,43 @@ function EventLog({
 					</Box>
 				);
 			})}
+			{!expanded && hiddenCount > 0 && (
+				<Button
+					size="small"
+					onClick={() => {
+						setExpanded(true);
+						setPage(0);
+					}}
+					sx={{ alignSelf: "flex-start" }}
+				>
+					Show {hiddenCount} more {hiddenCount === 1 ? "event" : "events"}
+				</Button>
+			)}
+			{expanded && (
+				<Stack
+					direction="row"
+					spacing={1}
+					sx={{ alignItems: "center", justifyContent: "space-between" }}
+				>
+					<Button
+						size="small"
+						onClick={() => {
+							setExpanded(false);
+							setPage(0);
+						}}
+					>
+						Show less
+					</Button>
+					{pageCount > 1 && (
+						<Pagination
+							size="small"
+							count={pageCount}
+							page={page + 1}
+							onChange={(_, p) => setPage(p - 1)}
+						/>
+					)}
+				</Stack>
+			)}
 		</Stack>
 	);
 }


### PR DESCRIPTION
## Summary

- Issue cards currently render every event in the log. Long-lived issues turn that into a scrollbar mess.
- `list_events` now returns `Page<EventData>` (items + total) and accepts `offset` alongside `limit`. The existing test was widened to cover offset paging.
- The `EventLog` component on the React side shows the three most recent events by default with a `Show N more events` button; expanded it switches to a 10-per-page paginator with a `Show less` toggle.