### PR TITLE
Remove issue ack

### DIFF
--- a/crates/commons-servers/src/tailscale_auth.rs
+++ b/crates/commons-servers/src/tailscale_auth.rs
@@ -137,7 +137,7 @@ where
 		};
 
 		// Cache the user's name + pic so endpoints that record human actions
-		// (issue/incident ack and resolve) can render avatars without
+		// (issue resolve, incident ack/resolve) can render avatars without
 		// round-tripping to Tailscale. Centralised here so every admin
 		// handler gets it for free.
 		let mut db = Db::from_ref(state).get().await?;

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -44,9 +44,6 @@ pub struct Issue {
 	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
 	pub last_seen: Timestamp,
 	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
-	pub acknowledged_at: Option<Timestamp>,
-	pub acknowledged_by: Option<String>,
-	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
 	pub resolved_at: Option<Timestamp>,
 	pub resolved_by: Option<String>,
 	/// Stored as nullable text; validated as `ResolvedReason` at the API layer
@@ -163,8 +160,6 @@ pub struct IssueListFilters {
 	/// Any server id in the group; the query walks to the root and then
 	/// restricts to issues on servers in the root's descendant tree.
 	pub server_group_id: Option<Uuid>,
-	/// `Some(true)` = acknowledged; `Some(false)` = un-acknowledged; `None` = either.
-	pub acked: Option<bool>,
 }
 
 fn hash_event(
@@ -208,7 +203,8 @@ impl NewEvent {
 			&& d.contains('\n')
 		{
 			return Err(AppError::BadRequest(
-				"description must be a single line (no newlines); use `message` for body text".into(),
+				"description must be a single line (no newlines); use `message` for body text"
+					.into(),
 			));
 		}
 
@@ -660,8 +656,6 @@ impl Issue {
 	/// - `server_group_id`: when `Some`, restrict to issues whose server is
 	///   in the descendant tree of that root (uses a recursive CTE via
 	///   `Server::descendant_ids`).
-	/// - `acked`: when `Some(true)`, only acknowledged; `Some(false)`, only
-	///   un-acknowledged; `None`, either.
 	pub async fn list(
 		db: &mut AsyncPgConnection,
 		filters: IssueListFilters,
@@ -692,11 +686,6 @@ impl Issue {
 		}
 		if let Some(ids) = group_ids {
 			q = q.filter(dsl::server_id.eq_any(ids));
-		}
-		match filters.acked {
-			Some(true) => q = q.filter(dsl::acknowledged_at.is_not_null()),
-			Some(false) => q = q.filter(dsl::acknowledged_at.is_null()),
-			None => {}
 		}
 		q.order(dsl::last_seen.desc())
 			.limit(limit)
@@ -738,35 +727,6 @@ impl Issue {
 					.and(dsl::server_id.eq_any(server_ids)),
 			)
 			.load(db)
-			.await
-			.map_err(AppError::from)
-	}
-
-	/// Mark an issue as acknowledged (or update the acker). Doesn't touch
-	/// incident membership — ack is purely informational.
-	pub async fn ack(db: &mut AsyncPgConnection, issue_id: Uuid, by: &str) -> Result<Self> {
-		use crate::schema::issues;
-
-		diesel::update(issues::table.filter(issues::id.eq(issue_id)))
-			.set((
-				issues::acknowledged_at.eq(jiff_diesel::Timestamp::from(Timestamp::now())),
-				issues::acknowledged_by.eq(Some(by)),
-			))
-			.returning(Self::as_select())
-			.get_result(db)
-			.await
-			.map_err(AppError::from)
-	}
-
-	pub async fn unack(db: &mut AsyncPgConnection, issue_id: Uuid) -> Result<Self> {
-		use crate::schema::issues;
-		diesel::update(issues::table.filter(issues::id.eq(issue_id)))
-			.set((
-				issues::acknowledged_at.eq(None::<jiff_diesel::Timestamp>),
-				issues::acknowledged_by.eq(None::<String>),
-			))
-			.returning(Self::as_select())
-			.get_result(db)
 			.await
 			.map_err(AppError::from)
 	}

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -165,8 +165,6 @@ diesel::table! {
 		active -> Bool,
 		first_seen -> Timestamptz,
 		last_seen -> Timestamptz,
-		acknowledged_at -> Nullable<Timestamptz>,
-		acknowledged_by -> Nullable<Text>,
 		resolved_at -> Nullable<Timestamptz>,
 		resolved_by -> Nullable<Text>,
 		resolved_reason -> Nullable<Text>,

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -403,17 +403,14 @@ impl Status {
 		if !self.healthy {
 			return HealthState::Unhealthy;
 		}
-		let any_failing = self
-			.health
-			.as_array()
-			.is_some_and(|arr| {
-				arr.iter().any(|e| {
-					e.as_object()
-						.and_then(|o| o.get("healthy"))
-						.and_then(|v| v.as_bool())
-						.is_some_and(|b| !b)
-				})
-			});
+		let any_failing = self.health.as_array().is_some_and(|arr| {
+			arr.iter().any(|e| {
+				e.as_object()
+					.and_then(|o| o.get("healthy"))
+					.and_then(|v| v.as_bool())
+					.is_some_and(|b| !b)
+			})
+		});
 		if any_failing {
 			HealthState::Warning
 		} else {

--- a/crates/database/src/tailscale_users.rs
+++ b/crates/database/src/tailscale_users.rs
@@ -1,6 +1,6 @@
 //! Cached display metadata for Tailscale users (name + profile picture).
 //!
-//! Handlers that record "this human did X" (issue/incident ack and resolve)
+//! Handlers that record "this human did X" (issue resolve, incident ack/resolve)
 //! upsert here from the request's Tailscale headers so the rest of the API
 //! can render avatars without having to round-trip through the Tailscale
 //! API.

--- a/crates/database/tests/upsert_from_ticket.rs
+++ b/crates/database/tests/upsert_from_ticket.rs
@@ -62,7 +62,10 @@ async fn upsert_from_ticket_persists_rank_and_trusts_device() {
 		assert_eq!(server.kind, ServerKind::Facility);
 
 		let device_id = server.device_id.expect("server has a device");
-		let device = Device::get_with_info(&mut conn, device_id).await.expect("device").device;
+		let device = Device::get_with_info(&mut conn, device_id)
+			.await
+			.expect("device")
+			.device;
 		assert_eq!(device.role, DeviceRole::Server);
 	})
 	.await
@@ -130,7 +133,10 @@ async fn upsert_from_ticket_preserves_higher_role_on_existing_device() {
 		)
 		.await
 		.expect("second upsert");
-		let device = Device::get_with_info(&mut conn, device_id).await.expect("device").device;
+		let device = Device::get_with_info(&mut conn, device_id)
+			.await
+			.expect("device")
+			.device;
 		assert_eq!(device.role, DeviceRole::Admin);
 	})
 	.await

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -38,12 +38,6 @@ pub struct IssueData {
 	pub active: bool,
 	pub first_seen: Timestamp,
 	pub last_seen: Timestamp,
-	pub acknowledged_at: Option<Timestamp>,
-	pub acknowledged_by: Option<String>,
-	/// Display name of the acker (from the cached Tailscale users table).
-	pub acknowledged_by_name: Option<String>,
-	/// Profile picture URL of the acker.
-	pub acknowledged_by_pic: Option<String>,
 	pub resolved_at: Option<Timestamp>,
 	pub resolved_by: Option<String>,
 	pub resolved_by_name: Option<String>,
@@ -88,7 +82,6 @@ struct IssueEnrichment<'a> {
 
 impl IssueData {
 	fn from_with(i: Issue, e: IssueEnrichment<'_>) -> Self {
-		let (ack_name, ack_pic) = lookup_user(e.users, i.acknowledged_by.as_deref());
 		let (res_name, res_pic) = lookup_user(e.users, i.resolved_by.as_deref());
 		Self {
 			id: i.id,
@@ -104,10 +97,6 @@ impl IssueData {
 			active: i.active,
 			first_seen: i.first_seen,
 			last_seen: i.last_seen,
-			acknowledged_at: i.acknowledged_at,
-			acknowledged_by: i.acknowledged_by,
-			acknowledged_by_name: ack_name,
-			acknowledged_by_pic: ack_pic,
 			resolved_at: i.resolved_at,
 			resolved_by: i.resolved_by,
 			resolved_by_name: res_name,
@@ -137,9 +126,6 @@ pub(crate) fn lookup_user(
 fn collect_user_logins(issues: &[Issue]) -> Vec<&str> {
 	let mut s: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
 	for i in issues {
-		if let Some(l) = i.acknowledged_by.as_deref() {
-			s.insert(l);
-		}
 		if let Some(l) = i.resolved_by.as_deref() {
 			s.insert(l);
 		}
@@ -253,8 +239,6 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(list_for_server))
 		.routes(routes!(list_events))
 		.routes(routes!(submit_manual_event))
-		.routes(routes!(ack))
-		.routes(routes!(unack))
 		.routes(routes!(resolve))
 		.routes(routes!(unresolve))
 		.routes(routes!(snooze))
@@ -280,8 +264,6 @@ pub struct ListArgs {
 	pub severities: Option<Vec<Severity>>,
 	#[serde(default)]
 	pub server_group_id: Option<Uuid>,
-	#[serde(default)]
-	pub acked: Option<bool>,
 	#[serde(default)]
 	pub limit: Option<i64>,
 }
@@ -310,7 +292,6 @@ pub async fn list(
 			active_only: args.active_only.unwrap_or(true),
 			severities: args.severities,
 			server_group_id: args.server_group_id,
-			acked: args.acked,
 		},
 		args.limit.unwrap_or(DEFAULT_LIMIT),
 	)
@@ -475,48 +456,6 @@ pub async fn submit_manual_event(
 #[derive(Deserialize, ToSchema)]
 pub struct IssueIdArgs {
 	pub issue_id: Uuid,
-}
-
-#[utoipa::path(
-	post,
-	path = "/ack",
-	operation_id = "issue_ack",
-	tag = "issues",
-	security(("tailscale-admin" = [])),
-	request_body = IssueIdArgs,
-	responses(
-		(status = 200, body = IssueData),
-	),
-)]
-pub async fn ack(
-	State(state): State<AppState>,
-	admin: TailscaleAdmin,
-	Json(args): Json<IssueIdArgs>,
-) -> Result<Json<IssueData>> {
-	let mut conn = state.db.get().await?;
-	let issue = Issue::ack(&mut conn, args.issue_id, &admin.0.login).await?;
-	Ok(Json(enrich_issue(&mut conn, issue).await?))
-}
-
-#[utoipa::path(
-	post,
-	path = "/unack",
-	operation_id = "issue_unack",
-	tag = "issues",
-	security(("tailscale-admin" = [])),
-	request_body = IssueIdArgs,
-	responses(
-		(status = 200, body = IssueData),
-	),
-)]
-pub async fn unack(
-	State(state): State<AppState>,
-	_admin: TailscaleAdmin,
-	Json(args): Json<IssueIdArgs>,
-) -> Result<Json<IssueData>> {
-	let mut conn = state.db.get().await?;
-	let issue = Issue::unack(&mut conn, args.issue_id).await?;
-	Ok(Json(enrich_issue(&mut conn, issue).await?))
 }
 
 #[derive(Deserialize, ToSchema)]

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -12,9 +12,7 @@ use commons_types::{
 	},
 	version::VersionStr,
 };
-use database::{
-	devices::DeviceConnection, servers::Server, statuses::Status, versions::Version,
-};
+use database::{devices::DeviceConnection, servers::Server, statuses::Status, versions::Version};
 use itertools::Itertools;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};

--- a/crates/private-server/tests/import_ticket.rs
+++ b/crates/private-server/tests/import_ticket.rs
@@ -48,7 +48,12 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 	server
 }
 
-fn synthesize_ticket(server_id: Uuid, hostname: &str, url: &str, tailscale_ip: &str) -> CanopyTicket {
+fn synthesize_ticket(
+	server_id: Uuid,
+	hostname: &str,
+	url: &str,
+	tailscale_ip: &str,
+) -> CanopyTicket {
 	use rcgen::{KeyPair, PKCS_ECDSA_P256_SHA256};
 
 	let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).expect("keygen");

--- a/crates/private-server/tests/issues.rs
+++ b/crates/private-server/tests/issues.rs
@@ -443,35 +443,6 @@ async fn open_issue(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn ack_does_not_close_incident() {
-	commons_tests::server::run(async |mut conn, _public, private| {
-		let server_id = Uuid::new_v4();
-		let issue_id = open_issue(&mut conn, &private, server_id).await;
-
-		let r = private
-			.post("/api/issues/ack")
-			.json(&serde_json::json!({ "issue_id": issue_id }))
-			.await;
-		r.assert_status_ok();
-		let body: serde_json::Value = r.json();
-		assert!(body.get("acknowledged_at").is_some_and(|v| !v.is_null()));
-		assert_eq!(
-			body.get("acknowledged_by").and_then(|v| v.as_str()),
-			Some("admin@localhost"),
-		);
-
-		// Incident should still be open.
-		let resp = private
-			.post("/api/incidents/list_for_server")
-			.json(&serde_json::json!({ "server_id": server_id }))
-			.await;
-		let items: Vec<serde_json::Value> = resp.json();
-		assert_eq!(items.len(), 1, "ack must not close the incident");
-	})
-	.await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn resolve_closes_incident_and_records_reason() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let server_id = Uuid::new_v4();

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -846,19 +846,6 @@
           "last_seen"
         ],
         "properties": {
-          "acknowledged_at": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "date-time"
-          },
-          "acknowledged_by": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "active": {
             "type": "boolean"
           },

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -405,5 +405,9 @@ fn split_health_from_extra(
 		}
 	}
 
-	Ok((healthy, serde_json::Value::Array(health_arr), serde_json::Value::Object(obj)))
+	Ok((
+		healthy,
+		serde_json::Value::Array(health_arr),
+		serde_json::Value::Object(obj),
+	))
 }

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -622,8 +622,14 @@ async fn submit_status_with_health_checks_persists() {
 			assert_eq!(arr[1]["check"], "disk");
 			assert_eq!(arr[1]["free_pct"], 4);
 			assert_eq!(arr[1]["message"], "almost full");
-			assert!(row.extra.get("health").is_none(), "`health` must not leak into `extra`");
-			assert_eq!(row.extra.get("timezone").and_then(|v| v.as_str()), Some("UTC"));
+			assert!(
+				row.extra.get("health").is_none(),
+				"`health` must not leak into `extra`"
+			);
+			assert_eq!(
+				row.extra.get("timezone").and_then(|v| v.as_str()),
+				Some("UTC")
+			);
 		},
 	)
 	.await
@@ -730,7 +736,13 @@ async fn submit_status_legacy_files_no_health_issues() {
 		async |mut conn, cert, device_id, public, _| {
 			let server_id = insert_health_test_server(&mut conn, device_id).await;
 
-			post_status(&public, &cert, server_id, serde_json::json!({ "uptime": 1 })).await;
+			post_status(
+				&public,
+				&cert,
+				server_id,
+				serde_json::json!({ "uptime": 1 }),
+			)
+			.await;
 
 			assert_eq!(
 				count_issues_for_server(&mut conn, server_id).await,
@@ -776,7 +788,11 @@ async fn submit_status_warning_check_only() {
 			assert!(per_check.message.contains("free_pct"));
 
 			// No roll-up while top-level healthy.
-			assert!(fetch_issue(&mut conn, server_id, "status", "health").await.is_none());
+			assert!(
+				fetch_issue(&mut conn, server_id, "status", "health")
+					.await
+					.is_none()
+			);
 			// Warning alone doesn't cross the incident threshold.
 			assert!(fetch_open_incident(&mut conn, server_id).await.is_none());
 		},
@@ -855,7 +871,10 @@ async fn submit_status_unhealthy_no_checks_files_roll_up_only() {
 				.expect("roll-up issue filed");
 			assert_eq!(roll_up.severity, "error");
 			assert!(roll_up.active);
-			assert_eq!(roll_up.description.as_deref(), Some("Server reports unhealthy"));
+			assert_eq!(
+				roll_up.description.as_deref(),
+				Some("Server reports unhealthy")
+			);
 			assert_eq!(count_issues_for_server(&mut conn, server_id).await, 1);
 			assert!(fetch_open_incident(&mut conn, server_id).await.is_some());
 		},

--- a/migrations/2026-05-21-022828-0000_drop_issue_ack/down.sql
+++ b/migrations/2026-05-21-022828-0000_drop_issue_ack/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE issues ADD COLUMN acknowledged_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE issues ADD COLUMN acknowledged_by TEXT;

--- a/migrations/2026-05-21-022828-0000_drop_issue_ack/up.sql
+++ b/migrations/2026-05-21-022828-0000_drop_issue_ack/up.sql
@@ -1,0 +1,6 @@
+-- Drop ack on issues. The "acknowledged" state is kept on incidents
+-- where it tracks "an operator is aware" of an incident-class outage,
+-- but on individual issues it was just tedious busywork — and
+-- orthogonal to resolution, which is what actually matters.
+ALTER TABLE issues DROP COLUMN acknowledged_at;
+ALTER TABLE issues DROP COLUMN acknowledged_by;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1471,41 +1471,6 @@
         ]
       }
     },
-    "/api/issues/ack": {
-      "post": {
-        "tags": [
-          "issues"
-        ],
-        "operationId": "issue_ack",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IssueIdArgs"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IssueData"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "tailscale-admin": []
-          }
-        ]
-      }
-    },
     "/api/issues/add_note": {
       "post": {
         "tags": [
@@ -1873,41 +1838,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetailsSchema"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "tailscale-admin": []
-          }
-        ]
-      }
-    },
-    "/api/issues/unack": {
-      "post": {
-        "tags": [
-          "issues"
-        ],
-        "operationId": "issue_unack",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IssueIdArgs"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IssueData"
                 }
               }
             }
@@ -3867,33 +3797,6 @@
           "incidents"
         ],
         "properties": {
-          "acknowledged_at": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "date-time"
-          },
-          "acknowledged_by": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "acknowledged_by_name": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Display name of the acker (from the cached Tailscale users table)."
-          },
-          "acknowledged_by_pic": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Profile picture URL of the acker."
-          },
           "active": {
             "type": "boolean"
           },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -602,22 +602,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/issues/ack": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["issue_ack"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/issues/add_note": {
         parameters: {
             query?: never;
@@ -773,22 +757,6 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["submit_manual_event"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/issues/unack": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post: operations["issue_unack"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1518,13 +1486,6 @@ export interface components {
             issues: components["schemas"]["IncidentIssueData"][];
         };
         IssueData: {
-            /** Format: date-time */
-            acknowledged_at?: string | null;
-            acknowledged_by?: string | null;
-            /** @description Display name of the acker (from the cached Tailscale users table). */
-            acknowledged_by_name?: string | null;
-            /** @description Profile picture URL of the acker. */
-            acknowledged_by_pic?: string | null;
             active: boolean;
             /** Format: date-time */
             created_at: string;
@@ -3139,29 +3100,6 @@ export interface operations {
             };
         };
     };
-    issue_ack: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["IssueIdArgs"];
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IssueData"];
-                };
-            };
-        };
-    };
     issue_add_note: {
         parameters: {
             query?: never;
@@ -3402,29 +3340,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
-                };
-            };
-        };
-    };
-    issue_unack: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["IssueIdArgs"];
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IssueData"];
                 };
             };
         };

--- a/private-web/src/components/IssueRow.tsx
+++ b/private-web/src/components/IssueRow.tsx
@@ -54,7 +54,7 @@ function headline(issue: IssueData): string {
  * incident links), the message body, action buttons and a two-column
  * Events / Notes panel. When collapsed, only the header row is visible —
  * even the action buttons are hidden. Header layout:
- * `[toggle] [server] [headline] [ack/avatar] [snapshot] [severity] [time]`.
+ * `[toggle] [server] [headline] [resolver-avatar?] [snapshot] [severity] [time]`.
  * The headline is struck through when the issue is inactive or resolved.
  * The server is always shown because incidents can span child servers in
  * a group — relying on a page H1 to identify the server is insufficient.
@@ -92,8 +92,6 @@ export default function IssueRow({
 				setExpanded={setExpanded}
 				snoozeActive={snoozeActive}
 				struckThrough={struckThrough}
-				isAdmin={isAdmin}
-				onChanged={onChanged}
 				headerSnapshotOpen={headerSnapshotOpen}
 				toggleHeaderSnapshot={() => setHeaderSnapshotOpen((v) => !v)}
 			/>
@@ -124,8 +122,6 @@ function Header({
 	setExpanded,
 	snoozeActive,
 	struckThrough,
-	isAdmin,
-	onChanged,
 	headerSnapshotOpen,
 	toggleHeaderSnapshot,
 }: {
@@ -134,8 +130,6 @@ function Header({
 	setExpanded: (v: (p: boolean) => boolean) => void;
 	snoozeActive: boolean;
 	struckThrough: boolean;
-	isAdmin: boolean;
-	onChanged: () => void;
 	headerSnapshotOpen: boolean;
 	toggleHeaderSnapshot: () => void;
 }) {
@@ -190,7 +184,7 @@ function Header({
 					snoozed
 				</Typography>
 			)}
-			<HeaderActor issue={issue} isAdmin={isAdmin} onChanged={onChanged} />
+			<HeaderActor issue={issue} />
 			<Box sx={{ flexShrink: 0 }}>
 				<StatusSnapshotButton
 					open={headerSnapshotOpen}
@@ -241,69 +235,24 @@ function ClosureOrTime({ issue }: { issue: IssueData }) {
 	return <TimeAgo timestamp={issue.last_seen} />;
 }
 
-/** Leftmost slot of the right-side header cluster. Avatar (resolver or
- * acker) when applicable; an Ack button otherwise (admins only). There is
- * no Unack in the UI — the backend still supports it. */
-function HeaderActor({
-	issue,
-	isAdmin,
-	onChanged,
-}: {
-	issue: IssueData;
-	isAdmin: boolean;
-	onChanged: () => void;
-}) {
-	const ack = useApiAction("issues", "ack");
-	const doAck = async () => {
-		try {
-			await ack.call({ issue_id: issue.id });
-			onChanged();
-		} catch {
-			/* surfaced via ack.error inside Body */
-		}
-	};
-	if (issue.resolved_at) {
-		return (
-			<Tooltip
-				title={`resolved (${issue.resolved_reason ?? "?"}) by ${
-					issue.resolved_by_name ?? issue.resolved_by ?? "?"
-				}`}
-			>
-				<span>
-					<UserAvatar
-						login={issue.resolved_by}
-						name={issue.resolved_by_name}
-						profilePic={issue.resolved_by_pic}
-					/>
-				</span>
-			</Tooltip>
-		);
-	}
-	if (issue.acknowledged_at) {
-		return (
-			<Tooltip
-				title={`acked by ${issue.acknowledged_by_name ?? issue.acknowledged_by ?? "?"}`}
-			>
-				<span>
-					<UserAvatar
-						login={issue.acknowledged_by}
-						name={issue.acknowledged_by_name}
-						profilePic={issue.acknowledged_by_pic}
-					/>
-				</span>
-			</Tooltip>
-		);
-	}
-	if (!isAdmin) return null;
+/** Leftmost slot of the right-side header cluster. Resolver avatar when the
+ * issue has been resolved; empty otherwise. */
+function HeaderActor({ issue }: { issue: IssueData }) {
+	if (!issue.resolved_at) return null;
 	return (
-		<Button
-			size="small"
-			variant="outlined"
-			onClick={doAck}
-			disabled={ack.pending}
+		<Tooltip
+			title={`resolved (${issue.resolved_reason ?? "?"}) by ${
+				issue.resolved_by_name ?? issue.resolved_by ?? "?"
+			}`}
 		>
-			Ack
-		</Button>
+			<span>
+				<UserAvatar
+					login={issue.resolved_by}
+					name={issue.resolved_by_name}
+					profilePic={issue.resolved_by_pic}
+				/>
+			</span>
+		</Tooltip>
 	);
 }
 
@@ -402,23 +351,15 @@ function IssueActions({
 						Unresolve
 					</Button>
 				) : (
-					<Tooltip
-						title={issue.acknowledged_at ? "" : "Ack the issue first"}
-						disableHoverListener={!!issue.acknowledged_at}
+					<Button
+						size="small"
+						variant="outlined"
+						color="success"
+						startIcon={<CheckCircleOutlinedIcon />}
+						onClick={() => setResolveOpen((v) => !v)}
 					>
-						<span>
-							<Button
-								size="small"
-								variant="outlined"
-								color="success"
-								startIcon={<CheckCircleOutlinedIcon />}
-								disabled={!issue.acknowledged_at}
-								onClick={() => setResolveOpen((v) => !v)}
-							>
-								Resolve…
-							</Button>
-						</span>
-					</Tooltip>
+						Resolve…
+					</Button>
 				)}
 				{snoozeActive ? (
 					<Button

--- a/private-web/src/routes/Incidents.tsx
+++ b/private-web/src/routes/Incidents.tsx
@@ -8,7 +8,6 @@ import {
 	ListItemText,
 	MenuItem,
 	Paper,
-	Select,
 	Stack,
 	Switch,
 	TextField,
@@ -25,13 +24,11 @@ import { SEVERITIES, type Severity } from "../types";
 
 const DEFAULT_LIMIT = 200;
 
-type AckedFilter = "either" | "acked" | "unacked";
-
 export default function Incidents() {
 	usePageTitle("Incidents");
 
 	// Page-level refresh signal: a single tick refetches incidents + issues
-	// together after any mutation (ack, resolve, snooze, manual submit).
+	// together after any mutation (resolve, snooze, manual submit).
 	const [refreshTick, setRefreshTick] = useState(0);
 	const bumpRefresh = () => setRefreshTick((t) => t + 1);
 
@@ -44,12 +41,6 @@ export default function Incidents() {
 		.split(",")
 		.filter((s) => s.length > 0) as Severity[];
 	const groupId = params.get("group") ?? "";
-	const acked: AckedFilter =
-		params.get("ack") === "acked"
-			? "acked"
-			: params.get("ack") === "unacked"
-				? "unacked"
-				: "either";
 
 	const updateParam = (key: string, value: string | null) => {
 		setParams(
@@ -66,8 +57,6 @@ export default function Incidents() {
 	const setSeverities = (v: Severity[]) =>
 		updateParam("severity", v.length === 0 ? null : v.join(","));
 	const setGroupId = (v: string) => updateParam("group", v === "" ? null : v);
-	const setAcked = (v: AckedFilter) =>
-		updateParam("ack", v === "either" ? null : v);
 
 	const incidents = useApi(
 		"incidents",
@@ -83,10 +72,9 @@ export default function Incidents() {
 			activeOnly,
 			severities: severities.length === 0 ? null : severities,
 			serverGroupId: groupId === "" ? null : groupId,
-			acked: acked === "either" ? null : acked === "acked",
 			limit: DEFAULT_LIMIT,
 		},
-		[refreshTick, activeOnly, severities.join(","), groupId, acked],
+		[refreshTick, activeOnly, severities.join(","), groupId],
 	);
 
 	return (
@@ -127,8 +115,6 @@ export default function Incidents() {
 				setSeverities={setSeverities}
 				groupId={groupId}
 				setGroupId={setGroupId}
-				acked={acked}
-				setAcked={setAcked}
 				roots={roots}
 				onRefresh={bumpRefresh}
 			/>
@@ -161,8 +147,6 @@ function FilterBar({
 	setSeverities,
 	groupId,
 	setGroupId,
-	acked,
-	setAcked,
 	roots,
 	onRefresh,
 }: {
@@ -172,8 +156,6 @@ function FilterBar({
 	setSeverities: (v: Severity[]) => void;
 	groupId: string;
 	setGroupId: (v: string) => void;
-	acked: AckedFilter;
-	setAcked: (v: AckedFilter) => void;
 	roots: ReturnType<typeof useApi<"servers", "list_roots">>;
 	onRefresh: () => void;
 }) {
@@ -242,16 +224,6 @@ function FilterBar({
 							</MenuItem>
 						))}
 				</TextField>
-				<Select
-					size="small"
-					value={acked}
-					onChange={(e) => setAcked(e.target.value as AckedFilter)}
-					sx={{ minWidth: 140 }}
-				>
-					<MenuItem value="either">Acked: any</MenuItem>
-					<MenuItem value="acked">Acked only</MenuItem>
-					<MenuItem value="unacked">Unacked only</MenuItem>
-				</Select>
 				<Box sx={{ ml: "auto" }}>
 					<IconButton aria-label="Refresh" size="small" onClick={onRefresh}>
 						<RefreshIcon fontSize="small" />

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -50,7 +50,7 @@ export default function ServerDetail() {
 	);
 	const isAdmin = useApi("commons", "is_current_user_admin");
 	// Single refresh signal for everything on the page that talks to the
-	// issues/incidents APIs. Any mutation (manual-event submit, ack/resolve/
+	// issues/incidents APIs. Any mutation (manual-event submit, resolve/
 	// snooze on a row, etc.) bumps this so all sibling panels refetch in
 	// lockstep — otherwise resolving an issue (which can auto-close an
 	// incident) leaves a stale incidents list.


### PR DESCRIPTION
## Summary

- Ack made sense on incidents (an operator is aware of an outage) but on individual issues it was just tedious busywork — and orthogonal to resolution, which is what actually matters. This drops it entirely from issues. Incident ack stays as-is.
- Migration drops `issues.acknowledged_at` and `issues.acknowledged_by`. The `incidents` table is untouched.
- Database model: `Issue` loses the two `acknowledged_*` fields; `Issue::ack` / `Issue::unack` are removed; the `acked` boolean filter is dropped from `IssueListFilters`.
- Private-server handlers: `/api/issues/ack` and `/api/issues/unack` removed; `IssueData` and `ListArgs` lose their `acknowledged_*` / `acked` fields.
- Frontend: the `Ack` button is gone from the issue card header (resolver avatar is the only thing left in that slot), the "Ack the issue first" gate on the Resolve button is removed, and the `Acked: any / acked / unacked` filter dropdown on the Incidents page is gone too.
- The reachability sweep test that asserted "ack doesn't close the incident" is removed.