### PR TITLE
slack-outbox: delay open notifications by 3 minutes to suppress flaps

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -562,6 +562,11 @@ async fn enqueue_slack_open(
 		&issue.r#ref,
 		&issue.message,
 	);
+	// Sit in the outbox for OPEN_DELAY before the drainer is allowed to
+	// pick the row up. If the incident closes within that window the
+	// resolve path will cancel this row outright (see
+	// `enqueue_slack_resolve_inner`), and Slack never hears about a flap.
+	let deliver_after = Timestamp::now() + crate::slack_outbox::OPEN_DELAY;
 	crate::slack_outbox::SlackOutbox::enqueue(
 		conn,
 		crate::slack_outbox::KIND_INCIDENT_OPEN,
@@ -569,6 +574,7 @@ async fn enqueue_slack_open(
 		Some(issue.id),
 		None,
 		payload,
+		deliver_after,
 	)
 	.await?;
 	Ok(())
@@ -593,6 +599,21 @@ async fn enqueue_slack_resolve_inner(
 	if incident.server_id == Uuid::nil() {
 		return Ok(());
 	}
+	// If the matching open is still inside its `deliver_after` window
+	// (or has otherwise not been delivered yet) we cancel it and skip
+	// posting the resolve too: Slack never heard about the incident,
+	// so there's nothing to "resolve" there. Once the drainer has shipped
+	// the open this update affects zero rows and we fall through to the
+	// normal enqueue.
+	let cancelled = crate::slack_outbox::SlackOutbox::cancel_pending_open(
+		conn,
+		incident.id,
+		"cancelled: incident resolved before the open had been delivered to Slack",
+	)
+	.await?;
+	if cancelled > 0 {
+		return Ok(());
+	}
 	let server = Server::get_by_id(conn, incident.server_id).await?;
 	let payload = crate::slack_outbox::vars::incident_resolve(&server, by);
 	crate::slack_outbox::SlackOutbox::enqueue(
@@ -602,6 +623,7 @@ async fn enqueue_slack_resolve_inner(
 		None,
 		None,
 		payload,
+		Timestamp::now(),
 	)
 	.await?;
 	Ok(())

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -202,6 +202,7 @@ diesel::table! {
 		last_error -> Nullable<Text>,
 		last_response -> Nullable<Text>,
 		gave_up_at -> Nullable<Timestamptz>,
+		deliver_after -> Timestamptz,
 	}
 }
 

--- a/crates/database/src/slack_outbox/mod.rs
+++ b/crates/database/src/slack_outbox/mod.rs
@@ -7,6 +7,15 @@
 //! transaction. The `slacker_outbox` job binary drains the table, posts to
 //! Slack, and stamps `delivered_at` on success.
 //!
+//! Each row carries a `deliver_after` timestamp. Resolves enqueue with
+//! `deliver_after = now`, so they ship on the next drain tick. Opens enqueue
+//! with a small future delay (see [`OPEN_DELAY`]) so a probe that flaps open
+//! and resolved within that window can be cancelled before we tell Slack
+//! anything happened: the cascade in [`crate::issues::Incident::resolve`]
+//! and the auto-close path both call [`SlackOutbox::cancel_pending_open`]
+//! before enqueueing the resolve, which marks the open row given-up and
+//! skips the resolve when it succeeds.
+//!
 //! The payload is rendered to Block Kit JSON at enqueue time, not at delivery
 //! time, so we capture state as it was when the event happened rather than
 //! risk reading a later (resolved / different-severity) state when the worker
@@ -15,7 +24,7 @@
 use commons_errors::{AppError, Result};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
-use jiff::Timestamp;
+use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
@@ -26,6 +35,13 @@ pub mod vars;
 pub const KIND_INCIDENT_OPEN: &str = "incident_open";
 /// Incident resolved — Phase A: top-level; Phase B: reply in the incident thread.
 pub const KIND_INCIDENT_RESOLVE: &str = "incident_resolve";
+
+/// How long an `incident_open` row sits in the outbox before the drainer
+/// is allowed to ship it. Long enough to swallow probe flaps that open and
+/// resolve within seconds; short enough that real incidents still page
+/// promptly. Resolve rows aren't delayed — once we've told Slack an
+/// incident opened, we want the resolve out as soon as it happens.
+pub const OPEN_DELAY: SignedDuration = SignedDuration::from_mins(3);
 
 #[derive(Clone, Debug, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name = crate::schema::slack_outbox)]
@@ -54,12 +70,22 @@ pub struct SlackOutbox {
 	/// pick them up again.
 	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
 	pub gave_up_at: Option<Timestamp>,
+	/// Earliest time `claim_pending` will return this row. Resolves are
+	/// enqueued with `deliver_after = now` (ship immediately); opens use
+	/// `now + OPEN_DELAY` so flap-and-resolve incidents can be cancelled
+	/// before they hit Slack.
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub deliver_after: Timestamp,
 }
 
 impl SlackOutbox {
 	/// Insert a new outbox row. Caller is expected to be inside the
 	/// transaction that's mutating the underlying incident/issue/note so
 	/// the outbox row and the state change commit (or roll back) together.
+	///
+	/// `deliver_after` is the earliest time the drainer is allowed to ship
+	/// this row. Most callers pass `Timestamp::now()`; the open path
+	/// passes `now + OPEN_DELAY`.
 	pub async fn enqueue(
 		db: &mut AsyncPgConnection,
 		kind: &str,
@@ -67,6 +93,7 @@ impl SlackOutbox {
 		issue_id: Option<Uuid>,
 		note_id: Option<Uuid>,
 		payload: JsonValue,
+		deliver_after: Timestamp,
 	) -> Result<Self> {
 		use crate::schema::slack_outbox;
 		diesel::insert_into(slack_outbox::table)
@@ -76,11 +103,43 @@ impl SlackOutbox {
 				slack_outbox::issue_id.eq(issue_id),
 				slack_outbox::note_id.eq(note_id),
 				slack_outbox::payload.eq(payload),
+				slack_outbox::deliver_after.eq(jiff_diesel::Timestamp::from(deliver_after)),
 			))
 			.returning(Self::as_select())
 			.get_result(db)
 			.await
 			.map_err(AppError::from)
+	}
+
+	/// Mark every still-pending `incident_open` row for this incident as
+	/// given-up, with a reason that documents why the cancellation
+	/// happened. Returns the number of rows affected — a non-zero result
+	/// means the open never reached Slack and the caller should skip the
+	/// resolve enqueue too (we don't want to "resolve" something Slack
+	/// never heard about). Rows the drainer has already delivered, or has
+	/// already given up on, are untouched.
+	pub async fn cancel_pending_open(
+		db: &mut AsyncPgConnection,
+		incident_id: Uuid,
+		reason: &str,
+	) -> Result<usize> {
+		use crate::schema::slack_outbox::dsl;
+		let now = Timestamp::now();
+		let rows = diesel::update(
+			dsl::slack_outbox
+				.filter(dsl::incident_id.eq(incident_id))
+				.filter(dsl::kind.eq(KIND_INCIDENT_OPEN))
+				.filter(dsl::delivered_at.is_null())
+				.filter(dsl::gave_up_at.is_null()),
+		)
+		.set((
+			dsl::gave_up_at.eq(jiff_diesel::Timestamp::from(now)),
+			dsl::last_error.eq(reason),
+		))
+		.execute(db)
+		.await
+		.map_err(AppError::from)?;
+		Ok(rows)
 	}
 
 	/// Claim up to `limit` pending rows in insertion order. Uses
@@ -92,10 +151,12 @@ impl SlackOutbox {
 	/// [`mark_given_up`](Self::mark_given_up) before committing.
 	pub async fn claim_pending(db: &mut AsyncPgConnection, limit: i64) -> Result<Vec<Self>> {
 		use crate::schema::slack_outbox::dsl;
+		let now = Timestamp::now();
 		dsl::slack_outbox
 			.select(Self::as_select())
 			.filter(dsl::delivered_at.is_null())
 			.filter(dsl::gave_up_at.is_null())
+			.filter(dsl::deliver_after.le(jiff_diesel::Timestamp::from(now)))
 			.order(dsl::created_at.asc())
 			.limit(limit)
 			.for_update()

--- a/crates/database/src/version_known_issues.rs
+++ b/crates/database/src/version_known_issues.rs
@@ -123,7 +123,11 @@ impl VersionKnownIssue {
 					.eq(v::major)
 					.and(k::min_minor.eq(v::minor))
 					.and(v::patch.ge(k::min_patch))
-					.and(k::max_patch.is_null().or(v::patch.lt(k::max_patch.assume_not_null())))),
+					.and(
+						k::max_patch
+							.is_null()
+							.or(v::patch.lt(k::max_patch.assume_not_null())),
+					)),
 			)
 			.select(v::id)
 			.filter(v::id.eq_any(ids))

--- a/crates/database/tests/slack_outbox_enqueue.rs
+++ b/crates/database/tests/slack_outbox_enqueue.rs
@@ -8,7 +8,7 @@
 use commons_types::issue::{ResolvedReason, Severity};
 use database::{
 	issues::{Incident, Issue, NewEvent},
-	slack_outbox::{KIND_INCIDENT_OPEN, KIND_INCIDENT_RESOLVE, SlackOutbox},
+	slack_outbox::{KIND_INCIDENT_OPEN, KIND_INCIDENT_RESOLVE, OPEN_DELAY, SlackOutbox},
 };
 use diesel::{QueryableByName, sql_query, sql_types};
 use diesel_async::RunQueryDsl;
@@ -51,6 +51,26 @@ async fn pending_for_incident(
 		.expect("load slack_outbox rows")
 }
 
+/// Force-deliver the open row for `incident_id` so a subsequent resolve
+/// no longer treats it as cancellable. Used by tests that want to
+/// exercise the post-delivery code path (where the resolve actually does
+/// enqueue) without waiting `OPEN_DELAY` for the real drainer.
+async fn mark_open_delivered(conn: &mut diesel_async::AsyncPgConnection, incident_id: Uuid) {
+	use database::diesel_async::RunQueryDsl;
+	use database::schema::slack_outbox::dsl;
+	use diesel::prelude::*;
+	let row_id: Uuid = dsl::slack_outbox
+		.select(dsl::id)
+		.filter(dsl::incident_id.eq(incident_id))
+		.filter(dsl::kind.eq(KIND_INCIDENT_OPEN))
+		.first(conn)
+		.await
+		.expect("open row exists");
+	SlackOutbox::mark_delivered(conn, row_id, "ok")
+		.await
+		.expect("mark delivered");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn opening_incident_enqueues_slack_open_row() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
@@ -86,6 +106,19 @@ async fn opening_incident_enqueues_slack_open_row() {
 		assert_eq!(open.issue_id, Some(issue.id));
 		assert!(open.delivered_at.is_none());
 		assert_eq!(open.attempts, 0);
+		// Open rows wait OPEN_DELAY (3 minutes today) before the drainer
+		// is allowed to ship them. `created_at` is set server-side by
+		// the migration default, so the gap should equal OPEN_DELAY
+		// give-or-take the round-trip time of the enqueue itself.
+		let target = open.created_at + OPEN_DELAY;
+		let drift = (open.deliver_after - target).get_seconds().unsigned_abs();
+		assert!(
+			drift <= 5,
+			"deliver_after should sit ~OPEN_DELAY past created_at; drift={drift}s \
+			 (created_at={}, deliver_after={})",
+			open.created_at,
+			open.deliver_after,
+		);
 		// Payload is a flat object matching the workflow trigger's variables.
 		// `link` is intentionally absent here — the drainer injects it at
 		// delivery time from PRIVATE_URL + row.incident_id.
@@ -103,7 +136,10 @@ async fn opening_incident_enqueues_slack_open_row() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn resolving_incident_enqueues_resolve_row() {
+async fn resolving_incident_after_open_delivered_enqueues_resolve_row() {
+	// Once Slack has heard about the open, we owe a resolve. The
+	// flap-suppression path only kicks in when the open hasn't shipped
+	// yet; everything past that point is the historical behaviour.
 	commons_tests::db::TestDb::run(async |mut conn, _| {
 		let server_id = insert_server(&mut conn, "http://resolve.invalid/").await;
 		let event = NewEvent {
@@ -122,6 +158,7 @@ async fn resolving_incident_enqueues_resolve_row() {
 			.into_iter()
 			.next()
 			.expect("incident opened");
+		mark_open_delivered(&mut conn, incident.id).await;
 
 		Incident::resolve(
 			&mut conn,
@@ -139,6 +176,73 @@ async fn resolving_incident_enqueues_resolve_row() {
 			.collect();
 		assert_eq!(resolves.len(), 1, "exactly one resolve row");
 		assert!(resolves[0].delivered_at.is_none());
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn resolving_before_open_ships_cancels_open_and_skips_resolve() {
+	// The flap-suppression contract. If the incident comes and goes
+	// inside the `deliver_after` window, the operator never sees a Slack
+	// noise about either edge — but the open row stays in the database
+	// (given-up, with a reason in `last_error`) for the audit trail.
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, "http://flap.invalid/").await;
+		let event = NewEvent {
+			source: "test".into(),
+			r#ref: "ref-flap".into(),
+			severity: Some(Severity::Error),
+			description: None,
+			message: "boom".into(),
+			active: Some(true),
+			occurred_at: None,
+		};
+		event.save(&mut conn, server_id, None).await.expect("save");
+		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list incidents")
+			.into_iter()
+			.next()
+			.expect("incident opened");
+
+		// Resolve before the open's deliver_after window passes.
+		Incident::resolve(
+			&mut conn,
+			incident.id,
+			"operator@example.test",
+			ResolvedReason::Fixed,
+		)
+		.await
+		.expect("resolve");
+
+		let rows = pending_for_incident(&mut conn, incident.id).await;
+		let opens: Vec<_> = rows
+			.iter()
+			.filter(|r| r.kind == KIND_INCIDENT_OPEN)
+			.collect();
+		assert_eq!(opens.len(), 1, "open row stays in the table for historicity");
+		assert!(
+			opens[0].gave_up_at.is_some(),
+			"open row marked given-up so the drainer won't ship it"
+		);
+		assert!(opens[0].delivered_at.is_none(), "open never delivered");
+		assert!(
+			opens[0]
+				.last_error
+				.as_deref()
+				.is_some_and(|e| e.contains("cancelled")),
+			"reason is recorded for the audit trail; got: {:?}",
+			opens[0].last_error
+		);
+
+		let resolves: Vec<_> = rows
+			.iter()
+			.filter(|r| r.kind == KIND_INCIDENT_RESOLVE)
+			.collect();
+		assert!(
+			resolves.is_empty(),
+			"no resolve row when the matching open never went to Slack"
+		);
 	})
 	.await
 }
@@ -167,6 +271,10 @@ async fn cascade_close_via_issue_resolve_attributes_to_operator() {
 			.into_iter()
 			.next()
 			.expect("incident opened");
+		// Pretend the drainer already shipped the open so the cascade
+		// resolve actually enqueues — otherwise the open would be
+		// cancelled and there'd be no resolve row to inspect.
+		mark_open_delivered(&mut conn, incident.id).await;
 
 		Issue::resolve(
 			&mut conn,
@@ -243,6 +351,10 @@ async fn mark_given_up_removes_row_from_claim_pending() {
 			occurred_at: None,
 		};
 		event.save(&mut conn, server_id, None).await.expect("save");
+		// `event.save` enqueues an open whose deliver_after sits
+		// OPEN_DELAY in the future. Drop it back to the past so
+		// claim_pending will return the row immediately.
+		expire_deliver_after(&mut conn).await;
 		let row = SlackOutbox::claim_pending(&mut conn, 10)
 			.await
 			.expect("claim")
@@ -263,6 +375,56 @@ async fn mark_given_up_removes_row_from_claim_pending() {
 		);
 	})
 	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn claim_pending_skips_rows_whose_deliver_after_is_in_the_future() {
+	// Direct check on the drainer's claim filter: an open row that's
+	// still inside its OPEN_DELAY window must not be claimed, but the
+	// moment its deliver_after slides into the past it becomes
+	// claimable. This is the core flap-suppression mechanism.
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, "http://delayed.invalid/").await;
+		let event = NewEvent {
+			source: "test".into(),
+			r#ref: "ref-d".into(),
+			severity: Some(Severity::Error),
+			description: None,
+			message: "boom".into(),
+			active: Some(true),
+			occurred_at: None,
+		};
+		event.save(&mut conn, server_id, None).await.expect("save");
+		let pending_before = SlackOutbox::claim_pending(&mut conn, 10)
+			.await
+			.expect("claim");
+		assert!(
+			pending_before.is_empty(),
+			"open row must wait OPEN_DELAY before becoming claimable; got {} rows",
+			pending_before.len(),
+		);
+
+		expire_deliver_after(&mut conn).await;
+
+		let pending_after = SlackOutbox::claim_pending(&mut conn, 10)
+			.await
+			.expect("claim again");
+		assert_eq!(
+			pending_after.len(),
+			1,
+			"row becomes claimable once deliver_after is in the past",
+		);
+	})
+	.await
+}
+
+/// Backdate every pending row's `deliver_after` so the drainer can pick
+/// them up without the test having to sleep through `OPEN_DELAY`.
+async fn expire_deliver_after(conn: &mut diesel_async::AsyncPgConnection) {
+	sql_query("UPDATE slack_outbox SET deliver_after = NOW() - INTERVAL '1 minute' WHERE delivered_at IS NULL AND gave_up_at IS NULL")
+		.execute(conn)
+		.await
+		.expect("backdate deliver_after");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/jobs/src/bin/slacker_outbox.rs
+++ b/crates/jobs/src/bin/slacker_outbox.rs
@@ -376,6 +376,7 @@ mod tests {
 			last_error: None,
 			last_response: None,
 			gave_up_at: None,
+			deliver_after: Timestamp::now(),
 		}
 	}
 

--- a/crates/private-server/src/fns/versions.rs
+++ b/crates/private-server/src/fns/versions.rs
@@ -287,15 +287,12 @@ pub async fn get_version_detail(
 	// Surface every issue ever raised against this minor (resolved or
 	// not), so the operator sees the full timeline of caveats for the
 	// branch.
-	let known_issues: Vec<KnownIssueData> = VersionKnownIssue::list_for_minor(
-		&mut conn,
-		version_record.major,
-		version_record.minor,
-	)
-	.await?
-	.into_iter()
-	.map(KnownIssueData::from)
-	.collect();
+	let known_issues: Vec<KnownIssueData> =
+		VersionKnownIssue::list_for_minor(&mut conn, version_record.major, version_record.minor)
+			.await?
+			.into_iter()
+			.map(KnownIssueData::from)
+			.collect();
 	// `ready` is whether THIS exact patch is unaffected — older issues
 	// fixed below this patch don't affect us.
 	let ready = VersionKnownIssue::version_is_ready(
@@ -630,11 +627,7 @@ pub async fn resolve_known_issue(
 		));
 	}
 	let fix = VersionStr::from_str(&args.fix_version)?;
-	let fix = (
-		fix.0.major as i32,
-		fix.0.minor as i32,
-		fix.0.patch as i32,
-	);
+	let fix = (fix.0.major as i32, fix.0.minor as i32, fix.0.patch as i32);
 	let mut conn = state.db.get().await?;
 	let row = VersionKnownIssue::resolve(
 		&mut conn,

--- a/migrations/2026-05-21-100000-0000_slack_outbox_deliver_after/down.sql
+++ b/migrations/2026-05-21-100000-0000_slack_outbox_deliver_after/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE slack_outbox DROP COLUMN deliver_after;

--- a/migrations/2026-05-21-100000-0000_slack_outbox_deliver_after/up.sql
+++ b/migrations/2026-05-21-100000-0000_slack_outbox_deliver_after/up.sql
@@ -1,0 +1,14 @@
+-- Earliest time the drainer is allowed to ship this row. Open rows get
+-- set this 3 minutes into the future so we can suppress the Slack notice
+-- for incidents that flap open-and-resolved-immediately (very common for
+-- transient probe failures). Resolve rows keep the default NOW() so they
+-- ship straight away.
+--
+-- See `enqueue_slack_open` / the resolve enqueue path in
+-- `crates/database/src/issues.rs` for the cancellation logic that pairs
+-- with this: a resolve that arrives while the open is still in the
+-- pre-deliver window cancels the open row outright and doesn't enqueue
+-- itself either — we never told Slack about the incident, so there's
+-- nothing to "resolve" there.
+ALTER TABLE slack_outbox
+	ADD COLUMN deliver_after TIMESTAMPTZ NOT NULL DEFAULT NOW();


### PR DESCRIPTION
## Summary

Probes that flap open-and-resolved within seconds are real incidents worth recording, but page-worthy noise in Slack. This change holds `incident_open` Slack messages in the outbox for 3 minutes; if the incident resolves inside that window, the open is cancelled outright and no resolve is posted either (we never told Slack about the incident, so there's nothing to "resolve").

- New `deliver_after TIMESTAMPTZ NOT NULL DEFAULT NOW()` column on `slack_outbox`. `claim_pending` now filters `deliver_after <= NOW()`.
- Opens enqueue with `deliver_after = now + OPEN_DELAY` (3 minutes). Resolves stay immediate.
- Resolve enqueue calls a new `SlackOutbox::cancel_pending_open` first. If it marks an undelivered open row as given-up (with a reason in `last_error` for audit), the resolve enqueue is skipped.
- Incidents themselves are unchanged — the DB still records the open/close pair for historicity.

The cancellation logic plays nicely with an in-flight drainer: if the drainer holds the open row's lock, the resolve's UPDATE blocks until the drainer commits, then either matches zero rows (delivered → enqueue resolve normally) or marks the row given-up (still undelivered → skip resolve).

The middle commit (`fmt: rustfmt drift…`) is rustfmt reformatting `cargo fmt` applied during `just migrate`, isolated so the substantive commit stays clean.