### PR TITLE
Gitignore the .claude harness state directory

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f45dee6c-031c-4133-bd17-b9cf58db7361","pid":3133251,"procStart":"44481162","acquiredAt":1778805539209}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Rocket.toml
 *.key
 identity.*.pem
 TODO.txt
+/.claude
 /private-web/node_modules
 /private-web/dist
 /private-web/test-results


### PR DESCRIPTION
## Summary

- The Claude Code harness writes session/scheduler state into `.claude/` at the repo root. That has been bleeding into branches — `scheduled_tasks.lock` was getting committed by accident.
- Adds `/.claude` to `.gitignore` and removes the previously-tracked `scheduled_tasks.lock` file from the index.