### PR TITLE
Show status dot on ServerShorty (group detail & other listings)

### DIFF
--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -14,7 +14,7 @@ use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::fns::Page;
-use crate::fns::servers::ServerInfo;
+use crate::fns::servers::{ServerInfo, decorate_with_status, server_to_info};
 use crate::state::AppState;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -191,25 +191,6 @@ fn format_key_as_pem(key_data: &[u8]) -> String {
 	pem
 }
 
-fn server_to_info(s: database::servers::Server) -> ServerInfo {
-	ServerInfo {
-		id: s.id,
-		name: s.name,
-		host: s.host.into(),
-		kind: s.kind,
-		rank: s.rank,
-		device_id: s.device_id,
-		group_id: s.group_id,
-		group_name: None,
-		public_name: s.public_name,
-		cloud: s.cloud,
-		geolocation: s.geolocation,
-		alert_when_down_for: s.alert_when_down_for.0.as_secs(),
-		notes: s.notes,
-		tags: s.tags,
-	}
-}
-
 pub fn routes() -> OpenApiRouter<AppState> {
 	OpenApiRouter::new()
 		.routes(routes!(get_device_by_id))
@@ -313,7 +294,9 @@ pub async fn get_servers_for_device(
 ) -> Result<Json<Vec<ServerInfo>>> {
 	let mut conn = state.db.get().await?;
 	let servers = Server::get_by_device_id(&mut conn, args.device_id).await?;
-	Ok(Json(servers.into_iter().map(server_to_info).collect()))
+	let mut infos: Vec<ServerInfo> = servers.into_iter().map(server_to_info).collect();
+	decorate_with_status(&mut conn, &mut infos).await?;
+	Ok(Json(infos))
 }
 
 #[utoipa::path(
@@ -333,7 +316,9 @@ pub async fn get_past_server_associations(
 ) -> Result<Json<Vec<ServerInfo>>> {
 	let mut conn = state.db.get().await?;
 	let servers = Server::get_past_associations_for_device(&mut conn, args.device_id).await?;
-	Ok(Json(servers.into_iter().map(server_to_info).collect()))
+	let mut infos: Vec<ServerInfo> = servers.into_iter().map(server_to_info).collect();
+	decorate_with_status(&mut conn, &mut infos).await?;
+	Ok(Json(infos))
 }
 
 #[derive(Deserialize, ToSchema)]

--- a/crates/private-server/src/fns/server_groups.rs
+++ b/crates/private-server/src/fns/server_groups.rs
@@ -84,6 +84,7 @@ pub async fn get(
 			.unwrap_or("")
 			.cmp(b.name.as_deref().unwrap_or(""))
 	});
+	super::servers::decorate_with_status(&mut conn, &mut servers).await?;
 	Ok(Json(GroupDetail { group, servers }))
 }
 

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -40,8 +40,9 @@ pub struct ServerDetailData {
 	/// server is ungrouped.
 	pub group: Option<ServerGroup>,
 	/// Other servers in the same group (excluding `server`). Empty when the
-	/// server is ungrouped or alone in its group.
-	pub siblings: Vec<(ShortStatus, HealthState, ServerInfo)>,
+	/// server is ungrouped or alone in its group. Each entry carries its
+	/// own `up` / `health` so the UI can render a status dot per sibling.
+	pub siblings: Vec<ServerInfo>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -67,6 +68,16 @@ pub struct ServerInfo {
 	pub alert_when_down_for: i64,
 	pub notes: String,
 	pub tags: TagMap,
+	/// Reachability of the server, derived from the most recent status row.
+	/// `None` when the endpoint that produced this row didn't batch-fetch
+	/// statuses (e.g. the cheap list/get endpoints); a populated value of
+	/// [`ShortStatus::Gone`] means "fetched and no status exists".
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub up: Option<ShortStatus>,
+	/// Self-reported health from the most recent status row. Same `None`
+	/// vs. populated-default semantics as [`Self::up`].
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub health: Option<HealthState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -160,7 +171,32 @@ pub(super) fn server_to_info(s: Server) -> ServerInfo {
 		alert_when_down_for: s.alert_when_down_for.0.as_secs(),
 		notes: s.notes,
 		tags: s.tags,
+		up: None,
+		health: None,
 	}
+}
+
+/// Batch-fetch the latest status for each server and write its short/health
+/// representation onto the corresponding `ServerInfo`. Use this on listing
+/// endpoints that feed a UI which renders status dots — skip it on cheap
+/// fetches that don't surface the dot.
+pub(super) async fn decorate_with_status(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	infos: &mut [ServerInfo],
+) -> Result<()> {
+	if infos.is_empty() {
+		return Ok(());
+	}
+	let ids: Vec<Uuid> = infos.iter().map(|i| i.id).collect();
+	let statuses = Status::latest_for_servers(conn, &ids).await?;
+	let by_server: std::collections::HashMap<Uuid, &Status> =
+		statuses.iter().map(|s| (s.server_id, s)).collect();
+	for info in infos.iter_mut() {
+		let st = by_server.get(&info.id).copied();
+		info.up = Some(st.map(|s| s.short_status()).unwrap_or_default());
+		info.health = Some(st.map(|s| s.health_state()).unwrap_or_default());
+	}
+	Ok(())
 }
 
 /// Like [`server_to_info`] but populates `group_name` by looking it up from
@@ -245,7 +281,8 @@ pub async fn list_ungrouped(
 	let mut conn = state.db.get().await?;
 	let total = Server::count_ungrouped(&mut conn).await?;
 	let servers = Server::list_ungrouped(&mut conn).await?;
-	let items = servers.into_iter().map(server_to_info).collect();
+	let mut items: Vec<ServerInfo> = servers.into_iter().map(server_to_info).collect();
+	decorate_with_status(&mut conn, &mut items).await?;
 	Ok(Json(Page { items, total }))
 }
 
@@ -406,26 +443,16 @@ pub async fn get_detail(
 
 	let siblings = if let Some(g) = group.as_ref() {
 		let raw_siblings = server.siblings(&mut conn).await?;
-		if raw_siblings.is_empty() {
-			Vec::new()
-		} else {
-			let sibling_ids: Vec<Uuid> = raw_siblings.iter().map(|s| s.id).collect();
-			let statuses = Status::latest_for_servers(&mut conn, &sibling_ids).await?;
-			let status_map: std::collections::HashMap<Uuid, &Status> =
-				statuses.iter().map(|s| (s.server_id, s)).collect();
-
-			raw_siblings
-				.into_iter()
-				.map(|s| {
-					let st = status_map.get(&s.id).copied();
-					let sib_up = st.map(|s| s.short_status()).unwrap_or_default();
-					let sib_health = st.map(|s| s.health_state()).unwrap_or_default();
-					let mut info = server_to_info(s);
-					info.group_name = Some(g.name.clone());
-					(sib_up, sib_health, info)
-				})
-				.collect()
-		}
+		let mut infos: Vec<ServerInfo> = raw_siblings
+			.into_iter()
+			.map(|s| {
+				let mut info = server_to_info(s);
+				info.group_name = Some(g.name.clone());
+				info
+			})
+			.collect();
+		decorate_with_status(&mut conn, &mut infos).await?;
+		infos
 	} else {
 		Vec::new()
 	};

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4787,6 +4787,17 @@
                   ],
                   "description": "Display name of the group this server belongs to (denormalised so list\nrows don't need to fetch the group separately). `None` if ungrouped."
                 },
+                "health": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/HealthState",
+                      "description": "Self-reported health from the most recent status row. Same `None`\nvs. populated-default semantics as [`Self::up`]."
+                    }
+                  ]
+                },
                 "host": {
                   "type": "string"
                 },
@@ -4825,6 +4836,17 @@
                 },
                 "tags": {
                   "$ref": "#/components/schemas/TagMap"
+                },
+                "up": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ShortStatus",
+                      "description": "Reachability of the server, derived from the most recent status row.\n`None` when the endpoint that produced this row didn't batch-fetch\nstatuses (e.g. the cheap list/get endpoints); a populated value of\n[`ShortStatus::Gone`] means \"fetched and no status exists\"."
+                    }
+                  ]
                 }
               }
             }
@@ -5263,125 +5285,9 @@
           "siblings": {
             "type": "array",
             "items": {
-              "type": "array",
-              "items": false,
-              "prefixItems": [
-                {
-                  "type": "string",
-                  "enum": [
-                    "up",
-                    "down",
-                    "away",
-                    "blip",
-                    "gone"
-                  ]
-                },
-                {
-                  "type": "string",
-                  "description": "Server's self-reported health state, derived from the most\nrecent status row's `healthy` field and `health[]` array.\nOrthogonal to [`ShortStatus`]: a server can be reachable\n(`up`) and reporting itself unhealthy at the same time.\n\nThe UI renders this as the *border* of `<StatusDot>` so both\ndimensions (reachability and self-report) show in one glyph.",
-                  "enum": [
-                    "healthy",
-                    "warning",
-                    "unhealthy"
-                  ]
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "id",
-                    "kind",
-                    "host",
-                    "alert_when_down_for",
-                    "notes",
-                    "tags"
-                  ],
-                  "properties": {
-                    "alert_when_down_for": {
-                      "type": "integer",
-                      "format": "int64",
-                      "description": "Downtime threshold in seconds before the reachability sweep files an\nissue. `0` (or any non-positive value) disables alerting for this\nserver; the default at creation is 600 (10 minutes)."
-                    },
-                    "cloud": {
-                      "type": [
-                        "boolean",
-                        "null"
-                      ]
-                    },
-                    "device_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "format": "uuid"
-                    },
-                    "geolocation": {
-                      "oneOf": [
-                        {
-                          "type": "null"
-                        },
-                        {
-                          "$ref": "#/components/schemas/GeoPoint"
-                        }
-                      ]
-                    },
-                    "group_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "format": "uuid"
-                    },
-                    "group_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Display name of the group this server belongs to (denormalised so list\nrows don't need to fetch the group separately). `None` if ungrouped."
-                    },
-                    "host": {
-                      "type": "string"
-                    },
-                    "id": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "kind": {
-                      "$ref": "#/components/schemas/ServerKind"
-                    },
-                    "name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "notes": {
-                      "type": "string"
-                    },
-                    "public_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Name this server appears under in the public mobile-app server list.\n`None` means the server is not listed publicly."
-                    },
-                    "rank": {
-                      "oneOf": [
-                        {
-                          "type": "null"
-                        },
-                        {
-                          "$ref": "#/components/schemas/ServerRank"
-                        }
-                      ]
-                    },
-                    "tags": {
-                      "$ref": "#/components/schemas/TagMap"
-                    }
-                  }
-                }
-              ]
+              "$ref": "#/components/schemas/ServerInfo"
             },
-            "description": "Other servers in the same group (excluding `server`). Empty when the\nserver is ungrouped or alone in its group."
+            "description": "Other servers in the same group (excluding `server`). Empty when the\nserver is ungrouped or alone in its group. Each entry carries its\nown `up` / `health` so the UI can render a status dot per sibling."
           },
           "up": {
             "$ref": "#/components/schemas/ShortStatus"
@@ -5531,6 +5437,17 @@
             ],
             "description": "Display name of the group this server belongs to (denormalised so list\nrows don't need to fetch the group separately). `None` if ungrouped."
           },
+          "health": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/HealthState",
+                "description": "Self-reported health from the most recent status row. Same `None`\nvs. populated-default semantics as [`Self::up`]."
+              }
+            ]
+          },
           "host": {
             "type": "string"
           },
@@ -5569,6 +5486,17 @@
           },
           "tags": {
             "$ref": "#/components/schemas/TagMap"
+          },
+          "up": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ShortStatus",
+                "description": "Reachability of the server, derived from the most recent status row.\n`None` when the endpoint that produced this row didn't batch-fetch\nstatuses (e.g. the cheap list/get endpoints); a populated value of\n[`ShortStatus::Gone`] means \"fetched and no status exists\"."
+              }
+            ]
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1855,6 +1855,7 @@ export interface components {
                  *     rows don't need to fetch the group separately). `None` if ungrouped.
                  */
                 group_name?: string | null;
+                health?: null | components["schemas"]["HealthState"];
                 host: string;
                 /** Format: uuid */
                 id: string;
@@ -1868,6 +1869,7 @@ export interface components {
                 public_name?: string | null;
                 rank?: null | components["schemas"]["ServerRank"];
                 tags: components["schemas"]["TagMap"];
+                up?: null | components["schemas"]["ShortStatus"];
             }[];
             /** Format: int64 */
             total: number;
@@ -2015,45 +2017,10 @@ export interface components {
             server: components["schemas"]["ServerInfo"];
             /**
              * @description Other servers in the same group (excluding `server`). Empty when the
-             *     server is ungrouped or alone in its group.
+             *     server is ungrouped or alone in its group. Each entry carries its
+             *     own `up` / `health` so the UI can render a status dot per sibling.
              */
-            siblings: [
-                "up" | "down" | "away" | "blip" | "gone",
-                "healthy" | "warning" | "unhealthy",
-                {
-                    /**
-                     * Format: int64
-                     * @description Downtime threshold in seconds before the reachability sweep files an
-                     *     issue. `0` (or any non-positive value) disables alerting for this
-                     *     server; the default at creation is 600 (10 minutes).
-                     */
-                    alert_when_down_for: number;
-                    cloud?: boolean | null;
-                    /** Format: uuid */
-                    device_id?: string | null;
-                    geolocation?: null | components["schemas"]["GeoPoint"];
-                    /** Format: uuid */
-                    group_id?: string | null;
-                    /**
-                     * @description Display name of the group this server belongs to (denormalised so list
-                     *     rows don't need to fetch the group separately). `None` if ungrouped.
-                     */
-                    group_name?: string | null;
-                    host: string;
-                    /** Format: uuid */
-                    id: string;
-                    kind: components["schemas"]["ServerKind"];
-                    name?: string | null;
-                    notes: string;
-                    /**
-                     * @description Name this server appears under in the public mobile-app server list.
-                     *     `None` means the server is not listed publicly.
-                     */
-                    public_name?: string | null;
-                    rank?: null | components["schemas"]["ServerRank"];
-                    tags: components["schemas"]["TagMap"];
-                }
-            ][];
+            siblings: components["schemas"]["ServerInfo"][];
             up: components["schemas"]["ShortStatus"];
         };
         ServerGroup: {
@@ -2106,6 +2073,7 @@ export interface components {
              *     rows don't need to fetch the group separately). `None` if ungrouped.
              */
             group_name?: string | null;
+            health?: null | components["schemas"]["HealthState"];
             host: string;
             /** Format: uuid */
             id: string;
@@ -2119,6 +2087,7 @@ export interface components {
             public_name?: string | null;
             rank?: null | components["schemas"]["ServerRank"];
             tags: components["schemas"]["TagMap"];
+            up?: null | components["schemas"]["ShortStatus"];
         };
         /** @enum {string} */
         ServerKind: "central" | "facility" | "canopy";

--- a/private-web/src/components/ServerShorty.tsx
+++ b/private-web/src/components/ServerShorty.tsx
@@ -1,9 +1,10 @@
 import { Box, Chip, Link as MuiLink, Stack, Tooltip, Typography } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
-import type { ServerKind, ServerRank } from "../types";
+import type { HealthState, ServerKind, ServerRank, ShortStatus } from "../types";
 import ServerKindChip from "./ServerKindChip";
 import ServerNameWithGroup from "./ServerNameWithGroup";
 import ServerRankChip from "./ServerRankChip";
+import StatusDot from "./StatusDot";
 
 export interface ServerInfo {
 	id: string;
@@ -13,6 +14,8 @@ export interface ServerInfo {
 	rank: ServerRank | null;
 	group_name?: string | null;
 	alert_when_down_for?: number;
+	up?: ShortStatus | null;
+	health?: HealthState | null;
 }
 
 export default function ServerShorty({ server }: { server: ServerInfo }) {
@@ -31,6 +34,9 @@ export default function ServerShorty({ server }: { server: ServerInfo }) {
 				alignItems: "center",
 			}}
 		>
+			{server.up && (
+				<StatusDot up={server.up} health={server.health ?? undefined} />
+			)}
 			<MuiLink
 				component={RouterLink}
 				to={`/servers/${server.id}`}

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -176,11 +176,11 @@ function Header({
 						title={data.server.name ?? ""}
 						size="0.8em"
 					/>
-					{data.siblings.map(([up, health, sib]) => (
+					{data.siblings.map((sib) => (
 						<StatusDot
 							key={sib.id}
-							up={up}
-							health={health}
+							up={sib.up ?? "gone"}
+							health={sib.health ?? undefined}
 							title={sib.name ?? ""}
 							dim
 							size="0.8em"
@@ -797,7 +797,7 @@ function SiblingServers({
 				Other servers in this group ({siblings.length})
 			</Typography>
 			<Stack spacing={1}>
-				{siblings.map(([up, health, sib]) => (
+				{siblings.map((sib) => (
 					<Stack
 						key={sib.id}
 						direction="row"
@@ -822,7 +822,10 @@ function SiblingServers({
 								<LanguageIcon fontSize="small" />
 							</IconButton>
 						</Tooltip>
-						<StatusDot up={up} health={health} />
+						<StatusDot
+							up={sib.up ?? "gone"}
+							health={sib.health ?? undefined}
+						/>
 						<MuiLink
 							component={RouterLink}
 							to={`/servers/${sib.id}`}

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -58,9 +58,9 @@ export type ApiBody<M extends ApiModule, F extends ApiFn<M>> =
 // that off, making `field: T | null`, which is what the wire shape actually
 // gives us.
 //
-// Tuples need separate handling so `[ShortStatus, ServerInfo]` doesn't collapse
-// into `(ShortStatus | ServerInfo)[]`. `number extends T['length']` is true for
-// regular arrays and false for fixed-length tuples.
+// Tuples need separate handling so `[u64, u64]` doesn't collapse into
+// `(u64 | u64)[]`. `number extends T['length']` is true for regular arrays
+// and false for fixed-length tuples.
 export type Solidify<T> = T extends readonly unknown[]
 	? number extends T["length"]
 		? Solidify<T[number]>[]


### PR DESCRIPTION
🤖 The group detail page lists members through \`ServerShorty\`, which had no reachability/health signal — operators couldn't tell at a glance which servers in a group were down or warning. The status dot already exists (\`StatusDot\`) and is rendered on the server detail page for siblings, but the data wasn't plumbed through anywhere else.

This adds optional \`up\`/\`health\` fields to \`ServerInfo\` and populates them on the endpoints that feed listings which render the dot:

- \`server_groups/get\` — group detail page (priority).
- \`servers/list_ungrouped\` — ungrouped tab.
- \`devices/get_servers_for_device\` and \`devices/get_past_server_associations\` — device detail's associated/past server lists.
- \`servers/get_detail\` siblings — already batch-fetched these; refactored to use the new shared helper.

\`ServerShorty\` renders \`<StatusDot>\` when \`up\` is present. Endpoints that don't populate the field (e.g. \`servers/list_some\`, \`servers/get_info\`) cost nothing extra and the dot is just absent.

While here, the siblings wire shape drops its bespoke \`(ShortStatus, HealthState, ServerInfo)\` tuple — the data lives on \`ServerInfo\` now, so the tuple was vestigial. The duplicate \`server_to_info\` in \`devices.rs\` is also gone (imports from \`fns::servers\`).