### PR TITLE
ui: wrap healthcheck detail values on any character

### DIFF
--- a/private-web/src/components/StatusSnapshot.tsx
+++ b/private-web/src/components/StatusSnapshot.tsx
@@ -233,7 +233,12 @@ function ChecksBlock({
 											</Box>
 											<Box
 												component="dd"
-												sx={{ m: 0, fontFamily: "monospace" }}
+												sx={{
+													m: 0,
+													fontFamily: "monospace",
+													minWidth: 0,
+													overflowWrap: "anywhere",
+												}}
 											>
 												{renderValue(v)}
 											</Box>


### PR DESCRIPTION
## Summary
- The status snapshot panel renders healthcheck detail values in a monospace font inside a CSS grid. Long unbreakable strings (e.g. compact JSON from the `logins` healthcheck like `[{"line":"pts/1","login":"...","tailscale":"..."}]`) had no overflow-wrap, so they blew past the grid column and pushed the layout off-screen.
- Set `overflowWrap: anywhere` (plus `minWidth: 0`) on the `<dd>` so values wrap mid-token rather than overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)