### PR TITLE
Filter the HTML root listing for ready versions

### DIFF
--- a/crates/public-server/src/lib.rs
+++ b/crates/public-server/src/lib.rs
@@ -55,6 +55,7 @@ async fn index(
 	State(tera): State<std::sync::Arc<tera::Tera>>,
 ) -> commons_errors::Result<axum::response::Html<String>> {
 	use commons_types::version::VersionStatus;
+	use database::version_known_issues::VersionKnownIssue;
 	use database::versions::Version;
 	use serde::Serialize;
 	use std::collections::BTreeMap;
@@ -85,6 +86,16 @@ async fn index(
 
 	let mut db = db.get().await?;
 	let versions = Version::get_all_including_drafts(&mut db).await?;
+
+	// Public listing only exposes ready versions, matching the JSON
+	// endpoints and the per-version detail pages (which 404 for
+	// non-ready versions via latest_matching_ready).
+	let version_ids: Vec<_> = versions.iter().map(|v| v.id).collect();
+	let affected = VersionKnownIssue::affected_versions(&mut db, &version_ids).await?;
+	let versions: Vec<Version> = versions
+		.into_iter()
+		.filter(|v| !affected.contains(&v.id))
+		.collect();
 
 	let mut grouped: BTreeMap<(i32, i32), Vec<Version>> = BTreeMap::new();
 	for version in versions {

--- a/crates/public-server/tests/index.rs
+++ b/crates/public-server/tests/index.rs
@@ -34,6 +34,31 @@ async fn index_page_with_versions() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn index_page_hides_versions_with_open_known_issues() {
+	commons_tests::server::run(async |mut conn, public, _| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+			('11111111-1111-1111-1111-111111111100', 1, 0, 0, 'good', 'published'),
+			('11111111-1111-1111-1111-111111111101', 1, 0, 1, 'broken', 'published');
+			INSERT INTO version_known_issues (author, description, min_major, min_minor, min_patch)
+			VALUES ('admin', 'broken', 1, 0, 1)",
+		)
+		.await
+		.unwrap();
+
+		let response = public.get("/").await;
+		response.assert_status_ok();
+		let body = response.text();
+		assert!(body.contains("1.0.0"), "ready version 1.0.0 missing");
+		assert!(
+			!body.contains("1.0.1"),
+			"non-ready 1.0.1 should not appear in listing"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn error_redirect() {
 	commons_tests::server::run(async |_conn, public, _| {
 		let response = public.get("/errors/some-error-slug").await;


### PR DESCRIPTION
## Summary

Follow-up to #156. The public-site root (e.g. https://meta.tamanu.app/) renders its own version listing via the Tera \`versions\` template — separate code path from the JSON \`/versions\` endpoint and the per-version detail pages. That path never got the ready filter, so:

- the root page listed every published version, including known-broken ones (2.52.6+ in the reported case)
- clicking through to a non-ready version's detail page 404'd, because \`view_artifacts\` resolves the range via \`latest_matching_ready\`, which correctly skips affected versions

This commit applies the same \`affected_versions\` filter to the index handler. Now the listing and the detail pages agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)