### PR TITLE
Reconcile all open incidents on startup (generalise PR #171)

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -526,6 +526,76 @@ pub async fn reevaluate_open_issues_for_server(
 	Ok(())
 }
 
+/// Re-evaluate every currently-open issue across every server in the
+/// database against incident membership. Intended as a startup pass for
+/// background workers: if the rules around incident eligibility change
+/// in code (or a migration silently bumped state the running code now
+/// reads differently — see PR #170), this drives the actual incident
+/// rows into agreement with what the current code says they should be.
+///
+/// Idempotent. Cheap when the database is already consistent — each
+/// issue's `re_evaluate_incident_membership` call short-circuits in the
+/// `_ => {}` arm when the incident state already matches.
+///
+/// Runs as a single transaction so a crash mid-reconcile doesn't leave
+/// the incident state half-fixed. The per-issue FOR UPDATE locks held
+/// inside `re_evaluate_incident_membership` accumulate across the
+/// transaction's lifetime — fine at canopy's scale (hundreds of open
+/// issues at most) but worth keeping in mind if the corpus grows.
+///
+/// Returns `(servers_walked, issues_evaluated)` for the caller to log.
+pub async fn reconcile_open_incidents(
+	db: &mut AsyncPgConnection,
+) -> Result<(usize, usize)> {
+	use crate::schema::issues::dsl;
+
+	db.transaction::<_, AppError, _>(async |conn| {
+		let open_issues: Vec<Issue> = dsl::issues
+			.select(Issue::as_select())
+			.filter(dsl::active.eq(true))
+			.filter(dsl::resolved_at.is_null())
+			.load(conn)
+			.await?;
+
+		if open_issues.is_empty() {
+			return Ok((0, 0));
+		}
+
+		let server_ids: Vec<Uuid> = {
+			let mut s: std::collections::HashSet<Uuid> =
+				open_issues.iter().map(|i| i.server_id).collect();
+			s.drain().collect()
+		};
+		let servers = Server::get_by_ids(conn, &server_ids).await?;
+		let by_id: std::collections::HashMap<Uuid, Server> =
+			servers.into_iter().map(|s| (s.id, s)).collect();
+
+		let now = Timestamp::now();
+		let mut evaluated = 0usize;
+		for issue in open_issues {
+			let Some(server) = by_id.get(&issue.server_id) else {
+				continue;
+			};
+			let Some(gid) = server.group_id else {
+				// Ungrouped servers can't have incidents; nothing to reconcile.
+				continue;
+			};
+			re_evaluate_incident_membership(
+				conn,
+				&issue,
+				gid,
+				server.is_monitored,
+				now,
+				None,
+			)
+			.await?;
+			evaluated += 1;
+		}
+		Ok((by_id.len(), evaluated))
+	})
+	.await
+}
+
 async fn is_issue_in_open_incident(db: &mut AsyncPgConnection, issue_id: Uuid) -> Result<bool> {
 	use crate::schema::incident_issues;
 

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -337,21 +337,6 @@ impl Server {
 			.map_err(AppError::from)
 	}
 
-	/// All servers with `is_monitored = false`. Used by the one-shot
-	/// post-migration cleanup that walks those servers' open issues to
-	/// close any spurious incidents opened during the deploy window of
-	/// the monitored-toggle split.
-	pub async fn list_unmonitored(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
-		use crate::schema::servers::dsl::*;
-		servers
-			.select(Self::as_select())
-			.filter(id.ne(Uuid::nil()))
-			.filter(is_monitored.eq(false))
-			.load(db)
-			.await
-			.map_err(AppError::from)
-	}
-
 	/// All servers without a group, ordered by name. Used by the Ungrouped UI tab.
 	pub async fn list_ungrouped(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
 		use crate::schema::servers::dsl::*;

--- a/crates/jobs/src/bin/reachability.rs
+++ b/crates/jobs/src/bin/reachability.rs
@@ -20,9 +20,7 @@ use commons_servers::{
 	tailnet_directory::{TailnetDirectory, TailnetDirectoryConfig},
 	tailnet_sweeps,
 };
-use database::{
-	issues::reevaluate_open_issues_for_server, servers::Server, statuses::Status,
-};
+use database::{issues::reconcile_open_incidents, statuses::Status};
 use lloggs::{LoggingArgs, PreArgs};
 use miette::IntoDiagnostic;
 use tokio::{
@@ -31,59 +29,49 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 
-/// One-shot cleanup for the deploy window of the monitored-toggle
-/// split (PR #170): the migration in that change bumped
-/// `alert_when_down_for` from 0 to 10 minutes for previously-off
-/// servers so the new `> 0` CHECK constraint would hold, but the
-/// old code (still serving during the rolling deploy) read that
-/// duration as "monitored" and ran one or more reachability sweeps
-/// against those servers, filing canopy/reachability issues and
-/// opening spurious incidents.
+/// Walk every open issue through `re_evaluate_incident_membership` so
+/// the recorded incident state matches what the current code says it
+/// should be.
 ///
-/// Walk every currently-unmonitored server through
-/// `reevaluate_open_issues_for_server`. With the new code's leave
-/// rule, any of its open issues that are still contributing to an
-/// incident now leave it and the incident closes if nothing else
-/// keeps it alive. Idempotent: once the database is clean,
-/// subsequent calls are no-ops.
-async fn cleanup_unmonitored_incidents(pool: &database::Db) {
+/// The reachability binary is the natural home for this: it already
+/// owns the canopy/reachability sweep and runs in its own pod, so a
+/// startup pass doesn't slow API request handling.
+///
+/// Reasons to do this on every startup rather than reach for a one-off:
+///
+/// - **Code changes drift the rules.** When the join/leave logic
+///   changes (new gates like `is_monitored`, `silenced`, …), existing
+///   open incidents that no longer satisfy the rules stay open until
+///   the next event arrives — which may be never for the servers in
+///   question. PR #170 hit exactly this: the migration's value bump
+///   tripped the OLD code's reachability sweep during the deploy
+///   window, opening 22 spurious incidents on unmonitored servers
+///   that the NEW code's rules would never have opened, and which
+///   nothing in the steady-state event flow would reconcile.
+/// - **Idempotent and cheap when consistent.** `re_evaluate_incident_membership`
+///   short-circuits in the `_ => {}` arm when the issue is already in
+///   the right state — so a clean DB only pays the read cost.
+async fn reconcile_on_startup(pool: &database::Db) {
 	let Ok(mut db) = pool.get().await else {
-		warn!("post-migration cleanup: failed to get database connection");
+		warn!("incident reconciliation: failed to get database connection");
 		return;
 	};
-	let unmonitored = match Server::list_unmonitored(&mut db).await {
-		Ok(rows) => rows,
-		Err(err) => {
-			warn!("post-migration cleanup: list_unmonitored failed: {err}");
-			return;
+	match reconcile_open_incidents(&mut db).await {
+		Ok((0, 0)) => debug!("incident reconciliation: nothing to walk"),
+		Ok((servers, issues)) => {
+			info!(
+				"incident reconciliation: walked {issues} open issue(s) across \
+				 {servers} server(s)"
+			);
 		}
-	};
-	if unmonitored.is_empty() {
-		debug!("post-migration cleanup: no unmonitored servers, skipping");
-		return;
-	}
-	info!(
-		"post-migration cleanup: re-evaluating {} unmonitored servers",
-		unmonitored.len()
-	);
-	let mut errors = 0usize;
-	for server in unmonitored {
-		if let Err(err) = reevaluate_open_issues_for_server(&mut db, server.id).await {
-			warn!(server_id = %server.id, "post-migration cleanup: re-evaluate failed: {err}");
-			errors += 1;
-		}
-	}
-	if errors > 0 {
-		warn!("post-migration cleanup: {errors} server(s) failed to re-evaluate");
-	} else {
-		info!("post-migration cleanup: done");
+		Err(err) => warn!("incident reconciliation: failed: {err}"),
 	}
 }
 
 pub fn spawn() -> JoinHandle<()> {
 	let pool = database::init();
 	task::spawn(async move {
-		cleanup_unmonitored_incidents(&pool).await;
+		reconcile_on_startup(&pool).await;
 
 		// The directory is optional: in dev / single-tenant deploys the
 		// TAILSCALE_* env vars aren't set, and the key-expiry sweep just


### PR DESCRIPTION
🤖 #171 wired in a startup hook that only walked unmonitored servers — narrowly targeted at that PR's specific deploy-window bug. But the same class of drift is going to recur every time the join/leave rules change in code: existing open incidents that the new rules would never have opened, on servers that aren't reporting and so don't trigger any event-driven re-evaluation.

The next instance is already on deck — a \`silenced_refs\` gate is in progress on the silence-this-ref-permanently feature. Without a general reconcile, every such change would either need its own bespoke startup migration or live with whatever drift gets baked in.

## Change

Replace the targeted walk with a generic \`reconcile_open_incidents\` pass:

- Loads every open issue across every server.
- For each, runs \`re_evaluate_incident_membership\` with the current code's view of \`monitored\` and (later) \`silenced\`.
- Mismatches reconcile in the right direction: spurious contributions leave (and close the incident if they were the only thing propping it up), missing contributions join (or open a fresh incident).

Idempotent and cheap when consistent — each evaluation short-circuits in the \`_ => {}\` arm when the recorded state already matches.

Runs as a single transaction so a crash mid-reconcile doesn't leave the state half-fixed. FOR UPDATE locks accumulate across the pass; fine at canopy's scale (hundreds of open issues at most) but documented in case the corpus grows.

Also drops \`Server::list_unmonitored\`, which was specific to #171's one-off.