### PR TITLE
private-web(held-badge): rephrase to 'Holding; posting…' on its own line

### DIFF
--- a/private-web/src/components/IncidentCard.tsx
+++ b/private-web/src/components/IncidentCard.tsx
@@ -36,18 +36,13 @@ export default function IncidentCard({ incident }: { incident: IncidentData }) {
 				</Typography>
 				<Typography variant="body2" color="text.secondary">
 					opened <TimeAgo timestamp={incident.opened_at} />
-					{held && incident.notification_held_until && (
-						<>
-							{" · "}
-							<Box component="span" sx={{ color: "warning.main" }}>
-								Slack notice held; ships{" "}
-								<TimeAgo
-									timestamp={incident.notification_held_until}
-								/>
-							</Box>
-						</>
-					)}
 				</Typography>
+				{held && incident.notification_held_until && (
+					<Typography variant="body2" sx={{ color: "warning.main" }}>
+						Holding; posting{" "}
+						<TimeAgo timestamp={incident.notification_held_until} />
+					</Typography>
+				)}
 			</Box>
 			<Stack
 				direction="row"

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -160,18 +160,13 @@ function ActiveIncidentCard({ incident }: { incident: IncidentData }) {
 						</Typography>
 						<Typography variant="body2" color="text.secondary">
 							opened <TimeAgo timestamp={incident.opened_at} />
-							{held && incident.notification_held_until && (
-								<>
-									{" · "}
-									<Box component="span" sx={{ color: "warning.main" }}>
-										Slack notice held; ships{" "}
-										<TimeAgo
-											timestamp={incident.notification_held_until}
-										/>
-									</Box>
-								</>
-							)}
 						</Typography>
+						{held && incident.notification_held_until && (
+							<Typography variant="body2" sx={{ color: "warning.main" }}>
+								Holding; posting{" "}
+								<TimeAgo timestamp={incident.notification_held_until} />
+							</Typography>
+						)}
 					</Box>
 				</Stack>
 				<Button

--- a/private-web/src/routes/IncidentDetail.tsx
+++ b/private-web/src/routes/IncidentDetail.tsx
@@ -226,7 +226,7 @@ function Header({
 								icon={<AccessTimeIcon />}
 								label={
 									<>
-										Slack notice held; ships{" "}
+										Holding; posting{" "}
 										<TimeAgo
 											timestamp={incident.notification_held_until}
 										/>


### PR DESCRIPTION
🤖

Two follow-up tweaks to the held-incident UI in #183:

- **Wording**: 'Slack notice held; ships {in time}' → 'Holding; posting {in time}'. Shorter, doesn't bake the channel into the copy, and the verb matches what an operator actually thinks of as the action (we're going to post to the channel).
- **Layout**: moved the badge text onto its own line in `IncidentCard` and `GroupDetail`'s active-incident card. Previously it followed the 'opened …' line as an inline ' · ' fragment, which wrapped awkwardly when the card narrowed (split mid-sentence). `IncidentDetail` already rendered it as a standalone Chip below the time line, so just the wording changed there.