### PR TITLE
Mark healthcheck badge as stale when server isn't currently reporting

### DIFF
--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -43,6 +43,7 @@ import type {
 	ServerGroup,
 	ServerInfo,
 	ServerLastStatusData,
+	ShortStatus,
 } from "../types";
 
 export default function ServerDetail() {
@@ -113,6 +114,7 @@ export default function ServerDetail() {
 			<InfoSection
 				server={data.server}
 				status={data.last_status}
+				up={data.up}
 			/>
 			{data.group && <GroupSection group={data.group} />}
 			{(data.server.notes || Object.keys(data.server.tags ?? {}).length > 0) && (
@@ -462,13 +464,15 @@ function deviceShortName(info: DeviceInfo): string {
 function InfoSection({
 	server,
 	status,
+	up,
 }: {
 	server: ServerInfo;
 	status: ServerLastStatusData | null;
+	up: ShortStatus;
 }) {
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
-			{status && <HealthIndicator healthy={status.healthy} />}
+			{status && <HealthIndicator healthy={status.healthy} up={up} />}
 			<Stack
 				direction="row"
 				spacing={4}
@@ -526,18 +530,39 @@ function InfoSection({
 
 /** Global health chip rendered at the top of the InfoSection. The
  * server's per-check breakdown is shown by `<ChecksTable>` below — this
- * is the "headline" answer to "does the server think it's OK". */
-function HealthIndicator({ healthy }: { healthy: boolean }) {
-	return (
-		<Box sx={{ mb: 1.5 }}>
+ * is the "headline" answer to "does the server think it's OK".
+ *
+ * When the server isn't currently reporting (anything other than `up` or
+ * `blip`), the chip is recoloured to a stale variant so an operator
+ * isn't misled into thinking a stale "Healthy" still holds — the data
+ * is whatever the server last said before going quiet. */
+function HealthIndicator({
+	healthy,
+	up,
+}: {
+	healthy: boolean;
+	up: ShortStatus;
+}) {
+	const reporting = up === "up" || up === "blip";
+	const chip = reporting ? (
+		<Chip
+			size="small"
+			color={healthy ? "success" : "error"}
+			icon={healthy ? <CheckCircleIcon /> : <CancelIcon />}
+			label={healthy ? "Healthy" : "Unhealthy"}
+		/>
+	) : (
+		<Tooltip title="Server isn't currently reporting status; this reflects its most recent received report.">
 			<Chip
 				size="small"
-				color={healthy ? "success" : "error"}
-				icon={healthy ? <CheckCircleIcon /> : <CancelIcon />}
-				label={healthy ? "Healthy" : "Unhealthy"}
+				variant="outlined"
+				color="warning"
+				icon={<WarningAmberIcon />}
+				label={healthy ? "Last reported healthy" : "Last reported unhealthy"}
 			/>
-		</Box>
+		</Tooltip>
 	);
+	return <Box sx={{ mb: 1.5 }}>{chip}</Box>;
 }
 
 /** Per-check table from the most recent status push. Failing entries


### PR DESCRIPTION
🤖

When a server's last status push said "healthy" but the server has since gone quiet, the headline chip in the server detail page kept reading "Healthy" with no hint that the data was stale. That's misleading — an operator looking at the page can't tell whether the green badge reflects fresh truth or an old snapshot from before the server stopped talking.

The chip now branches on the same reachability vocabulary `StatusDot` already uses (`up` / `blip` = reporting; `away` / `down` / `gone` = not reporting):

- Reporting: filled `success` "Healthy" or filled `error` "Unhealthy" — unchanged.
- Not reporting: outlined `warning` chip with a `WarningAmberIcon`, labelled "Last reported healthy" or "Last reported unhealthy", with a tooltip explaining that this reflects the most recent received report.

The "Last seen" timestamp rendered right next to the chip already tells the operator *when* — the new chip carries the "this is stale" framing so the colour/wording aren't a foot-gun.

The `StatusSnapshotPanel` chip (historical "as of timestamp X" view) is intentionally left alone — staleness doesn't apply there, that's the entire point of the panel.