### PR TITLE
fix(database): serialize incident creation per server

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -208,7 +208,8 @@ impl NewEvent {
 			&& d.contains('\n')
 		{
 			return Err(AppError::BadRequest(
-				"description must be a single line (no newlines); use `message` for body text".into(),
+				"description must be a single line (no newlines); use `message` for body text"
+					.into(),
 			));
 		}
 
@@ -504,12 +505,25 @@ async fn group_has_open_incident(db: &mut AsyncPgConnection, root_server_id: Uui
 /// The boolean is consumed by `re_evaluate_incident_membership` to decide
 /// whether a Slack `incident_open` outbox row should be enqueued (re-joining
 /// an existing incident shouldn't re-notify).
+///
+/// Two parallel event pushes against the same group must not each insert a
+/// fresh incident row. We take a `FOR UPDATE` lock on the root server's
+/// row up-front so the find-or-create pair serializes per-server. A
+/// unique partial index on `incidents (server_id) WHERE closed_at IS NULL`
+/// is the belt-and-braces backstop at the DB layer.
 async fn find_or_open_incident(
 	db: &mut AsyncPgConnection,
 	root_server_id: Uuid,
 	opened_at: Timestamp,
 ) -> Result<(Uuid, bool)> {
-	use crate::schema::incidents;
+	use crate::schema::{incidents, servers};
+
+	let _server_lock: Uuid = servers::table
+		.select(servers::id)
+		.filter(servers::id.eq(root_server_id))
+		.for_update()
+		.first(db)
+		.await?;
 
 	let open: Option<Incident> = incidents::table
 		.select(Incident::as_select())

--- a/migrations/2026-05-21-060134-0000_incidents_open_unique/down.sql
+++ b/migrations/2026-05-21-060134-0000_incidents_open_unique/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX incidents_open_by_server;
+CREATE INDEX incidents_open_by_server ON incidents (server_id) WHERE closed_at IS NULL;

--- a/migrations/2026-05-21-060134-0000_incidents_open_unique/up.sql
+++ b/migrations/2026-05-21-060134-0000_incidents_open_unique/up.sql
@@ -1,0 +1,6 @@
+-- Enforce at most one open incident per server. Promotes the existing
+-- partial index to UNIQUE so two concurrent event pushes for the same
+-- server can no longer both insert a fresh incident row.
+
+DROP INDEX incidents_open_by_server;
+CREATE UNIQUE INDEX incidents_open_by_server ON incidents (server_id) WHERE closed_at IS NULL;


### PR DESCRIPTION
## Summary
- Two concurrent event pushes against *different* issues on the same server could each insert a fresh incident row, leaving two open incidents for one server. The per-issue \`FOR UPDATE\` on the issue row doesn't help — the two events lock different issue rows, so they don't conflict at the issue level, but they then race on the find-or-create in \`find_or_open_incident\`.
- Take a \`SELECT ... FOR UPDATE\` on the root server's row at the top of \`find_or_open_incident\` so the find-or-create pair serializes per-server.
- Promote the existing \`incidents_open_by_server\` partial index on \`(server_id) WHERE closed_at IS NULL\` to UNIQUE. Belt-and-braces backstop at the DB layer: even if the lock is ever bypassed, the second concurrent insert fails outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)