### PR TITLE
incidents: surface 'slack notice held' state across the UI

### DIFF
--- a/crates/database/src/slack_outbox/mod.rs
+++ b/crates/database/src/slack_outbox/mod.rs
@@ -136,6 +136,37 @@ impl SlackOutbox {
 		Ok(rows)
 	}
 
+	/// For each of `incident_ids`, return the `deliver_after` of its
+	/// pending `incident_open` row — i.e. an incident that has been opened
+	/// in the database but whose Slack notice hasn't been sent yet (and
+	/// isn't given up on). Incidents whose open has already shipped, was
+	/// given up, or whose `deliver_after` has elapsed are absent from the
+	/// map. The UI uses this to distinguish "open and the world knows" from
+	/// "open but still inside the flap-suppression window".
+	pub async fn pending_opens_until(
+		db: &mut AsyncPgConnection,
+		incident_ids: &[Uuid],
+	) -> Result<std::collections::HashMap<Uuid, Timestamp>> {
+		use crate::schema::slack_outbox::dsl;
+		use std::collections::HashMap;
+
+		if incident_ids.is_empty() {
+			return Ok(HashMap::new());
+		}
+		let now = Timestamp::now();
+		let rows: Vec<(Uuid, jiff_diesel::Timestamp)> = dsl::slack_outbox
+			.select((dsl::incident_id, dsl::deliver_after))
+			.filter(dsl::kind.eq(KIND_INCIDENT_OPEN))
+			.filter(dsl::incident_id.eq_any(incident_ids))
+			.filter(dsl::delivered_at.is_null())
+			.filter(dsl::gave_up_at.is_null())
+			.filter(dsl::deliver_after.gt(jiff_diesel::Timestamp::from(now)))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(rows.into_iter().map(|(id, t)| (id, t.into())).collect())
+	}
+
 	/// Claim up to `limit` pending rows in insertion order. Uses
 	/// `FOR UPDATE SKIP LOCKED` so multiple workers (or a worker plus a
 	/// hand-run reprocess) won't fight over the same row. The caller must

--- a/crates/database/tests/slack_outbox_enqueue.rs
+++ b/crates/database/tests/slack_outbox_enqueue.rs
@@ -501,6 +501,72 @@ async fn open_delay_honours_per_group_slack_open_delay() {
 	.await
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn pending_opens_until_filters_to_undelivered_in_window() {
+	// `pending_opens_until` powers the UI's "held" state — only opens that
+	// are still inside their `deliver_after` window AND haven't been
+	// delivered or given up qualify.
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		// Held incident: default-delay group → open sits 3 min in the future.
+		let held_server = insert_server(&mut conn, "http://held.invalid/").await;
+		let event = NewEvent {
+			source: "test".into(),
+			r#ref: "ref-held".into(),
+			severity: Some(Severity::Error),
+			description: None,
+			message: "boom".into(),
+			active: Some(true),
+			occurred_at: None,
+		};
+		event
+			.save(&mut conn, held_server, None)
+			.await
+			.expect("save held");
+		let held_incident = Incident::list_for_server(&mut conn, held_server, false, 10)
+			.await
+			.expect("list incidents")[0]
+			.id;
+
+		// Delivered incident: open already shipped → not held any more.
+		let delivered_server = insert_server(&mut conn, "http://delivered.invalid/").await;
+		let event = NewEvent {
+			source: "test".into(),
+			r#ref: "ref-delivered".into(),
+			severity: Some(Severity::Error),
+			description: None,
+			message: "boom".into(),
+			active: Some(true),
+			occurred_at: None,
+		};
+		event
+			.save(&mut conn, delivered_server, None)
+			.await
+			.expect("save delivered");
+		let delivered_incident = Incident::list_for_server(&mut conn, delivered_server, false, 10)
+			.await
+			.expect("list incidents")[0]
+			.id;
+		mark_open_delivered(&mut conn, delivered_incident).await;
+
+		let held = SlackOutbox::pending_opens_until(
+			&mut conn,
+			&[held_incident, delivered_incident],
+		)
+		.await
+		.expect("pending_opens_until");
+
+		assert!(
+			held.contains_key(&held_incident),
+			"held incident must appear in the map",
+		);
+		assert!(
+			!held.contains_key(&delivered_incident),
+			"once shipped, the open is no longer held",
+		);
+	})
+	.await
+}
+
 /// Backdate every pending row's `deliver_after` so the drainer can pick
 /// them up without the test having to sleep through `slack_open_delay`.
 async fn expire_deliver_after(conn: &mut diesel_async::AsyncPgConnection) {

--- a/crates/private-server/src/fns/incidents.rs
+++ b/crates/private-server/src/fns/incidents.rs
@@ -36,6 +36,12 @@ pub struct IncidentData {
 	pub event_count: i64,
 	/// Combined: this incident's notes + notes on all contributing issues.
 	pub note_count: i64,
+	/// `Some(t)` when this incident's Slack `incident_open` notice is
+	/// still inside the per-group cooldown window (`deliver_after = t`,
+	/// not yet shipped, not given up). `None` once Slack has heard about
+	/// the incident — or the open was cancelled. Lets the UI distinguish
+	/// "open but quietly held" from "open and operators have been paged".
+	pub notification_held_until: Option<Timestamp>,
 	pub created_at: Timestamp,
 	pub updated_at: Timestamp,
 }
@@ -46,6 +52,7 @@ impl IncidentData {
 		server_group_name: String,
 		users: &std::collections::HashMap<String, CachedTailscaleUser>,
 		stats: IncidentStats,
+		notification_held_until: Option<Timestamp>,
 	) -> Self {
 		let (res_name, res_pic) = lookup_user(users, i.resolved_by.as_deref());
 		Self {
@@ -62,6 +69,7 @@ impl IncidentData {
 			issue_count: stats.issue_count,
 			event_count: stats.event_count,
 			note_count: stats.note_count,
+			notification_held_until,
 			created_at: i.created_at,
 			updated_at: i.updated_at,
 		}
@@ -91,6 +99,8 @@ async fn enrich_incidents(
 	let user_logins = collect_incident_user_logins(&incidents);
 	let users = CachedTailscaleUser::by_logins(conn, &user_logins).await?;
 	let stats = Incident::stats_for(pool, &incident_ids).await?;
+	let held =
+		database::slack_outbox::SlackOutbox::pending_opens_until(conn, &incident_ids).await?;
 	Ok(incidents
 		.into_iter()
 		.map(|i| {
@@ -99,7 +109,8 @@ async fn enrich_incidents(
 				.cloned()
 				.unwrap_or_default();
 			let s = stats.get(&i.id).copied().unwrap_or_default();
-			IncidentData::from_with(i, name, &users, s)
+			let held_until = held.get(&i.id).copied();
+			IncidentData::from_with(i, name, &users, s, held_until)
 		})
 		.collect())
 }
@@ -114,7 +125,12 @@ async fn enrich_incident(
 	let users = CachedTailscaleUser::by_logins(conn, &user_logins).await?;
 	let mut stats = Incident::stats_for(pool, &[incident.id]).await?;
 	let s = stats.remove(&incident.id).unwrap_or_default();
-	Ok(IncidentData::from_with(incident, group.name, &users, s))
+	let mut held =
+		database::slack_outbox::SlackOutbox::pending_opens_until(conn, &[incident.id]).await?;
+	let held_until = held.remove(&incident.id);
+	Ok(IncidentData::from_with(
+		incident, group.name, &users, s, held_until,
+	))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -143,6 +159,7 @@ pub struct IncidentWithIssues {
 pub fn routes() -> OpenApiRouter<AppState> {
 	OpenApiRouter::new()
 		.routes(routes!(list_for_server))
+		.routes(routes!(list_for_group))
 		.routes(routes!(list_active))
 		.routes(routes!(get_incident))
 		.routes(routes!(resolve))
@@ -181,6 +198,44 @@ pub async fn list_for_server(
 	let incidents = Incident::list_for_server(
 		&mut conn,
 		args.server_id,
+		args.include_closed.unwrap_or(false),
+		args.limit.unwrap_or(DEFAULT_LIMIT),
+	)
+	.await?;
+	Ok(Json(
+		enrich_incidents(&mut conn, &state.db, incidents).await?,
+	))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct ListForGroupArgs {
+	pub server_group_id: Uuid,
+	#[serde(default)]
+	pub include_closed: Option<bool>,
+	#[serde(default)]
+	pub limit: Option<i64>,
+}
+
+#[utoipa::path(
+	post,
+	path = "/list_for_group",
+	operation_id = "incident_list_for_group",
+	tag = "incidents",
+	security(("tailscale-user" = [])),
+	request_body = ListForGroupArgs,
+	responses(
+		(status = 200, body = Vec<IncidentData>),
+	),
+)]
+pub async fn list_for_group(
+	State(state): State<AppState>,
+	_user: TailscaleUser,
+	Json(args): Json<ListForGroupArgs>,
+) -> Result<Json<Vec<IncidentData>>> {
+	let mut conn = state.db.get().await?;
+	let incidents = Incident::list_for_group(
+		&mut conn,
+		args.server_group_id,
 		args.include_closed.unwrap_or(false),
 		args.limit.unwrap_or(DEFAULT_LIMIT),
 	)

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1255,6 +1255,44 @@
         ]
       }
     },
+    "/api/incidents/list_for_group": {
+      "post": {
+        "tags": [
+          "incidents"
+        ],
+        "operationId": "incident_list_for_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListForGroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IncidentData"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
     "/api/incidents/list_for_server": {
       "post": {
         "tags": [
@@ -4168,6 +4206,14 @@
             "format": "int64",
             "description": "Combined: this incident's notes + notes on all contributing issues."
           },
+          "notification_held_until": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "`Some(t)` when this incident's Slack `incident_open` notice is\nstill inside the per-group cooldown window (`deliver_after = t`,\nnot yet shipped, not given up). `None` once Slack has heard about\nthe incident — or the open was cancelled. Lets the UI distinguish\n\"open but quietly held\" from \"open and operators have been paged\"."
+          },
           "opened_at": {
             "type": "string",
             "format": "date-time"
@@ -4672,6 +4718,31 @@
               "null"
             ],
             "format": "int64"
+          }
+        }
+      },
+      "ListForGroupArgs": {
+        "type": "object",
+        "required": [
+          "server_group_id"
+        ],
+        "properties": {
+          "include_closed": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -506,6 +506,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/incidents/list_for_group": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["incident_list_for_group"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/incidents/list_for_server": {
         parameters: {
             query?: never;
@@ -1658,6 +1674,15 @@ export interface components {
              * @description Combined: this incident's notes + notes on all contributing issues.
              */
             note_count: number;
+            /**
+             * Format: date-time
+             * @description `Some(t)` when this incident's Slack `incident_open` notice is
+             *     still inside the per-group cooldown window (`deliver_after = t`,
+             *     not yet shipped, not given up). `None` once Slack has heard about
+             *     the incident — or the open was cancelled. Lets the UI distinguish
+             *     "open but quietly held" from "open and operators have been paged".
+             */
+            notification_held_until?: string | null;
             /** Format: date-time */
             opened_at: string;
             /** Format: date-time */
@@ -1834,6 +1859,13 @@ export interface components {
             device_id: string;
             /** Format: int64 */
             limit?: number | null;
+        };
+        ListForGroupArgs: {
+            include_closed?: boolean | null;
+            /** Format: int64 */
+            limit?: number | null;
+            /** Format: uuid */
+            server_group_id: string;
         };
         ListForServerArgs: {
             include_closed?: boolean | null;
@@ -3383,6 +3415,29 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["ListActiveArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IncidentData"][];
+                };
+            };
+        };
+    };
+    incident_list_for_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ListForGroupArgs"];
             };
         };
         responses: {

--- a/private-web/src/components/IncidentsLink.tsx
+++ b/private-web/src/components/IncidentsLink.tsx
@@ -6,7 +6,10 @@ import { useApi } from "../api";
 
 /** Server-detail header button into the incidents view. Any server id in
  * a group works — the backend resolves to the group root. Three states:
- * - open incident exists → direct link to /incidents/:id (error-coloured)
+ * - open incident exists → direct link to /incidents/:id (error-coloured,
+ *   or warning-coloured when the Slack notice is still inside the
+ *   per-group cooldown window so the operator can tell at a glance that
+ *   nobody else has been paged yet)
  * - no open incident, but active issues → /incidents filtered to this group
  * - nothing active → same, with `showAll=1` so closed/inactive surface */
 export default function IncidentsLink({
@@ -36,15 +39,22 @@ export default function IncidentsLink({
 	const hasActive = issues.status === "ok" && issues.data.length > 0;
 
 	if (openIncident) {
+		const held = openIncident.notification_held_until != null;
 		return (
 			<Button
 				component={RouterLink}
 				to={`/incidents/${openIncident.id}`}
 				variant="outlined"
-				color="error"
+				color={held ? "warning" : "error"}
 				startIcon={<WarningAmberIcon />}
+				title={
+					held
+						? "Slack notice still inside the per-group cooldown window"
+						: undefined
+				}
 			>
 				Incident {openIncident.id.slice(0, 8)}
+				{held && " (held)"}
 			</Button>
 		);
 	}

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -9,16 +9,27 @@ import {
 	Typography,
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import ServerShorty from "../components/ServerShorty";
 import SilencedRefsSection from "../components/SilencedRefsSection";
+import TimeAgo from "../components/TimeAgo";
 import { useApi } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
+import type { IncidentData } from "../types";
 
 export default function GroupDetail() {
 	const { id = "" } = useParams<{ id: string }>();
 	const detail = useApi("server_groups", "get", { server_group_id: id }, [id]);
 	const isAdmin = useApi("commons", "is_current_user_admin");
+	// Only the currently-open incident matters for the active-incident
+	// section; closed ones live behind the /incidents filter route.
+	const activeIncidents = useApi(
+		"incidents",
+		"list_for_group",
+		{ server_group_id: id, include_closed: false, limit: 1 },
+		[id],
+	);
 	usePageTitle(detail.status === "ok" ? detail.data.group.name : "Group");
 
 	if (detail.status === "loading" || detail.status === "idle") {
@@ -31,6 +42,10 @@ export default function GroupDetail() {
 	const { group, servers } = detail.data;
 	const admin = isAdmin.status === "ok" && isAdmin.data;
 	const tagEntries = Object.entries(group.tags ?? {});
+	const openIncident =
+		activeIncidents.status === "ok" && activeIncidents.data.length > 0
+			? activeIncidents.data[0]
+			: null;
 
 	return (
 		<Stack spacing={3}>
@@ -53,6 +68,8 @@ export default function GroupDetail() {
 					</Button>
 				)}
 			</Stack>
+
+			{openIncident && <ActiveIncidentCard incident={openIncident} />}
 
 			{group.notes && (
 				<Paper variant="outlined" sx={{ p: 2 }}>
@@ -103,5 +120,68 @@ export default function GroupDetail() {
 
 			<SilencedRefsSection scope="group" id={group.id} />
 		</Stack>
+	);
+}
+
+function ActiveIncidentCard({ incident }: { incident: IncidentData }) {
+	const held = incident.notification_held_until != null;
+	return (
+		<Paper
+			variant="outlined"
+			sx={{
+				p: 2,
+				borderColor: held ? "warning.main" : "error.main",
+				borderWidth: 2,
+			}}
+		>
+			<Stack
+				direction="row"
+				spacing={2}
+				sx={{ alignItems: "center", justifyContent: "space-between" }}
+			>
+				<Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
+					<WarningAmberIcon color={held ? "warning" : "error"} />
+					<Box>
+						<Typography variant="h6" component="h2">
+							Active incident
+							<Box
+								component="span"
+								sx={{
+									ml: 1,
+									fontFamily: "monospace",
+									color: "text.secondary",
+									fontWeight: "normal",
+									fontSize: "0.85em",
+								}}
+							>
+								{incident.id.slice(0, 8)}
+							</Box>
+						</Typography>
+						<Typography variant="body2" color="text.secondary">
+							opened <TimeAgo timestamp={incident.opened_at} />
+							{held && incident.notification_held_until && (
+								<>
+									{" · "}
+									<Box component="span" sx={{ color: "warning.main" }}>
+										Slack notice held; ships{" "}
+										<TimeAgo
+											timestamp={incident.notification_held_until}
+										/>
+									</Box>
+								</>
+							)}
+						</Typography>
+					</Box>
+				</Stack>
+				<Button
+					component={RouterLink}
+					to={`/incidents/${incident.id}`}
+					variant="outlined"
+					color={held ? "warning" : "error"}
+				>
+					Open
+				</Button>
+			</Stack>
+		</Paper>
 	);
 }

--- a/private-web/src/routes/IncidentDetail.tsx
+++ b/private-web/src/routes/IncidentDetail.tsx
@@ -13,6 +13,7 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import BugReportIcon from "@mui/icons-material/BugReport";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import NotesIcon from "@mui/icons-material/StickyNote2";
@@ -128,6 +129,7 @@ function Header({
 	onChanged: () => void;
 }) {
 	const open = incident.closed_at == null;
+	const held = open && incident.notification_held_until != null;
 	const isAdmin = useIsAdmin() === true;
 	const resolve = useApiAction("incidents", "resolve");
 	const unresolve = useApiAction("incidents", "unresolve");
@@ -174,7 +176,11 @@ function Header({
 			variant="outlined"
 			sx={{
 				p: 2,
-				borderColor: open ? "error.main" : "divider",
+				borderColor: open
+					? held
+						? "warning.main"
+						: "error.main"
+					: "divider",
 				borderWidth: open ? 2 : 1,
 			}}
 		>
@@ -205,6 +211,33 @@ function Header({
 					<Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
 						{timeText}
 					</Typography>
+					{held && incident.notification_held_until && (
+						<Stack
+							direction="row"
+							spacing={1}
+							sx={{ mt: 1, alignItems: "center", flexWrap: "wrap" }}
+							useFlexGap
+						>
+							<Chip
+								icon={<AccessTimeIcon />}
+								label={
+									<>
+										Slack notice held; ships{" "}
+										<TimeAgo
+											timestamp={incident.notification_held_until}
+										/>
+									</>
+								}
+								color="warning"
+								variant="outlined"
+								size="small"
+							/>
+							<Typography variant="caption" color="text.secondary">
+								Resolving inside the window cancels the open and skips
+								the resolve, so Slack never hears about either edge.
+							</Typography>
+						</Stack>
+					)}
 				</Box>
 				<Box sx={{ flexShrink: 0 }}>
 					{incident.resolved_at && (

--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -19,13 +19,22 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import { useReloadInterval } from "../hooks/useReloadInterval";
 import { type ServerGroupCard, SERVER_RANK_ORDER } from "../types";
 
+/// Held vs loud: a group has an open incident, but the Slack notice is
+/// still inside the per-group cooldown window (held) or has already fired
+/// or been cancelled (loud). Drives the warning-vs-error colouring on the
+/// Status page and elsewhere.
+export type IncidentLoudness = "held" | "loud";
+
 export default function Status() {
 	usePageTitle("Status");
 	const tick = useReloadInterval(60_000, "canopy-reload-status");
 	const incidents = useApi("incidents", "list_active", {}, [tick]);
-	const openIncidentGroups = new Set<string>(
+	const openIncidentGroups = new Map<string, IncidentLoudness>(
 		incidents.status === "ok"
-			? incidents.data.map((i) => i.server_group_id)
+			? incidents.data.map((i) => [
+					i.server_group_id,
+					i.notification_held_until ? "held" : "loud",
+				])
 			: [],
 	);
 	return (
@@ -74,7 +83,7 @@ function GroupCards({
 	openIncidentGroups,
 }: {
 	tick: number;
-	openIncidentGroups: Set<string>;
+	openIncidentGroups: Map<string, IncidentLoudness>;
 }) {
 	const grouped = useApi(
 		"statuses",
@@ -127,7 +136,7 @@ function GroupCards({
 								key={id}
 								groupId={id}
 								tick={tick}
-								hasOpenIncident={openIncidentGroups.has(id)}
+								openIncident={openIncidentGroups.get(id) ?? null}
 							/>
 						))}
 					</Box>
@@ -140,11 +149,11 @@ function GroupCards({
 function GroupCardLoader({
 	groupId,
 	tick,
-	hasOpenIncident,
+	openIncident,
 }: {
 	groupId: string;
 	tick: number;
-	hasOpenIncident: boolean;
+	openIncident: IncidentLoudness | null;
 }) {
 	const result = useApi(
 		"statuses",
@@ -152,6 +161,16 @@ function GroupCardLoader({
 		{ server_group_id: groupId },
 		[groupId, tick],
 	);
+
+	// Held incidents tone the border down to warning so an operator can see
+	// at a glance "yes there's a thing, but Slack hasn't been told yet — it
+	// might still self-resolve". Loud incidents stay full red.
+	const borderColor =
+		openIncident === "loud"
+			? "error.main"
+			: openIncident === "held"
+				? "warning.main"
+				: undefined;
 
 	return (
 		<MuiLink
@@ -165,8 +184,8 @@ function GroupCardLoader({
 				sx={{
 					transition: "background-color 150ms",
 					"&:hover": { bgcolor: "action.hover" },
-					...(hasOpenIncident && {
-						borderColor: "error.main",
+					...(borderColor && {
+						borderColor,
 						borderWidth: 2,
 					}),
 				}}
@@ -181,7 +200,7 @@ function GroupCardLoader({
 					) : (
 						<GroupCard
 							group={result.data}
-							hasOpenIncident={hasOpenIncident}
+							openIncident={openIncident}
 						/>
 					)}
 				</CardContent>
@@ -192,10 +211,10 @@ function GroupCardLoader({
 
 function GroupCard({
 	group,
-	hasOpenIncident,
+	openIncident,
 }: {
 	group: ServerGroupCard;
-	hasOpenIncident: boolean;
+	openIncident: IncidentLoudness | null;
 }) {
 	return (
 		<Stack spacing={1}>
@@ -244,8 +263,13 @@ function GroupCard({
 						</Tooltip>
 					))}
 				</Stack>
-				{hasOpenIncident && (
+				{openIncident === "loud" && (
 					<Chip label="incident" color="error" size="small" />
+				)}
+				{openIncident === "held" && (
+					<Tooltip title="Open incident; Slack notice is still inside the per-group cooldown window">
+						<Chip label="incident (held)" color="warning" size="small" />
+					</Tooltip>
 				)}
 			</Stack>
 		</Stack>


### PR DESCRIPTION
🤖 Follow-up to #180. With the per-group cooldown now configurable, the UI needs to distinguish "incident is open and Slack has been told" from "incident is open but the Slack notice is still inside the cooldown window" — the latter is much less urgent, and might still self-resolve before anyone is paged.

- New `IncidentData.notification_held_until: Option<Timestamp>` populated from a bulk `SlackOutbox::pending_opens_until` query (kind = `incident_open`, undelivered, not given up, `deliver_after > NOW()`).
- New `incidents/list_for_group` endpoint, used by the group detail page.

UI:
- Status page: groups with held incidents get a warning-coloured border + `incident (held)` chip; groups with delivered/loud incidents stay error-coloured.
- IncidentsLink (server-detail header): button switches to warning colour and appends "(held)" when the open incident is still in the cooldown window.
- IncidentDetail header: warning border (instead of error) when held, plus a chip noting "Slack notice held; ships <TimeAgo>" with a short reminder that resolving inside the window cancels both Slack notices.
- GroupDetail: new "Active incident" card linking to `/incidents/:id`, coloured warning/error to match.