### PR TITLE
Per-server alert_when_down_for downtime threshold

### DIFF
--- a/crates/database/src/pg_duration.rs
+++ b/crates/database/src/pg_duration.rs
@@ -1,20 +1,40 @@
 use diesel::{
-	data_types::PgInterval, deserialize, expression::AsExpression, pg::Pg, serialize,
+	data_types::PgInterval,
+	deserialize::{self, FromSqlRow},
+	expression::AsExpression,
+	pg::Pg,
+	serialize,
 	sql_types::Interval,
 };
 use jiff::SignedDuration;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 const DAYS_PER_MONTH: i64 = 30;
 const HOURS_PER_DAY: i64 = 24;
 const SECONDS_PER_DAY: i128 = 60 * 60 * 24;
 const MICROSECONDS_PER_SECOND: i128 = 1_000_000;
 
-#[derive(
-	Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, AsExpression, Serialize, Deserialize,
-)]
+/// A PostgreSQL `INTERVAL` mapped to a `jiff::SignedDuration`.
+///
+/// The wire format (serde) is whole seconds as an `i64` — convenient for
+/// the React frontend, which only ever talks in seconds/minutes. Sub-second
+/// precision in the column round-trips through the DB (via the inner
+/// `SignedDuration`) but is truncated on the wire.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, AsExpression, FromSqlRow)]
 #[diesel(sql_type = Interval)]
 pub struct PgDuration(pub SignedDuration);
+
+impl Serialize for PgDuration {
+	fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+		s.serialize_i64(self.0.as_secs())
+	}
+}
+
+impl<'de> Deserialize<'de> for PgDuration {
+	fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+		i64::deserialize(d).map(|s| PgDuration(SignedDuration::from_secs(s)))
+	}
+}
 
 impl serialize::ToSql<Interval, Pg> for PgDuration {
 	fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, Pg>) -> serialize::Result {

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -188,7 +188,7 @@ diesel::table! {
 		listed -> Bool,
 		cloud -> Nullable<Bool>,
 		geolocation -> Nullable<Array<Nullable<Float8>>>,
-		alert_when_down -> Bool,
+		alert_when_down_for -> Interval,
 	}
 }
 

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -6,10 +6,14 @@ use commons_types::{
 };
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::SignedDuration;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::pg_duration::PgDuration;
 use super::url_field::UrlField;
+
+const TEN_MINUTES: PgDuration = PgDuration(SignedDuration::from_secs(600));
 
 #[derive(
 	Debug,
@@ -45,16 +49,20 @@ pub struct Server {
 	pub cloud: Option<bool>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub geolocation: Option<GeoPoint>,
-	/// When true, the canopy reachability sweep observes this server's
-	/// status freshness and files an issue when it goes Blip/Away/Down/Gone.
-	/// Set to false on servers whose downtime is expected (test
-	/// environments, ad-hoc demos) — the sweep simply doesn't collect
-	/// events for them.
+	/// How long a server's status row may go un-updated before the canopy
+	/// reachability sweep files an issue.
 	///
-	/// The DB default is `true` for freshly-inserted rows, but the migration
-	/// that added the column backfilled existing rows with `false` to avoid
-	/// flooding incidents on rollout. Operators flip it on per server.
-	pub alert_when_down: bool,
+	/// `INTERVAL '0'` disables the sweep for this server entirely — useful
+	/// for test environments and ad-hoc demos whose downtime is expected.
+	/// Positive values are the per-server downtime threshold: bump it up
+	/// for flappy servers, drop it for critical ones that should page
+	/// promptly. Negative durations are rejected by a CHECK constraint on
+	/// the column.
+	///
+	/// Default 10 minutes for newly-inserted rows. On the JSON wire this
+	/// is represented as a count of whole seconds (`i64`).
+	#[schema(value_type = i64)]
+	pub alert_when_down_for: PgDuration,
 }
 
 impl Server {
@@ -255,7 +263,7 @@ impl Server {
 			listed: false,
 			cloud,
 			geolocation: None,
-			alert_when_down: true,
+			alert_when_down_for: TEN_MINUTES,
 		};
 
 		let kind_str = server_value.kind.to_string();
@@ -263,7 +271,7 @@ impl Server {
 
 		// Upsert: insert or update on conflict. Ticket-derived fields
 		// (kind, rank, cloud, parent_server_id) re-apply on update;
-		// operator-edited state (listed, geolocation, alert_when_down)
+		// operator-edited state (listed, geolocation, alert_when_down_for)
 		// is preserved.
 		diesel::insert_into(servers::table)
 			.values((
@@ -535,7 +543,7 @@ fn test_server_serialization() {
 		listed: true,
 		cloud: None,
 		geolocation: None,
-		alert_when_down: true,
+		alert_when_down_for: TEN_MINUTES,
 	};
 
 	let serialized = serde_json::to_string_pretty(&server).unwrap();
@@ -549,7 +557,7 @@ fn test_server_serialization() {
   "rank": "production",
   "device_id": "00000000-0000-0000-0000-000000000000",
   "listed": true,
-  "alert_when_down": true
+  "alert_when_down_for": 600
 }"#
 	);
 }
@@ -576,7 +584,7 @@ impl From<NewServer> for Server {
 			listed: false,
 			cloud: None,
 			geolocation: None,
-			alert_when_down: true,
+			alert_when_down_for: TEN_MINUTES,
 		}
 	}
 }
@@ -597,5 +605,7 @@ pub struct PartialServer {
 	pub listed: Option<bool>,
 	pub cloud: Option<Option<bool>>,
 	pub geolocation: Option<Option<GeoPoint>>,
-	pub alert_when_down: Option<bool>,
+	#[schema(value_type = Option<i64>)]
+	#[diesel(serialize_as = PgDuration)]
+	pub alert_when_down_for: Option<PgDuration>,
 }

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -31,25 +31,21 @@ pub const CANOPY_SOURCE: &str = "canopy";
 /// same issue row.
 pub const REACHABILITY_REF: &str = "reachability";
 
-/// Severity for canopy to file when a server's most recent status puts it in
-/// the given short state. `None` for `Up` — a healthy server doesn't open an
-/// issue.
-///
-/// The mapping escalates one step at a time below the incident floor
-/// (`Notice` → `Warning`), then jumps to `Error` (which opens an incident),
-/// then `Critical` for the long-gone state.
-pub fn reachability_severity(short: ShortStatus) -> Option<Severity> {
-	match short {
-		ShortStatus::Up => None,
-		ShortStatus::Blip => Some(Severity::Notice),
-		ShortStatus::Away => Some(Severity::Warning),
-		ShortStatus::Down => Some(Severity::Error),
-		ShortStatus::Gone => Some(Severity::Critical),
-	}
-}
-
 fn server_label(s: &Server) -> String {
 	s.name.clone().unwrap_or_else(|| s.host.0.to_string())
+}
+
+fn format_secs(secs: i64) -> String {
+	let s = secs.max(0);
+	if s >= 86_400 {
+		format!("{}d", s / 86_400)
+	} else if s >= 3_600 {
+		format!("{}h", s / 3_600)
+	} else if s >= 60 {
+		format!("{}m", s / 60)
+	} else {
+		format!("{s}s")
+	}
 }
 
 #[derive(
@@ -204,10 +200,10 @@ impl Status {
 		Ok(())
 	}
 
-	/// Sweep every server's most recent status. For each non-silenced server
-	/// whose state has crossed (or just left) one of the reachability tiers
-	/// (`Blip`/`Away`/`Down`/`Gone`), file (or close) a canopy-sourced issue
-	/// keyed by [`REACHABILITY_REF`].
+	/// Sweep every server's most recent status. For each monitored server
+	/// (i.e. `alert_when_down_for > 0`) whose freshness has crossed the
+	/// per-server threshold, file (or close) a canopy-sourced issue keyed
+	/// by [`REACHABILITY_REF`].
 	///
 	/// Most servers report by pushing their own status to the public-server
 	/// (so their `device_id` is non-null); the pingtask only handles legacy
@@ -219,7 +215,7 @@ impl Status {
 		let servers = Server::get_all(db, 0, None).await?;
 		let monitored: Vec<&Server> = servers
 			.iter()
-			.filter(|s| s.alert_when_down && s.id != Uuid::nil())
+			.filter(|s| s.alert_when_down_for.0 > SignedDuration::ZERO && s.id != Uuid::nil())
 			.collect();
 		if monitored.is_empty() {
 			return Ok(0);
@@ -237,17 +233,20 @@ impl Status {
 		let now = Timestamp::now();
 		let mut filed = 0usize;
 		for server in &monitored {
-			let short = status_map
-				.get(&server.id)
-				.map(Self::short_status)
-				.unwrap_or_default();
-			let severity = reachability_severity(short);
+			let threshold = server.alert_when_down_for.0;
+			let elapsed = match status_map.get(&server.id) {
+				Some(s) => now.duration_since(s.created_at).abs(),
+				// No status ever recorded: treat as infinite downtime so the
+				// threshold always trips. Caps at i64::MAX seconds for arithmetic.
+				None => SignedDuration::MAX,
+			};
+			let down = elapsed >= threshold;
 			let existing = issue_map.get(&server.id).copied();
 
-			let event = match (severity, existing) {
-				(None, None) => continue,
-				(None, Some(issue)) if !issue.active => continue,
-				(None, Some(_)) => NewEvent {
+			let event = match (down, existing) {
+				(false, None) => continue,
+				(false, Some(issue)) if !issue.active => continue,
+				(false, Some(_)) => NewEvent {
 					source: CANOPY_SOURCE.into(),
 					r#ref: REACHABILITY_REF.into(),
 					severity: Some(Severity::Info),
@@ -256,14 +255,16 @@ impl Status {
 					active: Some(false),
 					occurred_at: Some(now),
 				},
-				(Some(sev), _) => NewEvent {
+				(true, _) => NewEvent {
 					source: CANOPY_SOURCE.into(),
 					r#ref: REACHABILITY_REF.into(),
-					severity: Some(sev),
+					severity: Some(Severity::Error),
 					description: None,
 					message: format!(
-						"Server {} hasn't reported (state: {short})",
+						"Server {} has not reported for {} (threshold {})",
 						server_label(server),
+						format_secs(elapsed.as_secs()),
+						format_secs(threshold.as_secs()),
 					),
 					active: Some(true),
 					occurred_at: Some(now),
@@ -403,17 +404,14 @@ impl Status {
 		if !self.healthy {
 			return HealthState::Unhealthy;
 		}
-		let any_failing = self
-			.health
-			.as_array()
-			.is_some_and(|arr| {
-				arr.iter().any(|e| {
-					e.as_object()
-						.and_then(|o| o.get("healthy"))
-						.and_then(|v| v.as_bool())
-						.is_some_and(|b| !b)
-				})
-			});
+		let any_failing = self.health.as_array().is_some_and(|arr| {
+			arr.iter().any(|e| {
+				e.as_object()
+					.and_then(|o| o.get("healthy"))
+					.and_then(|v| v.as_bool())
+					.is_some_and(|b| !b)
+			})
+		});
 		if any_failing {
 			HealthState::Warning
 		} else {

--- a/crates/database/tests/reachability_sweep.rs
+++ b/crates/database/tests/reachability_sweep.rs
@@ -13,20 +13,23 @@ struct RowId {
 	id: Uuid,
 }
 
+/// Insert a server with the given `alert_when_down_for` threshold (seconds,
+/// stored as a PostgreSQL `INTERVAL`). `0` disables alerting; positive
+/// values are the per-server downtime threshold the sweep tests against.
 async fn insert_server(
 	conn: &mut diesel_async::AsyncPgConnection,
 	host: &str,
-	alert: bool,
+	alert_when_down_for_secs: i64,
 ) -> Uuid {
 	let row: RowId = sql_query(
 		r#"
-			INSERT INTO servers (host, alert_when_down)
-			VALUES ($1, $2)
+			INSERT INTO servers (host, alert_when_down_for)
+			VALUES ($1, ($2 || ' seconds')::INTERVAL)
 			RETURNING id
 		"#,
 	)
 	.bind::<sql_types::Text, _>(host)
-	.bind::<sql_types::Bool, _>(alert)
+	.bind::<sql_types::Text, _>(alert_when_down_for_secs.to_string())
 	.get_result(conn)
 	.await
 	.expect("insert server");
@@ -60,26 +63,38 @@ async fn issue_for(conn: &mut diesel_async::AsyncPgConnection, server_id: Uuid) 
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sweep_files_blip_as_notice() {
+async fn sweep_files_error_when_threshold_crossed() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		let id = insert_server(&mut conn, "http://blip.invalid/", true).await;
-		// 5 minutes old → Blip
-		insert_status_at(&mut conn, id, 5).await;
+		// 10-min threshold, status 15 minutes old → cross.
+		let id = insert_server(&mut conn, "http://down.invalid/", 600).await;
+		insert_status_at(&mut conn, id, 15).await;
 		let filed = Status::sweep_reachability(&mut conn).await.expect("sweep");
 		assert_eq!(filed, 1);
 		let issue = issue_for(&mut conn, id).await.expect("issue exists");
-		assert_eq!(issue.severity, Severity::Notice);
+		assert_eq!(issue.severity, Severity::Error);
 		assert!(issue.active);
 	})
 	.await
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sweep_files_down_as_error() {
+async fn sweep_skips_when_below_threshold() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		let id = insert_server(&mut conn, "http://down.invalid/", true).await;
-		// 45 minutes → Down
-		insert_status_at(&mut conn, id, 45).await;
+		// 10-min threshold, status 5 minutes old → still fresh.
+		let id = insert_server(&mut conn, "http://fresh.invalid/", 600).await;
+		insert_status_at(&mut conn, id, 5).await;
+		let filed = Status::sweep_reachability(&mut conn).await.expect("sweep");
+		assert_eq!(filed, 0);
+		assert!(issue_for(&mut conn, id).await.is_none());
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sweep_files_when_no_status_ever() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		// No status row at all → infinite downtime → always crosses threshold.
+		let id = insert_server(&mut conn, "http://gone.invalid/", 600).await;
 		Status::sweep_reachability(&mut conn).await.expect("sweep");
 		let issue = issue_for(&mut conn, id).await.expect("issue exists");
 		assert_eq!(issue.severity, Severity::Error);
@@ -88,22 +103,11 @@ async fn sweep_files_down_as_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sweep_files_no_status_as_critical() {
+async fn sweep_skips_when_threshold_zero() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		// No status row → Gone → Critical.
-		let id = insert_server(&mut conn, "http://gone.invalid/", true).await;
-		Status::sweep_reachability(&mut conn).await.expect("sweep");
-		let issue = issue_for(&mut conn, id).await.expect("issue exists");
-		assert_eq!(issue.severity, Severity::Critical);
-	})
-	.await
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn sweep_skips_when_alert_disabled() {
-	commons_tests::db::TestDb::run(async |mut conn, _| {
-		let id = insert_server(&mut conn, "http://silenced.invalid/", false).await;
-		insert_status_at(&mut conn, id, 45).await;
+		// `0` disables: never file regardless of how stale the status is.
+		let id = insert_server(&mut conn, "http://silenced.invalid/", 0).await;
+		insert_status_at(&mut conn, id, 120).await;
 		let filed = Status::sweep_reachability(&mut conn).await.expect("sweep");
 		assert_eq!(filed, 0);
 		assert!(issue_for(&mut conn, id).await.is_none());
@@ -114,7 +118,7 @@ async fn sweep_skips_when_alert_disabled() {
 #[tokio::test(flavor = "multi_thread")]
 async fn sweep_skips_up_server() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		let id = insert_server(&mut conn, "http://up.invalid/", true).await;
+		let id = insert_server(&mut conn, "http://up.invalid/", 600).await;
 		insert_status_at(&mut conn, id, 0).await;
 		let filed = Status::sweep_reachability(&mut conn).await.expect("sweep");
 		assert_eq!(filed, 0);
@@ -124,59 +128,71 @@ async fn sweep_skips_up_server() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sweep_escalates_severity_on_second_pass() {
+async fn sweep_uses_per_server_threshold() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		let id = insert_server(&mut conn, "http://esc.invalid/", true).await;
-		insert_status_at(&mut conn, id, 5).await; // Blip
-		Status::sweep_reachability(&mut conn)
-			.await
-			.expect("first sweep");
-		let issue = issue_for(&mut conn, id).await.expect("issue exists");
-		assert_eq!(issue.severity, Severity::Notice);
-		let id1 = issue.id;
+		// Flappy server: long threshold (30 min), 15-min-old status → still ok.
+		let flappy = insert_server(&mut conn, "http://flappy.invalid/", 1800).await;
+		insert_status_at(&mut conn, flappy, 15).await;
+		// Critical server: short threshold (60 s), 15-min-old status → crosses.
+		let critical = insert_server(&mut conn, "http://critical.invalid/", 60).await;
+		insert_status_at(&mut conn, critical, 15).await;
 
-		// Backdate the latest status so it now reads as Down.
-		sql_query(
-			"UPDATE statuses SET created_at = NOW() - INTERVAL '45 minutes' WHERE server_id = $1",
-		)
-		.bind::<sql_types::Uuid, _>(id)
-		.execute(&mut conn)
-		.await
-		.expect("backdate");
-		Status::sweep_reachability(&mut conn)
-			.await
-			.expect("second sweep");
-		let issue = issue_for(&mut conn, id).await.expect("issue still exists");
-		assert_eq!(issue.id, id1, "same issue, escalated in place");
-		assert_eq!(issue.severity, Severity::Error);
+		let filed = Status::sweep_reachability(&mut conn).await.expect("sweep");
+		assert_eq!(filed, 1);
+		assert!(issue_for(&mut conn, flappy).await.is_none());
+		assert!(issue_for(&mut conn, critical).await.is_some());
 	})
 	.await
 }
 
 #[derive(QueryableByName)]
-struct RowBool {
-	#[diesel(sql_type = sql_types::Bool)]
-	alert_when_down: bool,
+struct RowSecs {
+	#[diesel(sql_type = sql_types::Float8)]
+	seconds: f64,
 }
 
-/// Freshly-inserted servers (no explicit `alert_when_down`) inherit the
-/// column default. The migration sets it to `true` after backfilling
-/// existing rows with `false`, so anything registered post-migration
-/// alerts by default.
+/// Freshly-inserted servers inherit the column default of 10 minutes.
 #[tokio::test(flavor = "multi_thread")]
-async fn new_servers_default_to_alerting() {
+async fn new_servers_default_to_ten_minutes() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		let row: RowBool = sql_query(
+		sql_query(
+			"INSERT INTO servers (host) VALUES ('http://new.invalid/')",
+		)
+		.execute(&mut conn)
+		.await
+		.expect("insert default");
+
+		let row: RowSecs = sql_query(
 			r#"
-				INSERT INTO servers (host)
-				VALUES ('http://new.invalid/')
-				RETURNING alert_when_down
+				SELECT EXTRACT(EPOCH FROM alert_when_down_for)::float8 AS seconds
+				FROM servers
+				WHERE host = 'http://new.invalid/'
 			"#,
 		)
 		.get_result(&mut conn)
 		.await
-		.expect("insert default");
-		assert!(row.alert_when_down);
+		.expect("read default");
+		assert_eq!(row.seconds as i64, 600);
+	})
+	.await
+}
+
+/// Negative durations are rejected at the DB level by a CHECK constraint.
+#[tokio::test(flavor = "multi_thread")]
+async fn check_constraint_forbids_negative_duration() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let res = sql_query(
+			r#"
+				INSERT INTO servers (host, alert_when_down_for)
+				VALUES ('http://bad.invalid/', INTERVAL '-1 second')
+			"#,
+		)
+		.execute(&mut conn)
+		.await;
+		assert!(
+			res.is_err(),
+			"expected CHECK constraint to reject negative duration"
+		);
 	})
 	.await
 }
@@ -184,14 +200,14 @@ async fn new_servers_default_to_alerting() {
 #[tokio::test(flavor = "multi_thread")]
 async fn sweep_closes_issue_when_server_returns() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		let id = insert_server(&mut conn, "http://recover.invalid/", true).await;
+		let id = insert_server(&mut conn, "http://recover.invalid/", 600).await;
 		insert_status_at(&mut conn, id, 45).await;
 		Status::sweep_reachability(&mut conn)
 			.await
 			.expect("first sweep");
 		assert!(issue_for(&mut conn, id).await.unwrap().active);
 
-		// New status row at "now" → Up.
+		// New status row at "now" → fresh again, sweep should close the issue.
 		insert_status_at(&mut conn, id, 0).await;
 		Status::sweep_reachability(&mut conn)
 			.await

--- a/crates/database/tests/upsert_from_ticket.rs
+++ b/crates/database/tests/upsert_from_ticket.rs
@@ -62,7 +62,10 @@ async fn upsert_from_ticket_persists_rank_and_trusts_device() {
 		assert_eq!(server.kind, ServerKind::Facility);
 
 		let device_id = server.device_id.expect("server has a device");
-		let device = Device::get_with_info(&mut conn, device_id).await.expect("device").device;
+		let device = Device::get_with_info(&mut conn, device_id)
+			.await
+			.expect("device")
+			.device;
 		assert_eq!(device.role, DeviceRole::Server);
 	})
 	.await
@@ -130,7 +133,10 @@ async fn upsert_from_ticket_preserves_higher_role_on_existing_device() {
 		)
 		.await
 		.expect("second upsert");
-		let device = Device::get_with_info(&mut conn, device_id).await.expect("device").device;
+		let device = Device::get_with_info(&mut conn, device_id)
+			.await
+			.expect("device")
+			.device;
 		assert_eq!(device.role, DeviceRole::Admin);
 	})
 	.await

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -187,7 +187,7 @@ fn server_to_info(s: database::servers::Server) -> ServerInfo {
 		listed: s.listed,
 		cloud: s.cloud,
 		geolocation: s.geolocation,
-		alert_when_down: s.alert_when_down,
+		alert_when_down_for: s.alert_when_down_for.0.as_secs(),
 	}
 }
 

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -50,7 +50,10 @@ pub struct ServerInfo {
 	pub listed: bool,
 	pub cloud: Option<bool>,
 	pub geolocation: Option<GeoPoint>,
-	pub alert_when_down: bool,
+	/// Downtime threshold in seconds before the reachability sweep files an
+	/// issue. `0` (or any non-positive value) disables alerting for this
+	/// server; the default at creation is 600 (10 minutes).
+	pub alert_when_down_for: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -109,7 +112,7 @@ pub struct ServerDataUpdate {
 	)]
 	pub geolocation: Option<Option<GeoPoint>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub alert_when_down: Option<bool>,
+	pub alert_when_down_for: Option<i64>,
 }
 
 fn deserialize_some<'de, T, D>(deserializer: D) -> std::result::Result<Option<T>, D::Error>
@@ -133,7 +136,7 @@ fn server_to_info(s: Server) -> ServerInfo {
 		listed: s.listed,
 		cloud: s.cloud,
 		geolocation: s.geolocation,
-		alert_when_down: s.alert_when_down,
+		alert_when_down_for: s.alert_when_down_for.0.as_secs(),
 	}
 }
 
@@ -266,7 +269,7 @@ pub async fn get_info(
 		listed: server.listed,
 		cloud: server.cloud,
 		geolocation: server.geolocation,
-		alert_when_down: server.alert_when_down,
+		alert_when_down_for: server.alert_when_down_for.0.as_secs(),
 	}))
 }
 
@@ -326,7 +329,7 @@ pub async fn get_detail(
 		listed: server.listed,
 		cloud: server.cloud,
 		geolocation: server.geolocation,
-		alert_when_down: server.alert_when_down,
+		alert_when_down_for: server.alert_when_down_for.0.as_secs(),
 	};
 
 	let up = status
@@ -416,7 +419,7 @@ pub async fn get_detail(
 							device_id: child.device_id,
 							parent_server_id: Some(server.id),
 							parent_server_name: server.name.clone(),
-							alert_when_down: child.alert_when_down,
+							alert_when_down_for: child.alert_when_down_for.0.as_secs(),
 						},
 					)
 				})
@@ -476,7 +479,10 @@ pub async fn update(
 		listed: args.data.listed,
 		cloud: args.data.cloud,
 		geolocation: args.data.geolocation,
-		alert_when_down: args.data.alert_when_down,
+		alert_when_down_for: args
+			.data
+			.alert_when_down_for
+			.map(|s| database::pg_duration::PgDuration(jiff::SignedDuration::from_secs(s))),
 	};
 	Server::update(&mut conn, args.server_id, update_data).await?;
 	Ok(Json(()))
@@ -682,7 +688,7 @@ pub async fn attach_tailscale_device(
 			listed: None,
 			cloud: None,
 			geolocation: None,
-			alert_when_down: None,
+			alert_when_down_for: None,
 		},
 	)
 	.await?;

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -12,9 +12,7 @@ use commons_types::{
 	},
 	version::VersionStr,
 };
-use database::{
-	devices::DeviceConnection, servers::Server, statuses::Status, versions::Version,
-};
+use database::{devices::DeviceConnection, servers::Server, statuses::Status, versions::Version};
 use itertools::Itertools;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};

--- a/crates/private-server/tests/import_ticket.rs
+++ b/crates/private-server/tests/import_ticket.rs
@@ -48,7 +48,12 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 	server
 }
 
-fn synthesize_ticket(server_id: Uuid, hostname: &str, url: &str, tailscale_ip: &str) -> CanopyTicket {
+fn synthesize_ticket(
+	server_id: Uuid,
+	hostname: &str,
+	url: &str,
+	tailscale_ip: &str,
+) -> CanopyTicket {
 	use rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256};
 
 	let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).expect("keygen");

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -1033,11 +1033,12 @@
           "id"
         ],
         "properties": {
-          "alert_when_down": {
+          "alert_when_down_for": {
             "type": [
-              "boolean",
+              "integer",
               "null"
-            ]
+            ],
+            "format": "int64"
           },
           "cloud": {
             "type": [
@@ -1184,12 +1185,13 @@
           "host",
           "kind",
           "listed",
-          "alert_when_down"
+          "alert_when_down_for"
         ],
         "properties": {
-          "alert_when_down": {
-            "type": "boolean",
-            "description": "When true, the canopy reachability sweep observes this server's\nstatus freshness and files an issue when it goes Blip/Away/Down/Gone.\nSet to false on servers whose downtime is expected (test\nenvironments, ad-hoc demos) — the sweep simply doesn't collect\nevents for them.\n\nThe DB default is `true` for freshly-inserted rows, but the migration\nthat added the column backfilled existing rows with `false` to avoid\nflooding incidents on rollout. Operators flip it on per server."
+          "alert_when_down_for": {
+            "type": "integer",
+            "format": "int64",
+            "description": "How long a server's status row may go un-updated before the canopy\nreachability sweep files an issue.\n\n`INTERVAL '0'` disables the sweep for this server entirely — useful\nfor test environments and ad-hoc demos whose downtime is expected.\nPositive values are the per-server downtime threshold: bump it up\nfor flappy servers, drop it for critical ones that should page\npromptly. Negative durations are rejected by a CHECK constraint on\nthe column.\n\nDefault 10 minutes for newly-inserted rows. On the JSON wire this\nis represented as a count of whole seconds (`i64`)."
           },
           "cloud": {
             "type": [

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -405,5 +405,9 @@ fn split_health_from_extra(
 		}
 	}
 
-	Ok((healthy, serde_json::Value::Array(health_arr), serde_json::Value::Object(obj)))
+	Ok((
+		healthy,
+		serde_json::Value::Array(health_arr),
+		serde_json::Value::Object(obj),
+	))
 }

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -622,8 +622,14 @@ async fn submit_status_with_health_checks_persists() {
 			assert_eq!(arr[1]["check"], "disk");
 			assert_eq!(arr[1]["free_pct"], 4);
 			assert_eq!(arr[1]["message"], "almost full");
-			assert!(row.extra.get("health").is_none(), "`health` must not leak into `extra`");
-			assert_eq!(row.extra.get("timezone").and_then(|v| v.as_str()), Some("UTC"));
+			assert!(
+				row.extra.get("health").is_none(),
+				"`health` must not leak into `extra`"
+			);
+			assert_eq!(
+				row.extra.get("timezone").and_then(|v| v.as_str()),
+				Some("UTC")
+			);
 		},
 	)
 	.await
@@ -730,7 +736,13 @@ async fn submit_status_legacy_files_no_health_issues() {
 		async |mut conn, cert, device_id, public, _| {
 			let server_id = insert_health_test_server(&mut conn, device_id).await;
 
-			post_status(&public, &cert, server_id, serde_json::json!({ "uptime": 1 })).await;
+			post_status(
+				&public,
+				&cert,
+				server_id,
+				serde_json::json!({ "uptime": 1 }),
+			)
+			.await;
 
 			assert_eq!(
 				count_issues_for_server(&mut conn, server_id).await,
@@ -776,7 +788,11 @@ async fn submit_status_warning_check_only() {
 			);
 
 			// No roll-up while top-level healthy.
-			assert!(fetch_issue(&mut conn, server_id, "status", "health").await.is_none());
+			assert!(
+				fetch_issue(&mut conn, server_id, "status", "health")
+					.await
+					.is_none()
+			);
 			// Warning alone doesn't cross the incident threshold.
 			assert!(fetch_open_incident(&mut conn, server_id).await.is_none());
 		},

--- a/migrations/2026-05-20-000000-0000_servers_alert_when_down_for/down.sql
+++ b/migrations/2026-05-20-000000-0000_servers_alert_when_down_for/down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE servers
+	ADD COLUMN alert_when_down BOOLEAN NOT NULL DEFAULT TRUE;
+
+UPDATE servers SET alert_when_down = FALSE WHERE alert_when_down_for <= INTERVAL '0';
+
+ALTER TABLE servers DROP COLUMN alert_when_down_for;

--- a/migrations/2026-05-20-000000-0000_servers_alert_when_down_for/up.sql
+++ b/migrations/2026-05-20-000000-0000_servers_alert_when_down_for/up.sql
@@ -1,0 +1,19 @@
+-- Replace the on/off `alert_when_down` boolean with a per-server downtime
+-- threshold. Anything non-positive (`INTERVAL '0'`, negative intervals)
+-- disables alerting entirely; positive durations are how long a server
+-- must have failed to report for before the reachability sweep files an
+-- issue.
+--
+-- Default 10 minutes — long enough that a typical restart or network
+-- blip won't fire, short enough to catch real outages.
+--
+-- Backfill mapping:
+--   alert_when_down = false → INTERVAL '0'           (disabled)
+--   alert_when_down = true  → INTERVAL '10 minutes'  (default)
+ALTER TABLE servers
+	ADD COLUMN alert_when_down_for INTERVAL NOT NULL DEFAULT INTERVAL '10 minutes'
+		CHECK (alert_when_down_for >= INTERVAL '0');
+
+UPDATE servers SET alert_when_down_for = INTERVAL '0' WHERE NOT alert_when_down;
+
+ALTER TABLE servers DROP COLUMN alert_when_down;

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -70,7 +70,8 @@ export async function seedServer(
 		rank?: ServerRank | null;
 		parentServerId?: string;
 		deviceId?: string;
-		alertWhenDown?: boolean;
+		/** Threshold in seconds; `0` disables alerting (the default for e2e seeds). */
+		alertWhenDownFor?: number;
 	} = {},
 ): Promise<SeededServer> {
 	const id = randomUUID();
@@ -78,9 +79,9 @@ export async function seedServer(
 	const host = opts.host ?? `https://${randomLabel("host")}.e2e.invalid`;
 	const kind = opts.kind ?? "central";
 	const rank = opts.rank ?? "production";
-	const alertWhenDown = opts.alertWhenDown ?? false;
+	const alertWhenDownFor = opts.alertWhenDownFor ?? 0;
 	await sql.query(
-		`INSERT INTO servers (id, name, host, kind, rank, parent_server_id, device_id, alert_when_down)
+		`INSERT INTO servers (id, name, host, kind, rank, parent_server_id, device_id, alert_when_down_for)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 		[
 			id,
@@ -90,7 +91,7 @@ export async function seedServer(
 			rank,
 			opts.parentServerId ?? null,
 			opts.deviceId ?? null,
-			alertWhenDown,
+			alertWhenDownFor,
 		],
 	);
 	return { id, name, host, kind, rank };

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4384,11 +4384,13 @@
                 "kind",
                 "host",
                 "listed",
-                "alert_when_down"
+                "alert_when_down_for"
               ],
               "properties": {
-                "alert_when_down": {
-                  "type": "boolean"
+                "alert_when_down_for": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "Downtime threshold in seconds before the reachability sweep files an\nissue. `0` (or any non-positive value) disables alerting for this\nserver; the default at creation is 600 (10 minutes)."
                 },
                 "cloud": {
                   "type": [
@@ -4732,11 +4734,12 @@
       "ServerDataUpdate": {
         "type": "object",
         "properties": {
-          "alert_when_down": {
+          "alert_when_down_for": {
             "type": [
-              "boolean",
+              "integer",
               "null"
-            ]
+            ],
+            "format": "int64"
           },
           "cloud": {
             "type": [
@@ -4849,11 +4852,13 @@
                     "kind",
                     "host",
                     "listed",
-                    "alert_when_down"
+                    "alert_when_down_for"
                   ],
                   "properties": {
-                    "alert_when_down": {
-                      "type": "boolean"
+                    "alert_when_down_for": {
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "Downtime threshold in seconds before the reachability sweep files an\nissue. `0` (or any non-positive value) disables alerting for this\nserver; the default at creation is 600 (10 minutes)."
                     },
                     "cloud": {
                       "type": [
@@ -4987,11 +4992,13 @@
           "kind",
           "host",
           "listed",
-          "alert_when_down"
+          "alert_when_down_for"
         ],
         "properties": {
-          "alert_when_down": {
-            "type": "boolean"
+          "alert_when_down_for": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Downtime threshold in seconds before the reachability sweep files an\nissue. `0` (or any non-positive value) disables alerting for this\nserver; the default at creation is 600 (10 minutes)."
           },
           "cloud": {
             "type": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1697,7 +1697,13 @@ export interface components {
          */
         Page_ServerInfo: {
             items: {
-                alert_when_down: boolean;
+                /**
+                 * Format: int64
+                 * @description Downtime threshold in seconds before the reachability sweep files an
+                 *     issue. `0` (or any non-positive value) disables alerting for this
+                 *     server; the default at creation is 600 (10 minutes).
+                 */
+                alert_when_down_for: number;
                 cloud?: boolean | null;
                 /** Format: uuid */
                 device_id?: string | null;
@@ -1827,7 +1833,8 @@ export interface components {
             query: string;
         };
         ServerDataUpdate: {
-            alert_when_down?: boolean | null;
+            /** Format: int64 */
+            alert_when_down_for?: number | null;
             cloud?: boolean | null;
             /** Format: uuid */
             device_id?: string | null;
@@ -1845,7 +1852,13 @@ export interface components {
                 "up" | "down" | "away" | "blip" | "gone",
                 "healthy" | "warning" | "unhealthy",
                 {
-                    alert_when_down: boolean;
+                    /**
+                     * Format: int64
+                     * @description Downtime threshold in seconds before the reachability sweep files an
+                     *     issue. `0` (or any non-positive value) disables alerting for this
+                     *     server; the default at creation is 600 (10 minutes).
+                     */
+                    alert_when_down_for: number;
                     cloud?: boolean | null;
                     /** Format: uuid */
                     device_id?: string | null;
@@ -1877,7 +1890,13 @@ export interface components {
             server_id: string;
         };
         ServerInfo: {
-            alert_when_down: boolean;
+            /**
+             * Format: int64
+             * @description Downtime threshold in seconds before the reachability sweep files an
+             *     issue. `0` (or any non-positive value) disables alerting for this
+             *     server; the default at creation is 600 (10 minutes).
+             */
+            alert_when_down_for: number;
             cloud?: boolean | null;
             /** Format: uuid */
             device_id?: string | null;

--- a/private-web/src/lib/humanDuration.ts
+++ b/private-web/src/lib/humanDuration.ts
@@ -1,10 +1,13 @@
 /** Coarse, single-unit duration: "12s", "3m", "5h", "2d". */
 export function humanDuration(earliestIso: string, latestIso: string): string {
 	const ms = Date.parse(latestIso) - Date.parse(earliestIso);
-	if (ms <= 0) return "0s";
-	const sec = Math.round(ms / 1000);
-	if (sec < 60) return `${sec}s`;
-	const min = Math.round(sec / 60);
+	return humanSeconds(Math.round(ms / 1000));
+}
+
+export function humanSeconds(seconds: number): string {
+	if (seconds <= 0) return "0s";
+	if (seconds < 60) return `${seconds}s`;
+	const min = Math.round(seconds / 60);
 	if (min < 60) return `${min}m`;
 	const hr = Math.round(min / 60);
 	if (hr < 24) return `${hr}h`;

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -33,6 +33,7 @@ import ServerKindChip from "../components/ServerKindChip";
 import ServerRankChip from "../components/ServerRankChip";
 import { callApi, useApi, useApiAction } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
+import { humanSeconds } from "../lib/humanDuration";
 import type {
 	DeviceInfo,
 	ServerDetailData,
@@ -466,7 +467,11 @@ function InfoSection({
 				)}
 				<InfoItem
 					label="Status alerts"
-					value={server.alert_when_down ? "On" : "Off"}
+					value={
+						server.alert_when_down_for > 0
+							? `After ${humanSeconds(server.alert_when_down_for)}`
+							: "Off"
+					}
 				/>
 				{server.parent_server_id && (
 					<Stack spacing={0.25}>
@@ -798,7 +803,7 @@ function ChildServers({
 						</MuiLink>
 						{child.rank && <ServerRankChip rank={child.rank} />}
 						<ServerKindChip kind={child.kind} />
-						{!child.alert_when_down && (
+						{child.alert_when_down_for <= 0 && (
 							<Tooltip title="Status alerts are off for this server — canopy isn't watching it.">
 								<Chip
 									size="small"

--- a/private-web/src/routes/ServerEdit.tsx
+++ b/private-web/src/routes/ServerEdit.tsx
@@ -51,8 +51,16 @@ function EditForm({ info }: { info: ServerInfo }) {
 	const [kind, setKind] = useState<ServerKind>(info.kind);
 	const [rank, setRank] = useState<ServerRank | "">(info.rank ?? "");
 	const [listed, setListed] = useState(info.listed);
-	const [alertWhenDown, setAlertWhenDown] = useState(
-		info.alert_when_down,
+	// Threshold in seconds; 0 (or negative) means alerting is disabled. The
+	// UI works in minutes for the operator and the empty string represents
+	// "disabled" — converted back to seconds at submit time.
+	const [alertWhenDownEnabled, setAlertWhenDownEnabled] = useState(
+		info.alert_when_down_for > 0,
+	);
+	const [alertWhenDownMinutes, setAlertWhenDownMinutes] = useState<string>(
+		info.alert_when_down_for > 0
+			? Math.round(info.alert_when_down_for / 60).toString()
+			: "10",
 	);
 	const [parentId, setParentId] = useState<string | null>(
 		info.parent_server_id,
@@ -79,7 +87,9 @@ function EditForm({ info }: { info: ServerInfo }) {
 				lat && lon
 					? { lat: Number(lat), lon: Number(lon) }
 					: null,
-			alert_when_down: alertWhenDown,
+			alert_when_down_for: alertWhenDownEnabled
+				? Math.max(0, Math.round(Number(alertWhenDownMinutes) * 60))
+				: 0,
 		};
 		try {
 			await action.call({ server_id: info.id, data });
@@ -191,16 +201,36 @@ function EditForm({ info }: { info: ServerInfo }) {
 					/>
 				)}
 
-				<FormControlLabel
-					control={
-						<Checkbox
-							checked={alertWhenDown}
-							onChange={(e) => setAlertWhenDown(e.target.checked)}
-							disabled={action.pending}
-						/>
-					}
-					label="File an issue when this server goes unreachable (untick for test environments and other servers that are expected to be down sometimes)"
-				/>
+				<Stack
+					direction={{ xs: "column", md: "row" }}
+					spacing={2}
+					sx={{ alignItems: { md: "center" } }}
+				>
+					<FormControlLabel
+						control={
+							<Checkbox
+								checked={alertWhenDownEnabled}
+								onChange={(e) => setAlertWhenDownEnabled(e.target.checked)}
+								disabled={action.pending}
+							/>
+						}
+						label="File an issue when this server is unreachable for"
+					/>
+					<TextField
+						label="minutes"
+						type="number"
+						value={alertWhenDownMinutes}
+						onChange={(e) => setAlertWhenDownMinutes(e.target.value)}
+						disabled={action.pending || !alertWhenDownEnabled}
+						slotProps={{ htmlInput: { min: 0, step: 1 } }}
+						sx={{ width: 140 }}
+					/>
+				</Stack>
+				<Typography variant="caption" color="text.secondary">
+					Raise this for flappy servers (so brief blips don't fire) or lower it
+					for critical servers that should page promptly. Uncheck for test
+					environments and ad-hoc demos that are expected to be down.
+				</Typography>
 
 				{action.error && (
 					<Alert severity="error">{action.error.message}</Alert>


### PR DESCRIPTION
## Summary

- Replaces the on/off `alert_when_down` flag with a per-server `alert_when_down_for` downtime threshold. Stored as a PostgreSQL `INTERVAL`; on the JSON wire it's a whole-second `i64` so the React frontend can keep working in minutes.
- `INTERVAL '0'` disables alerting for that server. A CHECK constraint at the DB level rejects negative durations, so 0 is the only "disabled" value. Default is 10 minutes.
- The reachability sweep no longer escalates by the blip/away/down/gone tiers — it just compares `time-since-last-status` against each server's threshold and files a single Error-severity issue when crossed. Operators bump the duration up for flappy servers and down for critical ones.
- Migration backfills existing rows: `alert_when_down = true` → 10 minutes, `false` → `INTERVAL '0'` (disabled). The boolean column is dropped.
- Server edit page swaps the on/off checkbox for an enable checkbox plus a `minutes` input. Server detail shows `After Nm` / `Off`; the child-server list shows the `unmonitored` chip when the duration is 0.
- The previously-unused `PgDuration` wrapper in `crates/database/src/pg_duration.rs` is now actually used. Added a `FromSqlRow` derive so it can slot into `Server`'s `#[derive(Queryable, …)]`, and gave it custom `Serialize`/`Deserialize` impls that read/write whole seconds as `i64` for the JSON wire shape.
- Reachability sweep tests rewritten around the new threshold semantics, plus a test for the negative-duration CHECK constraint.