### PR TITLE
Show 'unmonitored' badge on server listings (group detail & friends)

### DIFF
--- a/private-web/src/components/ServerShorty.tsx
+++ b/private-web/src/components/ServerShorty.tsx
@@ -1,4 +1,4 @@
-import { Box, Link as MuiLink, Stack, Typography } from "@mui/material";
+import { Box, Chip, Link as MuiLink, Stack, Tooltip, Typography } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
 import type { ServerKind, ServerRank } from "../types";
 import ServerKindChip from "./ServerKindChip";
@@ -12,10 +12,13 @@ export interface ServerInfo {
 	kind: ServerKind;
 	rank: ServerRank | null;
 	group_name?: string | null;
+	alert_when_down_for?: number;
 }
 
 export default function ServerShorty({ server }: { server: ServerInfo }) {
 	const name = server.name || "Unnamed server";
+	const unmonitored =
+		server.alert_when_down_for !== undefined && server.alert_when_down_for <= 0;
 	return (
 		<Stack
 			direction="row"
@@ -42,6 +45,11 @@ export default function ServerShorty({ server }: { server: ServerInfo }) {
 			</MuiLink>
 			{server.rank && <ServerRankChip rank={server.rank} />}
 			<ServerKindChip kind={server.kind} />
+			{unmonitored && (
+				<Tooltip title="Status alerts are off for this server — canopy isn't watching it.">
+					<Chip size="small" variant="outlined" label="unmonitored" />
+				</Tooltip>
+			)}
 			<Box sx={{ ml: "auto" }}>
 				<Typography variant="body2" color="text.secondary">
 					{server.host}


### PR DESCRIPTION
🤖 Server detail's siblings section already shows an "unmonitored" badge for any server whose `alert_when_down_for ≤ 0`. The group detail page lists members through `ServerShorty`, which didn't carry that signal — operators couldn't tell at a glance which servers in a group were silently un-watched.

This teaches `ServerShorty` about `alert_when_down_for` and renders the same badge inline. The change is purely additive on the type (optional field), so it also lights up on the other two pages that use the component — `/groups/ungrouped` and the device detail's associated/past-server lists — wherever the backend already serves a full `ServerInfo`.