### PR TITLE
fix(reachability): close spurious incidents from PR #170's deploy window

### DIFF
--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -337,6 +337,21 @@ impl Server {
 			.map_err(AppError::from)
 	}
 
+	/// All servers with `is_monitored = false`. Used by the one-shot
+	/// post-migration cleanup that walks those servers' open issues to
+	/// close any spurious incidents opened during the deploy window of
+	/// the monitored-toggle split.
+	pub async fn list_unmonitored(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::servers::dsl::*;
+		servers
+			.select(Self::as_select())
+			.filter(id.ne(Uuid::nil()))
+			.filter(is_monitored.eq(false))
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
 	/// All servers without a group, ordered by name. Used by the Ungrouped UI tab.
 	pub async fn list_ungrouped(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
 		use crate::schema::servers::dsl::*;

--- a/crates/jobs/src/bin/reachability.rs
+++ b/crates/jobs/src/bin/reachability.rs
@@ -20,18 +20,71 @@ use commons_servers::{
 	tailnet_directory::{TailnetDirectory, TailnetDirectoryConfig},
 	tailnet_sweeps,
 };
-use database::statuses::Status;
+use database::{
+	issues::reevaluate_open_issues_for_server, servers::Server, statuses::Status,
+};
 use lloggs::{LoggingArgs, PreArgs};
 use miette::IntoDiagnostic;
 use tokio::{
 	task::{self, JoinHandle},
 	time::sleep,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
+
+/// One-shot cleanup for the deploy window of the monitored-toggle
+/// split (PR #170): the migration in that change bumped
+/// `alert_when_down_for` from 0 to 10 minutes for previously-off
+/// servers so the new `> 0` CHECK constraint would hold, but the
+/// old code (still serving during the rolling deploy) read that
+/// duration as "monitored" and ran one or more reachability sweeps
+/// against those servers, filing canopy/reachability issues and
+/// opening spurious incidents.
+///
+/// Walk every currently-unmonitored server through
+/// `reevaluate_open_issues_for_server`. With the new code's leave
+/// rule, any of its open issues that are still contributing to an
+/// incident now leave it and the incident closes if nothing else
+/// keeps it alive. Idempotent: once the database is clean,
+/// subsequent calls are no-ops.
+async fn cleanup_unmonitored_incidents(pool: &database::Db) {
+	let Ok(mut db) = pool.get().await else {
+		warn!("post-migration cleanup: failed to get database connection");
+		return;
+	};
+	let unmonitored = match Server::list_unmonitored(&mut db).await {
+		Ok(rows) => rows,
+		Err(err) => {
+			warn!("post-migration cleanup: list_unmonitored failed: {err}");
+			return;
+		}
+	};
+	if unmonitored.is_empty() {
+		debug!("post-migration cleanup: no unmonitored servers, skipping");
+		return;
+	}
+	info!(
+		"post-migration cleanup: re-evaluating {} unmonitored servers",
+		unmonitored.len()
+	);
+	let mut errors = 0usize;
+	for server in unmonitored {
+		if let Err(err) = reevaluate_open_issues_for_server(&mut db, server.id).await {
+			warn!(server_id = %server.id, "post-migration cleanup: re-evaluate failed: {err}");
+			errors += 1;
+		}
+	}
+	if errors > 0 {
+		warn!("post-migration cleanup: {errors} server(s) failed to re-evaluate");
+	} else {
+		info!("post-migration cleanup: done");
+	}
+}
 
 pub fn spawn() -> JoinHandle<()> {
 	let pool = database::init();
 	task::spawn(async move {
+		cleanup_unmonitored_incidents(&pool).await;
+
 		// The directory is optional: in dev / single-tenant deploys the
 		// TAILSCALE_* env vars aren't set, and the key-expiry sweep just
 		// no-ops. Build it once at startup so we don't re-mint OAuth


### PR DESCRIPTION
🤖 PR #170's migration bumped `alert_when_down_for` from 0 to 10 min for previously-off servers so the new `> 0` CHECK constraint would hold, but the old code still serving during the rolling deploy read `alert_when_down_for > 0` as 'monitored' and ran one (or more — the sweep is every 60s) reachability sweeps against those servers, filing `canopy/reachability` issues and opening 22 spurious incidents.

The new code never re-evaluates these issues on its own (no event arrives for an unmonitored server, and `reevaluate_open_issues_for_server` only runs in the update handler), so the spurious incidents stay open.

## Fix

On reachability-binary startup, walk every `is_monitored = false` server through `reevaluate_open_issues_for_server`. With the new code's `!monitored` leave rule, any of those servers' open contributions exit their incident; if the contribution was the only thing propping up an incident, it closes cleanly (with the proper cascade — Slack `incident_resolve` rows, `closed_at` set, etc.). Logs how many servers it walked.

Idempotent. Once the DB is clean, subsequent restarts find nothing to do and log nothing.