### PR TITLE
Make 'unmonitored' a real opt-out: skip incidents, keep the threshold

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -222,9 +222,12 @@ impl NewEvent {
 		// Look up the server's group up-front; needed by the incident-open
 		// path. If `None`, we still record the issue/event but skip
 		// incident logic — see `reevaluate_open_issues_for_server` for the
-		// catch-up path.
+		// catch-up path. `monitored` gates the incident workflow the same
+		// way: ungrouped *or* unmonitored → issue/event still recorded,
+		// but no incident contribution.
 		let server = Server::get_by_id(db, server_id).await?;
 		let server_group_id = server.group_id;
+		let monitored = server.is_monitored;
 
 		db.transaction::<_, AppError, _>(async |conn| {
 			// 1. find-or-create issue (FOR UPDATE so concurrent pushes on
@@ -348,7 +351,8 @@ impl NewEvent {
 			//    `by = None`: this came from a device push, not an operator action.
 			//    Skipped when the server is ungrouped: incidents are group-keyed.
 			if let Some(gid) = server_group_id {
-				re_evaluate_incident_membership(conn, &issue, gid, effective_time, None).await?;
+				re_evaluate_incident_membership(conn, &issue, gid, monitored, effective_time, None)
+					.await?;
 			}
 
 			Ok(issue)
@@ -360,9 +364,11 @@ impl NewEvent {
 /// Compute whether the issue *should* currently be contributing to an
 /// open incident, and apply join/leave accordingly. The rules:
 ///
-/// - **Leave**: `!active || resolved || snoozed`. Severity downgrade alone
-///   does *not* remove an issue — once contributing, it stays until it's
-///   actually gone or explicitly suppressed.
+/// - **Leave**: `!active || resolved || snoozed || !monitored`. Severity
+///   downgrade alone does *not* remove an issue — once contributing, it
+///   stays until it's actually gone or explicitly suppressed. Flipping
+///   the server to unmonitored *does* remove it: the operator has said
+///   they're not watching this server, so its issues stop counting.
 /// - **Join**: not leaving, AND one of:
 ///   - severity ≥ floor (`error`), so this issue is high-priority enough to
 ///     create a new incident on its own; or
@@ -370,6 +376,12 @@ impl NewEvent {
 ///     even low-severity ones, joins it. The threshold only governs
 ///     incident *creation*; once an incident is in progress everything else
 ///     piles in for context.
+///
+/// `monitored` reflects the server's `is_monitored()` at call time. When
+/// `false`, the issue is treated as a "leave": this is what makes
+/// `unmonitored` an opt-out of the incident workflow without losing the
+/// issue rows themselves.
+///
 /// `by` is the operator login when this re-evaluation was triggered by a
 /// human action (e.g. resolving an issue or incident). It's threaded
 /// through so a cascade close caused by that action can attribute the
@@ -380,6 +392,7 @@ async fn re_evaluate_incident_membership(
 	conn: &mut AsyncPgConnection,
 	issue: &Issue,
 	server_group_id: Uuid,
+	monitored: bool,
 	transition_time: Timestamp,
 	by: Option<&str>,
 ) -> Result<()> {
@@ -389,8 +402,9 @@ async fn re_evaluate_incident_membership(
 	let snoozed = issue.snoozed_until.map_or(false, |t| t > Timestamp::now());
 	let group_open = group_has_open_incident(conn, server_group_id).await?;
 
-	let should_leave = !issue.active || issue.resolved_at.is_some() || snoozed;
-	let should_join = issue.active
+	let should_leave = !issue.active || issue.resolved_at.is_some() || snoozed || !monitored;
+	let should_join = monitored
+		&& issue.active
 		&& issue.resolved_at.is_none()
 		&& !snoozed
 		&& (issue.severity.opens_incident() || group_open);
@@ -478,8 +492,13 @@ async fn re_evaluate_incident_membership(
 }
 
 /// Re-evaluate every currently-open issue on `server_id` against incident
-/// membership. Used by [`Server::assign_to_group`] to catch up issues that
-/// accumulated while the server was ungrouped.
+/// membership. Used as a catch-up when the operator flips a property of
+/// the server that changes its incident eligibility — currently:
+/// ungrouped→grouped (via [`Server::assign_to_group`]) and monitored
+/// toggles (via the private-server's server update handler). On flips
+/// that should *remove* issues from an incident (e.g. monitored→
+/// unmonitored), `re_evaluate_incident_membership` will leave them and
+/// close the incident if nothing else props it up.
 pub async fn reevaluate_open_issues_for_server(
 	db: &mut AsyncPgConnection,
 	server_id: Uuid,
@@ -490,6 +509,7 @@ pub async fn reevaluate_open_issues_for_server(
 	let Some(gid) = server.group_id else {
 		return Ok(());
 	};
+	let monitored = server.is_monitored;
 
 	let open_issues: Vec<Issue> = dsl::issues
 		.select(Issue::as_select())
@@ -501,7 +521,7 @@ pub async fn reevaluate_open_issues_for_server(
 
 	let now = Timestamp::now();
 	for issue in open_issues {
-		re_evaluate_incident_membership(db, &issue, gid, now, None).await?;
+		re_evaluate_incident_membership(db, &issue, gid, monitored, now, None).await?;
 	}
 	Ok(())
 }
@@ -824,8 +844,17 @@ impl Issue {
 				.returning(Self::as_select())
 				.get_result(conn)
 				.await?;
-			if let Some(gid) = Server::get_by_id(conn, issue.server_id).await?.group_id {
-				re_evaluate_incident_membership(conn, &issue, gid, now, Some(by)).await?;
+			let server = Server::get_by_id(conn, issue.server_id).await?;
+			if let Some(gid) = server.group_id {
+				re_evaluate_incident_membership(
+					conn,
+					&issue,
+					gid,
+					server.is_monitored,
+					now,
+					Some(by),
+				)
+				.await?;
 			}
 			Ok(issue)
 		})
@@ -846,9 +875,18 @@ impl Issue {
 				.returning(Self::as_select())
 				.get_result(conn)
 				.await?;
-			if let Some(gid) = Server::get_by_id(conn, issue.server_id).await?.group_id {
+			let server = Server::get_by_id(conn, issue.server_id).await?;
+			if let Some(gid) = server.group_id {
 				// Unresolve rejoins; cascade close path doesn't fire here.
-				re_evaluate_incident_membership(conn, &issue, gid, now, None).await?;
+				re_evaluate_incident_membership(
+					conn,
+					&issue,
+					gid,
+					server.is_monitored,
+					now,
+					None,
+				)
+				.await?;
 			}
 			Ok(issue)
 		})
@@ -876,8 +914,17 @@ impl Issue {
 				.returning(Self::as_select())
 				.get_result(conn)
 				.await?;
-			if let Some(gid) = Server::get_by_id(conn, issue.server_id).await?.group_id {
-				re_evaluate_incident_membership(conn, &issue, gid, now, None).await?;
+			let server = Server::get_by_id(conn, issue.server_id).await?;
+			if let Some(gid) = server.group_id {
+				re_evaluate_incident_membership(
+					conn,
+					&issue,
+					gid,
+					server.is_monitored,
+					now,
+					None,
+				)
+				.await?;
 			}
 			Ok(issue)
 		})
@@ -894,8 +941,17 @@ impl Issue {
 				.returning(Self::as_select())
 				.get_result(conn)
 				.await?;
-			if let Some(gid) = Server::get_by_id(conn, issue.server_id).await?.group_id {
-				re_evaluate_incident_membership(conn, &issue, gid, now, None).await?;
+			let server = Server::get_by_id(conn, issue.server_id).await?;
+			if let Some(gid) = server.group_id {
+				re_evaluate_incident_membership(
+					conn,
+					&issue,
+					gid,
+					server.is_monitored,
+					now,
+					None,
+				)
+				.await?;
 			}
 			Ok(issue)
 		})
@@ -1263,7 +1319,19 @@ impl Incident {
 					.returning(Issue::as_select())
 					.get_result(conn)
 					.await?;
-				re_evaluate_incident_membership(conn, &issue, gid, now, Some(by)).await?;
+				// The issue is now resolved so the leave path fires
+				// regardless of `monitored`; pass the live value
+				// anyway so the function never sees stale state.
+				let server = Server::get_by_id(conn, issue.server_id).await?;
+				re_evaluate_incident_membership(
+					conn,
+					&issue,
+					gid,
+					server.is_monitored,
+					now,
+					Some(by),
+				)
+				.await?;
 			}
 
 			let incident: Incident =

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -198,6 +198,7 @@ diesel::table! {
 		notes -> Text,
 		tags -> Jsonb,
 		public_name -> Nullable<Text>,
+		is_monitored -> Bool,
 	}
 }
 

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -54,18 +54,21 @@ pub struct Server {
 	pub cloud: Option<bool>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub geolocation: Option<GeoPoint>,
-	/// How long a server's status row may go un-updated before the canopy
-	/// reachability sweep files an issue.
+	/// Whether canopy is actively watching this server. When `false`, the
+	/// reachability sweep skips it entirely and any of its issues are
+	/// ignored by the incident workflow — operators flip this off for
+	/// test environments and ad-hoc demos. The accompanying
+	/// `alert_when_down_for` is preserved while muted so flipping back on
+	/// doesn't lose the chosen threshold.
+	pub is_monitored: bool,
+	/// Per-server downtime threshold: how long a server's status row may
+	/// go un-updated before the canopy reachability sweep files an issue.
+	/// Bump it up for flappy servers, drop it for critical ones that
+	/// should page promptly. Only consulted when `is_monitored` is `true`.
 	///
-	/// `INTERVAL '0'` disables the sweep for this server entirely — useful
-	/// for test environments and ad-hoc demos whose downtime is expected.
-	/// Positive values are the per-server downtime threshold: bump it up
-	/// for flappy servers, drop it for critical ones that should page
-	/// promptly. Negative durations are rejected by a CHECK constraint on
-	/// the column.
-	///
-	/// Default 10 minutes for newly-inserted rows. On the JSON wire this
-	/// is represented as a count of whole seconds (`i64`).
+	/// Constrained to strictly positive by the database. Default 10
+	/// minutes for newly-inserted rows. On the JSON wire this is
+	/// represented as a count of whole seconds (`i64`).
 	#[schema(value_type = i64)]
 	pub alert_when_down_for: PgDuration,
 	#[serde(default)]
@@ -505,6 +508,7 @@ fn test_server_serialization() {
 		public_name: Some("Test Server".to_string()),
 		cloud: None,
 		geolocation: None,
+		is_monitored: true,
 		alert_when_down_for: TEN_MINUTES,
 		notes: String::new(),
 		tags: TagMap::default(),
@@ -521,6 +525,7 @@ fn test_server_serialization() {
   "rank": "production",
   "device_id": "00000000-0000-0000-0000-000000000000",
   "public_name": "Test Server",
+  "is_monitored": true,
   "alert_when_down_for": 600,
   "notes": "",
   "tags": {}
@@ -552,6 +557,7 @@ impl From<NewServer> for Server {
 			public_name: None,
 			cloud: None,
 			geolocation: None,
+			is_monitored: true,
 			alert_when_down_for: TEN_MINUTES,
 			notes: String::new(),
 			tags: TagMap::default(),
@@ -575,6 +581,7 @@ pub struct PartialServer {
 	pub public_name: Option<Option<String>>,
 	pub cloud: Option<Option<bool>>,
 	pub geolocation: Option<Option<GeoPoint>>,
+	pub is_monitored: Option<bool>,
 	#[schema(value_type = Option<i64>)]
 	#[diesel(serialize_as = PgDuration)]
 	pub alert_when_down_for: Option<PgDuration>,

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -201,9 +201,9 @@ impl Status {
 	}
 
 	/// Sweep every server's most recent status. For each monitored server
-	/// (i.e. `alert_when_down_for > 0`) whose freshness has crossed the
-	/// per-server threshold, file (or close) a canopy-sourced issue keyed
-	/// by [`REACHABILITY_REF`].
+	/// (`is_monitored = true`) whose freshness has crossed the per-server
+	/// `alert_when_down_for` threshold, file (or close) a canopy-sourced
+	/// issue keyed by [`REACHABILITY_REF`].
 	///
 	/// Most servers report by pushing their own status to the public-server
 	/// (so their `device_id` is non-null); the pingtask only handles legacy
@@ -215,7 +215,7 @@ impl Status {
 		let servers = Server::get_all(db, 0, None).await?;
 		let monitored: Vec<&Server> = servers
 			.iter()
-			.filter(|s| s.alert_when_down_for.0 > SignedDuration::ZERO && s.id != Uuid::nil())
+			.filter(|s| s.is_monitored && s.id != Uuid::nil())
 			.collect();
 		if monitored.is_empty() {
 			return Ok(0);

--- a/crates/database/tests/reachability_sweep.rs
+++ b/crates/database/tests/reachability_sweep.rs
@@ -13,23 +13,32 @@ struct RowId {
 	id: Uuid,
 }
 
-/// Insert a server with the given `alert_when_down_for` threshold (seconds,
-/// stored as a PostgreSQL `INTERVAL`). `0` disables alerting; positive
-/// values are the per-server downtime threshold the sweep tests against.
+/// Insert a monitored server with the given `alert_when_down_for` threshold
+/// (seconds, stored as a PostgreSQL `INTERVAL`).
 async fn insert_server(
 	conn: &mut diesel_async::AsyncPgConnection,
 	host: &str,
 	alert_when_down_for_secs: i64,
 ) -> Uuid {
+	insert_server_full(conn, host, alert_when_down_for_secs, true).await
+}
+
+async fn insert_server_full(
+	conn: &mut diesel_async::AsyncPgConnection,
+	host: &str,
+	alert_when_down_for_secs: i64,
+	is_monitored: bool,
+) -> Uuid {
 	let row: RowId = sql_query(
 		r#"
-			INSERT INTO servers (host, alert_when_down_for)
-			VALUES ($1, ($2 || ' seconds')::INTERVAL)
+			INSERT INTO servers (host, alert_when_down_for, is_monitored)
+			VALUES ($1, ($2 || ' seconds')::INTERVAL, $3)
 			RETURNING id
 		"#,
 	)
 	.bind::<sql_types::Text, _>(host)
 	.bind::<sql_types::Text, _>(alert_when_down_for_secs.to_string())
+	.bind::<sql_types::Bool, _>(is_monitored)
 	.get_result(conn)
 	.await
 	.expect("insert server");
@@ -103,10 +112,13 @@ async fn sweep_files_when_no_status_ever() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sweep_skips_when_threshold_zero() {
+async fn sweep_skips_unmonitored_server() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		// `0` disables: never file regardless of how stale the status is.
-		let id = insert_server(&mut conn, "http://silenced.invalid/", 0).await;
+		// is_monitored = false: never file regardless of how stale the status
+		// is. The threshold is preserved so flipping monitoring back on
+		// resumes with the chosen value.
+		let id =
+			insert_server_full(&mut conn, "http://silenced.invalid/", 600, false).await;
 		insert_status_at(&mut conn, id, 120).await;
 		let filed = Status::sweep_reachability(&mut conn).await.expect("sweep");
 		assert_eq!(filed, 0);
@@ -175,22 +187,23 @@ async fn new_servers_default_to_ten_minutes() {
 	.await
 }
 
-/// Negative durations are rejected at the DB level by a CHECK constraint.
+/// Non-positive durations are rejected at the DB level by a CHECK
+/// constraint — "off" is now `is_monitored = false`, not a zero threshold.
 #[tokio::test(flavor = "multi_thread")]
-async fn check_constraint_forbids_negative_duration() {
+async fn check_constraint_forbids_non_positive_duration() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		let res = sql_query(
-			r#"
-				INSERT INTO servers (host, alert_when_down_for)
-				VALUES ('http://bad.invalid/', INTERVAL '-1 second')
-			"#,
-		)
-		.execute(&mut conn)
-		.await;
-		assert!(
-			res.is_err(),
-			"expected CHECK constraint to reject negative duration"
-		);
+		for bad in ["INTERVAL '-1 second'", "INTERVAL '0'"] {
+			let res = sql_query(&format!(
+				"INSERT INTO servers (host, alert_when_down_for) \
+				 VALUES ('http://bad.invalid/', {bad})"
+			))
+			.execute(&mut conn)
+			.await;
+			assert!(
+				res.is_err(),
+				"expected CHECK constraint to reject {bad}",
+			);
+		}
 	})
 	.await
 }

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -62,9 +62,13 @@ pub struct ServerInfo {
 	pub public_name: Option<String>,
 	pub cloud: Option<bool>,
 	pub geolocation: Option<GeoPoint>,
-	/// Downtime threshold in seconds before the reachability sweep files an
-	/// issue. `0` (or any non-positive value) disables alerting for this
-	/// server; the default at creation is 600 (10 minutes).
+	/// Whether canopy is actively watching this server. When `false`, the
+	/// reachability sweep skips it and its issues don't contribute to
+	/// incidents.
+	pub is_monitored: bool,
+	/// Threshold in seconds for the reachability sweep to consider this
+	/// server down. Always positive; only consulted when `is_monitored`
+	/// is `true`. The default at creation is 600 (10 minutes).
 	pub alert_when_down_for: i64,
 	pub notes: String,
 	pub tags: TagMap,
@@ -140,6 +144,8 @@ pub struct ServerDataUpdate {
 	)]
 	pub geolocation: Option<Option<GeoPoint>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
+	pub is_monitored: Option<bool>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub alert_when_down_for: Option<i64>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub notes: Option<String>,
@@ -168,6 +174,7 @@ pub(super) fn server_to_info(s: Server) -> ServerInfo {
 		public_name: s.public_name,
 		cloud: s.cloud,
 		geolocation: s.geolocation,
+		is_monitored: s.is_monitored,
 		alert_when_down_for: s.alert_when_down_for.0.as_secs(),
 		notes: s.notes,
 		tags: s.tags,
@@ -492,12 +499,15 @@ pub async fn update(
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
 
-	// `group_id` transitions ALSO go through Server::assign_to_group so a
-	// move from "ungrouped" → "grouped" can promote any pending issues into
-	// an incident. Capture the original state before the update so the
-	// catch-up decision sees the previous group.
-	let before_group_id = if args.data.group_id.is_some() {
-		Some(Server::get_by_id(&mut conn, args.server_id).await?.group_id)
+	// Capture the server's pre-update state when this request touches either
+	// of the two fields whose transitions warrant an incident catch-up:
+	// `group_id` (ungrouped → grouped opens pending issues into incidents)
+	// and `is_monitored` (un/monitored toggles incident eligibility
+	// symmetrically — on enrols open issues, off cascades them out).
+	let touches_catchup_field =
+		args.data.group_id.is_some() || args.data.is_monitored.is_some();
+	let before = if touches_catchup_field {
+		Some(Server::get_by_id(&mut conn, args.server_id).await?)
 	} else {
 		None
 	};
@@ -520,6 +530,7 @@ pub async fn update(
 		public_name: args.data.public_name,
 		cloud: args.data.cloud,
 		geolocation: args.data.geolocation,
+		is_monitored: args.data.is_monitored,
 		alert_when_down_for: args
 			.data
 			.alert_when_down_for
@@ -529,8 +540,15 @@ pub async fn update(
 	};
 	Server::update(&mut conn, args.server_id, update_data).await?;
 
-	// Catch up open issues if we just moved an ungrouped server into a group.
-	if let (Some(None), Some(Some(_))) = (before_group_id, new_group_id) {
+	let group_just_set = matches!(
+		(before.as_ref().map(|s| s.group_id), new_group_id),
+		(Some(None), Some(Some(_)))
+	);
+	let monitored_toggled = match (before.as_ref(), args.data.is_monitored) {
+		(Some(b), Some(new_value)) => b.is_monitored != new_value,
+		_ => false,
+	};
+	if group_just_set || monitored_toggled {
 		database::issues::reevaluate_open_issues_for_server(&mut conn, args.server_id).await?;
 	}
 	Ok(Json(()))
@@ -703,6 +721,7 @@ pub async fn attach_tailscale_device(
 			public_name: None,
 			cloud: None,
 			geolocation: None,
+			is_monitored: None,
 			alert_when_down_for: None,
 			notes: None,
 			tags: None,

--- a/crates/private-server/tests/issues.rs
+++ b/crates/private-server/tests/issues.rs
@@ -125,7 +125,11 @@ async fn incident_groups_at_server_group() {
 			.await;
 		resp.assert_status_ok();
 		let items: Vec<serde_json::Value> = resp.json();
-		assert_eq!(items.len(), 1, "originating member resolves to the same group");
+		assert_eq!(
+			items.len(),
+			1,
+			"originating member resolves to the same group"
+		);
 		assert_eq!(
 			items[0].get("id").and_then(|v| v.as_str()),
 			Some(group_incident_id.as_str()),
@@ -777,6 +781,153 @@ async fn snooze_leaves_incident_and_blocks_rejoin() {
 			"unsnooze should reopen incident if still eligible"
 		);
 		assert!(items[0].get("closed_at").map_or(false, |v| v.is_null()));
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unmonitored_server_event_does_not_open_incident() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		conn.batch_execute("INSERT INTO admins (email) VALUES ('admin@example.com')")
+			.await
+			.expect("seed admin");
+
+		let server_id = Uuid::new_v4();
+		let group_id = Uuid::new_v4();
+		conn.batch_execute(&format!(
+			"INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g');
+			 INSERT INTO servers (id, host, kind, group_id, is_monitored) VALUES \
+				('{server_id}', 'https://muted.example.com', 'central', '{group_id}', FALSE);"
+		))
+		.await
+		.expect("seed");
+
+		// Manual event with severity=error normally opens an incident. The
+		// server is unmonitored, so the issue is recorded but no incident
+		// fires.
+		let resp = private
+			.post("/api/issues/submit_manual_event")
+			.json(&serde_json::json!({
+				"serverId": server_id,
+				"ref": "ignored",
+				"severity": "error",
+				"message": "should not open an incident",
+			}))
+			.await;
+		resp.assert_status_ok();
+
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		resp.assert_status_ok();
+		let items: Vec<serde_json::Value> = resp.json();
+		assert!(items.is_empty(), "unmonitored servers don't open incidents");
+
+		// The issue itself is still there for the record.
+		let resp = private
+			.post("/api/issues/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		let issues: Vec<serde_json::Value> = resp.json();
+		assert_eq!(issues.len(), 1, "issue rows are kept even when unmonitored");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn enabling_monitoring_opens_pending_incident() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		conn.batch_execute("INSERT INTO admins (email) VALUES ('admin@example.com')")
+			.await
+			.expect("seed admin");
+
+		let server_id = Uuid::new_v4();
+		let group_id = Uuid::new_v4();
+		conn.batch_execute(&format!(
+			"INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g');
+			 INSERT INTO servers (id, host, kind, group_id, is_monitored) VALUES \
+				('{server_id}', 'https://later.example.com', 'central', '{group_id}', FALSE);"
+		))
+		.await
+		.expect("seed");
+
+		// File an issue while unmonitored: no incident.
+		let resp = private
+			.post("/api/issues/submit_manual_event")
+			.json(&serde_json::json!({
+				"serverId": server_id,
+				"ref": "stuck",
+				"severity": "error",
+				"message": "waiting to be re-enabled",
+			}))
+			.await;
+		resp.assert_status_ok();
+
+		// Flip monitoring on: the open issue should be promoted.
+		let resp = private
+			.post("/api/servers/update")
+			.json(&serde_json::json!({
+				"server_id": server_id,
+				"data": { "is_monitored": true },
+			}))
+			.await;
+		resp.assert_status_ok();
+
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		let items: Vec<serde_json::Value> = resp.json();
+		assert_eq!(items.len(), 1, "monitor-on promoted the open issue");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn disabling_monitoring_removes_open_contribution() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		conn.batch_execute("INSERT INTO admins (email) VALUES ('admin@example.com')")
+			.await
+			.expect("seed admin");
+
+		let server_id = Uuid::new_v4();
+		open_issue(&mut conn, &private, server_id).await;
+
+		// Sanity: there's an incident before we flip.
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		assert_eq!(resp.json::<Vec<serde_json::Value>>().len(), 1);
+
+		// Flip monitoring off: the lone contributor leaves, incident closes.
+		let resp = private
+			.post("/api/servers/update")
+			.json(&serde_json::json!({
+				"server_id": server_id,
+				"data": { "is_monitored": false },
+			}))
+			.await;
+		resp.assert_status_ok();
+
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id, "include_closed": true }))
+			.await;
+		let items: Vec<serde_json::Value> = resp.json();
+		assert_eq!(items.len(), 1, "incident row remains for history");
+		assert!(
+			items[0].get("closed_at").is_some_and(|v| !v.is_null()),
+			"unmonitor closed the incident",
+		);
+
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		let items: Vec<serde_json::Value> = resp.json();
+		assert!(items.is_empty(), "no open incidents after unmonitor");
 	})
 	.await;
 }

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -1139,6 +1139,12 @@
             "type": "string",
             "format": "uuid"
           },
+          "is_monitored": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "kind": {
             "oneOf": [
               {
@@ -1255,13 +1261,14 @@
           "id",
           "host",
           "kind",
+          "is_monitored",
           "alert_when_down_for"
         ],
         "properties": {
           "alert_when_down_for": {
             "type": "integer",
             "format": "int64",
-            "description": "How long a server's status row may go un-updated before the canopy\nreachability sweep files an issue.\n\n`INTERVAL '0'` disables the sweep for this server entirely — useful\nfor test environments and ad-hoc demos whose downtime is expected.\nPositive values are the per-server downtime threshold: bump it up\nfor flappy servers, drop it for critical ones that should page\npromptly. Negative durations are rejected by a CHECK constraint on\nthe column.\n\nDefault 10 minutes for newly-inserted rows. On the JSON wire this\nis represented as a count of whole seconds (`i64`)."
+            "description": "Per-server downtime threshold: how long a server's status row may\ngo un-updated before the canopy reachability sweep files an issue.\nBump it up for flappy servers, drop it for critical ones that\nshould page promptly. Only consulted when `is_monitored` is `true`.\n\nConstrained to strictly positive by the database. Default 10\nminutes for newly-inserted rows. On the JSON wire this is\nrepresented as a count of whole seconds (`i64`)."
           },
           "cloud": {
             "type": [
@@ -1299,6 +1306,10 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "is_monitored": {
+            "type": "boolean",
+            "description": "Whether canopy is actively watching this server. When `false`, the\nreachability sweep skips it entirely and any of its issues are\nignored by the incident workflow — operators flip this off for\ntest environments and ad-hoc demos. The accompanying\n`alert_when_down_for` is preserved while muted so flipping back on\ndoesn't lose the chosen threshold."
           },
           "kind": {
             "$ref": "#/components/schemas/ServerKind"

--- a/migrations/2026-05-23-100000-0000_servers_is_monitored/down.sql
+++ b/migrations/2026-05-23-100000-0000_servers_is_monitored/down.sql
@@ -1,0 +1,14 @@
+-- Restore the "0 means off" encoding by folding `is_monitored = false` rows
+-- back to `alert_when_down_for = 0`.
+
+ALTER TABLE servers
+	DROP CONSTRAINT servers_alert_when_down_for_check;
+ALTER TABLE servers
+	ADD CONSTRAINT servers_alert_when_down_for_check
+	CHECK (alert_when_down_for >= INTERVAL '0');
+
+UPDATE servers
+SET alert_when_down_for = INTERVAL '0'
+WHERE NOT is_monitored;
+
+ALTER TABLE servers DROP COLUMN is_monitored;

--- a/migrations/2026-05-23-100000-0000_servers_is_monitored/up.sql
+++ b/migrations/2026-05-23-100000-0000_servers_is_monitored/up.sql
@@ -1,0 +1,37 @@
+-- Split the monitoring on/off toggle out of `alert_when_down_for`, so an
+-- operator can mute a server temporarily without losing the timeout setting
+-- they picked for it.
+--
+-- Before: `alert_when_down_for INTERVAL` doubled as the toggle. Any
+-- non-positive value (typically `0`) meant "off" *and* lost whatever
+-- threshold the operator had set. Re-enabling required picking the value
+-- again from scratch.
+--
+-- After: `is_monitored BOOLEAN` carries the toggle, and
+-- `alert_when_down_for` is constrained to a strictly-positive duration that
+-- represents the threshold to use *when* monitored. Toggling off and back
+-- on preserves the threshold.
+
+ALTER TABLE servers ADD COLUMN is_monitored BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Carry the existing "off" semantic over (alert_when_down_for <= 0).
+UPDATE servers
+SET is_monitored = FALSE
+WHERE alert_when_down_for <= INTERVAL '0';
+
+-- Give muted rows a sensible threshold so the new strictly-positive
+-- constraint holds. 10 minutes mirrors the column default; operators can
+-- raise it later, and it doesn't take effect until they re-enable
+-- monitoring.
+UPDATE servers
+SET alert_when_down_for = INTERVAL '10 minutes'
+WHERE alert_when_down_for <= INTERVAL '0';
+
+-- Replace the old "non-negative" check with a strict "positive" one. A
+-- zero threshold is no longer a meaningful state — the boolean owns
+-- that case now.
+ALTER TABLE servers
+	DROP CONSTRAINT servers_alert_when_down_for_check;
+ALTER TABLE servers
+	ADD CONSTRAINT servers_alert_when_down_for_check
+	CHECK (alert_when_down_for > INTERVAL '0');

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -91,7 +91,10 @@ export async function seedServer(
 		deviceId?: string;
 		notes?: string;
 		tags?: Record<string, string>;
-		/** Threshold in seconds; `0` disables alerting (the default for e2e seeds). */
+		/** Whether canopy actively monitors this server. Off by default so
+		 * e2e seeds don't accidentally trip the reachability sweep. */
+		isMonitored?: boolean;
+		/** Threshold in seconds; defaults to 600 (10 min). Must be > 0. */
 		alertWhenDownFor?: number;
 	} = {},
 ): Promise<SeededServer> {
@@ -100,10 +103,11 @@ export async function seedServer(
 	const host = opts.host ?? `https://${randomLabel("host")}.e2e.invalid`;
 	const kind = opts.kind ?? "central";
 	const rank = opts.rank ?? "production";
-	const alertWhenDownFor = opts.alertWhenDownFor ?? 0;
+	const isMonitored = opts.isMonitored ?? false;
+	const alertWhenDownFor = opts.alertWhenDownFor ?? 600;
 	await sql.query(
-		`INSERT INTO servers (id, name, host, kind, rank, group_id, device_id, alert_when_down_for, notes, tags)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)`,
+		`INSERT INTO servers (id, name, host, kind, rank, group_id, device_id, is_monitored, alert_when_down_for, notes, tags)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)`,
 		[
 			id,
 			name,
@@ -112,6 +116,7 @@ export async function seedServer(
 			rank,
 			opts.groupId ?? null,
 			opts.deviceId ?? null,
+			isMonitored,
 			alertWhenDownFor,
 			opts.notes ?? "",
 			JSON.stringify(opts.tags ?? {}),

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4740,6 +4740,7 @@
                 "id",
                 "kind",
                 "host",
+                "is_monitored",
                 "alert_when_down_for",
                 "notes",
                 "tags"
@@ -4748,7 +4749,7 @@
                 "alert_when_down_for": {
                   "type": "integer",
                   "format": "int64",
-                  "description": "Downtime threshold in seconds before the reachability sweep files an\nissue. `0` (or any non-positive value) disables alerting for this\nserver; the default at creation is 600 (10 minutes)."
+                  "description": "Threshold in seconds for the reachability sweep to consider this\nserver down. Always positive; only consulted when `is_monitored`\nis `true`. The default at creation is 600 (10 minutes)."
                 },
                 "cloud": {
                   "type": [
@@ -4804,6 +4805,10 @@
                 "id": {
                   "type": "string",
                   "format": "uuid"
+                },
+                "is_monitored": {
+                  "type": "boolean",
+                  "description": "Whether canopy is actively watching this server. When `false`, the\nreachability sweep skips it and its issues don't contribute to\nincidents."
                 },
                 "kind": {
                   "$ref": "#/components/schemas/ServerKind"
@@ -5186,6 +5191,12 @@
               "null"
             ]
           },
+          "is_monitored": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "kind": {
             "oneOf": [
               {
@@ -5390,6 +5401,7 @@
           "id",
           "kind",
           "host",
+          "is_monitored",
           "alert_when_down_for",
           "notes",
           "tags"
@@ -5398,7 +5410,7 @@
           "alert_when_down_for": {
             "type": "integer",
             "format": "int64",
-            "description": "Downtime threshold in seconds before the reachability sweep files an\nissue. `0` (or any non-positive value) disables alerting for this\nserver; the default at creation is 600 (10 minutes)."
+            "description": "Threshold in seconds for the reachability sweep to consider this\nserver down. Always positive; only consulted when `is_monitored`\nis `true`. The default at creation is 600 (10 minutes)."
           },
           "cloud": {
             "type": [
@@ -5454,6 +5466,10 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "is_monitored": {
+            "type": "boolean",
+            "description": "Whether canopy is actively watching this server. When `false`, the\nreachability sweep skips it and its issues don't contribute to\nincidents."
           },
           "kind": {
             "$ref": "#/components/schemas/ServerKind"

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1839,9 +1839,9 @@ export interface components {
             items: {
                 /**
                  * Format: int64
-                 * @description Downtime threshold in seconds before the reachability sweep files an
-                 *     issue. `0` (or any non-positive value) disables alerting for this
-                 *     server; the default at creation is 600 (10 minutes).
+                 * @description Threshold in seconds for the reachability sweep to consider this
+                 *     server down. Always positive; only consulted when `is_monitored`
+                 *     is `true`. The default at creation is 600 (10 minutes).
                  */
                 alert_when_down_for: number;
                 cloud?: boolean | null;
@@ -1859,6 +1859,12 @@ export interface components {
                 host: string;
                 /** Format: uuid */
                 id: string;
+                /**
+                 * @description Whether canopy is actively watching this server. When `false`, the
+                 *     reachability sweep skips it and its issues don't contribute to
+                 *     incidents.
+                 */
+                is_monitored: boolean;
                 kind: components["schemas"]["ServerKind"];
                 name?: string | null;
                 notes: string;
@@ -2002,6 +2008,7 @@ export interface components {
             /** Format: uuid */
             group_id?: string | null;
             host?: string | null;
+            is_monitored?: boolean | null;
             kind?: null | components["schemas"]["ServerKind"];
             name?: string | null;
             notes?: string | null;
@@ -2057,9 +2064,9 @@ export interface components {
         ServerInfo: {
             /**
              * Format: int64
-             * @description Downtime threshold in seconds before the reachability sweep files an
-             *     issue. `0` (or any non-positive value) disables alerting for this
-             *     server; the default at creation is 600 (10 minutes).
+             * @description Threshold in seconds for the reachability sweep to consider this
+             *     server down. Always positive; only consulted when `is_monitored`
+             *     is `true`. The default at creation is 600 (10 minutes).
              */
             alert_when_down_for: number;
             cloud?: boolean | null;
@@ -2077,6 +2084,12 @@ export interface components {
             host: string;
             /** Format: uuid */
             id: string;
+            /**
+             * @description Whether canopy is actively watching this server. When `false`, the
+             *     reachability sweep skips it and its issues don't contribute to
+             *     incidents.
+             */
+            is_monitored: boolean;
             kind: components["schemas"]["ServerKind"];
             name?: string | null;
             notes: string;

--- a/private-web/src/components/ServerShorty.tsx
+++ b/private-web/src/components/ServerShorty.tsx
@@ -13,15 +13,14 @@ export interface ServerInfo {
 	kind: ServerKind;
 	rank: ServerRank | null;
 	group_name?: string | null;
-	alert_when_down_for?: number;
+	is_monitored?: boolean;
 	up?: ShortStatus | null;
 	health?: HealthState | null;
 }
 
 export default function ServerShorty({ server }: { server: ServerInfo }) {
 	const name = server.name || "Unnamed server";
-	const unmonitored =
-		server.alert_when_down_for !== undefined && server.alert_when_down_for <= 0;
+	const unmonitored = server.is_monitored === false;
 	return (
 		<Stack
 			direction="row"

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -485,7 +485,7 @@ function InfoSection({
 				<InfoItem
 					label="Status alerts"
 					value={
-						server.alert_when_down_for > 0
+						server.is_monitored
 							? `After ${humanSeconds(server.alert_when_down_for)}`
 							: "Off"
 					}
@@ -837,7 +837,7 @@ function SiblingServers({
 						</MuiLink>
 						{sib.rank && <ServerRankChip rank={sib.rank} />}
 						<ServerKindChip kind={sib.kind} />
-						{sib.alert_when_down_for <= 0 && (
+						{!sib.is_monitored && (
 							<Tooltip title="Status alerts are off for this server — canopy isn't watching it.">
 								<Chip
 									size="small"

--- a/private-web/src/routes/ServerEdit.tsx
+++ b/private-web/src/routes/ServerEdit.tsx
@@ -58,16 +58,12 @@ function EditForm({ info }: { info: ServerInfo }) {
 	const [kind, setKind] = useState<ServerKind>(info.kind);
 	const [rank, setRank] = useState<ServerRank | "">(info.rank ?? "");
 	const [publicName, setPublicName] = useState<string>(info.public_name ?? "");
-	// Threshold in seconds; 0 (or negative) means alerting is disabled. The
-	// UI works in minutes for the operator and the empty string represents
-	// "disabled" — converted back to seconds at submit time.
-	const [alertWhenDownEnabled, setAlertWhenDownEnabled] = useState(
-		info.alert_when_down_for > 0,
-	);
+	// `is_monitored` carries the on/off toggle; `alert_when_down_for` is the
+	// (always-positive) threshold to use when monitored. Stored separately
+	// so muting doesn't lose the chosen threshold. UI works in minutes.
+	const [isMonitored, setIsMonitored] = useState(info.is_monitored);
 	const [alertWhenDownMinutes, setAlertWhenDownMinutes] = useState<string>(
-		info.alert_when_down_for > 0
-			? Math.round(info.alert_when_down_for / 60).toString()
-			: "10",
+		Math.max(1, Math.round(info.alert_when_down_for / 60)).toString(),
 	);
 	const [groupId, setGroupId] = useState<string | null>(info.group_id);
 	const [deviceId, setDeviceId] = useState<string>(info.device_id ?? "");
@@ -94,9 +90,11 @@ function EditForm({ info }: { info: ServerInfo }) {
 				lat && lon
 					? { lat: Number(lat), lon: Number(lon) }
 					: null,
-			alert_when_down_for: alertWhenDownEnabled
-				? Math.max(0, Math.round(Number(alertWhenDownMinutes) * 60))
-				: 0,
+			is_monitored: isMonitored,
+			alert_when_down_for: Math.max(
+				60,
+				Math.round(Number(alertWhenDownMinutes) * 60),
+			),
 			notes,
 			tags,
 		};
@@ -204,35 +202,45 @@ function EditForm({ info }: { info: ServerInfo }) {
 					/>
 				)}
 
+				<FormControlLabel
+					control={
+						<Checkbox
+							checked={isMonitored}
+							onChange={(e) => setIsMonitored(e.target.checked)}
+							disabled={action.pending}
+						/>
+					}
+					label="Monitor this server"
+				/>
+				<Typography variant="caption" color="text.secondary">
+					When off, canopy stops watching this server: reachability sweeps
+					skip it and its events/issues no longer trigger or join incidents.
+					Existing issues are kept for the record. Use this for test
+					environments and ad-hoc demos that are expected to be down.
+				</Typography>
+
 				<Stack
 					direction={{ xs: "column", md: "row" }}
 					spacing={2}
 					sx={{ alignItems: { md: "center" } }}
 				>
-					<FormControlLabel
-						control={
-							<Checkbox
-								checked={alertWhenDownEnabled}
-								onChange={(e) => setAlertWhenDownEnabled(e.target.checked)}
-								disabled={action.pending}
-							/>
-						}
-						label="File an issue when this server is unreachable for"
-					/>
+					<Typography variant="body2">
+						File an issue when this server is unreachable for
+					</Typography>
 					<TextField
 						label="minutes"
 						type="number"
 						value={alertWhenDownMinutes}
 						onChange={(e) => setAlertWhenDownMinutes(e.target.value)}
-						disabled={action.pending || !alertWhenDownEnabled}
-						slotProps={{ htmlInput: { min: 0, step: 1 } }}
+						disabled={action.pending || !isMonitored}
+						slotProps={{ htmlInput: { min: 1, step: 1 } }}
 						sx={{ width: 140 }}
 					/>
 				</Stack>
 				<Typography variant="caption" color="text.secondary">
-					Raise this for flappy servers (so brief blips don't fire) or lower it
-					for critical servers that should page promptly. Uncheck for test
-					environments and ad-hoc demos that are expected to be down.
+					Raise this for flappy servers (so brief blips don't fire) or lower
+					it for critical servers that should page promptly. The value is
+					preserved while monitoring is off.
 				</Typography>
 
 				<TextField


### PR DESCRIPTION
🤖 Today the 'unmonitored' toggle is encoded as `alert_when_down_for <= 0`. Two problems:

1. **It's only a reachability gate.** Other event sources (status pushes reporting unhealth, manual events, tailnet sweeps) still flow into the incident workflow, so a server flagged as 'not watched' can still page an oncall.
2. **Muting loses the threshold.** Flipping the toggle off resets the duration; flipping it back on means re-picking a value.

This PR splits the toggle out into a dedicated `servers.is_monitored` boolean and constrains `alert_when_down_for` to be strictly positive — the duration is now always a valid threshold to use *when* monitored, regardless of the toggle.

## Behaviour

- **Reachability sweep**: gates on `is_monitored` directly (same as before, just a different field).
- **Event/issue ingestion**: `re_evaluate_incident_membership` treats `!is_monitored` as a 'should leave' reason. Issue rows are still recorded — they just don't contribute to incidents.
- **Toggle on**: runs the existing `reevaluate_open_issues_for_server` catch-up, so currently-open issues get promoted into an incident if they would otherwise qualify. Mirrors the ungrouped → grouped transition.
- **Toggle off**: same catch-up runs in reverse — open contributions leave their incident, closing it if nothing else props it up.

## UI

The server edit form now has a 'Monitor this server' checkbox separate from the threshold field. The threshold is enforced as a positive value and is preserved while muted. `ServerShorty`'s 'unmonitored' badge reads the boolean directly.

## Migration

`is_monitored BOOLEAN NOT NULL DEFAULT TRUE` backfilled from the existing semantic (`alert_when_down_for > 0`). Rows that were previously off (`alert_when_down_for = 0`) get the column default (10 min) so the new strictly-positive CHECK holds — the toggle still reads as off because `is_monitored = false`.