### PR TITLE
slack-outbox: per-group slack open cooldown

### DIFF
--- a/crates/commons-servers/src/tailnet_sweeps.rs
+++ b/crates/commons-servers/src/tailnet_sweeps.rs
@@ -72,10 +72,7 @@ pub async fn sweep_key_expiry(
 				r#ref: KEY_EXPIRY_REF.into(),
 				severity: Some(Severity::Info),
 				description: None,
-				message: format!(
-					"Tailscale key expiry disabled for {}",
-					entry.node_name,
-				),
+				message: format!("Tailscale key expiry disabled for {}", entry.node_name,),
 				active: Some(false),
 				occurred_at: Some(now),
 			},
@@ -84,10 +81,7 @@ pub async fn sweep_key_expiry(
 				source: TAILSCALE_SOURCE.into(),
 				r#ref: KEY_EXPIRY_REF.into(),
 				severity: Some(Severity::Critical),
-				description: Some(format!(
-					"Tailscale key will expire for {}",
-					entry.node_name,
-				)),
+				description: Some(format!("Tailscale key will expire for {}", entry.node_name,)),
 				message: format!(
 					"Tailnet node {} ({}) has key expiry enabled. When the \
 					 node's key expires, it will drop off the tailnet and \

--- a/crates/commons-types/src/server/tags.rs
+++ b/crates/commons-types/src/server/tags.rs
@@ -47,9 +47,9 @@ impl utoipa::PartialSchema for TagMap {
 
 		let mut object = Object::with_type(SchemaType::Type(Type::Object));
 		object.additional_properties = Some(Box::new(AdditionalProperties::RefOr(
-			utoipa::openapi::RefOr::T(utoipa::openapi::schema::Schema::Object(
-				Object::with_type(SchemaType::Type(Type::String)),
-			)),
+			utoipa::openapi::RefOr::T(utoipa::openapi::schema::Schema::Object(Object::with_type(
+				SchemaType::Type(Type::String),
+			))),
 		)));
 		utoipa::openapi::RefOr::T(utoipa::openapi::schema::Schema::Object(object))
 	}

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -639,9 +639,7 @@ pub async fn reevaluate_open_issues_for_group_ref(
 /// issues at most) but worth keeping in mind if the corpus grows.
 ///
 /// Returns `(servers_walked, issues_evaluated)` for the caller to log.
-pub async fn reconcile_open_incidents(
-	db: &mut AsyncPgConnection,
-) -> Result<(usize, usize)> {
+pub async fn reconcile_open_incidents(db: &mut AsyncPgConnection) -> Result<(usize, usize)> {
 	use crate::schema::issues::dsl;
 
 	db.transaction::<_, AppError, _>(async |conn| {
@@ -675,15 +673,8 @@ pub async fn reconcile_open_incidents(
 				// Ungrouped servers can't have incidents; nothing to reconcile.
 				continue;
 			};
-			re_evaluate_incident_membership(
-				conn,
-				&issue,
-				gid,
-				server.is_monitored,
-				now,
-				None,
-			)
-			.await?;
+			re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
+				.await?;
 			evaluated += 1;
 		}
 		Ok((by_id.len(), evaluated))

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -777,11 +777,11 @@ async fn enqueue_slack_open(
 		&issue.r#ref,
 		&issue.message,
 	);
-	// Sit in the outbox for OPEN_DELAY before the drainer is allowed to
-	// pick the row up. If the incident closes within that window the
-	// resolve path will cancel this row outright (see
+	// Sit in the outbox for the group's `slack_open_delay` before the
+	// drainer is allowed to pick the row up. If the incident closes within
+	// that window the resolve path will cancel this row outright (see
 	// `enqueue_slack_resolve_inner`), and Slack never hears about a flap.
-	let deliver_after = Timestamp::now() + crate::slack_outbox::OPEN_DELAY;
+	let deliver_after = Timestamp::now() + group.slack_open_delay.0;
 	crate::slack_outbox::SlackOutbox::enqueue(
 		conn,
 		crate::slack_outbox::KIND_INCIDENT_OPEN,

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -189,6 +189,7 @@ diesel::table! {
 		name -> Text,
 		notes -> Text,
 		tags -> Jsonb,
+		slack_open_delay -> Interval,
 	}
 }
 

--- a/crates/database/src/server_groups.rs
+++ b/crates/database/src/server_groups.rs
@@ -9,6 +9,7 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::pg_duration::PgDuration;
 use crate::servers::Server;
 
 fn higher_rank(a: ServerRank, b: ServerRank) -> ServerRank {
@@ -46,6 +47,13 @@ pub struct ServerGroup {
 	pub notes: String,
 	#[serde(default)]
 	pub tags: TagMap,
+	/// How long an `incident_open` Slack notification waits in the outbox
+	/// before the drainer is allowed to ship it. A resolve that arrives
+	/// inside this window cancels the open outright (and skips its own
+	/// notification), so groups with chronic flap can crank this up to
+	/// keep Slack quiet without losing the underlying incident record.
+	#[schema(value_type = i64, format = "int64")]
+	pub slack_open_delay: PgDuration,
 }
 
 #[derive(Debug, Clone, Deserialize, Insertable, utoipa::ToSchema)]
@@ -57,6 +65,9 @@ pub struct NewServerGroup {
 	pub notes: String,
 	#[serde(default)]
 	pub tags: TagMap,
+	#[serde(default)]
+	#[schema(value_type = Option<i64>, format = "int64")]
+	pub slack_open_delay: Option<PgDuration>,
 }
 
 #[derive(Debug, Clone, Deserialize, AsChangeset, utoipa::ToSchema)]
@@ -66,6 +77,8 @@ pub struct PartialServerGroup {
 	pub name: Option<String>,
 	pub notes: Option<String>,
 	pub tags: Option<TagMap>,
+	#[schema(value_type = Option<i64>, format = "int64")]
+	pub slack_open_delay: Option<PgDuration>,
 }
 
 impl ServerGroup {

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -428,7 +428,10 @@ impl Server {
 			.load(db)
 			.await
 			.map_err(AppError::from)?;
-		Ok(rows.into_iter().map(|(id, gid, gn)| (id, (gid, gn))).collect())
+		Ok(rows
+			.into_iter()
+			.map(|(id, gid, gn)| (id, (gid, gn)))
+			.collect())
 	}
 
 	pub async fn search_central(

--- a/crates/database/src/silenced_refs.rs
+++ b/crates/database/src/silenced_refs.rs
@@ -158,10 +158,7 @@ impl ServerSilencedRef {
 		Ok(())
 	}
 
-	pub async fn list_for_server(
-		db: &mut AsyncPgConnection,
-		server_id: Uuid,
-	) -> Result<Vec<Self>> {
+	pub async fn list_for_server(db: &mut AsyncPgConnection, server_id: Uuid) -> Result<Vec<Self>> {
 		use crate::schema::server_silenced_refs::dsl;
 		dsl::server_silenced_refs
 			.select(Self::as_select())

--- a/crates/database/src/slack_outbox/mod.rs
+++ b/crates/database/src/slack_outbox/mod.rs
@@ -9,12 +9,13 @@
 //!
 //! Each row carries a `deliver_after` timestamp. Resolves enqueue with
 //! `deliver_after = now`, so they ship on the next drain tick. Opens enqueue
-//! with a small future delay (see [`OPEN_DELAY`]) so a probe that flaps open
-//! and resolved within that window can be cancelled before we tell Slack
-//! anything happened: the cascade in [`crate::issues::Incident::resolve`]
-//! and the auto-close path both call [`SlackOutbox::cancel_pending_open`]
-//! before enqueueing the resolve, which marks the open row given-up and
-//! skips the resolve when it succeeds.
+//! with a small future delay (the per-group `slack_open_delay`) so a probe
+//! that flaps open and resolved within that window can be cancelled before
+//! we tell Slack anything happened: the cascade in
+//! [`crate::issues::Incident::resolve`] and the auto-close path both call
+//! [`SlackOutbox::cancel_pending_open`] before enqueueing the resolve,
+//! which marks the open row given-up and skips the resolve when it
+//! succeeds.
 //!
 //! The payload is rendered to Block Kit JSON at enqueue time, not at delivery
 //! time, so we capture state as it was when the event happened rather than
@@ -24,7 +25,7 @@
 use commons_errors::{AppError, Result};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
-use jiff::{SignedDuration, Timestamp};
+use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
@@ -35,13 +36,6 @@ pub mod vars;
 pub const KIND_INCIDENT_OPEN: &str = "incident_open";
 /// Incident resolved — Phase A: top-level; Phase B: reply in the incident thread.
 pub const KIND_INCIDENT_RESOLVE: &str = "incident_resolve";
-
-/// How long an `incident_open` row sits in the outbox before the drainer
-/// is allowed to ship it. Long enough to swallow probe flaps that open and
-/// resolve within seconds; short enough that real incidents still page
-/// promptly. Resolve rows aren't delayed — once we've told Slack an
-/// incident opened, we want the resolve out as soon as it happens.
-pub const OPEN_DELAY: SignedDuration = SignedDuration::from_mins(3);
 
 #[derive(Clone, Debug, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name = crate::schema::slack_outbox)]
@@ -72,8 +66,8 @@ pub struct SlackOutbox {
 	pub gave_up_at: Option<Timestamp>,
 	/// Earliest time `claim_pending` will return this row. Resolves are
 	/// enqueued with `deliver_after = now` (ship immediately); opens use
-	/// `now + OPEN_DELAY` so flap-and-resolve incidents can be cancelled
-	/// before they hit Slack.
+	/// `now + group.slack_open_delay` so flap-and-resolve incidents can be
+	/// cancelled before they hit Slack.
 	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
 	pub deliver_after: Timestamp,
 }
@@ -85,7 +79,7 @@ impl SlackOutbox {
 	///
 	/// `deliver_after` is the earliest time the drainer is allowed to ship
 	/// this row. Most callers pass `Timestamp::now()`; the open path
-	/// passes `now + OPEN_DELAY`.
+	/// passes `now + group.slack_open_delay`.
 	pub async fn enqueue(
 		db: &mut AsyncPgConnection,
 		kind: &str,

--- a/crates/database/tests/reachability_sweep.rs
+++ b/crates/database/tests/reachability_sweep.rs
@@ -117,8 +117,7 @@ async fn sweep_skips_unmonitored_server() {
 		// is_monitored = false: never file regardless of how stale the status
 		// is. The threshold is preserved so flipping monitoring back on
 		// resumes with the chosen value.
-		let id =
-			insert_server_full(&mut conn, "http://silenced.invalid/", 600, false).await;
+		let id = insert_server_full(&mut conn, "http://silenced.invalid/", 600, false).await;
 		insert_status_at(&mut conn, id, 120).await;
 		let filed = Status::sweep_reachability(&mut conn).await.expect("sweep");
 		assert_eq!(filed, 0);
@@ -199,10 +198,7 @@ async fn check_constraint_forbids_non_positive_duration() {
 			))
 			.execute(&mut conn)
 			.await;
-			assert!(
-				res.is_err(),
-				"expected CHECK constraint to reject {bad}",
-			);
+			assert!(res.is_err(), "expected CHECK constraint to reject {bad}",);
 		}
 	})
 	.await

--- a/crates/database/tests/slack_outbox_enqueue.rs
+++ b/crates/database/tests/slack_outbox_enqueue.rs
@@ -233,7 +233,11 @@ async fn resolving_before_open_ships_cancels_open_and_skips_resolve() {
 			.iter()
 			.filter(|r| r.kind == KIND_INCIDENT_OPEN)
 			.collect();
-		assert_eq!(opens.len(), 1, "open row stays in the table for historicity");
+		assert_eq!(
+			opens.len(),
+			1,
+			"open row stays in the table for historicity"
+		);
 		assert!(
 			opens[0].gave_up_at.is_some(),
 			"open row marked given-up so the drainer won't ship it"

--- a/crates/database/tests/slack_outbox_enqueue.rs
+++ b/crates/database/tests/slack_outbox_enqueue.rs
@@ -8,11 +8,16 @@
 use commons_types::issue::{ResolvedReason, Severity};
 use database::{
 	issues::{Incident, Issue, NewEvent},
-	slack_outbox::{KIND_INCIDENT_OPEN, KIND_INCIDENT_RESOLVE, OPEN_DELAY, SlackOutbox},
+	slack_outbox::{KIND_INCIDENT_OPEN, KIND_INCIDENT_RESOLVE, SlackOutbox},
 };
 use diesel::{QueryableByName, sql_query, sql_types};
 use diesel_async::RunQueryDsl;
+use jiff::SignedDuration;
 use uuid::Uuid;
+
+/// Migration default for `server_groups.slack_open_delay`. Tests that
+/// don't override it via `insert_server_with_delay` get this value.
+const DEFAULT_OPEN_DELAY: SignedDuration = SignedDuration::from_mins(3);
 
 #[derive(QueryableByName)]
 struct RowId {
@@ -21,18 +26,43 @@ struct RowId {
 }
 
 async fn insert_server(conn: &mut diesel_async::AsyncPgConnection, host: &str) -> Uuid {
+	insert_server_with_delay(conn, host, None).await
+}
+
+/// Variant of [`insert_server`] that pins the group's `slack_open_delay`
+/// to `delay_secs` instead of taking the migration default. Pass `None`
+/// to keep the default.
+async fn insert_server_with_delay(
+	conn: &mut diesel_async::AsyncPgConnection,
+	host: &str,
+	delay_secs: Option<i64>,
+) -> Uuid {
 	// Group + server pair so events can open incidents (incidents are
 	// group-keyed; ungrouped servers don't promote issues to incidents).
-	let group: RowId = sql_query(
-		r#"
-			INSERT INTO server_groups (name)
-			VALUES ('test-group')
-			RETURNING id
-		"#,
-	)
-	.get_result(conn)
-	.await
-	.expect("insert group");
+	let group: RowId = if let Some(secs) = delay_secs {
+		sql_query(
+			r#"
+				INSERT INTO server_groups (name, slack_open_delay)
+				VALUES ('test-group', make_interval(secs => $1))
+				RETURNING id
+			"#,
+		)
+		.bind::<sql_types::BigInt, _>(secs)
+		.get_result(conn)
+		.await
+		.expect("insert group with delay")
+	} else {
+		sql_query(
+			r#"
+				INSERT INTO server_groups (name)
+				VALUES ('test-group')
+				RETURNING id
+			"#,
+		)
+		.get_result(conn)
+		.await
+		.expect("insert group")
+	};
 	let row: RowId = sql_query(
 		r#"
 			INSERT INTO servers (host, group_id)
@@ -67,7 +97,7 @@ async fn pending_for_incident(
 /// Force-deliver the open row for `incident_id` so a subsequent resolve
 /// no longer treats it as cancellable. Used by tests that want to
 /// exercise the post-delivery code path (where the resolve actually does
-/// enqueue) without waiting `OPEN_DELAY` for the real drainer.
+/// enqueue) without waiting `slack_open_delay` for the real drainer.
 async fn mark_open_delivered(conn: &mut diesel_async::AsyncPgConnection, incident_id: Uuid) {
 	use database::diesel_async::RunQueryDsl;
 	use database::schema::slack_outbox::dsl;
@@ -119,15 +149,16 @@ async fn opening_incident_enqueues_slack_open_row() {
 		assert_eq!(open.issue_id, Some(issue.id));
 		assert!(open.delivered_at.is_none());
 		assert_eq!(open.attempts, 0);
-		// Open rows wait OPEN_DELAY (3 minutes today) before the drainer
-		// is allowed to ship them. `created_at` is set server-side by
-		// the migration default, so the gap should equal OPEN_DELAY
-		// give-or-take the round-trip time of the enqueue itself.
-		let target = open.created_at + OPEN_DELAY;
+		// Open rows wait the group's `slack_open_delay` (defaults to 3
+		// minutes) before the drainer is allowed to ship them.
+		// `created_at` is set server-side by the migration default, so
+		// the gap should equal the per-group delay give-or-take the
+		// round-trip time of the enqueue itself.
+		let target = open.created_at + DEFAULT_OPEN_DELAY;
 		let drift = (open.deliver_after - target).get_seconds().unsigned_abs();
 		assert!(
 			drift <= 5,
-			"deliver_after should sit ~OPEN_DELAY past created_at; drift={drift}s \
+			"deliver_after should sit ~slack_open_delay past created_at; drift={drift}s \
 			 (created_at={}, deliver_after={})",
 			open.created_at,
 			open.deliver_after,
@@ -364,7 +395,7 @@ async fn mark_given_up_removes_row_from_claim_pending() {
 		};
 		event.save(&mut conn, server_id, None).await.expect("save");
 		// `event.save` enqueues an open whose deliver_after sits
-		// OPEN_DELAY in the future. Drop it back to the past so
+		// `slack_open_delay` in the future. Drop it back to the past so
 		// claim_pending will return the row immediately.
 		expire_deliver_after(&mut conn).await;
 		let row = SlackOutbox::claim_pending(&mut conn, 10)
@@ -392,8 +423,8 @@ async fn mark_given_up_removes_row_from_claim_pending() {
 #[tokio::test(flavor = "multi_thread")]
 async fn claim_pending_skips_rows_whose_deliver_after_is_in_the_future() {
 	// Direct check on the drainer's claim filter: an open row that's
-	// still inside its OPEN_DELAY window must not be claimed, but the
-	// moment its deliver_after slides into the past it becomes
+	// still inside its `slack_open_delay` window must not be claimed,
+	// but the moment its deliver_after slides into the past it becomes
 	// claimable. This is the core flap-suppression mechanism.
 	commons_tests::db::TestDb::run(async |mut conn, _| {
 		let server_id = insert_server(&mut conn, "http://delayed.invalid/").await;
@@ -412,7 +443,7 @@ async fn claim_pending_skips_rows_whose_deliver_after_is_in_the_future() {
 			.expect("claim");
 		assert!(
 			pending_before.is_empty(),
-			"open row must wait OPEN_DELAY before becoming claimable; got {} rows",
+			"open row must wait the group delay before becoming claimable; got {} rows",
 			pending_before.len(),
 		);
 
@@ -430,8 +461,48 @@ async fn claim_pending_skips_rows_whose_deliver_after_is_in_the_future() {
 	.await
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn open_delay_honours_per_group_slack_open_delay() {
+	// A group with a custom `slack_open_delay` sets the new open's
+	// `deliver_after` from that value, not the migration default. Zero
+	// means "ship immediately" — the drainer's claim filter
+	// (`deliver_after <= NOW()`) will see the row on the very next tick.
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id =
+			insert_server_with_delay(&mut conn, "http://nowait.invalid/", Some(0)).await;
+		let event = NewEvent {
+			source: "test".into(),
+			r#ref: "ref-zero".into(),
+			severity: Some(Severity::Error),
+			description: None,
+			message: "boom".into(),
+			active: Some(true),
+			occurred_at: None,
+		};
+		event.save(&mut conn, server_id, None).await.expect("save");
+
+		let claimable = SlackOutbox::claim_pending(&mut conn, 10)
+			.await
+			.expect("claim");
+		assert_eq!(
+			claimable.len(),
+			1,
+			"zero-delay group ships its open immediately",
+		);
+		let open = &claimable[0];
+		let drift = (open.deliver_after - open.created_at)
+			.get_seconds()
+			.unsigned_abs();
+		assert!(
+			drift <= 2,
+			"zero delay should put deliver_after ≈ created_at; drift={drift}s",
+		);
+	})
+	.await
+}
+
 /// Backdate every pending row's `deliver_after` so the drainer can pick
-/// them up without the test having to sleep through `OPEN_DELAY`.
+/// them up without the test having to sleep through `slack_open_delay`.
 async fn expire_deliver_after(conn: &mut diesel_async::AsyncPgConnection) {
 	sql_query("UPDATE slack_outbox SET deliver_after = NOW() - INTERVAL '1 minute' WHERE delivered_at IS NULL AND gave_up_at IS NULL")
 		.execute(conn)

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -201,9 +201,7 @@ pub(crate) async fn enrich_issue(
 		.remove(&issue.server_id)
 		.unwrap_or((None, String::new()));
 	let mut group_refs = Server::group_refs_by_server_ids(conn, &[issue.server_id]).await?;
-	let (group_id, group_name) = group_refs
-		.remove(&issue.server_id)
-		.unwrap_or((None, None));
+	let (group_id, group_name) = group_refs.remove(&issue.server_id).unwrap_or((None, None));
 	let user_logins = collect_user_logins(std::slice::from_ref(&issue));
 	let users = CachedTailscaleUser::by_logins(conn, &user_logins).await?;
 	let mut incidents = Incident::for_issues(conn, &[issue.id]).await?;

--- a/crates/private-server/src/fns/server_groups.rs
+++ b/crates/private-server/src/fns/server_groups.rs
@@ -95,6 +95,11 @@ pub struct CreateArgs {
 	pub notes: String,
 	#[serde(default)]
 	pub tags: TagMap,
+	/// Optional initial value (seconds) for the group's Slack open
+	/// cooldown. Omit to let the database default apply.
+	#[serde(default)]
+	#[schema(value_type = Option<i64>, format = "int64")]
+	pub slack_open_delay: Option<database::pg_duration::PgDuration>,
 }
 
 #[utoipa::path(
@@ -121,6 +126,7 @@ pub async fn create(
 			name: args.name,
 			notes: args.notes,
 			tags: args.tags,
+			slack_open_delay: args.slack_open_delay,
 		},
 	)
 	.await?;

--- a/crates/private-server/tests/issues.rs
+++ b/crates/private-server/tests/issues.rs
@@ -1149,7 +1149,10 @@ async fn list_silenced_refs_for_server_and_group() {
 			.await;
 		let items: Vec<serde_json::Value> = resp.json();
 		assert_eq!(items.len(), 1);
-		assert_eq!(items[0].get("ref").and_then(|v| v.as_str()), Some("srv-ref"));
+		assert_eq!(
+			items[0].get("ref").and_then(|v| v.as_str()),
+			Some("srv-ref")
+		);
 
 		let resp = private
 			.post("/api/silenced_refs/list_for_group")
@@ -1157,7 +1160,10 @@ async fn list_silenced_refs_for_server_and_group() {
 			.await;
 		let items: Vec<serde_json::Value> = resp.json();
 		assert_eq!(items.len(), 1);
-		assert_eq!(items[0].get("ref").and_then(|v| v.as_str()), Some("grp-ref"));
+		assert_eq!(
+			items[0].get("ref").and_then(|v| v.as_str()),
+			Some("grp-ref")
+		);
 	})
 	.await;
 }

--- a/crates/private-server/tests/tailnet_key_expiry_sweep.rs
+++ b/crates/private-server/tests/tailnet_key_expiry_sweep.rs
@@ -69,9 +69,7 @@ async fn sweep_opens_critical_issue_when_key_expiry_enabled() {
 		let server_id = insert_server_for(&mut conn, device_id, "https://srv1.invalid/").await;
 
 		let dir = directory_with(false);
-		let filed = sweep_key_expiry(&mut conn, &dir)
-			.await
-			.expect("sweep");
+		let filed = sweep_key_expiry(&mut conn, &dir).await.expect("sweep");
 		assert_eq!(filed, 1);
 
 		let issue = issue_for(&mut conn, server_id).await.expect("issue");
@@ -89,9 +87,7 @@ async fn sweep_skips_when_key_expiry_disabled() {
 		let server_id = insert_server_for(&mut conn, device_id, "https://srv2.invalid/").await;
 
 		let dir = directory_with(true);
-		let filed = sweep_key_expiry(&mut conn, &dir)
-			.await
-			.expect("sweep");
+		let filed = sweep_key_expiry(&mut conn, &dir).await.expect("sweep");
 		assert_eq!(filed, 0);
 		assert!(issue_for(&mut conn, server_id).await.is_none());
 	})
@@ -146,9 +142,7 @@ async fn sweep_ignores_node_not_in_directory() {
 		let server_id = insert_server_for(&mut conn, device_id, "https://srv4.invalid/").await;
 
 		let empty = TailnetDirectory::for_test([]);
-		let filed = sweep_key_expiry(&mut conn, &empty)
-			.await
-			.expect("sweep");
+		let filed = sweep_key_expiry(&mut conn, &empty).await.expect("sweep");
 		assert_eq!(filed, 0);
 		assert!(issue_for(&mut conn, server_id).await.is_none());
 	})

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -135,8 +135,7 @@ async fn create(
 		true
 	} else {
 		let failing = collect_failing_checks(&health);
-		!failing.is_empty()
-			&& all_health_refs_silenced(&mut db, &server, &failing).await?
+		!failing.is_empty() && all_health_refs_silenced(&mut db, &server, &failing).await?
 	};
 
 	// Read previous-latest BEFORE the write transaction so we can
@@ -291,14 +290,9 @@ async fn all_health_refs_silenced(
 ) -> Result<bool> {
 	for check in failing {
 		let r#ref = format!("{HEALTH_REF}/{check}");
-		let silenced = silenced_refs::is_silenced(
-			conn,
-			server.id,
-			server.group_id,
-			STATUS_SOURCE,
-			&r#ref,
-		)
-		.await?;
+		let silenced =
+			silenced_refs::is_silenced(conn, server.id, server.group_id, STATUS_SOURCE, &r#ref)
+				.await?;
 		if !silenced {
 			return Ok(false);
 		}

--- a/migrations/2026-05-25-120000-0000_server_groups_slack_open_delay/down.sql
+++ b/migrations/2026-05-25-120000-0000_server_groups_slack_open_delay/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_groups DROP COLUMN slack_open_delay;

--- a/migrations/2026-05-25-120000-0000_server_groups_slack_open_delay/up.sql
+++ b/migrations/2026-05-25-120000-0000_server_groups_slack_open_delay/up.sql
@@ -1,0 +1,10 @@
+-- Per-group slack open cooldown. An `incident_open` Slack notice is held
+-- in the outbox for this long before the drainer is allowed to ship it,
+-- so a flap that opens and resolves within the window can be cancelled
+-- before we tell Slack anything happened (see `cancel_pending_open`).
+--
+-- Default 3 minutes — matches the previous hardcoded `OPEN_DELAY`. Set to
+-- `INTERVAL '0'` to ship opens immediately.
+ALTER TABLE server_groups
+	ADD COLUMN slack_open_delay INTERVAL NOT NULL DEFAULT INTERVAL '3 minutes'
+		CHECK (slack_open_delay >= INTERVAL '0');

--- a/private-web/e2e/groups.spec.ts
+++ b/private-web/e2e/groups.spec.ts
@@ -185,4 +185,31 @@ test.describe("group edit page", () => {
 		);
 		expect(rows[0]!.tags).toEqual({ env: "prod", tier: "1" });
 	});
+
+	test("editing the Slack cooldown minutes persists as the right interval", async ({
+		page,
+		sql,
+	}) => {
+		// Seeded at 3 minutes (180s); UI works in minutes; bumping to 5
+		// should round-trip through the API as 300 seconds in the DB.
+		const group = await seedServerGroup(sql, {
+			name: "cooldown-group",
+			slackOpenDelaySeconds: 180,
+		});
+
+		await page.goto(`/groups/${group.id}/edit`);
+
+		const minutesInput = page.getByLabel(/^minutes$/i);
+		await expect(minutesInput).toHaveValue("3");
+		await minutesInput.fill("5");
+		await page.getByRole("button", { name: /^save$/i }).click();
+		await page.waitForURL(`**/groups/${group.id}`);
+
+		const rows = await sql.query<{ secs: string }>(
+			"SELECT EXTRACT(EPOCH FROM slack_open_delay)::text AS secs \
+			 FROM server_groups WHERE id = $1",
+			[group.id],
+		);
+		expect(Number(rows[0]!.secs)).toBe(300);
+	});
 });

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -58,15 +58,35 @@ export interface SeededServerGroup {
 
 export async function seedServerGroup(
 	sql: Sql,
-	opts: { name?: string; notes?: string; tags?: Record<string, string> } = {},
+	opts: {
+		name?: string;
+		notes?: string;
+		tags?: Record<string, string>;
+		/** Slack open cooldown in seconds. Omit to keep the migration default. */
+		slackOpenDelaySeconds?: number;
+	} = {},
 ): Promise<SeededServerGroup> {
 	const id = randomUUID();
 	const name = opts.name ?? randomLabel("group");
-	await sql.query(
-		`INSERT INTO server_groups (id, name, notes, tags)
-		 VALUES ($1, $2, $3, $4::jsonb)`,
-		[id, name, opts.notes ?? "", JSON.stringify(opts.tags ?? {})],
-	);
+	if (opts.slackOpenDelaySeconds !== undefined) {
+		await sql.query(
+			`INSERT INTO server_groups (id, name, notes, tags, slack_open_delay)
+			 VALUES ($1, $2, $3, $4::jsonb, make_interval(secs => $5))`,
+			[
+				id,
+				name,
+				opts.notes ?? "",
+				JSON.stringify(opts.tags ?? {}),
+				opts.slackOpenDelaySeconds,
+			],
+		);
+	} else {
+		await sql.query(
+			`INSERT INTO server_groups (id, name, notes, tags)
+			 VALUES ($1, $2, $3, $4::jsonb)`,
+			[id, name, opts.notes ?? "", JSON.stringify(opts.tags ?? {})],
+		);
+	}
 	return { id, name };
 }
 

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -3638,6 +3638,14 @@
           "notes": {
             "type": "string"
           },
+          "slack_open_delay": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Optional initial value (seconds) for the group's Slack open\ncooldown. Omit to let the database default apply."
+          },
           "tags": {
             "$ref": "#/components/schemas/TagMap"
           }
@@ -5184,6 +5192,13 @@
               "null"
             ]
           },
+          "slack_open_delay": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
           "tags": {
             "oneOf": [
               {
@@ -5553,7 +5568,8 @@
           "id",
           "created_at",
           "updated_at",
-          "name"
+          "name",
+          "slack_open_delay"
         ],
         "properties": {
           "created_at": {
@@ -5569,6 +5585,11 @@
           },
           "notes": {
             "type": "string"
+          },
+          "slack_open_delay": {
+            "type": "integer",
+            "format": "int64",
+            "description": "How long an `incident_open` Slack notification waits in the outbox\nbefore the drainer is allowed to ship it. A resolve that arrives\ninside this window cancels the open outright (and skips its own\nnotification), so groups with chronic flap can crank this up to\nkeep Slack quiet without losing the underlying incident record."
           },
           "tags": {
             "$ref": "#/components/schemas/TagMap"

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1485,6 +1485,12 @@ export interface components {
         CreateArgs: {
             name: string;
             notes?: string;
+            /**
+             * Format: int64
+             * @description Optional initial value (seconds) for the group's Slack open
+             *     cooldown. Omit to let the database default apply.
+             */
+            slack_open_delay?: number | null;
             tags?: components["schemas"]["TagMap"];
         };
         CreateArtifactArgs: {
@@ -2013,6 +2019,8 @@ export interface components {
         PartialServerGroup: {
             name?: string | null;
             notes?: string | null;
+            /** Format: int64 */
+            slack_open_delay?: number | null;
             tags?: null | components["schemas"]["TagMap"];
         };
         /**
@@ -2144,6 +2152,15 @@ export interface components {
             id: string;
             name: string;
             notes?: string;
+            /**
+             * Format: int64
+             * @description How long an `incident_open` Slack notification waits in the outbox
+             *     before the drainer is allowed to ship it. A resolve that arrives
+             *     inside this window cancels the open outright (and skips its own
+             *     notification), so groups with chronic flap can crank this up to
+             *     keep Slack quiet without losing the underlying incident record.
+             */
+            slack_open_delay: number;
             tags?: components["schemas"]["TagMap"];
             /** Format: date-time */
             updated_at: string;

--- a/private-web/src/routes/GroupEdit.tsx
+++ b/private-web/src/routes/GroupEdit.tsx
@@ -48,13 +48,27 @@ function EditForm({
 	const [name, setName] = useState(group.name);
 	const [notes, setNotes] = useState(group.notes ?? "");
 	const [tags, setTags] = useState<TagMap>(group.tags ?? {});
+	// Slack open cooldown: how long a newly-opened incident's Slack notice
+	// sits in the outbox before the drainer is allowed to ship it. UI works
+	// in minutes; 0 = ship immediately.
+	const [slackOpenDelayMinutes, setSlackOpenDelayMinutes] = useState<string>(
+		Math.max(0, Math.round(group.slack_open_delay / 60)).toString(),
+	);
 
 	const onSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
 		try {
 			await update.call({
 				server_group_id: group.id,
-				data: { name, notes, tags },
+				data: {
+					name,
+					notes,
+					tags,
+					slack_open_delay: Math.max(
+						0,
+						Math.round(Number(slackOpenDelayMinutes) * 60),
+					),
+				},
 			});
 			navigate(`/groups/${group.id}`);
 		} catch {
@@ -104,6 +118,33 @@ function EditForm({
 					disabled={pending}
 					helperText="Plain text shown on the group's detail page."
 				/>
+
+				<Stack spacing={1}>
+					<Typography variant="subtitle1">Slack cooldown</Typography>
+					<Stack
+						direction={{ xs: "column", md: "row" }}
+						spacing={2}
+						sx={{ alignItems: { md: "center" } }}
+					>
+						<Typography variant="body2">
+							Hold incident-open Slack notices for
+						</Typography>
+						<TextField
+							label="minutes"
+							type="number"
+							value={slackOpenDelayMinutes}
+							onChange={(e) => setSlackOpenDelayMinutes(e.target.value)}
+							disabled={pending}
+							slotProps={{ htmlInput: { min: 0, step: 1 } }}
+							sx={{ width: 140 }}
+						/>
+					</Stack>
+					<Typography variant="caption" color="text.secondary">
+						If the incident resolves inside the window, no Slack notice is
+						sent for either edge — useful for flappy probes. Set to 0 to ship
+						opens immediately.
+					</Typography>
+				</Stack>
 
 				<Stack spacing={1}>
 					<Typography variant="subtitle1">Tags</Typography>


### PR DESCRIPTION
🤖 The `OPEN_DELAY` constant introduced in #158 governs how long an `incident_open` Slack notice sits in the outbox before the drainer ships it (the flap-suppression window). Some groups want a longer hold for chronically flappy probes; others want opens to page immediately. Move the value off the global constant and onto each `server_groups` row.

- New `server_groups.slack_open_delay INTERVAL NOT NULL DEFAULT '3 minutes' CHECK (>= 0)` column. The default carries the old hardcoded behaviour over.
- `ServerGroup` / `NewServerGroup` / `PartialServerGroup` gain a `slack_open_delay: PgDuration` field (seconds on the wire).
- `enqueue_slack_open` looks up the group it already has in scope and uses `group.slack_open_delay` instead of the constant.
- `OPEN_DELAY` constant removed — the migration's `DEFAULT INTERVAL '3 minutes'` is the single source of truth now.
- New unit test exercises the per-group override (zero-delay group must produce an immediately-claimable open row).
- New e2e test edits the cooldown via the group-edit form and asserts the DB sees the right interval.
- Group edit form gains a "Slack cooldown" section: a minutes input (0 = ship immediately) with a short helper explaining the flap-suppression contract.

There is no "create group" UI today (groups are created via the migration or by promoting servers), so no create-side form change.