### PR TITLE
private-web(incidents): fix 'ships X ago' wording and surface held state on cards

### DIFF
--- a/private-web/src/components/IncidentCard.tsx
+++ b/private-web/src/components/IncidentCard.tsx
@@ -4,12 +4,17 @@ import NotesIcon from "@mui/icons-material/StickyNote2";
 import TimelineIcon from "@mui/icons-material/Timeline";
 import { Link as RouterLink } from "react-router-dom";
 import TimeAgo from "./TimeAgo";
+import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 import type { IncidentData } from "../types";
 
 /** Compact view of an open incident; click-through goes to the incident
  * detail page. The body has a stats row (bottom-right) with issue / event
- * / note counts. */
+ * / note counts. A warning-coloured border (rather than the default error)
+ * signals that the Slack notice is still inside the per-group cooldown
+ * window — operators scanning the /incidents grid can tell at a glance
+ * which cards have already paged out. */
 export default function IncidentCard({ incident }: { incident: IncidentData }) {
+	const held = useIsNotificationHeld(incident.notification_held_until);
 	return (
 		<Box
 			component={RouterLink}
@@ -17,7 +22,7 @@ export default function IncidentCard({ incident }: { incident: IncidentData }) {
 			sx={{
 				p: 1.5,
 				border: 1,
-				borderColor: "error.main",
+				borderColor: held ? "warning.main" : "error.main",
 				borderRadius: 1,
 				textDecoration: "none",
 				color: "text.primary",
@@ -31,6 +36,17 @@ export default function IncidentCard({ incident }: { incident: IncidentData }) {
 				</Typography>
 				<Typography variant="body2" color="text.secondary">
 					opened <TimeAgo timestamp={incident.opened_at} />
+					{held && incident.notification_held_until && (
+						<>
+							{" · "}
+							<Box component="span" sx={{ color: "warning.main" }}>
+								Slack notice held; ships{" "}
+								<TimeAgo
+									timestamp={incident.notification_held_until}
+								/>
+							</Box>
+						</>
+					)}
 				</Typography>
 			</Box>
 			<Stack

--- a/private-web/src/components/IncidentsLink.tsx
+++ b/private-web/src/components/IncidentsLink.tsx
@@ -3,6 +3,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Link as RouterLink } from "react-router-dom";
 import { useApi } from "../api";
+import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 
 /** Server-detail header button into the incidents view. Any server id in
  * a group works — the backend resolves to the group root. Three states:
@@ -38,8 +39,10 @@ export default function IncidentsLink({
 	);
 	const hasActive = issues.status === "ok" && issues.data.length > 0;
 
+	const held = useIsNotificationHeld(
+		openIncident?.notification_held_until ?? null,
+	);
 	if (openIncident) {
-		const held = openIncident.notification_held_until != null;
 		return (
 			<Button
 				component={RouterLink}

--- a/private-web/src/components/TimeAgo.tsx
+++ b/private-web/src/components/TimeAgo.tsx
@@ -8,8 +8,9 @@ function formatSecs(secs: number): string {
 	return `${Math.floor(s / 86_400)}d`;
 }
 
-/** Renders a relative time like "5m ago" with the absolute timestamp as a tooltip.
- * Refreshes every 10 seconds while the page is visible. */
+/** Renders a relative time like "5m ago" — or "in 5m" when the timestamp is
+ * in the future. With the absolute timestamp as a tooltip. Refreshes every
+ * 10 seconds while the page is visible. */
 export default function TimeAgo({ timestamp }: { timestamp: string }) {
 	const ts = Date.parse(timestamp);
 	const [now, setNow] = useState(() => Date.now());
@@ -25,7 +26,12 @@ export default function TimeAgo({ timestamp }: { timestamp: string }) {
 	if (Number.isNaN(ts)) return <span>?</span>;
 
 	const secs = (now - ts) / 1000;
-	const text = Math.abs(secs) < 60 ? "now" : `${formatSecs(secs)} ago`;
+	const text =
+		Math.abs(secs) < 60
+			? "now"
+			: secs < 0
+				? `in ${formatSecs(secs)}`
+				: `${formatSecs(secs)} ago`;
 	return (
 		<Tooltip title={new Date(ts).toLocaleString()}>
 			<span>{text}</span>

--- a/private-web/src/hooks/useIsNotificationHeld.ts
+++ b/private-web/src/hooks/useIsNotificationHeld.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/** "Held" means the per-group Slack cooldown hasn't elapsed yet — so the
+ * incident is open but operators haven't been paged. Once `heldUntil`
+ * slips into the past, the worker has either shipped the notice or is
+ * about to; the UI can't be sure without a refetch, so the safest signal
+ * is "no longer held" and the page will catch up on its next reload.
+ *
+ * Ticks every 10s while visible so badges that key off this hide
+ * themselves automatically when the deadline passes — without that, a
+ * stale page would keep claiming "held" indefinitely. */
+export function useIsNotificationHeld(heldUntil: string | null): boolean {
+	const ts = heldUntil ? Date.parse(heldUntil) : NaN;
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		if (Number.isNaN(ts)) return;
+		const id = window.setInterval(() => {
+			if (!document.hidden) setNow(Date.now());
+		}, 10_000);
+		return () => window.clearInterval(id);
+	}, [ts]);
+	if (Number.isNaN(ts)) return false;
+	return ts > now;
+}

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -15,6 +15,7 @@ import ServerShorty from "../components/ServerShorty";
 import SilencedRefsSection from "../components/SilencedRefsSection";
 import TimeAgo from "../components/TimeAgo";
 import { useApi } from "../api";
+import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 import { usePageTitle } from "../hooks/usePageTitle";
 import type { IncidentData } from "../types";
 
@@ -124,7 +125,7 @@ export default function GroupDetail() {
 }
 
 function ActiveIncidentCard({ incident }: { incident: IncidentData }) {
-	const held = incident.notification_held_until != null;
+	const held = useIsNotificationHeld(incident.notification_held_until);
 	return (
 		<Paper
 			variant="outlined"

--- a/private-web/src/routes/IncidentDetail.tsx
+++ b/private-web/src/routes/IncidentDetail.tsx
@@ -25,6 +25,7 @@ import { useApi, useApiAction } from "../api";
 import IssueRow from "../components/IssueRow";
 import { AddNoteButton } from "../components/NotesList";
 import { useIsAdmin } from "../hooks/useIsAdmin";
+import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 import TimeAgo from "../components/TimeAgo";
 import UserAvatar from "../components/UserAvatar";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -129,7 +130,10 @@ function Header({
 	onChanged: () => void;
 }) {
 	const open = incident.closed_at == null;
-	const held = open && incident.notification_held_until != null;
+	const heldUntilActive = useIsNotificationHeld(
+		incident.notification_held_until,
+	);
+	const held = open && heldUntilActive;
 	const isAdmin = useIsAdmin() === true;
 	const resolve = useApiAction("incidents", "resolve");
 	const unresolve = useApiAction("incidents", "unresolve");

--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -29,11 +29,20 @@ export default function Status() {
 	usePageTitle("Status");
 	const tick = useReloadInterval(60_000, "canopy-reload-status");
 	const incidents = useApi("incidents", "list_active", {}, [tick]);
+	// `held` only counts while the deliver-after deadline is still ahead:
+	// once it slips into the past the worker has shipped (or is about to)
+	// and this page is just behind on the data — fall through to "loud"
+	// rather than asserting a held state we can't verify. The 60s tick
+	// re-evaluates this naturally.
+	const now = Date.now();
 	const openIncidentGroups = new Map<string, IncidentLoudness>(
 		incidents.status === "ok"
 			? incidents.data.map((i) => [
 					i.server_group_id,
-					i.notification_held_until ? "held" : "loud",
+					i.notification_held_until &&
+					Date.parse(i.notification_held_until) > now
+						? "held"
+						: "loud",
 				])
 			: [],
 	);


### PR DESCRIPTION
🤖

Two follow-ups to the slack-notice-held UI (#181) after seeing an open incident render as `opened now · Slack notice held; ships 9m ago`:

**`TimeAgo` was unconditionally appending "ago"** — even when the timestamp was in the future. The held badge passes `notification_held_until`, which is always a future timestamp at fetch time, so it rendered as "ships 9m ago" instead of "ships in 9m". Fixed to render future timestamps as `in 9m`. The component already used `Math.abs` for the magnitude, so this just splits the suffix on the sign of the delta. Past-time call sites are unchanged.

**`held = notification_held_until != null` keeps the held badge up forever** once the page goes stale. The backend's `pending_opens_until` filters with `deliver_after > now`, so a present value implies a future deadline at fetch time — but if the page sits open past the deadline, the badge keeps asserting "held" even though the worker has likely shipped. Added a `useIsNotificationHeld` hook that re-evaluates `held_until > now` on a 10s tick (same cadence as `TimeAgo`), so the badge auto-hides once the deadline passes and the page can catch up on its next reload without lying in the meantime. `Status` doesn't need the hook — it already reloads every 60s — so it gets an inline `Date.parse(...) > now` check instead. Wired into `IncidentDetail`, `IncidentsLink`, and `GroupDetail`'s active-incident card.

**`/incidents` cards didn't differentiate held vs loud.** `IncidentCard` now uses a warning-coloured border (vs the default error) when the incident is still inside the cooldown window, and shows the same `Slack notice held; ships <when>` annotation under the "opened …" line that `GroupDetail`'s active-incident card already had. Operators scanning the grid can tell at a glance which cards have already paged out.