### PR TITLE
Known issues on versions with a ready flag

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -18,6 +18,7 @@ pub mod sql_playground_history;
 pub mod statuses;
 pub mod tailscale_users;
 pub mod url_field;
+pub mod version_known_issues;
 pub mod versions;
 pub mod views;
 

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -242,6 +242,19 @@ diesel::table! {
 }
 
 diesel::table! {
+	version_known_issues (id) {
+		id -> Uuid,
+		created_at -> Timestamptz,
+		version_id -> Uuid,
+		author -> Text,
+		description -> Text,
+		resolved_at -> Nullable<Timestamptz>,
+		resolved_by -> Nullable<Text>,
+		resolution_message -> Nullable<Text>,
+	}
+}
+
+diesel::table! {
 	versions (id) {
 		id -> Uuid,
 		created_at -> Timestamptz,
@@ -275,6 +288,7 @@ diesel::joinable!(slack_outbox -> incidents (incident_id));
 diesel::joinable!(slack_outbox -> issues (issue_id));
 diesel::joinable!(statuses -> devices (device_id));
 diesel::joinable!(statuses -> servers (server_id));
+diesel::joinable!(version_known_issues -> versions (version_id));
 diesel::joinable!(versions -> devices (device_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -297,5 +311,6 @@ diesel::allow_tables_to_appear_in_same_query!(
 	sql_playground_history,
 	statuses,
 	tailscale_users,
+	version_known_issues,
 	versions,
 );

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -403,17 +403,14 @@ impl Status {
 		if !self.healthy {
 			return HealthState::Unhealthy;
 		}
-		let any_failing = self
-			.health
-			.as_array()
-			.is_some_and(|arr| {
-				arr.iter().any(|e| {
-					e.as_object()
-						.and_then(|o| o.get("healthy"))
-						.and_then(|v| v.as_bool())
-						.is_some_and(|b| !b)
-				})
-			});
+		let any_failing = self.health.as_array().is_some_and(|arr| {
+			arr.iter().any(|e| {
+				e.as_object()
+					.and_then(|o| o.get("healthy"))
+					.and_then(|v| v.as_bool())
+					.is_some_and(|b| !b)
+			})
+		});
 		if any_failing {
 			HealthState::Warning
 		} else {

--- a/crates/database/src/version_known_issues.rs
+++ b/crates/database/src/version_known_issues.rs
@@ -1,0 +1,121 @@
+//! Operator-flagged known issues attached to a version.
+//!
+//! Rows are append-only: instead of editing or deleting, an operator
+//! resolves an issue with a `resolution_message`. A version is `ready`
+//! when it has no unresolved (open) known issues.
+
+use commons_errors::{AppError, Result};
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::versions::Version;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Queryable, Selectable, Associations)]
+#[diesel(belongs_to(Version))]
+#[diesel(table_name = crate::schema::version_known_issues)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct VersionKnownIssue {
+	pub id: Uuid,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub created_at: Timestamp,
+	pub version_id: Uuid,
+	pub author: String,
+	pub description: String,
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	pub resolved_at: Option<Timestamp>,
+	pub resolved_by: Option<String>,
+	pub resolution_message: Option<String>,
+}
+
+impl VersionKnownIssue {
+	pub async fn add(
+		db: &mut AsyncPgConnection,
+		version_id: Uuid,
+		author: &str,
+		description: &str,
+	) -> Result<Self> {
+		use crate::schema::version_known_issues;
+		diesel::insert_into(version_known_issues::table)
+			.values((
+				version_known_issues::version_id.eq(version_id),
+				version_known_issues::author.eq(author),
+				version_known_issues::description.eq(description),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	pub async fn list_for_version(
+		db: &mut AsyncPgConnection,
+		version_id: Uuid,
+	) -> Result<Vec<Self>> {
+		use crate::schema::version_known_issues::dsl;
+		dsl::version_known_issues
+			.select(Self::as_select())
+			.filter(dsl::version_id.eq(version_id))
+			.order(dsl::created_at.desc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	pub async fn resolve(
+		db: &mut AsyncPgConnection,
+		issue_id: Uuid,
+		resolved_by: &str,
+		resolution_message: &str,
+	) -> Result<Self> {
+		use crate::schema::version_known_issues::dsl;
+		let now = Timestamp::now();
+		diesel::update(dsl::version_known_issues)
+			.filter(dsl::id.eq(issue_id))
+			.filter(dsl::resolved_at.is_null())
+			.set((
+				dsl::resolved_at.eq(jiff_diesel::NullableTimestamp::from(Some(now))),
+				dsl::resolved_by.eq(resolved_by),
+				dsl::resolution_message.eq(resolution_message),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Return the set of version IDs (from `ids`) that have at least one
+	/// unresolved known issue. Used to compute the `ready` flag in batch.
+	pub async fn versions_with_open(
+		db: &mut AsyncPgConnection,
+		ids: &[Uuid],
+	) -> Result<std::collections::HashSet<Uuid>> {
+		use crate::schema::version_known_issues::dsl;
+		if ids.is_empty() {
+			return Ok(std::collections::HashSet::new());
+		}
+		let rows: Vec<Uuid> = dsl::version_known_issues
+			.select(dsl::version_id)
+			.filter(dsl::version_id.eq_any(ids))
+			.filter(dsl::resolved_at.is_null())
+			.distinct()
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(rows.into_iter().collect())
+	}
+
+	pub async fn version_is_ready(db: &mut AsyncPgConnection, version_id: Uuid) -> Result<bool> {
+		use crate::schema::version_known_issues::dsl;
+		let count: i64 = dsl::version_known_issues
+			.filter(dsl::version_id.eq(version_id))
+			.filter(dsl::resolved_at.is_null())
+			.count()
+			.get_result(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(count == 0)
+	}
+}

--- a/crates/database/tests/upsert_from_ticket.rs
+++ b/crates/database/tests/upsert_from_ticket.rs
@@ -62,7 +62,10 @@ async fn upsert_from_ticket_persists_rank_and_trusts_device() {
 		assert_eq!(server.kind, ServerKind::Facility);
 
 		let device_id = server.device_id.expect("server has a device");
-		let device = Device::get_with_info(&mut conn, device_id).await.expect("device").device;
+		let device = Device::get_with_info(&mut conn, device_id)
+			.await
+			.expect("device")
+			.device;
 		assert_eq!(device.role, DeviceRole::Server);
 	})
 	.await
@@ -130,7 +133,10 @@ async fn upsert_from_ticket_preserves_higher_role_on_existing_device() {
 		)
 		.await
 		.expect("second upsert");
-		let device = Device::get_with_info(&mut conn, device_id).await.expect("device").device;
+		let device = Device::get_with_info(&mut conn, device_id)
+			.await
+			.expect("device")
+			.device;
 		assert_eq!(device.role, DeviceRole::Admin);
 	})
 	.await

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -12,9 +12,7 @@ use commons_types::{
 	},
 	version::VersionStr,
 };
-use database::{
-	devices::DeviceConnection, servers::Server, statuses::Status, versions::Version,
-};
+use database::{devices::DeviceConnection, servers::Server, statuses::Status, versions::Version};
 use itertools::Itertools;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};

--- a/crates/private-server/src/fns/versions.rs
+++ b/crates/private-server/src/fns/versions.rs
@@ -4,9 +4,11 @@ use std::str::FromStr;
 use axum::Json;
 use axum::extract::State;
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
-use commons_servers::tailscale_auth::TailscaleAdmin;
+use commons_servers::tailscale_auth::{TailscaleAdmin, TailscaleUser};
 use commons_types::version::{VersionStatus, VersionStr};
-use database::{artifacts::Artifact, versions::Version};
+use database::{
+	artifacts::Artifact, version_known_issues::VersionKnownIssue, versions::Version,
+};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -22,6 +24,10 @@ pub struct VersionData {
 	pub patch: i32,
 	pub status: VersionStatus,
 	pub created_at: Timestamp,
+	/// `true` when this version has no unresolved known issues. See the
+	/// `version_known_issues` table and `add_known_issue`/`resolve_known_issue`
+	/// endpoints for management.
+	pub ready: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -48,6 +54,34 @@ pub struct VersionDetail {
 	pub min_chrome_version: Option<u32>,
 	pub is_latest_in_minor: bool,
 	pub related_versions: Vec<RelatedVersionData>,
+	/// `true` when this version has no unresolved known issues.
+	pub ready: bool,
+	pub known_issues: Vec<KnownIssueData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct KnownIssueData {
+	pub id: Uuid,
+	pub created_at: Timestamp,
+	pub author: String,
+	pub description: String,
+	pub resolved_at: Option<Timestamp>,
+	pub resolved_by: Option<String>,
+	pub resolution_message: Option<String>,
+}
+
+impl From<VersionKnownIssue> for KnownIssueData {
+	fn from(k: VersionKnownIssue) -> Self {
+		Self {
+			id: k.id,
+			created_at: k.created_at,
+			author: k.author,
+			description: k.description,
+			resolved_at: k.resolved_at,
+			resolved_by: k.resolved_by,
+			resolution_message: k.resolution_message,
+		}
+	}
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -84,6 +118,9 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(update_artifact))
 		.routes(routes!(create_artifact))
 		.routes(routes!(delete_artifact))
+		.routes(routes!(list_known_issues))
+		.routes(routes!(add_known_issue))
+		.routes(routes!(resolve_known_issue))
 }
 
 #[utoipa::path(
@@ -100,6 +137,11 @@ pub async fn get_grouped_versions(
 ) -> Result<Json<Vec<MinorVersionGroup>>> {
 	let mut conn = state.db.get().await?;
 	let versions = Version::get_all_including_drafts(&mut conn).await?;
+
+	// One batched query to compute `ready` for every version returned.
+	let version_ids: Vec<Uuid> = versions.iter().map(|v| v.id).collect();
+	let with_open_issues =
+		VersionKnownIssue::versions_with_open(&mut conn, &version_ids).await?;
 
 	let mut grouped: BTreeMap<(i32, i32), Vec<Version>> = BTreeMap::new();
 	for version in versions {
@@ -141,6 +183,7 @@ pub async fn get_grouped_versions(
 			let version_data: Vec<VersionData> = versions
 				.into_iter()
 				.map(|v| VersionData {
+					ready: !with_open_issues.contains(&v.id),
 					major: v.major,
 					minor: v.minor,
 					patch: v.patch,
@@ -218,6 +261,14 @@ pub async fn get_version_detail(
 		})
 		.collect();
 
+	let known_issues: Vec<KnownIssueData> =
+		VersionKnownIssue::list_for_version(&mut conn, version_record.id)
+			.await?
+			.into_iter()
+			.map(KnownIssueData::from)
+			.collect();
+	let ready = known_issues.iter().all(|k| k.resolved_at.is_some());
+
 	Ok(Json(VersionDetail {
 		id: version_record.id,
 		major: version_record.major,
@@ -230,6 +281,8 @@ pub async fn get_version_detail(
 		min_chrome_version,
 		is_latest_in_minor,
 		related_versions,
+		ready,
+		known_issues,
 	}))
 }
 
@@ -440,4 +493,99 @@ pub async fn delete_artifact(
 	let mut conn = state.db.get().await?;
 	Artifact::delete(&mut conn, args.artifact_id).await?;
 	Ok(Json(()))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct VersionIdArgs {
+	pub version_id: Uuid,
+}
+
+#[utoipa::path(
+	post,
+	path = "/list_known_issues",
+	tag = "versions",
+	security(("tailscale-user" = [])),
+	request_body = VersionIdArgs,
+	responses(
+		(status = 200, body = Vec<KnownIssueData>),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn list_known_issues(
+	State(state): State<AppState>,
+	_user: TailscaleUser,
+	Json(args): Json<VersionIdArgs>,
+) -> Result<Json<Vec<KnownIssueData>>> {
+	let mut conn = state.db.get().await?;
+	let rows = VersionKnownIssue::list_for_version(&mut conn, args.version_id).await?;
+	Ok(Json(rows.into_iter().map(KnownIssueData::from).collect()))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct AddKnownIssueArgs {
+	pub version_id: Uuid,
+	pub description: String,
+}
+
+#[utoipa::path(
+	post,
+	path = "/add_known_issue",
+	tag = "versions",
+	security(("tailscale-admin" = [])),
+	request_body = AddKnownIssueArgs,
+	responses(
+		(status = 200, body = KnownIssueData),
+		(status = 400, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn add_known_issue(
+	State(state): State<AppState>,
+	admin: TailscaleAdmin,
+	Json(args): Json<AddKnownIssueArgs>,
+) -> Result<Json<KnownIssueData>> {
+	let description = args.description.trim();
+	if description.is_empty() {
+		return Err(AppError::BadRequest(
+			"Description must not be empty".into(),
+		));
+	}
+	let mut conn = state.db.get().await?;
+	let row =
+		VersionKnownIssue::add(&mut conn, args.version_id, &admin.0.login, description).await?;
+	Ok(Json(KnownIssueData::from(row)))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct ResolveKnownIssueArgs {
+	pub known_issue_id: Uuid,
+	pub resolution_message: String,
+}
+
+#[utoipa::path(
+	post,
+	path = "/resolve_known_issue",
+	tag = "versions",
+	security(("tailscale-admin" = [])),
+	request_body = ResolveKnownIssueArgs,
+	responses(
+		(status = 200, body = KnownIssueData),
+		(status = 400, body = ProblemDetailsSchema),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn resolve_known_issue(
+	State(state): State<AppState>,
+	admin: TailscaleAdmin,
+	Json(args): Json<ResolveKnownIssueArgs>,
+) -> Result<Json<KnownIssueData>> {
+	let resolution = args.resolution_message.trim();
+	if resolution.is_empty() {
+		return Err(AppError::BadRequest(
+			"Resolution message must not be empty".into(),
+		));
+	}
+	let mut conn = state.db.get().await?;
+	let row = VersionKnownIssue::resolve(&mut conn, args.known_issue_id, &admin.0.login, resolution)
+		.await?;
+	Ok(Json(KnownIssueData::from(row)))
 }

--- a/crates/private-server/tests/import_ticket.rs
+++ b/crates/private-server/tests/import_ticket.rs
@@ -48,7 +48,12 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 	server
 }
 
-fn synthesize_ticket(server_id: Uuid, hostname: &str, url: &str, tailscale_ip: &str) -> CanopyTicket {
+fn synthesize_ticket(
+	server_id: Uuid,
+	hostname: &str,
+	url: &str,
+	tailscale_ip: &str,
+) -> CanopyTicket {
 	use rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256};
 
 	let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).expect("keygen");

--- a/crates/private-server/tests/version_known_issues.rs
+++ b/crates/private-server/tests/version_known_issues.rs
@@ -1,0 +1,200 @@
+use commons_tests::{diesel_async::SimpleAsyncConnection, server};
+use serde_json::Value;
+
+async fn seed_version(conn: &mut commons_tests::diesel_async::AsyncPgConnection) -> &'static str {
+	conn.batch_execute(
+		"INSERT INTO versions (id, major, minor, patch, status, changelog) VALUES
+		('11111111-1111-1111-1111-111111111111', 1, 0, 0, 'published', 'Version 1.0.0')",
+	)
+	.await
+	.unwrap();
+	"11111111-1111-1111-1111-111111111111"
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ready_is_true_when_no_known_issues() {
+	server::run(async |mut conn, _public, private| {
+		let version_id = seed_version(&mut conn).await;
+
+		let detail: Value = private
+			.post("/api/versions/get_version_detail")
+			.json(&serde_json::json!({ "version": "1.0.0" }))
+			.await
+			.json();
+		assert_eq!(detail.get("ready").and_then(|v| v.as_bool()), Some(true));
+		assert_eq!(
+			detail.get("known_issues").and_then(|v| v.as_array()).map(|a| a.len()),
+			Some(0)
+		);
+
+		let grouped: Value = private
+			.post("/api/versions/get_grouped_versions")
+			.json(&serde_json::json!({}))
+			.await
+			.json();
+		let group = &grouped.as_array().unwrap()[0];
+		let v = &group["versions"].as_array().unwrap()[0];
+		assert_eq!(v.get("ready"), Some(&Value::Bool(true)));
+
+		// version_id is referenced from the database state, drop the local
+		// binding so the compiler doesn't flag it as unused on test paths
+		// that don't query by it directly.
+		let _ = version_id;
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn add_open_issue_makes_version_not_ready() {
+	server::run(async |mut conn, _public, private| {
+		let version_id = seed_version(&mut conn).await;
+
+		let resp = private
+			.post("/api/versions/add_known_issue")
+			.json(&serde_json::json!({
+				"version_id": version_id,
+				"description": "Reports filter fails on Postgres 17",
+			}))
+			.await;
+		resp.assert_status_ok();
+
+		let detail: Value = private
+			.post("/api/versions/get_version_detail")
+			.json(&serde_json::json!({ "version": "1.0.0" }))
+			.await
+			.json();
+		assert_eq!(detail.get("ready").and_then(|v| v.as_bool()), Some(false));
+		let issues = detail["known_issues"].as_array().unwrap();
+		assert_eq!(issues.len(), 1);
+		assert_eq!(
+			issues[0]["description"],
+			"Reports filter fails on Postgres 17"
+		);
+		assert!(issues[0]["resolved_at"].is_null());
+
+		let grouped: Value = private
+			.post("/api/versions/get_grouped_versions")
+			.json(&serde_json::json!({}))
+			.await
+			.json();
+		let v = &grouped.as_array().unwrap()[0]["versions"].as_array().unwrap()[0];
+		assert_eq!(v.get("ready"), Some(&Value::Bool(false)));
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn resolving_the_issue_restores_ready() {
+	server::run(async |mut conn, _public, private| {
+		let version_id = seed_version(&mut conn).await;
+
+		let added: Value = private
+			.post("/api/versions/add_known_issue")
+			.json(&serde_json::json!({
+				"version_id": version_id,
+				"description": "Slow startup on cold boot",
+			}))
+			.await
+			.json();
+		let known_issue_id = added["id"].as_str().unwrap().to_string();
+
+		let resolve_resp = private
+			.post("/api/versions/resolve_known_issue")
+			.json(&serde_json::json!({
+				"known_issue_id": known_issue_id,
+				"resolution_message": "Fixed in 1.0.1",
+			}))
+			.await;
+		resolve_resp.assert_status_ok();
+		let resolved: Value = resolve_resp.json();
+		assert_eq!(resolved["resolution_message"], "Fixed in 1.0.1");
+		assert!(!resolved["resolved_at"].is_null());
+
+		let detail: Value = private
+			.post("/api/versions/get_version_detail")
+			.json(&serde_json::json!({ "version": "1.0.0" }))
+			.await
+			.json();
+		assert_eq!(detail.get("ready").and_then(|v| v.as_bool()), Some(true));
+		let issues = detail["known_issues"].as_array().unwrap();
+		assert_eq!(issues.len(), 1);
+		assert_eq!(issues[0]["resolution_message"], "Fixed in 1.0.1");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cannot_resolve_twice() {
+	server::run(async |mut conn, _public, private| {
+		let version_id = seed_version(&mut conn).await;
+		let added: Value = private
+			.post("/api/versions/add_known_issue")
+			.json(&serde_json::json!({
+				"version_id": version_id,
+				"description": "x",
+			}))
+			.await
+			.json();
+		let known_issue_id = added["id"].as_str().unwrap().to_string();
+		private
+			.post("/api/versions/resolve_known_issue")
+			.json(&serde_json::json!({
+				"known_issue_id": known_issue_id,
+				"resolution_message": "fixed",
+			}))
+			.await
+			.assert_status_ok();
+		// Second resolve hits the NOT FOUND path because the filter
+		// `resolved_at IS NULL` excludes already-resolved rows.
+		let resp = private
+			.post("/api/versions/resolve_known_issue")
+			.json(&serde_json::json!({
+				"known_issue_id": known_issue_id,
+				"resolution_message": "again",
+			}))
+			.await;
+		assert_eq!(resp.status_code(), 404);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_known_issues_returns_all_for_version() {
+	server::run(async |mut conn, _public, private| {
+		let version_id = seed_version(&mut conn).await;
+		for desc in ["a", "b", "c"] {
+			private
+				.post("/api/versions/add_known_issue")
+				.json(&serde_json::json!({
+					"version_id": version_id,
+					"description": desc,
+				}))
+				.await
+				.assert_status_ok();
+		}
+		let resp = private
+			.post("/api/versions/list_known_issues")
+			.json(&serde_json::json!({ "version_id": version_id }))
+			.await;
+		resp.assert_status_ok();
+		let issues: Vec<Value> = resp.json();
+		assert_eq!(issues.len(), 3);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn add_rejects_empty_description() {
+	server::run(async |mut conn, _public, private| {
+		let version_id = seed_version(&mut conn).await;
+		let resp = private
+			.post("/api/versions/add_known_issue")
+			.json(&serde_json::json!({
+				"version_id": version_id,
+				"description": "   ",
+			}))
+			.await;
+		assert_eq!(resp.status_code(), 400);
+	})
+	.await;
+}

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -405,5 +405,9 @@ fn split_health_from_extra(
 		}
 	}
 
-	Ok((healthy, serde_json::Value::Array(health_arr), serde_json::Value::Object(obj)))
+	Ok((
+		healthy,
+		serde_json::Value::Array(health_arr),
+		serde_json::Value::Object(obj),
+	))
 }

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -622,8 +622,14 @@ async fn submit_status_with_health_checks_persists() {
 			assert_eq!(arr[1]["check"], "disk");
 			assert_eq!(arr[1]["free_pct"], 4);
 			assert_eq!(arr[1]["message"], "almost full");
-			assert!(row.extra.get("health").is_none(), "`health` must not leak into `extra`");
-			assert_eq!(row.extra.get("timezone").and_then(|v| v.as_str()), Some("UTC"));
+			assert!(
+				row.extra.get("health").is_none(),
+				"`health` must not leak into `extra`"
+			);
+			assert_eq!(
+				row.extra.get("timezone").and_then(|v| v.as_str()),
+				Some("UTC")
+			);
 		},
 	)
 	.await
@@ -730,7 +736,13 @@ async fn submit_status_legacy_files_no_health_issues() {
 		async |mut conn, cert, device_id, public, _| {
 			let server_id = insert_health_test_server(&mut conn, device_id).await;
 
-			post_status(&public, &cert, server_id, serde_json::json!({ "uptime": 1 })).await;
+			post_status(
+				&public,
+				&cert,
+				server_id,
+				serde_json::json!({ "uptime": 1 }),
+			)
+			.await;
 
 			assert_eq!(
 				count_issues_for_server(&mut conn, server_id).await,
@@ -776,7 +788,11 @@ async fn submit_status_warning_check_only() {
 			);
 
 			// No roll-up while top-level healthy.
-			assert!(fetch_issue(&mut conn, server_id, "status", "health").await.is_none());
+			assert!(
+				fetch_issue(&mut conn, server_id, "status", "health")
+					.await
+					.is_none()
+			);
 			// Warning alone doesn't cross the incident threshold.
 			assert!(fetch_open_incident(&mut conn, server_id).await.is_none());
 		},

--- a/migrations/2026-05-20-122242-0000_version_known_issues/down.sql
+++ b/migrations/2026-05-20-122242-0000_version_known_issues/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE version_known_issues;

--- a/migrations/2026-05-20-122242-0000_version_known_issues/up.sql
+++ b/migrations/2026-05-20-122242-0000_version_known_issues/up.sql
@@ -1,0 +1,32 @@
+-- Known issues attached to a version. Operators add these to flag a
+-- released version with caveats; a version with no unresolved known
+-- issues is considered `ready` (surfaced as a boolean in API responses).
+--
+-- Rows are append-only: instead of editing or deleting a known issue,
+-- an operator resolves it with a `resolution_message`. The combination
+-- of (description, resolution_message) becomes a small audit trail of
+-- what was wrong and how it was addressed (a fix in a later patch,
+-- known-good workaround, false alarm, etc).
+
+CREATE TABLE version_known_issues (
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+	version_id UUID NOT NULL REFERENCES versions (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	author TEXT NOT NULL,
+	description TEXT NOT NULL,
+	resolved_at TIMESTAMP WITH TIME ZONE,
+	resolved_by TEXT,
+	resolution_message TEXT,
+	CONSTRAINT resolved_consistency CHECK (
+		(resolved_at IS NULL AND resolved_by IS NULL AND resolution_message IS NULL)
+		OR (resolved_at IS NOT NULL AND resolved_by IS NOT NULL AND resolution_message IS NOT NULL)
+	)
+);
+
+CREATE INDEX version_known_issues_version_created
+	ON version_known_issues (version_id, created_at DESC);
+
+-- Fast lookup of "does this version have any unresolved known issues?"
+CREATE INDEX version_known_issues_open
+	ON version_known_issues (version_id)
+	WHERE resolved_at IS NULL;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -2683,6 +2683,51 @@
         }
       }
     },
+    "/api/versions/add_known_issue": {
+      "post": {
+        "tags": [
+          "versions"
+        ],
+        "operationId": "add_known_issue",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddKnownIssueArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnownIssueData"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/versions/create_artifact": {
       "post": {
         "tags": [
@@ -2862,6 +2907,109 @@
         }
       }
     },
+    "/api/versions/list_known_issues": {
+      "post": {
+        "tags": [
+          "versions"
+        ],
+        "operationId": "list_known_issues",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VersionIdArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/KnownIssueData"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
+    "/api/versions/resolve_known_issue": {
+      "post": {
+        "tags": [
+          "versions"
+        ],
+        "operationId": "resolve_known_issue",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResolveKnownIssueArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnownIssueData"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/versions/update_artifact": {
       "post": {
         "tags": [
@@ -2967,6 +3115,22 @@
         "properties": {
           "email": {
             "type": "string"
+          }
+        }
+      },
+      "AddKnownIssueArgs": {
+        "type": "object",
+        "required": [
+          "version_id",
+          "description"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "version_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },
@@ -4071,6 +4235,50 @@
           }
         }
       },
+      "KnownIssueData": {
+        "type": "object",
+        "required": [
+          "id",
+          "created_at",
+          "author",
+          "description"
+        ],
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "resolution_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "resolved_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "resolved_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
       "ListActiveArgs": {
         "type": "object",
         "properties": {
@@ -4619,6 +4827,22 @@
           },
           "reason": {
             "$ref": "#/components/schemas/ResolvedReason"
+          }
+        }
+      },
+      "ResolveKnownIssueArgs": {
+        "type": "object",
+        "required": [
+          "known_issue_id",
+          "resolution_message"
+        ],
+        "properties": {
+          "known_issue_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "resolution_message": {
+            "type": "string"
           }
         }
       },
@@ -5609,7 +5833,8 @@
           "minor",
           "patch",
           "status",
-          "created_at"
+          "created_at",
+          "ready"
         ],
         "properties": {
           "created_at": {
@@ -5628,6 +5853,10 @@
             "type": "integer",
             "format": "int32"
           },
+          "ready": {
+            "type": "boolean",
+            "description": "`true` when this version has no unresolved known issues. See the\n`version_known_issues` table and `add_known_issue`/`resolve_known_issue`\nendpoints for management."
+          },
           "status": {
             "$ref": "#/components/schemas/VersionStatus"
           }
@@ -5645,7 +5874,9 @@
           "updated_at",
           "changelog",
           "is_latest_in_minor",
-          "related_versions"
+          "related_versions",
+          "ready",
+          "known_issues"
         ],
         "properties": {
           "changelog": {
@@ -5661,6 +5892,12 @@
           },
           "is_latest_in_minor": {
             "type": "boolean"
+          },
+          "known_issues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KnownIssueData"
+            }
           },
           "major": {
             "type": "integer",
@@ -5682,6 +5919,10 @@
             "type": "integer",
             "format": "int32"
           },
+          "ready": {
+            "type": "boolean",
+            "description": "`true` when this version has no unresolved known issues."
+          },
           "related_versions": {
             "type": "array",
             "items": {
@@ -5694,6 +5935,18 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "VersionIdArgs": {
+        "type": "object",
+        "required": [
+          "version_id"
+        ],
+        "properties": {
+          "version_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1111,6 +1111,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/versions/add_known_issue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["add_known_issue"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/versions/create_artifact": {
         parameters: {
             query?: never;
@@ -1191,6 +1207,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/versions/list_known_issues": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["list_known_issues"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/versions/resolve_known_issue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["resolve_known_issue"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/versions/update_artifact": {
         parameters: {
             query?: never;
@@ -1245,6 +1293,11 @@ export interface components {
     schemas: {
         AddArgs: {
             email: string;
+        };
+        AddKnownIssueArgs: {
+            description: string;
+            /** Format: uuid */
+            version_id: string;
         };
         AddNoteArgs: {
             body: string;
@@ -1592,6 +1645,18 @@ export interface components {
             /** Format: uuid */
             issue_id: string;
         };
+        KnownIssueData: {
+            author: string;
+            /** Format: date-time */
+            created_at: string;
+            description: string;
+            /** Format: uuid */
+            id: string;
+            resolution_message?: string | null;
+            /** Format: date-time */
+            resolved_at?: string | null;
+            resolved_by?: string | null;
+        };
         ListActiveArgs: {
             /** Format: int64 */
             limit?: number | null;
@@ -1783,6 +1848,11 @@ export interface components {
             /** Format: uuid */
             incident_id: string;
             reason: components["schemas"]["ResolvedReason"];
+        };
+        ResolveKnownIssueArgs: {
+            /** Format: uuid */
+            known_issue_id: string;
+            resolution_message: string;
         };
         ResolveTailnetIdentifierArgs: {
             identifier: string;
@@ -2061,6 +2131,12 @@ export interface components {
             minor: number;
             /** Format: int32 */
             patch: number;
+            /**
+             * @description `true` when this version has no unresolved known issues. See the
+             *     `version_known_issues` table and `add_known_issue`/`resolve_known_issue`
+             *     endpoints for management.
+             */
+            ready: boolean;
             status: components["schemas"]["VersionStatus"];
         };
         VersionDetail: {
@@ -2070,6 +2146,7 @@ export interface components {
             /** Format: uuid */
             id: string;
             is_latest_in_minor: boolean;
+            known_issues: components["schemas"]["KnownIssueData"][];
             /** Format: int32 */
             major: number;
             /** Format: int32 */
@@ -2078,10 +2155,16 @@ export interface components {
             minor: number;
             /** Format: int32 */
             patch: number;
+            /** @description `true` when this version has no unresolved known issues. */
+            ready: boolean;
             related_versions: components["schemas"]["RelatedVersionData"][];
             status: components["schemas"]["VersionStatus"];
             /** Format: date-time */
             updated_at: string;
+        };
+        VersionIdArgs: {
+            /** Format: uuid */
+            version_id: string;
         };
         /** @enum {string} */
         VersionStatus: "draft" | "published" | "yanked";
@@ -3986,6 +4069,37 @@ export interface operations {
             };
         };
     };
+    add_known_issue: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AddKnownIssueArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KnownIssueData"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
     create_artifact: {
         parameters: {
             query?: never;
@@ -4107,6 +4221,76 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["VersionDetail"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    list_known_issues: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VersionIdArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KnownIssueData"][];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    resolve_known_issue: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResolveKnownIssueArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KnownIssueData"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
                 };
             };
             404: {

--- a/private-web/src/routes/VersionDetail.tsx
+++ b/private-web/src/routes/VersionDetail.tsx
@@ -2,6 +2,11 @@ import {
 	Alert,
 	Box,
 	Button,
+	Chip,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
 	IconButton,
 	LinearProgress,
 	MenuItem,
@@ -17,19 +22,23 @@ import {
 	TextField,
 	Typography,
 } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
 import LockIcon from "@mui/icons-material/Lock";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 import { useState } from "react";
 import { useParams } from "react-router-dom";
 import Markdown from "../components/Markdown";
+import TimeAgo from "../components/TimeAgo";
 import VersionStatusChip from "../components/VersionStatusChip";
 import { useApi, useApiAction } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { prettifyVersionRange } from "../lib/versionRange";
 import type {
 	ArtifactData,
+	KnownIssueData,
 	RelatedVersionData,
 	VersionDetail as VersionDetailData,
 	VersionStatus,
@@ -64,9 +73,12 @@ export default function VersionDetail() {
 				spacing={2}
 				sx={{ alignItems: "center", justifyContent: "space-between" }}
 			>
-				<Typography variant="h4" component="h1" sx={{ fontFamily: "monospace" }}>
-					{versionStr}
-				</Typography>
+				<Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+					<Typography variant="h4" component="h1" sx={{ fontFamily: "monospace" }}>
+						{versionStr}
+					</Typography>
+					<ReadyChip ready={v.ready} />
+				</Stack>
 				<StatusControl
 					detail={v}
 					versionStr={versionStr}
@@ -86,6 +98,13 @@ export default function VersionDetail() {
 			<ChangelogSection
 				detail={v}
 				versionStr={versionStr}
+				isAdmin={admin}
+				onChanged={() => detail.reload()}
+			/>
+
+			<KnownIssuesSection
+				versionId={v.id}
+				issues={v.known_issues}
 				isAdmin={admin}
 				onChanged={() => detail.reload()}
 			/>
@@ -709,4 +728,323 @@ function RelatedVersionsSection({
 
 function formatDate(iso: string): string {
 	return iso.slice(0, 10);
+}
+
+function ReadyChip({ ready }: { ready: boolean }) {
+	if (ready) {
+		return (
+			<Chip
+				size="small"
+				color="success"
+				variant="outlined"
+				icon={<CheckCircleIcon />}
+				label="Ready"
+			/>
+		);
+	}
+	return (
+		<Chip
+			size="small"
+			color="warning"
+			variant="outlined"
+			icon={<ErrorOutlineIcon />}
+			label="Known issues"
+		/>
+	);
+}
+
+function KnownIssuesSection({
+	versionId,
+	issues,
+	isAdmin,
+	onChanged,
+}: {
+	versionId: string;
+	issues: KnownIssueData[];
+	isAdmin: boolean;
+	onChanged: () => void;
+}) {
+	const [addOpen, setAddOpen] = useState(false);
+
+	const open = issues.filter((i) => i.resolved_at == null);
+	const resolved = issues.filter((i) => i.resolved_at != null);
+
+	return (
+		<Box>
+			<Stack
+				direction="row"
+				spacing={1}
+				sx={{ mb: 1, alignItems: "center", justifyContent: "space-between" }}
+			>
+				<Typography variant="h5" component="h2">
+					Known issues
+				</Typography>
+				{isAdmin && (
+					<Button
+						variant="outlined"
+						size="small"
+						onClick={() => setAddOpen(true)}
+					>
+						Add known issue
+					</Button>
+				)}
+			</Stack>
+
+			{issues.length === 0 ? (
+				<Typography variant="body2" color="text.secondary">
+					No known issues — this version is marked ready.
+				</Typography>
+			) : (
+				<Stack spacing={1}>
+					{open.map((k) => (
+						<KnownIssueRow
+							key={k.id}
+							issue={k}
+							isAdmin={isAdmin}
+							onChanged={onChanged}
+						/>
+					))}
+					{resolved.length > 0 && open.length > 0 && (
+						<Typography
+							variant="caption"
+							color="text.secondary"
+							sx={{ mt: 1 }}
+						>
+							Resolved
+						</Typography>
+					)}
+					{resolved.map((k) => (
+						<KnownIssueRow
+							key={k.id}
+							issue={k}
+							isAdmin={isAdmin}
+							onChanged={onChanged}
+						/>
+					))}
+				</Stack>
+			)}
+
+			<AddKnownIssueDialog
+				open={addOpen}
+				onClose={() => setAddOpen(false)}
+				versionId={versionId}
+				onAdded={() => {
+					setAddOpen(false);
+					onChanged();
+				}}
+			/>
+		</Box>
+	);
+}
+
+function KnownIssueRow({
+	issue,
+	isAdmin,
+	onChanged,
+}: {
+	issue: KnownIssueData;
+	isAdmin: boolean;
+	onChanged: () => void;
+}) {
+	const [resolveOpen, setResolveOpen] = useState(false);
+	const open = issue.resolved_at == null;
+
+	return (
+		<Paper
+			variant="outlined"
+			sx={{
+				p: 1.5,
+				borderLeft: 4,
+				borderLeftColor: open ? "warning.main" : "success.main",
+			}}
+		>
+			<Stack
+				direction="row"
+				spacing={1}
+				sx={{ alignItems: "center", justifyContent: "space-between" }}
+			>
+				<Typography variant="caption" color="text.secondary">
+					{issue.author} • <TimeAgo timestamp={issue.created_at} />
+				</Typography>
+				{open && isAdmin && (
+					<Button size="small" onClick={() => setResolveOpen(true)}>
+						Resolve
+					</Button>
+				)}
+			</Stack>
+			<Typography
+				variant="body2"
+				component="pre"
+				sx={{ mt: 0.5, mb: 0, whiteSpace: "pre-wrap", fontFamily: "inherit" }}
+			>
+				{issue.description}
+			</Typography>
+			{!open && issue.resolution_message && (
+				<Box
+					sx={{
+						mt: 1,
+						pt: 1,
+						borderTop: 1,
+						borderTopColor: "divider",
+					}}
+				>
+					<Typography variant="caption" color="text.secondary">
+						Resolved by {issue.resolved_by ?? "?"}
+						{issue.resolved_at && (
+							<>
+								{" "}
+								(<TimeAgo timestamp={issue.resolved_at} />)
+							</>
+						)}
+					</Typography>
+					<Typography
+						variant="body2"
+						component="pre"
+						sx={{ mt: 0.5, whiteSpace: "pre-wrap", fontFamily: "inherit" }}
+					>
+						{issue.resolution_message}
+					</Typography>
+				</Box>
+			)}
+			<ResolveKnownIssueDialog
+				open={resolveOpen}
+				onClose={() => setResolveOpen(false)}
+				knownIssueId={issue.id}
+				onResolved={() => {
+					setResolveOpen(false);
+					onChanged();
+				}}
+			/>
+		</Paper>
+	);
+}
+
+function AddKnownIssueDialog({
+	open,
+	onClose,
+	versionId,
+	onAdded,
+}: {
+	open: boolean;
+	onClose: () => void;
+	versionId: string;
+	onAdded: () => void;
+}) {
+	const [draft, setDraft] = useState("");
+	const action = useApiAction("versions", "add_known_issue");
+	const submit = async () => {
+		const description = draft.trim();
+		if (description === "") return;
+		try {
+			await action.call({ version_id: versionId, description });
+			setDraft("");
+			onAdded();
+		} catch {
+			/* surfaced via action.error */
+		}
+	};
+	const cancel = () => {
+		setDraft("");
+		onClose();
+	};
+	return (
+		<Dialog open={open} onClose={cancel} fullWidth maxWidth="sm">
+			<DialogTitle>Add known issue</DialogTitle>
+			<DialogContent>
+				<TextField
+					autoFocus
+					fullWidth
+					multiline
+					minRows={3}
+					value={draft}
+					onChange={(e) => setDraft(e.target.value)}
+					disabled={action.pending}
+					placeholder="Describe the issue, including any user-facing impact"
+					sx={{ mt: 1 }}
+				/>
+				{action.error && (
+					<Alert severity="error" sx={{ mt: 1 }}>
+						{action.error.message}
+					</Alert>
+				)}
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={cancel} disabled={action.pending}>
+					Cancel
+				</Button>
+				<Button
+					variant="contained"
+					onClick={submit}
+					disabled={action.pending || draft.trim() === ""}
+				>
+					{action.pending ? "Adding…" : "Add"}
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}
+
+function ResolveKnownIssueDialog({
+	open,
+	onClose,
+	knownIssueId,
+	onResolved,
+}: {
+	open: boolean;
+	onClose: () => void;
+	knownIssueId: string;
+	onResolved: () => void;
+}) {
+	const [draft, setDraft] = useState("");
+	const action = useApiAction("versions", "resolve_known_issue");
+	const submit = async () => {
+		const resolution_message = draft.trim();
+		if (resolution_message === "") return;
+		try {
+			await action.call({ known_issue_id: knownIssueId, resolution_message });
+			setDraft("");
+			onResolved();
+		} catch {
+			/* surfaced via action.error */
+		}
+	};
+	const cancel = () => {
+		setDraft("");
+		onClose();
+	};
+	return (
+		<Dialog open={open} onClose={cancel} fullWidth maxWidth="sm">
+			<DialogTitle>Resolve known issue</DialogTitle>
+			<DialogContent>
+				<TextField
+					autoFocus
+					fullWidth
+					multiline
+					minRows={3}
+					value={draft}
+					onChange={(e) => setDraft(e.target.value)}
+					disabled={action.pending}
+					placeholder="How was this resolved? (e.g. fixed in 1.0.1, workaround documented)"
+					sx={{ mt: 1 }}
+				/>
+				{action.error && (
+					<Alert severity="error" sx={{ mt: 1 }}>
+						{action.error.message}
+					</Alert>
+				)}
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={cancel} disabled={action.pending}>
+					Cancel
+				</Button>
+				<Button
+					variant="contained"
+					onClick={submit}
+					disabled={action.pending || draft.trim() === ""}
+				>
+					{action.pending ? "Resolving…" : "Resolve"}
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
 }

--- a/private-web/src/routes/Versions.tsx
+++ b/private-web/src/routes/Versions.tsx
@@ -4,11 +4,14 @@ import {
 	AccordionSummary,
 	Alert,
 	Box,
+	Chip,
 	LinearProgress,
 	Link as MuiLink,
 	Stack,
+	Tooltip,
 	Typography,
 } from "@mui/material";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Link as RouterLink } from "react-router-dom";
 import VersionStatusChip from "../components/VersionStatusChip";
@@ -118,6 +121,17 @@ function MinorGroup({ group }: { group: MinorVersionGroup }) {
 									</Typography>
 									{v.status !== "published" && (
 										<VersionStatusChip status={v.status} />
+									)}
+									{!v.ready && (
+										<Tooltip title="This version has unresolved known issues">
+											<Chip
+												size="small"
+												color="warning"
+												variant="outlined"
+												icon={<ErrorOutlineIcon />}
+												label="Known issues"
+											/>
+										</Tooltip>
 									)}
 									<Typography
 										variant="body2"

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -91,6 +91,7 @@ export type VersionData = Solidify<Schemas["VersionData"]>;
 export type MinorVersionGroup = Solidify<Schemas["MinorVersionGroup"]>;
 export type RelatedVersionData = Solidify<Schemas["RelatedVersionData"]>;
 export type VersionDetail = Solidify<Schemas["VersionDetail"]>;
+export type KnownIssueData = Solidify<Schemas["KnownIssueData"]>;
 export type ArtifactData = Solidify<Schemas["ArtifactData"]>;
 
 export type ServerInfo = Solidify<Schemas["ServerInfo"]>;


### PR DESCRIPTION
## Summary

- New `version_known_issues` table (append-only): operators flag a version with caveats, and resolve each one with a `resolution_message` rather than editing or deleting. The constraint `resolved_consistency` keeps `resolved_at`, `resolved_by` and `resolution_message` either all-null or all-set.
- API additions on `/api/versions/`:
  - `list_known_issues` — read-only, any tailscale user
  - `add_known_issue` — admin, rejects empty descriptions
  - `resolve_known_issue` — admin, refuses to resolve an already-resolved row (returns 404)
- `VersionDetail` gains `ready` (true iff no unresolved issues) and a `known_issues` array. The grouped versions list also carries `ready` per version, computed in a single batched query.
- Frontend: `Known issues` section on the version detail page with Add / Resolve dialogs, plus a `Ready` / `Known issues` chip next to the version number and on the version list rows.