### PR TITLE
statuses: render healthcheck names and values as code in markdown

### DIFF
--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -312,7 +312,7 @@ fn per_check_description(
 			serde_json::Value::String(s) => s.clone(),
 			other => other.to_string(),
 		};
-		lines.push(format!("- **{k}**: {rendered}"));
+		lines.push(format!("- **{k}**: `{rendered}`"));
 	}
 	(!lines.is_empty()).then(|| lines.join("\n"))
 }
@@ -337,7 +337,7 @@ fn roll_up_unhealthy_description(health: &serde_json::Value) -> Option<String> {
 				return None;
 			}
 			let check = obj.get("check")?.as_str()?;
-			Some(format!("- {check}"))
+			Some(format!("- `{check}`"))
 		})
 		.collect();
 	(!bullets.is_empty()).then(|| format!("Failing checks:\n{}", bullets.join("\n")))


### PR DESCRIPTION
## Summary
- Stacked on #162.
- The roll-up and per-check issue `message` bodies are rendered as markdown in the admin UI, but check names and detail values were emitted as plain text — inconsistent with the status snapshot panel where the same content is shown in monospace.
- Wrap detail values in `per_check_description` and check names in `roll_up_unhealthy_description` in backticks so the markdown view matches the snapshot styling.
- `roll_up_unhealthy_message` (the issue `description`, which becomes the headline and is rendered as plain text) is intentionally left untouched — backticks there would render literally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)