### PR TITLE
fix(incidents): only severity "error" or above keeps an incident open

### DIFF
--- a/crates/commons-types/src/issue.rs
+++ b/crates/commons-types/src/issue.rs
@@ -40,12 +40,20 @@ pub enum Severity {
 }
 
 impl Severity {
+	/// Severities that may open an incident on their own and may keep one
+	/// open. Low-severity issues (warning and below) join an already-open
+	/// incident for context but don't hold it open — see
+	/// `database::issues::re_evaluate_incident_membership`.
+	pub const OPENS_INCIDENT: &'static [Severity] = &[
+		Self::Emergency,
+		Self::Alert,
+		Self::Critical,
+		Self::Error,
+	];
+
 	/// Issues at or above this severity open incidents.
 	pub fn opens_incident(self) -> bool {
-		matches!(
-			self,
-			Self::Emergency | Self::Alert | Self::Critical | Self::Error
-		)
+		Self::OPENS_INCIDENT.contains(&self)
 	}
 }
 

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -506,14 +506,24 @@ async fn re_evaluate_incident_membership(
 				.get_result(conn)
 				.await?;
 			if remaining_open == 0 {
-				let closed: Incident = diesel::update(
-					incidents::table.filter(incidents::id.eq(open_link.incident_id)),
+				// Filter on `closed_at IS NULL` so that when a stranded
+				// low-severity contributor eventually leaves an already-
+				// closed incident (because the severity-filter close above
+				// already retired it), we skip both the no-op update and
+				// the double Slack resolve.
+				let closed: Option<Incident> = diesel::update(
+					incidents::table
+						.filter(incidents::id.eq(open_link.incident_id))
+						.filter(incidents::closed_at.is_null()),
 				)
 				.set(incidents::closed_at.eq(jiff_diesel::Timestamp::from(transition_time)))
 				.returning(Incident::as_select())
 				.get_result(conn)
-				.await?;
-				enqueue_slack_resolve_inner(conn, &closed, by).await?;
+				.await
+				.optional()?;
+				if let Some(closed) = closed {
+					enqueue_slack_resolve_inner(conn, &closed, by).await?;
+				}
 			}
 		}
 		_ => {}

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -378,6 +378,13 @@ impl NewEvent {
 ///     even low-severity ones, joins it. The threshold only governs
 ///     incident *creation*; once an incident is in progress everything else
 ///     piles in for context.
+/// - **Close**: the incident auto-closes when the last contributor at
+///   severity ≥ error leaves. Low-severity contributors that joined
+///   because the group had an open incident stay attached (so the audit
+///   trail and Slack thread retain them) but **do not** hold the incident
+///   open by themselves. Without this asymmetry, a check that's stuck
+///   firing at warning could keep an incident open indefinitely after the
+///   higher-severity contributor that opened it has long since gone away.
 ///
 /// `monitored` reflects the server's `is_monitored()` at call time. When
 /// `false`, the issue is treated as a "leave": this is what makes
@@ -478,11 +485,22 @@ async fn re_evaluate_incident_membership(
 			.execute(conn)
 			.await?;
 
+			// Only count contributors that are *currently* at a severity
+			// that opens an incident. Low-severity issues stay attached
+			// for context but don't hold the incident open on their own;
+			// see the function doc-comment for the rationale.
+			let opens_incident_severities: Vec<String> = Severity::OPENS_INCIDENT
+				.iter()
+				.map(|s| s.to_string())
+				.collect();
+			use crate::schema::issues;
 			let remaining_open: i64 = incident_issues::table
+				.inner_join(issues::table.on(issues::id.eq(incident_issues::issue_id)))
 				.filter(
 					incident_issues::incident_id
 						.eq(open_link.incident_id)
-						.and(incident_issues::left_at.is_null()),
+						.and(incident_issues::left_at.is_null())
+						.and(issues::severity.eq_any(&opens_incident_severities)),
 				)
 				.count()
 				.get_result(conn)

--- a/crates/database/tests/incident_close_severity.rs
+++ b/crates/database/tests/incident_close_severity.rs
@@ -1,0 +1,280 @@
+//! The auto-close path in `re_evaluate_incident_membership` counts only
+//! severity ≥ error contributors when deciding whether an incident still
+//! has reason to stay open. Lower-severity issues that joined while the
+//! incident was open stay attached (audit trail / Slack context) but
+//! don't hold the incident open by themselves.
+
+use commons_types::issue::Severity;
+use database::issues::{Incident, NewEvent};
+use database::slack_outbox::{KIND_INCIDENT_OPEN, KIND_INCIDENT_RESOLVE, SlackOutbox};
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_grouped_server(conn: &mut diesel_async::AsyncPgConnection, host: &str) -> Uuid {
+	let group: RowId =
+		sql_query("INSERT INTO server_groups (name) VALUES ('test-group') RETURNING id")
+			.get_result(conn)
+			.await
+			.expect("group");
+	let row: RowId = sql_query("INSERT INTO servers (host, group_id) VALUES ($1, $2) RETURNING id")
+		.bind::<sql_types::Text, _>(host)
+		.bind::<sql_types::Uuid, _>(group.id)
+		.get_result(conn)
+		.await
+		.expect("server");
+	row.id
+}
+
+async fn save_event(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	r#ref: &str,
+	severity: Severity,
+	active: bool,
+	message: &str,
+) {
+	NewEvent {
+		source: "test".into(),
+		r#ref: r#ref.into(),
+		severity: Some(severity),
+		description: None,
+		message: message.into(),
+		active: Some(active),
+		occurred_at: None,
+	}
+	.save(conn, server_id, None)
+	.await
+	.expect("save event");
+}
+
+/// Move the pending `incident_open` row past its `cancel_pending_open`
+/// window so that closing the incident enqueues a `incident_resolve`
+/// rather than cancelling the open. Mirrors the helper used by
+/// slack_outbox_enqueue.rs.
+async fn mark_open_delivered(conn: &mut diesel_async::AsyncPgConnection, incident_id: Uuid) {
+	#[derive(QueryableByName)]
+	struct Row {
+		#[diesel(sql_type = sql_types::Uuid)]
+		id: Uuid,
+	}
+	let row: Row = sql_query(
+		"SELECT id FROM slack_outbox WHERE incident_id = $1 AND kind = $2 LIMIT 1",
+	)
+	.bind::<sql_types::Uuid, _>(incident_id)
+	.bind::<sql_types::Text, _>(KIND_INCIDENT_OPEN)
+	.get_result(conn)
+	.await
+	.expect("pending open row exists");
+	SlackOutbox::mark_delivered(conn, row.id, "ok")
+		.await
+		.expect("mark delivered");
+}
+
+async fn count_resolve_rows(
+	conn: &mut diesel_async::AsyncPgConnection,
+	incident_id: Uuid,
+) -> i64 {
+	#[derive(QueryableByName)]
+	struct Count {
+		#[diesel(sql_type = sql_types::BigInt)]
+		count: i64,
+	}
+	let row: Count = sql_query(
+		"SELECT COUNT(*) AS count FROM slack_outbox \
+		 WHERE incident_id = $1 AND kind = $2",
+	)
+	.bind::<sql_types::Uuid, _>(incident_id)
+	.bind::<sql_types::Text, _>(KIND_INCIDENT_RESOLVE)
+	.get_result(conn)
+	.await
+	.expect("count");
+	row.count
+}
+
+/// Scenario: error issue opens an incident, warning issue joins (because
+/// the group already has an open incident), error issue resolves. Under
+/// the old logic the warning would have held the incident open
+/// indefinitely; under the new logic the incident closes because no
+/// remaining contributor is at severity ≥ error.
+#[tokio::test(flavor = "multi_thread")]
+async fn warning_does_not_hold_incident_open_after_error_resolves() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn, "http://stranded-warning.invalid/").await;
+
+		// Error issue opens the incident.
+		save_event(
+			&mut conn,
+			server_id,
+			"error-ref",
+			Severity::Error,
+			true,
+			"boom",
+		)
+		.await;
+		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list incidents")
+			.into_iter()
+			.next()
+			.expect("incident opened by error issue");
+
+		// Pretend Slack has heard about the open so the resolve enqueue
+		// isn't short-circuited by the flap-suppression cancel-pending path.
+		mark_open_delivered(&mut conn, incident.id).await;
+
+		// Warning issue arrives — joins because the group has an open incident.
+		save_event(
+			&mut conn,
+			server_id,
+			"warning-ref",
+			Severity::Warning,
+			true,
+			"noise",
+		)
+		.await;
+
+		// Sanity: incident still open with both attached.
+		assert!(
+			!Incident::list_for_server(&mut conn, server_id, false, 10)
+				.await
+				.expect("list")
+				.is_empty(),
+			"incident is still open while error contributor is alive"
+		);
+
+		// Resolve the error issue (active=false).
+		save_event(
+			&mut conn,
+			server_id,
+			"error-ref",
+			Severity::Info,
+			false,
+			"recovered",
+		)
+		.await;
+
+		// New logic: incident closes despite the warning still being active.
+		let still_open = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list");
+		assert!(
+			still_open.is_empty(),
+			"incident must close once no severity≥error contributor is alive, got: {still_open:?}",
+		);
+
+		// One Slack resolve enqueued (not two — the guard against re-close fires).
+		assert_eq!(
+			count_resolve_rows(&mut conn, incident.id).await,
+			1,
+			"exactly one slack_resolve row at this point"
+		);
+	})
+	.await
+}
+
+/// Sibling test: two error contributors, resolving only one keeps the
+/// incident open. Guards against an overzealous filter that would close
+/// when any single error issue leaves.
+#[tokio::test(flavor = "multi_thread")]
+async fn incident_stays_open_while_a_second_error_contributor_is_alive() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn, "http://two-errors.invalid/").await;
+
+		save_event(&mut conn, server_id, "error-a", Severity::Error, true, "a").await;
+		save_event(&mut conn, server_id, "error-b", Severity::Error, true, "b").await;
+
+		// Resolve only one.
+		save_event(
+			&mut conn,
+			server_id,
+			"error-a",
+			Severity::Info,
+			false,
+			"recovered",
+		)
+		.await;
+
+		let still_open = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list");
+		assert_eq!(
+			still_open.len(),
+			1,
+			"incident stays open with second error contributor alive"
+		);
+	})
+	.await
+}
+
+/// Edge case: warning leaves an already-closed incident. The (true, _, true)
+/// arm fires for the warning issue's `active=false` event, but the
+/// closed_at-guard on the close UPDATE prevents a second Slack resolve.
+#[tokio::test(flavor = "multi_thread")]
+async fn stranded_warning_resolve_does_not_re_enqueue_slack() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn, "http://double-close.invalid/").await;
+
+		save_event(
+			&mut conn,
+			server_id,
+			"error-ref",
+			Severity::Error,
+			true,
+			"boom",
+		)
+		.await;
+		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list")
+			.into_iter()
+			.next()
+			.expect("opened");
+		mark_open_delivered(&mut conn, incident.id).await;
+		save_event(
+			&mut conn,
+			server_id,
+			"warning-ref",
+			Severity::Warning,
+			true,
+			"noise",
+		)
+		.await;
+
+		// Error resolves → incident closes (one slack resolve).
+		save_event(
+			&mut conn,
+			server_id,
+			"error-ref",
+			Severity::Info,
+			false,
+			"recovered",
+		)
+		.await;
+		assert_eq!(count_resolve_rows(&mut conn, incident.id).await, 1);
+
+		// Warning eventually resolves too. Incident is already closed; this
+		// must NOT enqueue another slack_resolve.
+		save_event(
+			&mut conn,
+			server_id,
+			"warning-ref",
+			Severity::Info,
+			false,
+			"settled",
+		)
+		.await;
+		assert_eq!(
+			count_resolve_rows(&mut conn, incident.id).await,
+			1,
+			"warning's later resolve must not enqueue a second slack_resolve"
+		);
+	})
+	.await
+}

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -1227,6 +1227,11 @@ async fn submit_status_reachability_to_health_handoff() {
 		async |mut conn, cert, device_id, public, _| {
 			let server_id = insert_health_test_server(&mut conn, device_id).await;
 
+			// db is at Error in the catalog so the per-check is a
+			// meaningful contributor that can hold the incident open
+			// once reachability resolves.
+			set_check_severity(&mut conn, "db", "error").await;
+
 			// Initial state: server silent → reachability sweep files a
 			// canopy/reachability issue at Critical (severity for `Gone`),
 			// which opens an incident on the server's group.
@@ -1241,11 +1246,9 @@ async fn submit_status_reachability_to_health_handoff() {
 				.await
 				.expect("incident opened by reachability");
 
-			// Server pings in with a failing per-check; the per-check issue
-			// (default Warning severity from the catalog) joins the existing
-			// incident rather than opening a separate one. Group already has
-			// an open incident, so any active issue piles in regardless of
-			// severity floor.
+			// Server pings in with a failing per-check; the per-check
+			// issue joins the existing incident rather than opening a
+			// separate one.
 			post_status(
 				&public,
 				&cert,


### PR DESCRIPTION
🤖

Fixes the stuck-incident scenario:

1. Check A is broken and fires at warning (always-failing).
2. Check B fires at error → opens an incident on the group.
3. Check A joins for context (low-severity issues join any open incident, regardless of their own severity).
4. Check B recovers → leaves.
5. The incident has only Check A left — which never recovers — so the incident stays open forever.

After this change the join logic is unchanged (low-severity issues still attach for the audit trail and Slack context), but the auto-close path counts only contributors at severity ≥ error. The fallback case — a stranded low-severity issue eventually leaving an already-closed incident — is guarded by an extra `closed_at IS NULL` clause on the close UPDATE so we don't double-close or enqueue a second Slack `incident_resolve`.

No migration needed: the existing startup `reconcile_open_incidents` pass walks every active issue and re-runs `re_evaluate_incident_membership`, so stuck-open incidents in prod close themselves on next deploy (one Slack notification per).

Commits:
- `commons-types`: `Severity::OPENS_INCIDENT` constant + `opens_incident()` delegates to it.
- `issues`: filter the `remaining_open` count by severity.
- `issues`: guard the auto-close UPDATE on `closed_at IS NULL`.
- Three new database tests covering the scenarios above.