### PR TITLE
Silence individual healthchecks from the ChecksTable

### DIFF
--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -13,6 +13,7 @@ use database::{
 	diesel_async::{AsyncConnection, AsyncPgConnection},
 	issues::NewEvent,
 	servers::Server,
+	silenced_refs,
 	statuses::{NewStatus, Status},
 };
 use serde::Deserialize;
@@ -111,9 +112,8 @@ async fn create(
 	let mut db = db.get().await?;
 	let Device { role, id, .. } = device.0.0;
 
-	let is_authorized = role == DeviceRole::Admin || {
-		Server::get_by_id(&mut db, server_id).await?.device_id == Some(id)
-	};
+	let server = Server::get_by_id(&mut db, server_id).await?;
+	let is_authorized = role == DeviceRole::Admin || server.device_id == Some(id);
 
 	if !is_authorized {
 		return Err(AppError::custom(
@@ -123,6 +123,21 @@ async fn create(
 
 	let raw = body.map(|j| j.0).unwrap_or(serde_json::Value::Null);
 	let (healthy, health, extra) = split_health_from_extra(raw)?;
+
+	// "Healthy by proxy of silence": if the device reports unhealthy but
+	// every failing check's `(status, health/<check>)` ref is silenced at
+	// server or group scope, treat the overall as healthy. Without this,
+	// the per-check issues correctly skip the incident workflow (silence
+	// gates them) but the *roll-up* `(status, health)` issue still fires
+	// — opening an incident anyway, defeating the silence. See
+	// `database::silenced_refs::is_silenced`.
+	let healthy = if healthy {
+		true
+	} else {
+		let failing = collect_failing_checks(&health);
+		!failing.is_empty()
+			&& all_health_refs_silenced(&mut db, &server, &failing).await?
+	};
 
 	// Read previous-latest BEFORE the write transaction so we can
 	// detect transitions (top-level healthy and per-check). The
@@ -263,6 +278,32 @@ async fn file_health_events(
 	}
 
 	Ok(())
+}
+
+/// Returns true iff every check in `failing` has a silence at server or
+/// group scope. Empty input returns true vacuously; callers wanting the
+/// "no per-check info → don't correct" semantic should check that
+/// themselves.
+async fn all_health_refs_silenced(
+	conn: &mut AsyncPgConnection,
+	server: &Server,
+	failing: &BTreeSet<String>,
+) -> Result<bool> {
+	for check in failing {
+		let r#ref = format!("{HEALTH_REF}/{check}");
+		let silenced = silenced_refs::is_silenced(
+			conn,
+			server.id,
+			server.group_id,
+			STATUS_SOURCE,
+			&r#ref,
+		)
+		.await?;
+		if !silenced {
+			return Ok(false);
+		}
+	}
+	Ok(true)
 }
 
 /// Names of checks in a `health[]` blob where `healthy == false`.

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -894,6 +894,106 @@ async fn submit_status_unhealthy_no_checks_files_roll_up_only() {
 	.await
 }
 
+/// All failing checks are silenced at server scope → the public-server
+/// corrects the top-level `healthy` to `true` so no incident opens.
+#[tokio::test(flavor = "multi_thread")]
+async fn submit_status_with_all_failing_checks_silenced_is_corrected_to_healthy() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+
+			// Pre-silence both failing checks at server scope.
+			for check in ["database", "disk"] {
+				sql_query(
+					"INSERT INTO server_silenced_refs (server_id, source, ref) \
+					 VALUES ($1, 'status', $2)",
+				)
+				.bind::<sql_types::Uuid, _>(server_id)
+				.bind::<sql_types::Text, _>(format!("health/{check}"))
+				.execute(&mut conn)
+				.await
+				.expect("seed silence");
+			}
+
+			post_status(
+				&public,
+				&cert,
+				server_id,
+				serde_json::json!({
+					"healthy": false,
+					"health": [
+						{ "check": "database", "healthy": false },
+						{ "check": "disk", "healthy": false },
+					],
+				}),
+			)
+			.await;
+
+			// Persisted as healthy=true (corrected by proxy of silence).
+			let row = fetch_latest_health(&mut conn, server_id).await;
+			assert!(row.healthy, "all-silenced should correct to healthy");
+
+			// No roll-up issue, no per-check issues (the silence path skips
+			// them too because the corrected `healthy=true` demotes them).
+			assert!(
+				fetch_issue(&mut conn, server_id, "status", "health")
+					.await
+					.is_none(),
+				"roll-up must not fire when corrected to healthy"
+			);
+			assert!(fetch_open_incident(&mut conn, server_id).await.is_none());
+		},
+	)
+	.await
+}
+
+/// A mix of silenced and unsilenced failing checks does NOT correct: at
+/// least one check still warrants an incident.
+#[tokio::test(flavor = "multi_thread")]
+async fn submit_status_with_partial_silence_still_files_roll_up() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+
+			// Silence only one of the two failing checks.
+			sql_query(
+				"INSERT INTO server_silenced_refs (server_id, source, ref) \
+				 VALUES ($1, 'status', 'health/database')",
+			)
+			.bind::<sql_types::Uuid, _>(server_id)
+			.execute(&mut conn)
+			.await
+			.expect("seed silence");
+
+			post_status(
+				&public,
+				&cert,
+				server_id,
+				serde_json::json!({
+					"healthy": false,
+					"health": [
+						{ "check": "database", "healthy": false },
+						{ "check": "disk", "healthy": false },
+					],
+				}),
+			)
+			.await;
+
+			let row = fetch_latest_health(&mut conn, server_id).await;
+			assert!(!row.healthy, "partial silence shouldn't correct");
+			assert!(
+				fetch_issue(&mut conn, server_id, "status", "health")
+					.await
+					.is_some(),
+				"roll-up fires because one failing check is unsilenced"
+			);
+		},
+	)
+	.await
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn submit_status_severity_demotes_on_recovery_of_top_level() {
 	commons_tests::server::run_with_device_auth(

--- a/private-web/src/components/SilencedRefsSection.tsx
+++ b/private-web/src/components/SilencedRefsSection.tsx
@@ -20,9 +20,14 @@ import TimeAgo from "./TimeAgo";
 export default function SilencedRefsSection({
 	scope,
 	id,
+	refreshKey,
 }: {
 	scope: "server" | "group";
 	id: string;
+	/** Parent-controlled cache-bust; bump to refetch the list after the
+	 * parent took an action that may have added a silence (e.g. silencing
+	 * a healthcheck from the ChecksTable). */
+	refreshKey?: number;
 }) {
 	const isAdmin = useIsAdmin() === true;
 	const [tick, setTick] = useState(0);
@@ -34,13 +39,13 @@ export default function SilencedRefsSection({
 					"silenced_refs",
 					"list_for_server",
 					{ server_id: id },
-					[id, tick],
+					[id, tick, refreshKey],
 				)
 			: useApi(
 					"silenced_refs",
 					"list_for_group",
 					{ server_group_id: id },
-					[id, tick],
+					[id, tick, refreshKey],
 				);
 
 	if (result.status === "loading" || result.status === "idle") {

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -474,11 +474,12 @@ function deviceShortName(info: DeviceInfo): string {
 function InfoSection({
 	server,
 	status,
+	onSilenced,
 	up,
 }: {
 	server: ServerInfo;
 	status: ServerLastStatusData | null;
-  onSilenced: () => void;
+	onSilenced: () => void;
 	up: ShortStatus;
 }) {
 	return (

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -11,6 +11,7 @@ import {
 	LinearProgress,
 	Link as MuiLink,
 	Paper,
+	Popover,
 	Stack,
 	TextField,
 	Tooltip,
@@ -20,6 +21,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import EditIcon from "@mui/icons-material/Edit";
 import LanguageIcon from "@mui/icons-material/Language";
+import NotificationsOffOutlinedIcon from "@mui/icons-material/NotificationsOffOutlined";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Fragment, useEffect, useState } from "react";
 import { Link as RouterLink, useParams } from "react-router-dom";
@@ -35,6 +37,7 @@ import { HealthLegend, StatusLegend, VersionLegend } from "../components/Legends
 import ServerKindChip from "../components/ServerKindChip";
 import ServerRankChip from "../components/ServerRankChip";
 import { callApi, useApi, useApiAction } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { humanSeconds } from "../lib/humanDuration";
 import ServerNameWithGroup from "../components/ServerNameWithGroup";
@@ -114,6 +117,7 @@ export default function ServerDetail() {
 			<InfoSection
 				server={data.server}
 				status={data.last_status}
+				onSilenced={bumpRefresh}
 			/>
 			{data.group && <GroupSection group={data.group} />}
 			{(data.server.notes || Object.keys(data.server.tags ?? {}).length > 0) && (
@@ -130,7 +134,11 @@ export default function ServerDetail() {
 					onEventSubmitted={bumpRefresh}
 				/>
 			)}
-			<SilencedRefsSection scope="server" id={data.server.id} />
+			<SilencedRefsSection
+				scope="server"
+				id={data.server.id}
+				refreshKey={refreshTick}
+			/>
 			<Box>
 				<VersionLegend />
 				<Box sx={{ mt: 1 }}>
@@ -464,9 +472,11 @@ function deviceShortName(info: DeviceInfo): string {
 function InfoSection({
 	server,
 	status,
+	onSilenced,
 }: {
 	server: ServerInfo;
 	status: ServerLastStatusData | null;
+	onSilenced: () => void;
 }) {
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
@@ -500,7 +510,13 @@ function InfoSection({
 				)}
 			</Stack>
 			{status && (
-				<ChecksTable health={status.health} overallHealthy={status.healthy} />
+				<ChecksTable
+					health={status.health}
+					overallHealthy={status.healthy}
+					serverId={server.id}
+					groupId={server.group_id}
+					onSilenced={onSilenced}
+				/>
 			)}
 			{status && Object.keys((status.extra ?? {}) as Record<string, unknown>).length > 0 && (
 				<Box sx={{ mt: 2 }}>
@@ -551,9 +567,15 @@ function HealthIndicator({ healthy }: { healthy: boolean }) {
 function ChecksTable({
 	health,
 	overallHealthy,
+	serverId,
+	groupId,
+	onSilenced,
 }: {
 	health: ServerLastStatusData["health"];
 	overallHealthy: boolean;
+	serverId: string;
+	groupId: string | null;
+	onSilenced: () => void;
 }) {
 	const entries = parseChecks(health);
 	const [expanded, setExpanded] = useState(false);
@@ -572,6 +594,9 @@ function ChecksTable({
 						key={entry.check}
 						entry={entry}
 						overallHealthy={overallHealthy}
+						serverId={serverId}
+						groupId={groupId}
+						onSilenced={onSilenced}
 					/>
 				))}
 			</Stack>
@@ -631,10 +656,17 @@ function parseChecks(health: ServerLastStatusData["health"]): ParsedCheck[] {
 function CheckRow({
 	entry,
 	overallHealthy,
+	serverId,
+	groupId,
+	onSilenced,
 }: {
 	entry: ParsedCheck;
 	overallHealthy: boolean;
+	serverId: string;
+	groupId: string | null;
+	onSilenced: () => void;
 }) {
+	const isAdmin = useIsAdmin() === true;
 	return (
 		<Stack
 			direction="row"
@@ -688,7 +720,115 @@ function CheckRow({
 					</Box>
 				)}
 			</Box>
+			{isAdmin && (
+				<SilenceCheckButton
+					check={entry.check}
+					serverId={serverId}
+					groupId={groupId}
+					onSilenced={onSilenced}
+				/>
+			)}
 		</Stack>
+	);
+}
+
+/** Compact silence trigger on each `CheckRow`. Opens a popover with
+ * "For this server" / "For this group" (the latter only when the
+ * server is grouped). On success, calls the parent's `onSilenced` so
+ * the `SilencedRefsSection` at the bottom of the page refetches. */
+function SilenceCheckButton({
+	check,
+	serverId,
+	groupId,
+	onSilenced,
+}: {
+	check: string;
+	serverId: string;
+	groupId: string | null;
+	onSilenced: () => void;
+}) {
+	const silenceServer = useApiAction("silenced_refs", "silence_server");
+	const silenceGroup = useApiAction("silenced_refs", "silence_group");
+	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+	const error = silenceServer.error ?? silenceGroup.error;
+	const refName = `health/${check}`;
+	const handle = async (fn: () => Promise<unknown>) => {
+		try {
+			await fn();
+			onSilenced();
+			setAnchorEl(null);
+		} catch {
+			/* surfaced via error */
+		}
+	};
+	return (
+		<>
+			<Tooltip title="Silence this check…">
+				<IconButton
+					size="small"
+					aria-label={`Silence ${check}`}
+					onClick={(e) => setAnchorEl(e.currentTarget)}
+				>
+					<NotificationsOffOutlinedIcon fontSize="small" />
+				</IconButton>
+			</Tooltip>
+			<Popover
+				open={!!anchorEl}
+				anchorEl={anchorEl}
+				onClose={() => setAnchorEl(null)}
+				anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+				transformOrigin={{ vertical: "top", horizontal: "right" }}
+			>
+				<Box sx={{ p: 1.5, maxWidth: 320 }}>
+					<Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+						Permanently ignore <code>status/{refName}</code>. The check still
+						records, but no longer triggers or joins incidents. Manage from
+						the "Silenced refs" section below.
+					</Typography>
+					<Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }} useFlexGap>
+						<Button
+							size="small"
+							variant="outlined"
+							startIcon={<NotificationsOffOutlinedIcon />}
+							onClick={() =>
+								handle(() =>
+									silenceServer.call({
+										server_id: serverId,
+										source: "status",
+										ref: refName,
+									}),
+								)
+							}
+						>
+							For this server
+						</Button>
+						{groupId && (
+							<Button
+								size="small"
+								variant="outlined"
+								startIcon={<NotificationsOffOutlinedIcon />}
+								onClick={() =>
+									handle(() =>
+										silenceGroup.call({
+											server_group_id: groupId,
+											source: "status",
+											ref: refName,
+										}),
+									)
+								}
+							>
+								For this group
+							</Button>
+						)}
+					</Stack>
+					{error && (
+						<Alert severity="error" sx={{ mt: 1 }}>
+							{error.message}
+						</Alert>
+					)}
+				</Box>
+			</Popover>
+		</>
 	);
 }
 


### PR DESCRIPTION
🤖 Follow-up to #173. A healthcheck becomes a `(status, health/<check>)` issue when it trips, which the silence machinery from #173 already covers — but operators had no ergonomic way to silence a check without waiting for the issue to file and clicking through the issue card.

## UI

Each row in the per-server `ChecksTable` now has a small silence icon button. Clicking opens a popover with "For this server" and (when grouped) "For this group" — same scope picker as the issue-card flow. On success it triggers a parent refresh so the "Silenced refs" section at the bottom of the page updates without a page reload.

## Backend: correct overall `healthy` when all failures are silenced

The user flagged that silencing per-check refs solves half the problem: the per-check issues correctly skip the incident workflow (silence gates them in `re_evaluate_incident_membership`), but the *roll-up* `(status, health)` issue would still fire — opening an incident by proxy.

In `public-server/src/statuses.rs::create()`, when the device reports `healthy: false`, the handler now checks whether **every** failing check is silenced at server or group scope. If so, the persisted status's `healthy` is flipped to `true` and the roll-up event isn't filed.

A mix of silenced and unsilenced failing checks doesn't correct: at least one unsilenced failure still warrants the incident.

## Notes

- Persisting the corrected `healthy` (rather than just skipping the roll-up file) means subsequent reads see the corrected state — the UI doesn't flicker between healthy/unhealthy across pushes, and `health_state()` returns `Healthy` consistently. The original `health[]` array still records which checks were failing, so the audit trail is preserved.
- Existing open incidents are NOT auto-closed by silencing a check; the next status push reconciles via the new corrected `healthy: true` triggering the roll-up close event. This matches the existing pattern (silence catch-up is per-ref, doesn't cross-reference the roll-up).