### PR TITLE
Replace the public mobile toggle on servers with a public_name field

### DIFF
--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -128,12 +128,12 @@ diesel::table! {
 		id -> Uuid,
 		created_at -> Timestamptz,
 		updated_at -> Timestamptz,
-		server_group_id -> Uuid,
 		opened_at -> Timestamptz,
 		closed_at -> Nullable<Timestamptz>,
 		resolved_at -> Nullable<Timestamptz>,
 		resolved_by -> Nullable<Text>,
 		resolved_reason -> Nullable<Text>,
+		server_group_id -> Uuid,
 	}
 }
 
@@ -191,13 +191,13 @@ diesel::table! {
 		host -> Text,
 		device_id -> Nullable<Uuid>,
 		kind -> Text,
-		group_id -> Nullable<Uuid>,
-		listed -> Bool,
 		cloud -> Nullable<Bool>,
 		geolocation -> Nullable<Array<Nullable<Float8>>>,
 		alert_when_down_for -> Interval,
+		group_id -> Nullable<Uuid>,
 		notes -> Text,
 		tags -> Jsonb,
+		public_name -> Nullable<Text>,
 	}
 }
 

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -44,7 +44,12 @@ pub struct Server {
 	pub device_id: Option<Uuid>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub group_id: Option<Uuid>,
-	pub listed: bool,
+	/// If `Some`, the server appears in the public `/servers` list under this
+	/// name (used by the Tamanu Mobile app). `None` means not listed. Decoupled
+	/// from `name` because server `name`s are scoped within a group and may not
+	/// be globally meaningful.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub public_name: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cloud: Option<bool>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -245,7 +250,7 @@ impl Server {
 
 		// Upsert: insert or update on conflict. Ticket-derived fields
 		// (kind, rank, cloud) re-apply on update; operator-edited state
-		// (listed, geolocation, alert_when_down_for, group_id, notes,
+		// (public_name, geolocation, alert_when_down_for, group_id, notes,
 		// tags) is preserved.
 		diesel::insert_into(servers::table)
 			.values((
@@ -255,7 +260,6 @@ impl Server {
 				servers::kind.eq(&kind_str),
 				servers::rank.eq(&rank_str),
 				servers::device_id.eq(Some(device.id)),
-				servers::listed.eq(false),
 				servers::cloud.eq(cloud),
 			))
 			.on_conflict(servers::id)
@@ -409,7 +413,7 @@ impl Server {
 		let mut query_builder = servers
 			.select(Self::as_select())
 			.filter(kind.eq(ServerKind::Central.to_string()))
-			.filter(listed.eq(true))
+			.filter(public_name.is_not_null())
 			.into_boxed();
 
 		if let Ok(query_uuid) = query.parse::<Uuid>() {
@@ -498,7 +502,7 @@ fn test_server_serialization() {
 		host: UrlField("https://example.com/".parse().unwrap()),
 		device_id: Some(Uuid::nil()),
 		group_id: None,
-		listed: true,
+		public_name: Some("Test Server".to_string()),
 		cloud: None,
 		geolocation: None,
 		alert_when_down_for: TEN_MINUTES,
@@ -516,7 +520,7 @@ fn test_server_serialization() {
   "kind": "central",
   "rank": "production",
   "device_id": "00000000-0000-0000-0000-000000000000",
-  "listed": true,
+  "public_name": "Test Server",
   "alert_when_down_for": 600,
   "notes": "",
   "tags": {}
@@ -545,7 +549,7 @@ impl From<NewServer> for Server {
 			host: server.host,
 			device_id: server.device_id,
 			group_id: server.group_id,
-			listed: false,
+			public_name: None,
 			cloud: None,
 			geolocation: None,
 			alert_when_down_for: TEN_MINUTES,
@@ -568,7 +572,7 @@ pub struct PartialServer {
 	pub host: Option<UrlField>,
 	pub device_id: Option<Option<Uuid>>,
 	pub group_id: Option<Option<Uuid>>,
-	pub listed: Option<bool>,
+	pub public_name: Option<Option<String>>,
 	pub cloud: Option<Option<bool>>,
 	pub geolocation: Option<Option<GeoPoint>>,
 	#[schema(value_type = Option<i64>)]

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -201,7 +201,7 @@ fn server_to_info(s: database::servers::Server) -> ServerInfo {
 		device_id: s.device_id,
 		group_id: s.group_id,
 		group_name: None,
-		listed: s.listed,
+		public_name: s.public_name,
 		cloud: s.cloud,
 		geolocation: s.geolocation,
 		alert_when_down_for: s.alert_when_down_for.0.as_secs(),

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -56,7 +56,9 @@ pub struct ServerInfo {
 	/// Display name of the group this server belongs to (denormalised so list
 	/// rows don't need to fetch the group separately). `None` if ungrouped.
 	pub group_name: Option<String>,
-	pub listed: bool,
+	/// Name this server appears under in the public mobile-app server list.
+	/// `None` means the server is not listed publicly.
+	pub public_name: Option<String>,
 	pub cloud: Option<bool>,
 	pub geolocation: Option<GeoPoint>,
 	/// Downtime threshold in seconds before the reachability sweep files an
@@ -108,8 +110,12 @@ pub struct ServerDataUpdate {
 		skip_serializing_if = "Option::is_none"
 	)]
 	pub group_id: Option<Option<Uuid>>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub listed: Option<bool>,
+	#[serde(
+		default,
+		deserialize_with = "deserialize_some",
+		skip_serializing_if = "Option::is_none"
+	)]
+	pub public_name: Option<Option<String>>,
 	#[serde(
 		default,
 		deserialize_with = "deserialize_some",
@@ -148,7 +154,7 @@ pub(super) fn server_to_info(s: Server) -> ServerInfo {
 		device_id: s.device_id,
 		group_id: s.group_id,
 		group_name: None,
-		listed: s.listed,
+		public_name: s.public_name,
 		cloud: s.cloud,
 		geolocation: s.geolocation,
 		alert_when_down_for: s.alert_when_down_for.0.as_secs(),
@@ -484,7 +490,7 @@ pub async fn update(
 		},
 		device_id: args.data.device_id,
 		group_id: new_group_id,
-		listed: args.data.listed,
+		public_name: args.data.public_name,
 		cloud: args.data.cloud,
 		geolocation: args.data.geolocation,
 		alert_when_down_for: args
@@ -667,7 +673,7 @@ pub async fn attach_tailscale_device(
 			host: None,
 			device_id: Some(Some(device.id)),
 			group_id: None,
-			listed: None,
+			public_name: None,
 			cloud: None,
 			geolocation: None,
 			alert_when_down_for: None,

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -1149,12 +1149,6 @@
               }
             ]
           },
-          "listed": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "name": {
             "type": [
               "string",
@@ -1162,6 +1156,12 @@
             ]
           },
           "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "public_name": {
             "type": [
               "string",
               "null"
@@ -1255,7 +1255,6 @@
           "id",
           "host",
           "kind",
-          "listed",
           "alert_when_down_for"
         ],
         "properties": {
@@ -1304,9 +1303,6 @@
           "kind": {
             "$ref": "#/components/schemas/ServerKind"
           },
-          "listed": {
-            "type": "boolean"
-          },
           "name": {
             "type": [
               "string",
@@ -1315,6 +1311,13 @@
           },
           "notes": {
             "type": "string"
+          },
+          "public_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "If `Some`, the server appears in the public `/servers` list under this\nname (used by the Tamanu Mobile app). `None` means not listed. Decoupled\nfrom `name` because server `name`s are scoped within a group and may not\nbe globally meaningful."
           },
           "rank": {
             "oneOf": [

--- a/crates/public-server/src/servers.rs
+++ b/crates/public-server/src/servers.rs
@@ -52,29 +52,21 @@ pub async fn list(State(db): State<Db>) -> Result<Json<Vec<PublicServer>>> {
 		.await?
 		.into_iter()
 		.filter_map(|s| {
-			s.listed
-				.then(|| s.name.map(|name| (name, s.host, s.rank)))
-				.flatten()
-		})
-		.map(|(name, host, rank)| {
-			(
-				PublicServer {
-					name: name.clone(),
-					host,
-					rank,
-				},
+			s.public_name.map(|name| PublicServer {
 				name,
-			)
+				host: s.host,
+				rank: s.rank,
+			})
 		})
 		.collect::<Vec<_>>();
 
-	servers.sort_by(|(a, a_name), (b, b_name)| {
+	servers.sort_by(|a, b| {
 		rank_order(&a.rank)
 			.cmp(&rank_order(&b.rank))
-			.then_with(|| a_name.cmp(b_name))
+			.then_with(|| a.name.cmp(&b.name))
 	});
 
-	Ok(Json(servers.into_iter().map(|(s, _)| s).collect()))
+	Ok(Json(servers))
 }
 
 #[utoipa::path(

--- a/crates/public-server/tests/servers_list.rs
+++ b/crates/public-server/tests/servers_list.rs
@@ -22,10 +22,16 @@ pub struct NewServer {
 #[derive(Debug, Serialize)]
 pub struct PartialServer {
 	pub id: Uuid,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub host: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub kind: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub rank: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub public_name: Option<String>,
 }
 
 #[derive(QueryableByName)]
@@ -63,7 +69,7 @@ async fn get_empty_list() {
 async fn get_with_central_server() {
 	commons_tests::server::run(async |mut conn, public, _| {
 		conn.batch_execute(
-			"INSERT INTO servers (name, host, kind, rank, listed) VALUES ('Test Server', 'https://test.com', 'central', 'production', true)",
+			"INSERT INTO servers (name, host, kind, rank, public_name) VALUES ('Test Server', 'https://test.com', 'central', 'production', 'Test Server')",
 		)
 		.await
 		.unwrap();
@@ -82,10 +88,10 @@ async fn get_with_central_server() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn get_with_unnamed_server() {
+async fn get_without_public_name() {
 	commons_tests::server::run(async |mut conn, public, _| {
 		conn.batch_execute(
-			"INSERT INTO servers (host, kind, rank, listed) VALUES ('https://test.com', 'central', 'production', true)",
+			"INSERT INTO servers (name, host, kind, rank) VALUES ('Internal Server', 'https://test.com', 'central', 'production')",
 		)
 		.await
 		.unwrap();
@@ -101,9 +107,9 @@ async fn get_with_unnamed_server() {
 async fn get_filters_facility_servers() {
 	commons_tests::server::run(async |mut conn, public, _| {
 		conn.batch_execute(
-			"INSERT INTO servers (name, host, kind, rank, listed) VALUES
-			('Central Server', 'https://central.com', 'central', 'production', true),
-			('Facility Server', 'https://facility.com', 'facility', 'production', false)",
+			"INSERT INTO servers (name, host, kind, rank, public_name) VALUES
+			('Central Server', 'https://central.com', 'central', 'production', 'Central Server'),
+			('Facility Server', 'https://facility.com', 'facility', 'production', NULL)",
 		)
 		.await
 		.unwrap();
@@ -123,9 +129,9 @@ async fn get_filters_facility_servers() {
 async fn get_multiple_central_servers() {
 	commons_tests::server::run(async |mut conn, public, _| {
 		conn.batch_execute(
-			"INSERT INTO servers (name, host, kind, rank, listed) VALUES
-			('Server A', 'https://a.com', 'central', 'production', true),
-			('Server B', 'https://b.com', 'central', 'staging', true)",
+			"INSERT INTO servers (name, host, kind, rank, public_name) VALUES
+			('Server A', 'https://a.com', 'central', 'production', 'Server A'),
+			('Server B', 'https://b.com', 'central', 'staging', 'Server B')",
 		)
 		.await
 		.unwrap();
@@ -277,6 +283,7 @@ async fn patch_edit_server_success() {
 			host: Some("https://updated.com".to_string()),
 			kind: None,
 			rank: Some("production".to_string()),
+			public_name: None,
 		};
 
 		let response = public.patch("/servers")
@@ -318,6 +325,7 @@ async fn patch_edit_server_unauthorized() {
 			host: None,
 			kind: None,
 			rank: None,
+			public_name: None,
 		};
 
 		let response = public.patch("/servers").json(&partial_server).await;
@@ -338,6 +346,7 @@ async fn patch_edit_nonexistent_server() {
 				host: None,
 				kind: None,
 				rank: None,
+				public_name: None,
 			};
 
 			let response = public
@@ -370,6 +379,7 @@ async fn delete_server_success_with_admin() {
 			host: None,
 			kind: None,
 			rank: None,
+			public_name: None,
 		};
 
 		let response = public.delete("/servers")
@@ -408,6 +418,7 @@ async fn delete_server_unauthorized_no_auth() {
 			host: None,
 			kind: None,
 			rank: None,
+			public_name: None,
 		};
 
 		let response = public.delete("/servers").json(&partial_server).await;
@@ -434,6 +445,7 @@ async fn delete_server_unauthorized_server_role() {
 			host: None,
 			kind: None,
 			rank: None,
+			public_name: None,
 		};
 
 		let response = public.delete("/servers")
@@ -457,6 +469,7 @@ async fn delete_nonexistent_server() {
 				host: None,
 				kind: None,
 				rank: None,
+				public_name: None,
 			};
 
 			public.add_header("mtls-certificate", &cert);
@@ -555,6 +568,7 @@ async fn patch_edit_server_invalid_certificate() {
 			host: None,
 			kind: None,
 			rank: None,
+			public_name: None,
 		};
 
 		// Send invalid certificate data
@@ -584,6 +598,7 @@ async fn delete_server_invalid_certificate() {
 			host: None,
 			kind: None,
 			rank: None,
+			public_name: None,
 		};
 
 		// Send invalid certificate data
@@ -626,7 +641,7 @@ async fn integration_full_crud_cycle() {
 			.unwrap();
 			let server_id = server_rows[0].id;
 
-			sql_query("UPDATE servers SET listed = true WHERE id = $1")
+			sql_query("UPDATE servers SET public_name = 'CRUD Test Server' WHERE id = $1")
 				.bind::<diesel::sql_types::Uuid, _>(server_id)
 				.execute(&mut conn)
 				.await
@@ -640,13 +655,15 @@ async fn integration_full_crud_cycle() {
 				.find(|s| s.name == "CRUD Test Server")
 				.unwrap();
 
-			// Update the server
+			// Update the server, including the public_name so it shows up
+			// under the new label in the public list.
 			let partial_server = PartialServer {
 				id: server_id,
 				name: Some("Updated CRUD Server".to_string()),
 				host: None,
 				kind: None,
 				rank: Some("production".to_string()),
+				public_name: Some("Updated CRUD Server".to_string()),
 			};
 
 			let response = public
@@ -673,6 +690,7 @@ async fn integration_full_crud_cycle() {
 				host: None,
 				kind: None,
 				rank: None,
+				public_name: None,
 			};
 
 			let response = public

--- a/migrations/2026-05-23-000000-0000_servers_public_name/down.sql
+++ b/migrations/2026-05-23-000000-0000_servers_public_name/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE servers ADD COLUMN listed BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE servers SET listed = TRUE WHERE public_name IS NOT NULL;
+
+ALTER TABLE servers DROP COLUMN public_name;

--- a/migrations/2026-05-23-000000-0000_servers_public_name/up.sql
+++ b/migrations/2026-05-23-000000-0000_servers_public_name/up.sql
@@ -1,0 +1,13 @@
+-- Replace `servers.listed` (boolean toggle for the public mobile list) with
+-- `public_name` (nullable text). The mobile list now shows each server under
+-- the operator-chosen public name, and NULL means "not listed". With server
+-- groups in play, the server's internal `name` is no longer guaranteed to be
+-- a useful global label, so this decouples the two.
+
+ALTER TABLE servers ADD COLUMN public_name TEXT;
+
+UPDATE servers
+SET public_name = name
+WHERE listed = TRUE AND name IS NOT NULL;
+
+ALTER TABLE servers DROP COLUMN listed;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4740,7 +4740,6 @@
                 "id",
                 "kind",
                 "host",
-                "listed",
                 "alert_when_down_for",
                 "notes",
                 "tags"
@@ -4798,9 +4797,6 @@
                 "kind": {
                   "$ref": "#/components/schemas/ServerKind"
                 },
-                "listed": {
-                  "type": "boolean"
-                },
                 "name": {
                   "type": [
                     "string",
@@ -4809,6 +4805,13 @@
                 },
                 "notes": {
                   "type": "string"
+                },
+                "public_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Name this server appears under in the public mobile-app server list.\n`None` means the server is not listed publicly."
                 },
                 "rank": {
                   "oneOf": [
@@ -5171,12 +5174,6 @@
               }
             ]
           },
-          "listed": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "name": {
             "type": [
               "string",
@@ -5184,6 +5181,12 @@
             ]
           },
           "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "public_name": {
             "type": [
               "string",
               "null"
@@ -5288,7 +5291,6 @@
                     "id",
                     "kind",
                     "host",
-                    "listed",
                     "alert_when_down_for",
                     "notes",
                     "tags"
@@ -5346,9 +5348,6 @@
                     "kind": {
                       "$ref": "#/components/schemas/ServerKind"
                     },
-                    "listed": {
-                      "type": "boolean"
-                    },
                     "name": {
                       "type": [
                         "string",
@@ -5357,6 +5356,13 @@
                     },
                     "notes": {
                       "type": "string"
+                    },
+                    "public_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Name this server appears under in the public mobile-app server list.\n`None` means the server is not listed publicly."
                     },
                     "rank": {
                       "oneOf": [
@@ -5478,7 +5484,6 @@
           "id",
           "kind",
           "host",
-          "listed",
           "alert_when_down_for",
           "notes",
           "tags"
@@ -5536,9 +5541,6 @@
           "kind": {
             "$ref": "#/components/schemas/ServerKind"
           },
-          "listed": {
-            "type": "boolean"
-          },
           "name": {
             "type": [
               "string",
@@ -5547,6 +5549,13 @@
           },
           "notes": {
             "type": "string"
+          },
+          "public_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Name this server appears under in the public mobile-app server list.\n`None` means the server is not listed publicly."
           },
           "rank": {
             "oneOf": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1859,9 +1859,13 @@ export interface components {
                 /** Format: uuid */
                 id: string;
                 kind: components["schemas"]["ServerKind"];
-                listed: boolean;
                 name?: string | null;
                 notes: string;
+                /**
+                 * @description Name this server appears under in the public mobile-app server list.
+                 *     `None` means the server is not listed publicly.
+                 */
+                public_name?: string | null;
                 rank?: null | components["schemas"]["ServerRank"];
                 tags: components["schemas"]["TagMap"];
             }[];
@@ -1997,9 +2001,9 @@ export interface components {
             group_id?: string | null;
             host?: string | null;
             kind?: null | components["schemas"]["ServerKind"];
-            listed?: boolean | null;
             name?: string | null;
             notes?: string | null;
+            public_name?: string | null;
             rank?: null | components["schemas"]["ServerRank"];
             tags?: null | components["schemas"]["TagMap"];
         };
@@ -2039,9 +2043,13 @@ export interface components {
                     /** Format: uuid */
                     id: string;
                     kind: components["schemas"]["ServerKind"];
-                    listed: boolean;
                     name?: string | null;
                     notes: string;
+                    /**
+                     * @description Name this server appears under in the public mobile-app server list.
+                     *     `None` means the server is not listed publicly.
+                     */
+                    public_name?: string | null;
                     rank?: null | components["schemas"]["ServerRank"];
                     tags: components["schemas"]["TagMap"];
                 }
@@ -2102,9 +2110,13 @@ export interface components {
             /** Format: uuid */
             id: string;
             kind: components["schemas"]["ServerKind"];
-            listed: boolean;
             name?: string | null;
             notes: string;
+            /**
+             * @description Name this server appears under in the public mobile-app server list.
+             *     `None` means the server is not listed publicly.
+             */
+            public_name?: string | null;
             rank?: null | components["schemas"]["ServerRank"];
             tags: components["schemas"]["TagMap"];
         };

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -477,7 +477,10 @@ function InfoSection({
 			>
 				{status && <StatusInfoFields status={status} />}
 				{server.kind === "central" && (
-					<InfoItem label="Mobile list" value={server.listed ? "Public" : "No"} />
+					<InfoItem
+						label="Mobile list"
+						value={server.public_name ?? "Not listed"}
+					/>
 				)}
 				<InfoItem
 					label="Status alerts"

--- a/private-web/src/routes/ServerEdit.tsx
+++ b/private-web/src/routes/ServerEdit.tsx
@@ -57,7 +57,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 	const [host, setHost] = useState(info.host);
 	const [kind, setKind] = useState<ServerKind>(info.kind);
 	const [rank, setRank] = useState<ServerRank | "">(info.rank ?? "");
-	const [listed, setListed] = useState(info.listed);
+	const [publicName, setPublicName] = useState<string>(info.public_name ?? "");
 	// Threshold in seconds; 0 (or negative) means alerting is disabled. The
 	// UI works in minutes for the operator and the empty string represents
 	// "disabled" — converted back to seconds at submit time.
@@ -86,7 +86,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 			host: host.trim(),
 			kind,
 			rank: rank === "" ? null : rank,
-			listed,
+			public_name: publicName.trim() === "" ? null : publicName.trim(),
 			group_id: groupId,
 			device_id: deviceId.trim() === "" ? null : deviceId.trim(),
 			cloud: cloud === "" ? null : cloud === "true",
@@ -195,15 +195,12 @@ function EditForm({ info }: { info: ServerInfo }) {
 				</Stack>
 
 				{kind === "central" && (
-					<FormControlLabel
-						control={
-							<Checkbox
-								checked={listed}
-								onChange={(e) => setListed(e.target.checked)}
-								disabled={action.pending}
-							/>
-						}
-						label="Available in Tamanu Mobile app"
+					<TextField
+						label="Name in Tamanu Mobile app"
+						value={publicName}
+						onChange={(e) => setPublicName(e.target.value)}
+						disabled={action.pending}
+						helperText="Leave empty to hide this server from the public mobile-app list."
 					/>
 				)}
 


### PR DESCRIPTION
🤖 With server groups in play, a server's `name` is scoped to its group and is no longer guaranteed to be a useful global label. The public `/servers` endpoint (which feeds the Tamanu Mobile app's server picker) was returning that name verbatim — fine before groups, misleading after.

This swaps the `servers.listed` boolean for a `servers.public_name` nullable text column. `NULL` means "not listed"; any non-null value is the name the server appears under in the public list.

## Changes

- Migration copies `name` → `public_name` for currently-listed rows, then drops `listed`. (Down migration restores `listed = TRUE WHERE public_name IS NOT NULL`.)
- Public `/servers` endpoint emits each server's `public_name` as the public `name`; filter is `public_name IS NOT NULL` instead of `listed = true`.
- Database `Server` / `PartialServer`, private-server `ServerInfo` / `ServerDataUpdate`: `listed: bool` → `public_name: Option<String>`.
- `upsert_from_ticket` no longer sets the column on insert — operators pick a public name from the admin UI after import (same workflow as before, just with a name instead of a checkbox).
- React edit form: checkbox replaced with a "Name in Tamanu Mobile app" text field (empty = not listed). Detail view shows the public name or "Not listed".
- Regenerated `openapi.json` (both crates) and `api-types.ts`.