### PR TITLE
private-server(incidents): dedupe rejoined issues in get_with_issues

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -1373,6 +1373,10 @@ impl Incident {
 		Ok(out)
 	}
 
+	/// One row per distinct issue. An issue that left and rejoined this
+	/// incident shows up once with its most recent link metadata
+	/// (`joined_at`/`left_at`); without the dedup a flapping issue can
+	/// produce hundreds of repeated rows.
 	pub async fn get_with_issues(
 		db: &mut AsyncPgConnection,
 		incident_id: Uuid,
@@ -1385,13 +1389,18 @@ impl Incident {
 			.first(db)
 			.await?;
 
-		let rows: Vec<(IncidentIssue, Issue)> = incident_issues::table
+		let mut rows: Vec<(IncidentIssue, Issue)> = incident_issues::table
 			.inner_join(issues::table.on(issues::id.eq(incident_issues::issue_id)))
 			.select((IncidentIssue::as_select(), Issue::as_select()))
 			.filter(incident_issues::incident_id.eq(incident_id))
-			.order(incident_issues::joined_at.asc())
+			.distinct_on(incident_issues::issue_id)
+			.order((
+				incident_issues::issue_id,
+				incident_issues::joined_at.desc(),
+			))
 			.load(db)
 			.await?;
+		rows.sort_by_key(|(link, _)| link.joined_at);
 		Ok((incident, rows))
 	}
 

--- a/crates/database/tests/incident_get_with_issues.rs
+++ b/crates/database/tests/incident_get_with_issues.rs
@@ -1,0 +1,66 @@
+//! `Incident::get_with_issues` must dedupe `(incident_id, issue_id)`
+//! before returning rows. `incident_issues` is keyed on `(incident_id,
+//! issue_id, joined_at)`, so an issue that leaves and rejoins the same
+//! incident produces a row per rejoin. Without dedup the incident detail
+//! timeline renders the same issue hundreds of times for a flapping
+//! source.
+
+use database::issues::Incident;
+use diesel_async::SimpleAsyncConnection as _;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_with_issues_dedupes_repeat_join_rows() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let group_id = Uuid::new_v4();
+		let server_id = Uuid::new_v4();
+		let device_id = Uuid::new_v4();
+		let issue_a = Uuid::new_v4();
+		let issue_b = Uuid::new_v4();
+		let incident_id = Uuid::new_v4();
+
+		conn.batch_execute(&format!(
+			"INSERT INTO devices (id, role) VALUES ('{device_id}', 'server'); \
+			 INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g'); \
+			 INSERT INTO servers (id, host, kind, device_id, group_id) VALUES \
+				('{server_id}', 'https://example.com', 'central', '{device_id}', '{group_id}'); \
+			 INSERT INTO issues \
+				(id, server_id, device_id, source, ref, severity, message, active, first_seen, last_seen) \
+			   VALUES \
+				('{issue_a}', '{server_id}', '{device_id}', 'test', 'a', 'error', 'm', true, NOW(), NOW()), \
+				('{issue_b}', '{server_id}', '{device_id}', 'test', 'b', 'error', 'm', true, NOW(), NOW()); \
+			 INSERT INTO incidents (id, server_group_id, opened_at) \
+			   VALUES ('{incident_id}', '{group_id}', NOW()); \
+			 INSERT INTO incident_issues (incident_id, issue_id, joined_at, left_at) VALUES \
+				('{incident_id}', '{issue_a}', NOW() - interval '5 min', NOW() - interval '4 min'), \
+				('{incident_id}', '{issue_a}', NOW() - interval '4 min', NOW() - interval '3 min'), \
+				('{incident_id}', '{issue_a}', NOW() - interval '3 min', NOW() - interval '2 min'), \
+				('{incident_id}', '{issue_a}', NOW() - interval '2 min', NOW() - interval '1 min'), \
+				('{incident_id}', '{issue_a}', NOW(), NULL), \
+				('{incident_id}', '{issue_b}', NOW() - interval '10 min', NOW() - interval '9 min');"
+		))
+		.await
+		.expect("seed");
+
+		let (incident, rows) = Incident::get_with_issues(&mut conn, incident_id)
+			.await
+			.expect("get_with_issues");
+		assert_eq!(incident.id, incident_id);
+		assert_eq!(rows.len(), 2, "two distinct issues despite 5 rejoin rows");
+
+		// Most recent link metadata wins for the flapping issue: the open
+		// link (left_at NULL) is what the UI should see.
+		let a = rows
+			.iter()
+			.find(|(l, _)| l.issue_id == issue_a)
+			.expect("issue a present");
+		assert!(a.0.left_at.is_none(), "kept the most recent open link");
+
+		let b = rows
+			.iter()
+			.find(|(l, _)| l.issue_id == issue_b)
+			.expect("issue b present");
+		assert!(b.0.left_at.is_some(), "single historical link preserved");
+	})
+	.await
+}


### PR DESCRIPTION
🤖 A flapping issue produces one `incident_issues` row per rejoin (the table is keyed on `(incident_id, issue_id, joined_at)`), so a single noisy issue could balloon the incident detail timeline — and the `Issues (N)` chip count — into hundreds of rows for the same underlying issue. The stats path already dedupes; the timeline path didn't.

`Incident::get_with_issues` now uses `DISTINCT ON (issue_id)` ordered by `joined_at DESC` to keep the most recent link per distinct issue, then re-sorts the result by `joined_at` ASC for consumers expecting timeline-ascending order.

Regression test in `crates/database/tests/incident_get_with_issues.rs` seeds five rejoin rows for one issue plus one row for another and asserts two rows come back, with the open link (`left_at NULL`) preserved for the flapping issue.