### PR TITLE
Permanent silence for issue refs at server / group scope

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -364,11 +364,13 @@ impl NewEvent {
 /// Compute whether the issue *should* currently be contributing to an
 /// open incident, and apply join/leave accordingly. The rules:
 ///
-/// - **Leave**: `!active || resolved || snoozed || !monitored`. Severity
-///   downgrade alone does *not* remove an issue — once contributing, it
-///   stays until it's actually gone or explicitly suppressed. Flipping
-///   the server to unmonitored *does* remove it: the operator has said
-///   they're not watching this server, so its issues stop counting.
+/// - **Leave**: `!active || resolved || snoozed || silenced || !monitored`.
+///   Severity downgrade alone does *not* remove an issue — once
+///   contributing, it stays until it's actually gone or explicitly
+///   suppressed. Flipping the server to unmonitored *does* remove it: the
+///   operator has said they're not watching this server, so its issues
+///   stop counting. The same applies if `(source, ref)` is on the server
+///   or group silence list — see [`crate::silenced_refs`].
 /// - **Join**: not leaving, AND one of:
 ///   - severity ≥ floor (`error`), so this issue is high-priority enough to
 ///     create a new incident on its own; or
@@ -400,10 +402,20 @@ async fn re_evaluate_incident_membership(
 
 	let was_in = is_issue_in_open_incident(conn, issue.id).await?;
 	let snoozed = issue.snoozed_until.map_or(false, |t| t > Timestamp::now());
+	let silenced = crate::silenced_refs::is_silenced(
+		conn,
+		issue.server_id,
+		Some(server_group_id),
+		&issue.source,
+		&issue.r#ref,
+	)
+	.await?;
 	let group_open = group_has_open_incident(conn, server_group_id).await?;
 
-	let should_leave = !issue.active || issue.resolved_at.is_some() || snoozed || !monitored;
+	let should_leave =
+		!issue.active || issue.resolved_at.is_some() || snoozed || silenced || !monitored;
 	let should_join = monitored
+		&& !silenced
 		&& issue.active
 		&& issue.resolved_at.is_none()
 		&& !snoozed
@@ -526,6 +538,89 @@ pub async fn reevaluate_open_issues_for_server(
 	Ok(())
 }
 
+/// Re-evaluate every currently-open issue on `server_id` with the given
+/// `(source, ref)`. Narrower variant of [`reevaluate_open_issues_for_server`]
+/// used after a server-scoped silence is added or removed: only the matching
+/// refs need to revisit their incident membership.
+pub async fn reevaluate_open_issues_for_server_ref(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	source: &str,
+	r#ref: &str,
+) -> Result<()> {
+	use crate::schema::issues::dsl;
+
+	let server = Server::get_by_id(db, server_id).await?;
+	let Some(gid) = server.group_id else {
+		return Ok(());
+	};
+	let monitored = server.is_monitored;
+
+	let open_issues: Vec<Issue> = dsl::issues
+		.select(Issue::as_select())
+		.filter(dsl::server_id.eq(server_id))
+		.filter(dsl::source.eq(source))
+		.filter(dsl::ref_.eq(r#ref))
+		.filter(dsl::active.eq(true))
+		.filter(dsl::resolved_at.is_null())
+		.load(db)
+		.await?;
+
+	let now = Timestamp::now();
+	for issue in open_issues {
+		re_evaluate_incident_membership(db, &issue, gid, monitored, now, None).await?;
+	}
+	Ok(())
+}
+
+/// Re-evaluate every currently-open issue in the group with the given
+/// `(source, ref)`. Used after a group-scoped silence is added or removed.
+pub async fn reevaluate_open_issues_for_group_ref(
+	db: &mut AsyncPgConnection,
+	server_group_id: Uuid,
+	source: &str,
+	r#ref: &str,
+) -> Result<()> {
+	use crate::schema::{issues, servers};
+
+	let server_ids: Vec<Uuid> = servers::table
+		.select(servers::id)
+		.filter(servers::group_id.eq(server_group_id))
+		.load(db)
+		.await?;
+	if server_ids.is_empty() {
+		return Ok(());
+	}
+
+	let open_issues: Vec<Issue> = issues::table
+		.select(Issue::as_select())
+		.filter(issues::server_id.eq_any(&server_ids))
+		.filter(issues::source.eq(source))
+		.filter(issues::ref_.eq(r#ref))
+		.filter(issues::active.eq(true))
+		.filter(issues::resolved_at.is_null())
+		.load(db)
+		.await?;
+
+	let now = Timestamp::now();
+	// Servers in the same group all share the same `monitored` only by
+	// coincidence; look each up so the re-evaluation sees current state.
+	let mut monitored_by_server: std::collections::HashMap<Uuid, bool> =
+		std::collections::HashMap::new();
+	for sid in &server_ids {
+		let s = Server::get_by_id(db, *sid).await?;
+		monitored_by_server.insert(*sid, s.is_monitored);
+	}
+	for issue in open_issues {
+		let monitored = monitored_by_server
+			.get(&issue.server_id)
+			.copied()
+			.unwrap_or(true);
+		re_evaluate_incident_membership(db, &issue, server_group_id, monitored, now, None).await?;
+	}
+	Ok(())
+}
+
 /// Re-evaluate every currently-open issue across every server in the
 /// database against incident membership. Intended as a startup pass for
 /// background workers: if the rules around incident eligibility change
@@ -595,7 +690,6 @@ pub async fn reconcile_open_incidents(
 	})
 	.await
 }
-
 async fn is_issue_in_open_incident(db: &mut AsyncPgConnection, issue_id: Uuid) -> Result<bool> {
 	use crate::schema::incident_issues;
 
@@ -948,15 +1042,8 @@ impl Issue {
 			let server = Server::get_by_id(conn, issue.server_id).await?;
 			if let Some(gid) = server.group_id {
 				// Unresolve rejoins; cascade close path doesn't fire here.
-				re_evaluate_incident_membership(
-					conn,
-					&issue,
-					gid,
-					server.is_monitored,
-					now,
-					None,
-				)
-				.await?;
+				re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
+					.await?;
 			}
 			Ok(issue)
 		})
@@ -986,15 +1073,8 @@ impl Issue {
 				.await?;
 			let server = Server::get_by_id(conn, issue.server_id).await?;
 			if let Some(gid) = server.group_id {
-				re_evaluate_incident_membership(
-					conn,
-					&issue,
-					gid,
-					server.is_monitored,
-					now,
-					None,
-				)
-				.await?;
+				re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
+					.await?;
 			}
 			Ok(issue)
 		})
@@ -1013,15 +1093,8 @@ impl Issue {
 				.await?;
 			let server = Server::get_by_id(conn, issue.server_id).await?;
 			if let Some(gid) = server.group_id {
-				re_evaluate_incident_membership(
-					conn,
-					&issue,
-					gid,
-					server.is_monitored,
-					now,
-					None,
-				)
-				.await?;
+				re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
+					.await?;
 			}
 			Ok(issue)
 		})

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -14,6 +14,7 @@ pub mod pg_duration;
 pub mod schema;
 pub mod server_groups;
 pub mod servers;
+pub mod silenced_refs;
 pub mod slack_outbox;
 pub mod sql_playground_history;
 pub mod statuses;

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -171,6 +171,17 @@ diesel::table! {
 }
 
 diesel::table! {
+	server_group_silenced_refs (server_group_id, source, ref_) {
+		server_group_id -> Uuid,
+		source -> Text,
+		#[sql_name = "ref"]
+		ref_ -> Text,
+		created_at -> Timestamptz,
+		created_by -> Nullable<Text>,
+	}
+}
+
+diesel::table! {
 	server_groups (id) {
 		id -> Uuid,
 		created_at -> Timestamptz,
@@ -178,6 +189,17 @@ diesel::table! {
 		name -> Text,
 		notes -> Text,
 		tags -> Jsonb,
+	}
+}
+
+diesel::table! {
+	server_silenced_refs (server_id, source, ref_) {
+		server_id -> Uuid,
+		source -> Text,
+		#[sql_name = "ref"]
+		ref_ -> Text,
+		created_at -> Timestamptz,
+		created_by -> Nullable<Text>,
 	}
 }
 
@@ -298,6 +320,8 @@ diesel::joinable!(incidents -> server_groups (server_group_id));
 diesel::joinable!(issue_notes -> issues (issue_id));
 diesel::joinable!(issues -> devices (device_id));
 diesel::joinable!(issues -> servers (server_id));
+diesel::joinable!(server_group_silenced_refs -> server_groups (server_group_id));
+diesel::joinable!(server_silenced_refs -> servers (server_id));
 diesel::joinable!(servers -> devices (device_id));
 diesel::joinable!(servers -> server_groups (group_id));
 diesel::joinable!(slack_outbox -> incident_notes (note_id));
@@ -322,7 +346,9 @@ diesel::allow_tables_to_appear_in_same_query!(
 	incidents,
 	issue_notes,
 	issues,
+	server_group_silenced_refs,
 	server_groups,
+	server_silenced_refs,
 	servers,
 	slack_outbox,
 	sql_playground_history,

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -405,6 +405,32 @@ impl Server {
 		Ok(rows.into_iter().collect())
 	}
 
+	/// Bulk-fetch `(group_id, group_name)` for each given server. Servers
+	/// that are ungrouped (or don't exist) get `(None, None)`.
+	pub async fn group_refs_by_server_ids(
+		db: &mut AsyncPgConnection,
+		ids: &[Uuid],
+	) -> Result<std::collections::HashMap<Uuid, (Option<Uuid>, Option<String>)>> {
+		use crate::schema::{server_groups, servers};
+		use std::collections::HashMap;
+
+		if ids.is_empty() {
+			return Ok(HashMap::new());
+		}
+		let rows: Vec<(Uuid, Option<Uuid>, Option<String>)> = servers::table
+			.left_join(server_groups::table.on(server_groups::id.nullable().eq(servers::group_id)))
+			.select((
+				servers::id,
+				servers::group_id,
+				server_groups::name.nullable(),
+			))
+			.filter(servers::id.eq_any(ids))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(rows.into_iter().map(|(id, gid, gn)| (id, (gid, gn))).collect())
+	}
+
 	pub async fn search_central(
 		db: &mut AsyncPgConnection,
 		query: &str,

--- a/crates/database/src/silenced_refs.rs
+++ b/crates/database/src/silenced_refs.rs
@@ -1,0 +1,246 @@
+//! Operator-managed silence list for issue refs.
+//!
+//! A silenced `(source, ref)` tuple at server or group scope tells the
+//! incident workflow to ignore the matching issues — they still record
+//! (so the issue and event rows exist), but
+//! [`crate::issues::re_evaluate_incident_membership`] treats them as a
+//! "should leave" reason, the same way it treats snoozed or unmonitored.
+//!
+//! Two sibling tables (`server_silenced_refs`, `server_group_silenced_refs`)
+//! keep referential integrity tight without nullable FKs. A given issue is
+//! silenced if either applies (server-scope wins for the server itself,
+//! group-scope catches the whole group).
+
+use commons_errors::{AppError, Result};
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::issues::{reevaluate_open_issues_for_group_ref, reevaluate_open_issues_for_server_ref};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::server_silenced_refs)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ServerSilencedRef {
+	pub server_id: Uuid,
+	pub source: String,
+	#[diesel(column_name = ref_)]
+	#[serde(rename = "ref")]
+	pub r#ref: String,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub created_at: Timestamp,
+	pub created_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::server_group_silenced_refs)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ServerGroupSilencedRef {
+	pub server_group_id: Uuid,
+	pub source: String,
+	#[diesel(column_name = ref_)]
+	#[serde(rename = "ref")]
+	pub r#ref: String,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub created_at: Timestamp,
+	pub created_by: Option<String>,
+}
+
+/// Does either the server-scope or group-scope silence list contain
+/// `(source, ref)` for this server? `group_id` is the server's current
+/// group; pass `None` if the server is ungrouped (and so can't be silenced
+/// at group scope).
+pub async fn is_silenced(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	group_id: Option<Uuid>,
+	source: &str,
+	r#ref: &str,
+) -> Result<bool> {
+	use crate::schema::{server_group_silenced_refs, server_silenced_refs};
+
+	let server_hit: i64 = server_silenced_refs::table
+		.filter(
+			server_silenced_refs::server_id
+				.eq(server_id)
+				.and(server_silenced_refs::source.eq(source))
+				.and(server_silenced_refs::ref_.eq(r#ref)),
+		)
+		.count()
+		.get_result(db)
+		.await
+		.map_err(AppError::from)?;
+	if server_hit > 0 {
+		return Ok(true);
+	}
+
+	let Some(gid) = group_id else {
+		return Ok(false);
+	};
+
+	let group_hit: i64 = server_group_silenced_refs::table
+		.filter(
+			server_group_silenced_refs::server_group_id
+				.eq(gid)
+				.and(server_group_silenced_refs::source.eq(source))
+				.and(server_group_silenced_refs::ref_.eq(r#ref)),
+		)
+		.count()
+		.get_result(db)
+		.await
+		.map_err(AppError::from)?;
+	Ok(group_hit > 0)
+}
+
+impl ServerSilencedRef {
+	/// Add a server-scoped silence and re-evaluate any currently-open
+	/// matching issues so they leave their incident. Idempotent: a
+	/// duplicate (`server_id`, `source`, `ref`) is a no-op (the
+	/// existing row's metadata is preserved).
+	pub async fn add(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+		source: &str,
+		r#ref: &str,
+		created_by: Option<&str>,
+	) -> Result<Self> {
+		use crate::schema::server_silenced_refs;
+
+		let row: Self = diesel::insert_into(server_silenced_refs::table)
+			.values((
+				server_silenced_refs::server_id.eq(server_id),
+				server_silenced_refs::source.eq(source),
+				server_silenced_refs::ref_.eq(r#ref),
+				server_silenced_refs::created_by.eq(created_by),
+			))
+			.on_conflict((
+				server_silenced_refs::server_id,
+				server_silenced_refs::source,
+				server_silenced_refs::ref_,
+			))
+			.do_update()
+			// no-op update so we can RETURNING the existing row
+			.set(server_silenced_refs::server_id.eq(server_id))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)?;
+
+		reevaluate_open_issues_for_server_ref(db, server_id, source, r#ref).await?;
+		Ok(row)
+	}
+
+	/// Remove a server-scoped silence and re-evaluate any currently-open
+	/// matching issues so they (re)join an incident if eligible.
+	pub async fn remove(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+		source: &str,
+		r#ref: &str,
+	) -> Result<()> {
+		use crate::schema::server_silenced_refs;
+
+		diesel::delete(
+			server_silenced_refs::table.filter(
+				server_silenced_refs::server_id
+					.eq(server_id)
+					.and(server_silenced_refs::source.eq(source))
+					.and(server_silenced_refs::ref_.eq(r#ref)),
+			),
+		)
+		.execute(db)
+		.await
+		.map_err(AppError::from)?;
+
+		reevaluate_open_issues_for_server_ref(db, server_id, source, r#ref).await?;
+		Ok(())
+	}
+
+	pub async fn list_for_server(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+	) -> Result<Vec<Self>> {
+		use crate::schema::server_silenced_refs::dsl;
+		dsl::server_silenced_refs
+			.select(Self::as_select())
+			.filter(dsl::server_id.eq(server_id))
+			.order(dsl::created_at.desc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+}
+
+impl ServerGroupSilencedRef {
+	pub async fn add(
+		db: &mut AsyncPgConnection,
+		server_group_id: Uuid,
+		source: &str,
+		r#ref: &str,
+		created_by: Option<&str>,
+	) -> Result<Self> {
+		use crate::schema::server_group_silenced_refs;
+
+		let row: Self = diesel::insert_into(server_group_silenced_refs::table)
+			.values((
+				server_group_silenced_refs::server_group_id.eq(server_group_id),
+				server_group_silenced_refs::source.eq(source),
+				server_group_silenced_refs::ref_.eq(r#ref),
+				server_group_silenced_refs::created_by.eq(created_by),
+			))
+			.on_conflict((
+				server_group_silenced_refs::server_group_id,
+				server_group_silenced_refs::source,
+				server_group_silenced_refs::ref_,
+			))
+			.do_update()
+			.set(server_group_silenced_refs::server_group_id.eq(server_group_id))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)?;
+
+		reevaluate_open_issues_for_group_ref(db, server_group_id, source, r#ref).await?;
+		Ok(row)
+	}
+
+	pub async fn remove(
+		db: &mut AsyncPgConnection,
+		server_group_id: Uuid,
+		source: &str,
+		r#ref: &str,
+	) -> Result<()> {
+		use crate::schema::server_group_silenced_refs;
+
+		diesel::delete(
+			server_group_silenced_refs::table.filter(
+				server_group_silenced_refs::server_group_id
+					.eq(server_group_id)
+					.and(server_group_silenced_refs::source.eq(source))
+					.and(server_group_silenced_refs::ref_.eq(r#ref)),
+			),
+		)
+		.execute(db)
+		.await
+		.map_err(AppError::from)?;
+
+		reevaluate_open_issues_for_group_ref(db, server_group_id, source, r#ref).await?;
+		Ok(())
+	}
+
+	pub async fn list_for_group(
+		db: &mut AsyncPgConnection,
+		server_group_id: Uuid,
+	) -> Result<Vec<Self>> {
+		use crate::schema::server_group_silenced_refs::dsl;
+		dsl::server_group_silenced_refs
+			.select(Self::as_select())
+			.filter(dsl::server_group_id.eq(server_group_id))
+			.order(dsl::created_at.desc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+}

--- a/crates/private-server/src/fns.rs
+++ b/crates/private-server/src/fns.rs
@@ -9,6 +9,7 @@ pub mod incidents;
 pub mod issues;
 pub mod server_groups;
 pub mod servers;
+pub mod silenced_refs;
 pub mod sql;
 pub mod statuses;
 pub mod versions;
@@ -34,6 +35,7 @@ pub fn routes() -> OpenApiRouter<crate::state::AppState> {
 			.nest("/issues", issues::routes())
 			.nest("/server_groups", server_groups::routes())
 			.nest("/servers", servers::routes())
+			.nest("/silenced_refs", silenced_refs::routes())
 			.nest("/sql", sql::routes())
 			.nest("/statuses", statuses::routes())
 			.nest("/versions", versions::routes()),

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -29,6 +29,10 @@ pub struct IssueData {
 	/// The issue's server name (may be null — fall back to `server_host`).
 	pub server_name: Option<String>,
 	pub server_host: String,
+	/// Group id the issue's server belongs to; `None` when ungrouped. Used
+	/// by the UI to offer group-scope actions (silence, etc.) without a
+	/// second fetch.
+	pub server_group_id: Option<Uuid>,
 	/// Display name of the group the issue's server belongs to. `None` when
 	/// the server is ungrouped; the UI hides the group prefix in that case.
 	pub server_group_name: Option<String>,
@@ -80,6 +84,7 @@ impl From<IssueIncidentRef> for IssueIncidentLink {
 struct IssueEnrichment<'a> {
 	server_name: Option<String>,
 	server_host: String,
+	server_group_id: Option<Uuid>,
 	server_group_name: Option<String>,
 	users: &'a std::collections::HashMap<String, CachedTailscaleUser>,
 	incidents: Vec<IssueIncidentLink>,
@@ -93,6 +98,7 @@ impl IssueData {
 			server_id: i.server_id,
 			server_name: e.server_name,
 			server_host: e.server_host,
+			server_group_id: e.server_group_id,
 			server_group_name: e.server_group_name,
 			device_id: i.device_id,
 			source: i.source,
@@ -148,7 +154,7 @@ pub(crate) async fn enrich_issues(
 ) -> Result<Vec<IssueData>> {
 	let server_ids: Vec<Uuid> = issues.iter().map(|i| i.server_id).collect();
 	let names = Server::names_by_ids(conn, &server_ids).await?;
-	let group_names = Server::group_names_by_server_ids(conn, &server_ids).await?;
+	let group_refs = Server::group_refs_by_server_ids(conn, &server_ids).await?;
 	let user_logins = collect_user_logins(&issues);
 	let users = CachedTailscaleUser::by_logins(conn, &user_logins).await?;
 	let issue_ids: Vec<Uuid> = issues.iter().map(|i| i.id).collect();
@@ -160,7 +166,10 @@ pub(crate) async fn enrich_issues(
 				.get(&i.server_id)
 				.cloned()
 				.unwrap_or((None, String::new()));
-			let group_name = group_names.get(&i.server_id).cloned().unwrap_or(None);
+			let (group_id, group_name) = group_refs
+				.get(&i.server_id)
+				.cloned()
+				.unwrap_or((None, None));
 			let links = incidents
 				.remove(&i.id)
 				.unwrap_or_default()
@@ -172,6 +181,7 @@ pub(crate) async fn enrich_issues(
 				IssueEnrichment {
 					server_name: name,
 					server_host: host,
+					server_group_id: group_id,
 					server_group_name: group_name,
 					users: &users,
 					incidents: links,
@@ -190,8 +200,10 @@ pub(crate) async fn enrich_issue(
 	let (name, host) = names
 		.remove(&issue.server_id)
 		.unwrap_or((None, String::new()));
-	let mut group_names = Server::group_names_by_server_ids(conn, &[issue.server_id]).await?;
-	let group_name = group_names.remove(&issue.server_id).unwrap_or(None);
+	let mut group_refs = Server::group_refs_by_server_ids(conn, &[issue.server_id]).await?;
+	let (group_id, group_name) = group_refs
+		.remove(&issue.server_id)
+		.unwrap_or((None, None));
 	let user_logins = collect_user_logins(std::slice::from_ref(&issue));
 	let users = CachedTailscaleUser::by_logins(conn, &user_logins).await?;
 	let mut incidents = Incident::for_issues(conn, &[issue.id]).await?;
@@ -206,6 +218,7 @@ pub(crate) async fn enrich_issue(
 		IssueEnrichment {
 			server_name: name,
 			server_host: host,
+			server_group_id: group_id,
 			server_group_name: group_name,
 			users: &users,
 			incidents: links,

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -504,8 +504,7 @@ pub async fn update(
 	// `group_id` (ungrouped → grouped opens pending issues into incidents)
 	// and `is_monitored` (un/monitored toggles incident eligibility
 	// symmetrically — on enrols open issues, off cascades them out).
-	let touches_catchup_field =
-		args.data.group_id.is_some() || args.data.is_monitored.is_some();
+	let touches_catchup_field = args.data.group_id.is_some() || args.data.is_monitored.is_some();
 	let before = if touches_catchup_field {
 		Some(Server::get_by_id(&mut conn, args.server_id).await?)
 	} else {

--- a/crates/private-server/src/fns/silenced_refs.rs
+++ b/crates/private-server/src/fns/silenced_refs.rs
@@ -1,0 +1,182 @@
+use axum::Json;
+use axum::extract::State;
+use commons_errors::{ProblemDetailsSchema, Result};
+use commons_servers::tailscale_auth::TailscaleAdmin;
+use commons_types::Uuid;
+use database::silenced_refs::{ServerGroupSilencedRef, ServerSilencedRef};
+use serde::Deserialize;
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::state::AppState;
+
+pub fn routes() -> OpenApiRouter<AppState> {
+	OpenApiRouter::new()
+		.routes(routes!(list_for_server))
+		.routes(routes!(list_for_group))
+		.routes(routes!(silence_server))
+		.routes(routes!(unsilence_server))
+		.routes(routes!(silence_group))
+		.routes(routes!(unsilence_group))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct ServerScopeArgs {
+	pub server_id: Uuid,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct GroupScopeArgs {
+	pub server_group_id: Uuid,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct SilenceServerArgs {
+	pub server_id: Uuid,
+	pub source: String,
+	#[serde(rename = "ref")]
+	pub r#ref: String,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct SilenceGroupArgs {
+	pub server_group_id: Uuid,
+	pub source: String,
+	#[serde(rename = "ref")]
+	pub r#ref: String,
+}
+
+#[utoipa::path(
+	post,
+	path = "/list_for_server",
+	tag = "silenced_refs",
+	security(("tailscale-user" = [])),
+	request_body = ServerScopeArgs,
+	responses(
+		(status = 200, body = Vec<ServerSilencedRef>),
+	),
+)]
+pub async fn list_for_server(
+	State(state): State<AppState>,
+	Json(args): Json<ServerScopeArgs>,
+) -> Result<Json<Vec<ServerSilencedRef>>> {
+	let mut conn = state.db.get().await?;
+	let rows = ServerSilencedRef::list_for_server(&mut conn, args.server_id).await?;
+	Ok(Json(rows))
+}
+
+#[utoipa::path(
+	post,
+	path = "/list_for_group",
+	tag = "silenced_refs",
+	security(("tailscale-user" = [])),
+	request_body = GroupScopeArgs,
+	responses(
+		(status = 200, body = Vec<ServerGroupSilencedRef>),
+	),
+)]
+pub async fn list_for_group(
+	State(state): State<AppState>,
+	Json(args): Json<GroupScopeArgs>,
+) -> Result<Json<Vec<ServerGroupSilencedRef>>> {
+	let mut conn = state.db.get().await?;
+	let rows = ServerGroupSilencedRef::list_for_group(&mut conn, args.server_group_id).await?;
+	Ok(Json(rows))
+}
+
+#[utoipa::path(
+	post,
+	path = "/silence_server",
+	tag = "silenced_refs",
+	security(("tailscale-admin" = [])),
+	request_body = SilenceServerArgs,
+	responses(
+		(status = 200, body = ServerSilencedRef),
+		(status = 400, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn silence_server(
+	State(state): State<AppState>,
+	admin: TailscaleAdmin,
+	Json(args): Json<SilenceServerArgs>,
+) -> Result<Json<ServerSilencedRef>> {
+	let mut conn = state.db.get().await?;
+	let row = ServerSilencedRef::add(
+		&mut conn,
+		args.server_id,
+		&args.source,
+		&args.r#ref,
+		Some(&admin.0.login),
+	)
+	.await?;
+	Ok(Json(row))
+}
+
+#[utoipa::path(
+	post,
+	path = "/unsilence_server",
+	tag = "silenced_refs",
+	security(("tailscale-admin" = [])),
+	request_body = SilenceServerArgs,
+	responses(
+		(status = 200),
+	),
+)]
+pub async fn unsilence_server(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<SilenceServerArgs>,
+) -> Result<Json<()>> {
+	let mut conn = state.db.get().await?;
+	ServerSilencedRef::remove(&mut conn, args.server_id, &args.source, &args.r#ref).await?;
+	Ok(Json(()))
+}
+
+#[utoipa::path(
+	post,
+	path = "/silence_group",
+	tag = "silenced_refs",
+	security(("tailscale-admin" = [])),
+	request_body = SilenceGroupArgs,
+	responses(
+		(status = 200, body = ServerGroupSilencedRef),
+		(status = 400, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn silence_group(
+	State(state): State<AppState>,
+	admin: TailscaleAdmin,
+	Json(args): Json<SilenceGroupArgs>,
+) -> Result<Json<ServerGroupSilencedRef>> {
+	let mut conn = state.db.get().await?;
+	let row = ServerGroupSilencedRef::add(
+		&mut conn,
+		args.server_group_id,
+		&args.source,
+		&args.r#ref,
+		Some(&admin.0.login),
+	)
+	.await?;
+	Ok(Json(row))
+}
+
+#[utoipa::path(
+	post,
+	path = "/unsilence_group",
+	tag = "silenced_refs",
+	security(("tailscale-admin" = [])),
+	request_body = SilenceGroupArgs,
+	responses(
+		(status = 200),
+	),
+)]
+pub async fn unsilence_group(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<SilenceGroupArgs>,
+) -> Result<Json<()>> {
+	let mut conn = state.db.get().await?;
+	ServerGroupSilencedRef::remove(&mut conn, args.server_group_id, &args.source, &args.r#ref)
+		.await?;
+	Ok(Json(()))
+}

--- a/crates/private-server/tests/issues.rs
+++ b/crates/private-server/tests/issues.rs
@@ -933,6 +933,236 @@ async fn disabling_monitoring_removes_open_contribution() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn silencing_server_ref_closes_only_matching_open_incident() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		conn.batch_execute("INSERT INTO admins (email) VALUES ('admin@example.com')")
+			.await
+			.expect("seed admin");
+
+		let server_id = Uuid::new_v4();
+		let _issue_id = open_issue(&mut conn, &private, server_id).await;
+
+		// File a *different* ref on the same server — also an incident-class
+		// issue. Two incidents, or one incident with two contributors? Per
+		// the existing semantics, the first opens a group incident and the
+		// second joins it. We'll see one open incident with two contributors.
+		let resp = private
+			.post("/api/issues/submit_manual_event")
+			.json(&serde_json::json!({
+				"serverId": server_id,
+				"ref": "other",
+				"severity": "error",
+				"message": "second contributor",
+			}))
+			.await;
+		resp.assert_status_ok();
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		assert_eq!(resp.json::<Vec<serde_json::Value>>().len(), 1);
+
+		// Silence the first ref at server scope. The second contributor
+		// keeps the incident open.
+		let resp = private
+			.post("/api/silenced_refs/silence_server")
+			.json(&serde_json::json!({
+				"server_id": server_id,
+				"source": "manual",
+				"ref": "x",
+			}))
+			.await;
+		resp.assert_status_ok();
+
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		let items: Vec<serde_json::Value> = resp.json();
+		assert_eq!(items.len(), 1, "still open via the unsilenced contributor");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unsilencing_server_ref_rejoins_open_incident() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		conn.batch_execute("INSERT INTO admins (email) VALUES ('admin@example.com')")
+			.await
+			.expect("seed admin");
+
+		let server_id = Uuid::new_v4();
+		let _issue_id = open_issue(&mut conn, &private, server_id).await;
+
+		// Silence then unsilence: the (re-)evaluation should leave the issue
+		// in the same state we started in.
+		let resp = private
+			.post("/api/silenced_refs/silence_server")
+			.json(&serde_json::json!({
+				"server_id": server_id,
+				"source": "manual",
+				"ref": "x",
+			}))
+			.await;
+		resp.assert_status_ok();
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id, "include_closed": true }))
+			.await;
+		let items: Vec<serde_json::Value> = resp.json();
+		assert_eq!(items.len(), 1, "incident row exists for history");
+		assert!(
+			items[0].get("closed_at").is_some_and(|v| !v.is_null()),
+			"silenced lone contributor closes the incident",
+		);
+
+		let resp = private
+			.post("/api/silenced_refs/unsilence_server")
+			.json(&serde_json::json!({
+				"server_id": server_id,
+				"source": "manual",
+				"ref": "x",
+			}))
+			.await;
+		resp.assert_status_ok();
+
+		// Unsilence reopens via a fresh incident (the old one stays closed).
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		let items: Vec<serde_json::Value> = resp.json();
+		assert_eq!(items.len(), 1, "fresh incident after unsilence");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn group_silence_blocks_events_from_all_members() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		conn.batch_execute("INSERT INTO admins (email) VALUES ('admin@example.com')")
+			.await
+			.expect("seed admin");
+
+		let group_id = Uuid::new_v4();
+		let server_a = Uuid::new_v4();
+		let server_b = Uuid::new_v4();
+		conn.batch_execute(&format!(
+			"INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g');
+			 INSERT INTO servers (id, host, kind, group_id) VALUES \
+				('{server_a}', 'https://a.example.com', 'central', '{group_id}'),
+				('{server_b}', 'https://b.example.com', 'central', '{group_id}');"
+		))
+		.await
+		.expect("seed");
+
+		// Silence the ref at group scope.
+		let resp = private
+			.post("/api/silenced_refs/silence_group")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"source": "manual",
+				"ref": "noisy",
+			}))
+			.await;
+		resp.assert_status_ok();
+
+		// Either member firing the silenced ref doesn't open an incident.
+		for sid in [server_a, server_b] {
+			let resp = private
+				.post("/api/issues/submit_manual_event")
+				.json(&serde_json::json!({
+					"serverId": sid,
+					"ref": "noisy",
+					"severity": "error",
+					"message": "should not fire",
+				}))
+				.await;
+			resp.assert_status_ok();
+		}
+
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_a }))
+			.await;
+		assert!(resp.json::<Vec<serde_json::Value>>().is_empty());
+
+		// A different ref still opens an incident — silence is ref-specific.
+		let resp = private
+			.post("/api/issues/submit_manual_event")
+			.json(&serde_json::json!({
+				"serverId": server_a,
+				"ref": "other",
+				"severity": "error",
+				"message": "should still fire",
+			}))
+			.await;
+		resp.assert_status_ok();
+		let resp = private
+			.post("/api/incidents/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_a }))
+			.await;
+		assert_eq!(resp.json::<Vec<serde_json::Value>>().len(), 1);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_silenced_refs_for_server_and_group() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		conn.batch_execute("INSERT INTO admins (email) VALUES ('admin@example.com')")
+			.await
+			.expect("seed admin");
+
+		let group_id = Uuid::new_v4();
+		let server_id = Uuid::new_v4();
+		conn.batch_execute(&format!(
+			"INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g');
+			 INSERT INTO servers (id, host, kind, group_id) VALUES \
+				('{server_id}', 'https://l.example.com', 'central', '{group_id}');"
+		))
+		.await
+		.expect("seed");
+
+		private
+			.post("/api/silenced_refs/silence_server")
+			.json(&serde_json::json!({
+				"server_id": server_id,
+				"source": "manual",
+				"ref": "srv-ref",
+			}))
+			.await
+			.assert_status_ok();
+		private
+			.post("/api/silenced_refs/silence_group")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"source": "canopy",
+				"ref": "grp-ref",
+			}))
+			.await
+			.assert_status_ok();
+
+		let resp = private
+			.post("/api/silenced_refs/list_for_server")
+			.json(&serde_json::json!({ "server_id": server_id }))
+			.await;
+		let items: Vec<serde_json::Value> = resp.json();
+		assert_eq!(items.len(), 1);
+		assert_eq!(items[0].get("ref").and_then(|v| v.as_str()), Some("srv-ref"));
+
+		let resp = private
+			.post("/api/silenced_refs/list_for_group")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		let items: Vec<serde_json::Value> = resp.json();
+		assert_eq!(items.len(), 1);
+		assert_eq!(items[0].get("ref").and_then(|v| v.as_str()), Some("grp-ref"));
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn incident_resolve_metadata() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let server_id = Uuid::new_v4();

--- a/migrations/2026-05-23-200000-0000_silenced_refs/down.sql
+++ b/migrations/2026-05-23-200000-0000_silenced_refs/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE server_group_silenced_refs;
+DROP TABLE server_silenced_refs;

--- a/migrations/2026-05-23-200000-0000_silenced_refs/up.sql
+++ b/migrations/2026-05-23-200000-0000_silenced_refs/up.sql
@@ -1,0 +1,31 @@
+-- Operator-managed silence list for issue refs. A silenced (source, ref)
+-- tuple at server or group scope prevents the matching issues from
+-- contributing to incidents — they still record (so the audit trail
+-- works) but the incident workflow treats them as if they had left.
+--
+-- Two tables rather than one nullable-FK table so referential integrity
+-- and uniqueness are enforced by Postgres without a CHECK gymnastics
+-- pattern. The scope is implicit in which table the row lives in.
+
+CREATE TABLE server_silenced_refs (
+	server_id UUID NOT NULL REFERENCES servers (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	source TEXT NOT NULL,
+	ref TEXT NOT NULL,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+	created_by TEXT,
+	PRIMARY KEY (server_id, source, ref)
+);
+
+CREATE TABLE server_group_silenced_refs (
+	server_group_id UUID NOT NULL REFERENCES server_groups (id) ON DELETE CASCADE ON UPDATE CASCADE,
+	source TEXT NOT NULL,
+	ref TEXT NOT NULL,
+	created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+	created_by TEXT,
+	PRIMARY KEY (server_group_id, source, ref)
+);
+
+-- Secondary lookups by (source, ref) — when the incident-membership
+-- re-evaluation asks "is this (server_id, source, ref) silenced at server
+-- scope?", the primary key index is exactly what we need. The same is
+-- true for the group-scoped table. So no extra indexes for now.

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -2439,6 +2439,228 @@
         ]
       }
     },
+    "/api/silenced_refs/list_for_group": {
+      "post": {
+        "tags": [
+          "silenced_refs"
+        ],
+        "operationId": "list_for_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GroupScopeArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServerGroupSilencedRef"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
+    "/api/silenced_refs/list_for_server": {
+      "post": {
+        "tags": [
+          "silenced_refs"
+        ],
+        "operationId": "list_for_server",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServerScopeArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ServerSilencedRef"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
+    "/api/silenced_refs/silence_group": {
+      "post": {
+        "tags": [
+          "silenced_refs"
+        ],
+        "operationId": "silence_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SilenceGroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerGroupSilencedRef"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/silenced_refs/silence_server": {
+      "post": {
+        "tags": [
+          "silenced_refs"
+        ],
+        "operationId": "silence_server",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SilenceServerArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerSilencedRef"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/silenced_refs/unsilence_group": {
+      "post": {
+        "tags": [
+          "silenced_refs"
+        ],
+        "operationId": "unsilence_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SilenceGroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/silenced_refs/unsilence_server": {
+      "post": {
+        "tags": [
+          "silenced_refs"
+        ],
+        "operationId": "unsilence_server",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SilenceServerArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/sql/execute_query": {
       "post": {
         "tags": [
@@ -3812,6 +4034,18 @@
           }
         }
       },
+      "GroupScopeArgs": {
+        "type": "object",
+        "required": [
+          "server_group_id"
+        ],
+        "properties": {
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "HealthState": {
         "type": "string",
         "description": "Server's self-reported health state, derived from the most\nrecent status row's `healthy` field and `health[]` array.\nOrthogonal to [`ShortStatus`]: a server can be reachable\n(`up`) and reporting itself unhealthy at the same time.\n\nThe UI renders this as the *border* of `<StatusDot>` so both\ndimensions (reachability and self-report) show in one glyph.",
@@ -4152,6 +4386,14 @@
               "null"
             ],
             "description": "The string stored in the DB; parses to `ResolvedReason` if valid.\nKept as String to round-trip any historical value."
+          },
+          "server_group_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Group id the issue's server belongs to; `None` when ungrouped. Used\nby the UI to offer group-scope actions (silence, etc.) without a\nsecond fetch."
           },
           "server_group_name": {
             "type": [
@@ -5383,6 +5625,37 @@
           }
         }
       },
+      "ServerGroupSilencedRef": {
+        "type": "object",
+        "required": [
+          "server_group_id",
+          "source",
+          "ref",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref": {
+            "type": "string"
+          },
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
+      },
       "ServerIdArgs": {
         "type": "object",
         "required": [
@@ -5615,6 +5888,49 @@
           "dev"
         ]
       },
+      "ServerScopeArgs": {
+        "type": "object",
+        "required": [
+          "server_id"
+        ],
+        "properties": {
+          "server_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "ServerSilencedRef": {
+        "type": "object",
+        "required": [
+          "server_id",
+          "source",
+          "ref",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref": {
+            "type": "string"
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
+      },
       "Severity": {
         "type": "string",
         "description": "RFC 5424 syslog severities.\n\nStored as text in Postgres; validated as this enum at the API layer.\nDefault is `Error` (incidents only open at severity ≥ Error, so the\ndefault is intentionally above the floor — most devices that bother\npushing an event mean it).",
@@ -5638,6 +5954,46 @@
           "blip",
           "gone"
         ]
+      },
+      "SilenceGroupArgs": {
+        "type": "object",
+        "required": [
+          "server_group_id",
+          "source",
+          "ref"
+        ],
+        "properties": {
+          "ref": {
+            "type": "string"
+          },
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
+      },
+      "SilenceServerArgs": {
+        "type": "object",
+        "required": [
+          "server_id",
+          "source",
+          "ref"
+        ],
+        "properties": {
+          "ref": {
+            "type": "string"
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
       },
       "SnapshotArgs": {
         "type": "object",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -999,6 +999,102 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/silenced_refs/list_for_group": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["list_for_group"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/silenced_refs/list_for_server": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["list_for_server"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/silenced_refs/silence_group": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["silence_group"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/silenced_refs/silence_server": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["silence_server"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/silenced_refs/unsilence_group": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["unsilence_group"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/silenced_refs/unsilence_server": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["unsilence_server"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/sql/execute_query": {
         parameters: {
             query?: never;
@@ -1508,6 +1604,10 @@ export interface components {
             /** Format: uuid */
             server_group_id: string;
         };
+        GroupScopeArgs: {
+            /** Format: uuid */
+            server_group_id: string;
+        };
         /**
          * @description Server's self-reported health state, derived from the most
          *     recent status row's `healthy` field and `health[]` array.
@@ -1626,6 +1726,13 @@ export interface components {
              *     Kept as String to round-trip any historical value.
              */
             resolved_reason?: string | null;
+            /**
+             * Format: uuid
+             * @description Group id the issue's server belongs to; `None` when ungrouped. Used
+             *     by the UI to offer group-scope actions (silence, etc.) without a
+             *     second fetch.
+             */
+            server_group_id?: string | null;
             /**
              * @description Display name of the group the issue's server belongs to. `None` when
              *     the server is ungrouped; the UI hides the group prefix in that case.
@@ -2057,6 +2164,15 @@ export interface components {
             /** Format: int64 */
             version_distance?: number | null;
         };
+        ServerGroupSilencedRef: {
+            /** Format: date-time */
+            created_at: string;
+            created_by?: string | null;
+            ref: string;
+            /** Format: uuid */
+            server_group_id: string;
+            source: string;
+        };
         ServerIdArgs: {
             /** Format: uuid */
             server_id: string;
@@ -2129,6 +2245,19 @@ export interface components {
         };
         /** @enum {string} */
         ServerRank: "production" | "clone" | "demo" | "test" | "dev";
+        ServerScopeArgs: {
+            /** Format: uuid */
+            server_id: string;
+        };
+        ServerSilencedRef: {
+            /** Format: date-time */
+            created_at: string;
+            created_by?: string | null;
+            ref: string;
+            /** Format: uuid */
+            server_id: string;
+            source: string;
+        };
         /**
          * @description RFC 5424 syslog severities.
          *
@@ -2141,6 +2270,18 @@ export interface components {
         Severity: "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug";
         /** @enum {string} */
         ShortStatus: "up" | "down" | "away" | "blip" | "gone";
+        SilenceGroupArgs: {
+            ref: string;
+            /** Format: uuid */
+            server_group_id: string;
+            source: string;
+        };
+        SilenceServerArgs: {
+            ref: string;
+            /** Format: uuid */
+            server_id: string;
+            source: string;
+        };
         SnapshotArgs: {
             /**
              * Format: date-time
@@ -4044,6 +4185,156 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
                 };
+            };
+        };
+    };
+    list_for_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupScopeArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ServerGroupSilencedRef"][];
+                };
+            };
+        };
+    };
+    list_for_server: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ServerScopeArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ServerSilencedRef"][];
+                };
+            };
+        };
+    };
+    silence_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SilenceGroupArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ServerGroupSilencedRef"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    silence_server: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SilenceServerArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ServerSilencedRef"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    unsilence_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SilenceGroupArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    unsilence_server: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SilenceServerArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/private-web/src/components/IssueRow.tsx
+++ b/private-web/src/components/IssueRow.tsx
@@ -14,6 +14,7 @@ import {
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import NotificationsOffOutlinedIcon from "@mui/icons-material/NotificationsOffOutlined";
 import SnoozeIcon from "@mui/icons-material/Snooze";
 import { Fragment, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
@@ -326,9 +327,12 @@ function IssueActions({
 	const unresolve = useApiAction("issues", "unresolve");
 	const snooze = useApiAction("issues", "snooze");
 	const unsnooze = useApiAction("issues", "unsnooze");
+	const silenceServer = useApiAction("silenced_refs", "silence_server");
+	const silenceGroup = useApiAction("silenced_refs", "silence_group");
 
 	const [resolveOpen, setResolveOpen] = useState(false);
 	const [snoozeOpen, setSnoozeOpen] = useState(false);
+	const [silenceOpen, setSilenceOpen] = useState(false);
 	const [reason, setReason] = useState<ResolvedReason>("fixed");
 	const [snoozeHours, setSnoozeHours] = useState(4);
 
@@ -342,7 +346,12 @@ function IssueActions({
 	};
 
 	const error =
-		resolve.error ?? unresolve.error ?? snooze.error ?? unsnooze.error;
+		resolve.error
+		?? unresolve.error
+		?? snooze.error
+		?? unsnooze.error
+		?? silenceServer.error
+		?? silenceGroup.error;
 
 	return (
 		<Box sx={{ mt: 1 }}>
@@ -388,6 +397,14 @@ function IssueActions({
 						Snooze…
 					</Button>
 				)}
+				<Button
+					size="small"
+					variant="outlined"
+					startIcon={<NotificationsOffOutlinedIcon />}
+					onClick={() => setSilenceOpen((v) => !v)}
+				>
+					Silence ref…
+				</Button>
 				<AddNoteButton
 					apiModule="issues"
 					parentKey="issue_id"
@@ -467,6 +484,58 @@ function IssueActions({
 					>
 						Cancel
 					</Button>
+				</Stack>
+			)}
+			{silenceOpen && (
+				<Stack spacing={1} sx={{ mt: 1 }}>
+					<Typography variant="body2" color="text.secondary">
+						Permanently ignore <code>{issue.source}/{issue.ref}</code> issues at
+						the chosen scope. The issues still record, but no longer trigger or
+						join incidents. Manage and un-silence from the detail page.
+					</Typography>
+					<Stack direction="row" spacing={1}>
+						<Button
+							variant="outlined"
+							size="small"
+							startIcon={<NotificationsOffOutlinedIcon />}
+							onClick={() =>
+								wrap(() =>
+									silenceServer.call({
+										server_id: issue.server_id,
+										source: issue.source,
+										ref: issue.ref,
+									}),
+								).then(() => setSilenceOpen(false))
+							}
+						>
+							For this server
+						</Button>
+						{issue.server_group_id && (
+							<Button
+								variant="outlined"
+								size="small"
+								startIcon={<NotificationsOffOutlinedIcon />}
+								onClick={() =>
+									wrap(() =>
+										silenceGroup.call({
+											server_group_id: issue.server_group_id!,
+											source: issue.source,
+											ref: issue.ref,
+										}),
+									).then(() => setSilenceOpen(false))
+								}
+							>
+								For this group
+							</Button>
+						)}
+						<Button
+							variant="outlined"
+							size="small"
+							onClick={() => setSilenceOpen(false)}
+						>
+							Cancel
+						</Button>
+					</Stack>
 				</Stack>
 			)}
 			{error && (

--- a/private-web/src/components/SilencedRefsSection.tsx
+++ b/private-web/src/components/SilencedRefsSection.tsx
@@ -1,0 +1,194 @@
+import {
+	Alert,
+	Box,
+	Button,
+	LinearProgress,
+	Paper,
+	Stack,
+	Typography,
+} from "@mui/material";
+import NotificationsActiveOutlinedIcon from "@mui/icons-material/NotificationsActiveOutlined";
+import { useState } from "react";
+import { useApi, useApiAction } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
+import TimeAgo from "./TimeAgo";
+
+/// Listed at the bottom of the server / group detail page. Renders the
+/// `(source, ref)` tuples that the operator has silenced at that scope and
+/// offers an un-silence button per row. Silenced refs don't contribute to
+/// incidents — see `database::silenced_refs` for the matching backend.
+export default function SilencedRefsSection({
+	scope,
+	id,
+}: {
+	scope: "server" | "group";
+	id: string;
+}) {
+	const isAdmin = useIsAdmin() === true;
+	const [tick, setTick] = useState(0);
+	const reload = () => setTick((t) => t + 1);
+
+	const result =
+		scope === "server"
+			? useApi(
+					"silenced_refs",
+					"list_for_server",
+					{ server_id: id },
+					[id, tick],
+				)
+			: useApi(
+					"silenced_refs",
+					"list_for_group",
+					{ server_group_id: id },
+					[id, tick],
+				);
+
+	if (result.status === "loading" || result.status === "idle") {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<SectionHeading scope={scope} />
+				<LinearProgress />
+			</Paper>
+		);
+	}
+	if (result.status === "error") {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<SectionHeading scope={scope} />
+				<Alert severity="error">{result.error.message}</Alert>
+			</Paper>
+		);
+	}
+	const rows = result.data;
+	if (rows.length === 0) {
+		return null;
+	}
+
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }}>
+			<SectionHeading scope={scope} />
+			<Stack spacing={1}>
+				{rows.map((row) => (
+					<SilencedRow
+						key={`${row.source}\x00${row.ref}`}
+						scope={scope}
+						id={id}
+						source={row.source}
+						refName={row.ref}
+						createdAt={row.created_at}
+						createdBy={row.created_by ?? null}
+						isAdmin={isAdmin}
+						onChanged={reload}
+					/>
+				))}
+			</Stack>
+		</Paper>
+	);
+}
+
+function SectionHeading({ scope }: { scope: "server" | "group" }) {
+	return (
+		<Typography variant="h6" component="h2" gutterBottom>
+			Silenced refs
+			<Typography
+				component="span"
+				variant="body2"
+				color="text.secondary"
+				sx={{ ml: 1 }}
+			>
+				{scope === "server"
+					? "— issues with these refs on this server don't open incidents."
+					: "— issues with these refs anywhere in this group don't open incidents."}
+			</Typography>
+		</Typography>
+	);
+}
+
+function SilencedRow({
+	scope,
+	id,
+	source,
+	refName,
+	createdAt,
+	createdBy,
+	isAdmin,
+	onChanged,
+}: {
+	scope: "server" | "group";
+	id: string;
+	source: string;
+	refName: string;
+	createdAt: string;
+	createdBy: string | null;
+	isAdmin: boolean;
+	onChanged: () => void;
+}) {
+	const unsilenceServer = useApiAction("silenced_refs", "unsilence_server");
+	const unsilenceGroup = useApiAction("silenced_refs", "unsilence_group");
+	const pending =
+		scope === "server" ? unsilenceServer.pending : unsilenceGroup.pending;
+	const error =
+		scope === "server" ? unsilenceServer.error : unsilenceGroup.error;
+	const unsilence = async () => {
+		try {
+			if (scope === "server") {
+				await unsilenceServer.call({
+					server_id: id,
+					source,
+					ref: refName,
+				});
+			} else {
+				await unsilenceGroup.call({
+					server_group_id: id,
+					source,
+					ref: refName,
+				});
+			}
+			onChanged();
+		} catch {
+			/* surfaced via error */
+		}
+	};
+
+	return (
+		<Box
+			sx={{
+				p: 1.5,
+				border: 1,
+				borderColor: "divider",
+				borderRadius: 1,
+			}}
+		>
+			<Stack
+				direction="row"
+				spacing={1}
+				sx={{ alignItems: "center", flexWrap: "wrap" }}
+				useFlexGap
+			>
+				<Typography
+					component="code"
+					sx={{ fontFamily: "monospace", fontWeight: 500 }}
+				>
+					{source}/{refName}
+				</Typography>
+				<Box sx={{ flex: 1 }} />
+				<Typography variant="caption" color="text.secondary">
+					silenced <TimeAgo timestamp={createdAt} />
+					{createdBy && ` by ${createdBy}`}
+				</Typography>
+				{isAdmin && (
+					<Button
+						size="small"
+						variant="outlined"
+						startIcon={<NotificationsActiveOutlinedIcon />}
+						disabled={pending}
+						onClick={unsilence}
+					>
+						Un-silence
+					</Button>
+				)}
+			</Stack>
+			{error && <Alert severity="error" sx={{ mt: 1 }}>{error.message}</Alert>}
+		</Box>
+	);
+}

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -11,6 +11,7 @@ import {
 import EditIcon from "@mui/icons-material/Edit";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import ServerShorty from "../components/ServerShorty";
+import SilencedRefsSection from "../components/SilencedRefsSection";
 import { useApi } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
 
@@ -99,6 +100,8 @@ export default function GroupDetail() {
 					</Stack>
 				)}
 			</Box>
+
+			<SilencedRefsSection scope="group" id={group.id} />
 		</Stack>
 	);
 }

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -25,6 +25,7 @@ import { Fragment, useEffect, useState } from "react";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import IncidentsLink from "../components/IncidentsLink";
 import ManualEventButton from "../components/ManualEventButton";
+import SilencedRefsSection from "../components/SilencedRefsSection";
 import StatusDot from "../components/StatusDot";
 import TailnetIdentitySection from "../components/TailnetIdentitySection";
 import TimeAgo from "../components/TimeAgo";
@@ -129,6 +130,7 @@ export default function ServerDetail() {
 					onEventSubmitted={bumpRefresh}
 				/>
 			)}
+			<SilencedRefsSection scope="server" id={data.server.id} />
 			<Box>
 				<VersionLegend />
 				<Box sx={{ mt: 1 }}>

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -101,6 +101,8 @@ export type ServerInfo = Solidify<Schemas["ServerInfo"]>;
 export type ServerLastStatusData = Solidify<Schemas["ServerLastStatusData"]>;
 export type ServerDetailData = Solidify<Schemas["ServerDetailData"]>;
 export type StatusSnapshotData = Solidify<Schemas["StatusSnapshotData"]>;
+export type ServerSilencedRef = Solidify<Schemas["ServerSilencedRef"]>;
+export type ServerGroupSilencedRef = Solidify<Schemas["ServerGroupSilencedRef"]>;
 
 export type DeviceData = Solidify<Schemas["DeviceData"]>;
 export type DeviceKeyInfo = Solidify<Schemas["DeviceKeyInfo"]>;


### PR DESCRIPTION
🤖 Operators want a way to permanently silence a specific issue ref either for a particular server or for a particular server group — sister to snooze, but with no expiry. Issues that match a silenced (source, ref) still record (rows go in, events coalesce), they just don't trigger or join incidents.

## Data model

Two sibling tables — `server_silenced_refs` and `server_group_silenced_refs` — each keyed on `(parent_id, source, ref)` with `created_at` and `created_by`. Separate tables rather than one nullable-FK + CHECK because referential integrity is cheaper that way and the scope is implicit in which table the row lives in.

## Incident hook

The silence check slots in next to the existing `snoozed` / `monitored` gates in `re_evaluate_incident_membership`:

```rust
let should_leave = !active || resolved || snoozed || silenced || !monitored;
let should_join = monitored && !silenced && active && !resolved && !snoozed && ...;
```

Add/remove run the same catch-up the monitored toggle uses (`reevaluate_open_issues_for_{server,group}_ref`) so flipping the silence drives matching open issues to leave (closing their incident if they were the only contributor) or rejoin immediately.

## UI

- **Silenced refs section** at the bottom of server detail and group detail pages: lists each silenced (source, ref), who silenced it and when, with an "Un-silence" button per row. Section hides itself when empty so it doesn't add visual noise.
- **"Silence ref…" action** on each issue row, sibling to Resolve / Snooze. Opens a panel offering "For this server" and (when grouped) "For this group", with a one-line explainer about what silence does.

## Backend changes worth flagging

- `IssueData` gains `server_group_id` so the silence UI can offer group-scope without a second fetch. Powered by a new `Server::group_refs_by_server_ids` batch helper.
- Six new endpoints under `/api/silenced_refs/`: list_for_{server,group}, silence_{server,group}, unsilence_{server,group}. List is tailscale-user; mutations are tailscale-admin.