### PR TITLE
private-web(healthchecks): word labels for rule operators + label the severity select

### DIFF
--- a/private-web/src/routes/HealthcheckDetail.tsx
+++ b/private-web/src/routes/HealthcheckDetail.tsx
@@ -44,14 +44,14 @@ import { SEVERITIES, type HealthcheckSeverityData, type Severity } from "../type
 
 const RULE_OPS = ["==", "!=", "<", "<=", ">", ">=", "in_range"] as const;
 type RuleOp = (typeof RULE_OPS)[number];
-const OP_SYMBOL: Record<RuleOp, string> = {
-	"==": "=",
-	"!=": "≠",
-	"<": "<",
-	"<=": "≤",
-	">": ">",
-	">=": "≥",
-	in_range: "∈",
+const OP_LABEL: Record<RuleOp, string> = {
+	"==": "equal",
+	"!=": "not equal",
+	"<": "less than",
+	"<=": "less than or equal",
+	">": "greater than",
+	">=": "greater than or equal",
+	in_range: "version in range",
 };
 const VAR_PATTERN = /^(check|status|tag)\.[A-Za-z0-9_]+$/;
 
@@ -429,7 +429,7 @@ function RulesCard({
 								<TableRow key={idx} hover>
 									<TableCell>{idx}</TableCell>
 									<TableCell sx={{ fontFamily: "monospace", fontSize: "0.85em" }}>
-										{b.varPath} {OP_SYMBOL[b.op]} {valueToInputText(b.value)}
+										{b.varPath} {OP_LABEL[b.op]} {valueToInputText(b.value)}
 									</TableCell>
 									<TableCell>
 										<SeverityChip severity={b.severity} />
@@ -577,18 +577,20 @@ function BranchDialog({
 						onChange={(e) => setVarPath(e.target.value)}
 					/>
 					<Stack direction="row" spacing={1}>
-						<Select
+						<TextField
+							select
+							label="Operator"
 							size="small"
 							value={op}
 							onChange={(e) => setOp(e.target.value as RuleOp)}
-							sx={{ minWidth: 100 }}
+							sx={{ minWidth: 220 }}
 						>
 							{RULE_OPS.map((o) => (
 								<MenuItem key={o} value={o}>
-									{OP_SYMBOL[o]} ({o})
+									{OP_LABEL[o]}
 								</MenuItem>
 							))}
-						</Select>
+						</TextField>
 						<TextField
 							label="Value"
 							size="small"
@@ -602,7 +604,9 @@ function BranchDialog({
 							onChange={(e) => setValueText(e.target.value)}
 						/>
 					</Stack>
-					<Select
+					<TextField
+						select
+						label="Severity"
 						size="small"
 						value={severity}
 						onChange={(e) => setSeverity(e.target.value as Severity)}
@@ -612,7 +616,7 @@ function BranchDialog({
 								<SeverityChip severity={s} />
 							</MenuItem>
 						))}
-					</Select>
+					</TextField>
 				</Stack>
 			</DialogContent>
 			<DialogActions>


### PR DESCRIPTION
🤖

The op dropdown in the add-rule dialog was rendering both a Unicode glyph and the JsonLogic symbol on each line (`= (==)`, `∈ (in_range)`, …), which read as duplicate information without making clear how they related. The rules table cell also used the glyph form (`check.used_pct > 95`), creating two different shorthands for the same operator.

This PR picks one vocabulary — full English words — and uses it everywhere a human reads an op:

- Dropdown options: `equal`, `not equal`, `less than`, `less than or equal`, `greater than`, `greater than or equal`, `version in range`.
- Rules table cell: `check.used_pct greater than 95`.

The wire representation (`==`, `!=`, `in_range`) is unchanged; this is rendering only.

Also rewraps the severity select as a labelled TextField so the field shows `Severity` instead of an unlabelled dropdown.