### PR TITLE
Healthchecks: sample endpoint + autocomplete + var validation in the rule editor

### DIFF
--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -276,6 +276,51 @@ impl Status {
 		Ok(filed)
 	}
 
+	/// Most recent status row (across all servers) whose `health` array
+	/// contains an entry for `check_name`. Used by the rule-editor UI to
+	/// surface a realistic sample of the variables an operator can
+	/// predicate on (the check's extras, the status-level extras, and
+	/// the server's tags resolved up the group).
+	pub async fn latest_for_check_name(
+		db: &mut AsyncPgConnection,
+		check_name: &str,
+	) -> Result<Option<Status>> {
+		use diesel::sql_types::{Text, Uuid as DUuid};
+		use diesel::{QueryableByName, sql_query};
+
+		#[derive(QueryableByName)]
+		struct Picked {
+			#[diesel(sql_type = DUuid, column_name = "id")]
+			row_id: Uuid,
+		}
+
+		// Two-step: pick the id via raw SQL (JSONB containment needs a
+		// parameterised JSON literal that Diesel's typed DSL doesn't
+		// express cleanly), then load the typed Status row by id.
+		let picked: Option<Picked> = sql_query(
+			"SELECT id FROM statuses \
+			 WHERE health @> jsonb_build_array(jsonb_build_object('check', $1::text)) \
+			 ORDER BY created_at DESC LIMIT 1",
+		)
+		.bind::<Text, _>(check_name)
+		.get_result(db)
+		.await
+		.optional()
+		.map_err(AppError::from)?;
+		let Some(Picked { row_id }) = picked else {
+			return Ok(None);
+		};
+
+		use crate::schema::statuses::dsl;
+		dsl::statuses
+			.select(Self::as_select())
+			.filter(dsl::id.eq(row_id))
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
 	pub async fn latest_for_server(
 		db: &mut AsyncPgConnection,
 		server: Uuid,

--- a/crates/private-server/src/fns/healthchecks.rs
+++ b/crates/private-server/src/fns/healthchecks.rs
@@ -9,9 +9,12 @@ use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use commons_types::issue::Severity;
 use database::healthcheck_severities::{HealthcheckSeverity, IfLadder};
+use database::servers::Server;
+use database::statuses::Status;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
@@ -22,6 +25,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(list))
 		.routes(routes!(update))
 		.routes(routes!(update_rules))
+		.routes(routes!(sample))
 }
 
 /// Catalog row enriched with `pending_review` and `rule_count` derivations
@@ -192,4 +196,112 @@ pub async fn update_rules(
 	)
 	.await?;
 	Ok(Json(row.into()))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct SampleArgs {
+	pub check_name: String,
+}
+
+/// Materialised sample of the inputs available to a rule when this check
+/// fails — fetched from the most recent status push (across all servers)
+/// that reported `check_name`. The UI uses this to power autocomplete
+/// suggestions, pass/warn validation on `var` input, and live previews
+/// of a rule's effect against realistic data.
+#[derive(Serialize, ToSchema)]
+pub struct HealthcheckSample {
+	/// Top-level status extras (`statuses.extra`).
+	pub status_extra: serde_json::Map<String, JsonValue>,
+	/// The failing check's own fields (`health[i]` minus `check` /
+	/// `healthy`).
+	pub check_extra: serde_json::Map<String, JsonValue>,
+	/// Server's resolved tag map (server + group merge).
+	pub tags: HashMap<String, String>,
+	/// Server hostname for display.
+	pub server_host: String,
+	/// Optional friendly server name.
+	pub server_name: Option<String>,
+	/// When the sampled status push happened.
+	pub seen_at: Timestamp,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct HealthcheckSampleResponse {
+	pub check_name: String,
+	pub sample: Option<HealthcheckSample>,
+}
+
+#[utoipa::path(
+	post,
+	path = "/sample",
+	operation_id = "healthcheck_sample",
+	tag = "healthchecks",
+	security(("tailscale-admin" = [])),
+	request_body = SampleArgs,
+	responses(
+		(status = 200, description = "Sample payload or null if no server has reported this check yet.", body = HealthcheckSampleResponse),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn sample(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<SampleArgs>,
+) -> Result<Json<HealthcheckSampleResponse>> {
+	let mut conn = state.db.get().await?;
+	let Some(status) = Status::latest_for_check_name(&mut conn, &args.check_name).await? else {
+		return Ok(Json(HealthcheckSampleResponse {
+			check_name: args.check_name,
+			sample: None,
+		}));
+	};
+	let server = Server::get_by_id(&mut conn, status.server_id).await?;
+
+	// Top-level extras — the column is always an object after our
+	// ingestion path strips reserved keys.
+	let status_extra = status
+		.extra
+		.as_object()
+		.cloned()
+		.unwrap_or_default();
+
+	// Pull the failing-check entry out of the health array (any entry
+	// matching by name; we don't require unhealthy here so we still
+	// surface the check's typical shape even on a healthy push). Strip
+	// the reserved fields so the UI sees only the operator-predicatable
+	// extras — mirrors what the ingestion path passes to severity_for.
+	let check_extra = status
+		.health
+		.as_array()
+		.and_then(|arr| {
+			arr.iter().find_map(|e| {
+				let obj = e.as_object()?;
+				let name = obj.get("check")?.as_str()?;
+				if name == args.check_name {
+					let mut m = obj.clone();
+					m.remove("check");
+					m.remove("healthy");
+					Some(m)
+				} else {
+					None
+				}
+			})
+		})
+		.unwrap_or_default();
+
+	let tag_map = server.tags_merged_with_group(&mut conn).await?;
+	let tags: HashMap<String, String> = tag_map.0.into_iter().collect();
+
+	Ok(Json(HealthcheckSampleResponse {
+		check_name: args.check_name,
+		sample: Some(HealthcheckSample {
+			status_extra,
+			check_extra,
+			tags,
+			server_host: server.host.0.to_string(),
+			server_name: server.name,
+			seen_at: status.created_at,
+		}),
+	}))
 }

--- a/crates/private-server/tests/healthchecks.rs
+++ b/crates/private-server/tests/healthchecks.rs
@@ -278,3 +278,112 @@ async fn update_rules_rejects_malformed_shapes() {
 	})
 	.await
 }
+
+// ── /sample ───────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sample_returns_null_when_no_server_has_reported_the_check() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO healthcheck_severities (check_name) VALUES ('uncharted_check');",
+		)
+		.await
+		.unwrap();
+		let response = private
+			.post("/api/healthchecks/sample")
+			.json(&json!({"check_name": "uncharted_check"}))
+			.await;
+		response.assert_status_ok();
+		let body: serde_json::Value = response.json();
+		assert_eq!(body["check_name"], "uncharted_check");
+		assert!(body["sample"].is_null());
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sample_materialises_latest_push_for_this_check() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO server_groups (id, name, tags) VALUES \
+				('11111111-1111-1111-1111-111111111111', 'prod', '{\"env\": \"prod\"}'::jsonb); \
+			 INSERT INTO servers (id, host, name, kind, group_id, tags) VALUES \
+				('22222222-2222-2222-2222-222222222222', 'https://prod-host', 'Prod Central', 'central', \
+				 '11111111-1111-1111-1111-111111111111', '{\"region\": \"au\"}'::jsonb); \
+			 INSERT INTO statuses (server_id, healthy, health, extra, created_at) VALUES \
+				('22222222-2222-2222-2222-222222222222', false, \
+				 '[{\"check\": \"disk_space\", \"healthy\": false, \"used_pct\": 97}, {\"check\": \"other\", \"healthy\": true}]'::jsonb, \
+				 '{\"bestoolVersion\": \"1.13.0\", \"uptimeSecs\": 6038594}'::jsonb, \
+				 NOW() - interval '2 minutes');",
+		)
+		.await
+		.unwrap();
+
+		let response = private
+			.post("/api/healthchecks/sample")
+			.json(&json!({"check_name": "disk_space"}))
+			.await;
+		response.assert_status_ok();
+		let body: serde_json::Value = response.json();
+		assert_eq!(body["check_name"], "disk_space");
+		let sample = &body["sample"];
+		assert!(!sample.is_null(), "sample populated when a status push exists");
+
+		// Status-level extras come straight from statuses.extra.
+		assert_eq!(sample["status_extra"]["bestoolVersion"], "1.13.0");
+		assert_eq!(sample["status_extra"]["uptimeSecs"], 6_038_594);
+
+		// Check-level extras strip the reserved fields.
+		assert_eq!(sample["check_extra"]["used_pct"], 97);
+		assert!(
+			sample["check_extra"].get("check").is_none(),
+			"reserved `check` must be stripped"
+		);
+		assert!(
+			sample["check_extra"].get("healthy").is_none(),
+			"reserved `healthy` must be stripped"
+		);
+
+		// Tags merge: server overlays group; both keys present here.
+		assert_eq!(sample["tags"]["env"], "prod");
+		assert_eq!(sample["tags"]["region"], "au");
+
+		assert_eq!(sample["server_host"], "https://prod-host/");
+		assert_eq!(sample["server_name"], "Prod Central");
+		assert!(sample["seen_at"].is_string());
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sample_picks_the_most_recent_push_across_servers() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO servers (id, host, kind) VALUES \
+				('33333333-3333-3333-3333-333333333333', 'https://older-host', 'central'), \
+				('44444444-4444-4444-4444-444444444444', 'https://newer-host', 'central'); \
+			 INSERT INTO statuses (server_id, healthy, health, extra, created_at) VALUES \
+				('33333333-3333-3333-3333-333333333333', false, \
+				 '[{\"check\": \"cert_expiry\", \"healthy\": false, \"days_remaining\": 30}]'::jsonb, \
+				 '{}'::jsonb, NOW() - interval '1 hour'), \
+				('44444444-4444-4444-4444-444444444444', false, \
+				 '[{\"check\": \"cert_expiry\", \"healthy\": false, \"days_remaining\": 5}]'::jsonb, \
+				 '{}'::jsonb, NOW() - interval '1 minute');",
+		)
+		.await
+		.unwrap();
+
+		let response = private
+			.post("/api/healthchecks/sample")
+			.json(&json!({"check_name": "cert_expiry"}))
+			.await;
+		response.assert_status_ok();
+		let body: serde_json::Value = response.json();
+		assert_eq!(
+			body["sample"]["check_extra"]["days_remaining"], 5,
+			"newer push wins"
+		);
+		assert_eq!(body["sample"]["server_host"], "https://newer-host/");
+	})
+	.await
+}

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1147,6 +1147,61 @@
         ]
       }
     },
+    "/api/healthchecks/sample": {
+      "post": {
+        "tags": [
+          "healthchecks"
+        ],
+        "operationId": "healthcheck_sample",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SampleArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Sample payload or null if no server has reported this check yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthcheckSampleResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/healthchecks/update": {
       "post": {
         "tags": [
@@ -4269,6 +4324,86 @@
           "unhealthy"
         ]
       },
+      "HealthcheckSample": {
+        "type": "object",
+        "description": "Materialised sample of the inputs available to a rule when this check\nfails — fetched from the most recent status push (across all servers)\nthat reported `check_name`. The UI uses this to power autocomplete\nsuggestions, pass/warn validation on `var` input, and live previews\nof a rule's effect against realistic data.",
+        "required": [
+          "status_extra",
+          "check_extra",
+          "tags",
+          "server_host",
+          "seen_at"
+        ],
+        "properties": {
+          "check_extra": {
+            "type": "object",
+            "description": "The failing check's own fields (`health[i]` minus `check` /\n`healthy`).",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Value"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the sampled status push happened."
+          },
+          "server_host": {
+            "type": "string",
+            "description": "Server hostname for display."
+          },
+          "server_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional friendly server name."
+          },
+          "status_extra": {
+            "type": "object",
+            "description": "Top-level status extras (`statuses.extra`).",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Value"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "object",
+            "description": "Server's resolved tag map (server + group merge).",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "HealthcheckSampleResponse": {
+        "type": "object",
+        "required": [
+          "check_name"
+        ],
+        "properties": {
+          "check_name": {
+            "type": "string"
+          },
+          "sample": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/HealthcheckSample"
+              }
+            ]
+          }
+        }
+      },
       "HealthcheckSeverityData": {
         "type": "object",
         "description": "Catalog row enriched with `pending_review` and `rule_count` derivations\nfor the UI. `rules` is the raw JsonLogic blob exactly as stored; the\nReact side parses it client-side (or the per-check editor rebuilds it\nfrom form state and POSTs to /update_rules). Malformed `rules` parses\nto `rule_count: 0` and the row behaves as \"no conditional rules\" — the\nevaluator does the same on the ingestion path.",
@@ -5660,6 +5795,17 @@
           "duplicate",
           "flapping"
         ]
+      },
+      "SampleArgs": {
+        "type": "object",
+        "required": [
+          "check_name"
+        ],
+        "properties": {
+          "check_name": {
+            "type": "string"
+          }
+        }
       },
       "SaveArgs": {
         "type": "object",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -458,6 +458,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/healthchecks/sample": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["healthcheck_sample"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/healthchecks/update": {
         parameters: {
             query?: never;
@@ -1690,6 +1706,43 @@ export interface components {
          */
         HealthState: "healthy" | "warning" | "unhealthy";
         /**
+         * @description Materialised sample of the inputs available to a rule when this check
+         *     fails — fetched from the most recent status push (across all servers)
+         *     that reported `check_name`. The UI uses this to power autocomplete
+         *     suggestions, pass/warn validation on `var` input, and live previews
+         *     of a rule's effect against realistic data.
+         */
+        HealthcheckSample: {
+            /**
+             * @description The failing check's own fields (`health[i]` minus `check` /
+             *     `healthy`).
+             */
+            check_extra: {
+                [key: string]: components["schemas"]["Value"];
+            };
+            /**
+             * Format: date-time
+             * @description When the sampled status push happened.
+             */
+            seen_at: string;
+            /** @description Server hostname for display. */
+            server_host: string;
+            /** @description Optional friendly server name. */
+            server_name?: string | null;
+            /** @description Top-level status extras (`statuses.extra`). */
+            status_extra: {
+                [key: string]: components["schemas"]["Value"];
+            };
+            /** @description Server's resolved tag map (server + group merge). */
+            tags: {
+                [key: string]: string;
+            };
+        };
+        HealthcheckSampleResponse: {
+            check_name: string;
+            sample?: null | components["schemas"]["HealthcheckSample"];
+        };
+        /**
          * @description Catalog row enriched with `pending_review` and `rule_count` derivations
          *     for the UI. `rules` is the raw JsonLogic blob exactly as stored; the
          *     React side parses it client-side (or the per-check editor rebuilds it
@@ -2213,6 +2266,9 @@ export interface components {
          * @enum {string}
          */
         ResolvedReason: "fixed" | "wont_fix" | "expected" | "duplicate" | "flapping";
+        SampleArgs: {
+            check_name: string;
+        };
         SaveArgs: {
             description?: string | null;
             name: string;
@@ -3434,6 +3490,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HealthcheckSeverityData"][];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    healthcheck_sample: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SampleArgs"];
+            };
+        };
+        responses: {
+            /** @description Sample payload or null if no server has reported this check yet. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthcheckSampleResponse"];
                 };
             };
             401: {

--- a/private-web/src/routes/HealthcheckDetail.tsx
+++ b/private-web/src/routes/HealthcheckDetail.tsx
@@ -1,5 +1,6 @@
 import {
 	Alert,
+	Autocomplete,
 	Box,
 	Button,
 	Chip,
@@ -8,6 +9,7 @@ import {
 	DialogContent,
 	DialogTitle,
 	IconButton,
+	InputAdornment,
 	LinearProgress,
 	MenuItem,
 	Paper,
@@ -24,8 +26,10 @@ import {
 } from "@mui/material";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { useMemo, useState } from "react";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import { ApiError, useApi, useApiAction } from "../api";
@@ -33,7 +37,12 @@ import SeverityChip from "../components/SeverityChip";
 import TimeAgo from "../components/TimeAgo";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { SEVERITIES, type HealthcheckSeverityData, type Severity } from "../types";
+import {
+	SEVERITIES,
+	type HealthcheckSample,
+	type HealthcheckSeverityData,
+	type Severity,
+} from "../types";
 
 // ── Constrained JsonLogic shape ───────────────────────────────────────────
 //
@@ -361,6 +370,14 @@ function RulesCard({
 	const [dialog, setDialog] = useState<{ index: number | null } | null>(null);
 	const update = useApiAction("healthchecks", "update_rules");
 
+	// Pull a representative sample of variables operators can reach for —
+	// the most recent status push (across all servers) that reported
+	// this check. Powers the Add/Edit dialog's autocomplete + validation.
+	// Fetched lazily; the dialog handles a null sample gracefully.
+	const sampleResp = useApi("healthchecks", "sample", { check_name: row.check_name });
+	const sample: HealthcheckSample | null =
+		sampleResp.status === "ok" ? (sampleResp.data.sample ?? null) : null;
+
 	const dirty = useMemo(
 		() => JSON.stringify(branches) !== JSON.stringify(parsed.branches),
 		[branches, parsed.branches],
@@ -405,6 +422,18 @@ function RulesCard({
 				Evaluated top-to-bottom on every failing push for this check. First matching
 				branch's severity wins; if none match, the base severity above is used.
 			</Typography>
+			{sample ? (
+				<Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
+					Editor uses the most recent push from{" "}
+					<code>{sample.server_name ?? sample.server_host}</code> (
+					<TimeAgo timestamp={sample.seen_at} />) to suggest fields and validate inputs.
+				</Typography>
+			) : sampleResp.status === "ok" ? (
+				<Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
+					No server has reported this check yet — the editor can't suggest fields
+					until one does.
+				</Typography>
+			) : null}
 			{parsed.error && (
 				<Alert severity="warning" sx={{ mb: 1 }}>
 					Stored rules are malformed ({parsed.error}) — ingestion falls back to the
@@ -510,6 +539,7 @@ function RulesCard({
 			{dialog && (
 				<BranchDialog
 					initial={dialog.index != null ? branches[dialog.index] : null}
+					sample={sample}
 					onCancel={() => setDialog(null)}
 					onSave={(b) => {
 						setBranches((bs) => {
@@ -532,12 +562,24 @@ function swap<T>(arr: T[], i: number, j: number): T[] {
 	return next;
 }
 
+/// Fields available on the sample, projected as dotted paths.
+function sampleVarOptions(sample: HealthcheckSample | null): string[] {
+	if (!sample) return [];
+	const opts: string[] = [];
+	for (const k of Object.keys(sample.check_extra)) opts.push(`check.${k}`);
+	for (const k of Object.keys(sample.status_extra)) opts.push(`status.${k}`);
+	for (const k of Object.keys(sample.tags)) opts.push(`tag.${k}`);
+	return opts.sort();
+}
+
 function BranchDialog({
 	initial,
+	sample,
 	onCancel,
 	onSave,
 }: {
 	initial: Branch | null;
+	sample: HealthcheckSample | null;
 	onCancel: () => void;
 	onSave: (b: Branch) => void;
 }) {
@@ -549,6 +591,12 @@ function BranchDialog({
 	const [severity, setSeverity] = useState<Severity>(initial?.severity ?? "error");
 	const varValid = VAR_PATTERN.test(varPath);
 
+	// Did the sample carry a value for this exact var path? Powers the
+	// pass/warn badge: green when the operator's predicating on a field
+	// the most recent push actually had, yellow otherwise.
+	const options = useMemo(() => sampleVarOptions(sample), [sample]);
+	const varInSample = varValid && options.includes(varPath);
+
 	const submit = () => {
 		if (!varValid) return;
 		onSave({
@@ -559,22 +607,64 @@ function BranchDialog({
 		});
 	};
 
+	const varAdornment = varValid ? (
+		varInSample ? (
+			<InputAdornment position="end">
+				<CheckCircleIcon
+					fontSize="small"
+					color="success"
+					titleAccess="Field is present in the sample push"
+				/>
+			</InputAdornment>
+		) : sample ? (
+			<InputAdornment position="end">
+				<WarningAmberIcon
+					fontSize="small"
+					color="warning"
+					titleAccess="Field is not present in the sampled push — the rule will be evaluated against an absent value (typically falsy)."
+				/>
+			</InputAdornment>
+		) : undefined
+	) : undefined;
+
+	const varHelper = !varValid
+		? "Must match check.<field>, status.<field>, or tag.<field>"
+		: !sample
+			? "No sample available to validate against. Path like status.bestoolVersion, check.used_pct, tag.environment."
+			: varInSample
+				? "Field is present in the sampled push."
+				: "Field is not present in the sample — predicates referring to it will see an absent value at evaluation time.";
+
 	return (
 		<Dialog open onClose={onCancel} fullWidth maxWidth="sm">
 			<DialogTitle>{initial ? "Edit rule" : "Add rule"}</DialogTitle>
 			<DialogContent>
 				<Stack spacing={2} sx={{ mt: 1 }}>
-					<TextField
-						label="Variable"
-						helperText={
-							varValid
-								? "Path like status.bestoolVersion, check.used_pct, tag.environment"
-								: "Must match check.<field>, status.<field>, or tag.<field>"
-						}
-						error={!varValid}
-						size="small"
+					<Autocomplete
+						freeSolo
+						options={options}
 						value={varPath}
-						onChange={(e) => setVarPath(e.target.value)}
+						onInputChange={(_, v) => setVarPath(v)}
+						renderInput={(params) => (
+							<TextField
+								{...params}
+								label="Variable"
+								helperText={varHelper}
+								error={!varValid}
+								size="small"
+								slotProps={{
+									input: {
+										...params.slotProps.input,
+										endAdornment: (
+											<>
+												{varAdornment}
+												{params.slotProps.input.endAdornment}
+											</>
+										),
+									},
+								}}
+							/>
+						)}
 					/>
 					<Stack direction="row" spacing={1}>
 						<Select

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -111,6 +111,8 @@ export type DeviceInfo = Solidify<Schemas["DeviceInfo"]>;
 export type TailnetLiveInfo = Solidify<Schemas["TailnetLiveInfo"]>;
 
 export type HealthcheckSeverityData = Solidify<Schemas["HealthcheckSeverityData"]>;
+export type HealthcheckSample = Solidify<Schemas["HealthcheckSample"]>;
+export type HealthcheckSampleResponse = Solidify<Schemas["HealthcheckSampleResponse"]>;
 
 export type IssueData = Solidify<Schemas["IssueData"]>;
 export type IssueIncidentLink = Solidify<Schemas["IssueIncidentLink"]>;


### PR DESCRIPTION
🤖

Two related improvements to the rule editor on /healthchecks/<check>:

## Backend: GET sample for a check

`POST /api/healthchecks/sample {check_name}` returns the most recent status push (across all servers) that reported this check, projected into the same shape the ingestion-side rule evaluator consumes:

- `status_extra` — top-level extras (bestoolVersion, tamanuVersion, …)
- `check_extra` — the failing-check entry's own fields, with the reserved `check` / `healthy` stripped
- `tags` — server + group merged map
- `server_host` / `server_name` / `seen_at` for display

Returns `sample: null` when no server has yet reported this check.

Backed by a new `Status::latest_for_check_name` on the database crate that uses JSONB containment (`health @> jsonb_build_array(jsonb_build_object('check', $1))`) to pick the latest matching row.

## Frontend: autocomplete + pass/warn in the rule dialog

The variable field is now an Autocomplete:
- Options are the sample's available paths (`check.*`, `status.*`, `tag.*`), sorted.
- Free-typing is allowed — operators can predicate on fields that aren't in this particular sample (some are only emitted under specific conditions).
- A small adornment indicates whether the entered path resolves in the sample: green check if yes, amber warning if no. Predicates on absent fields evaluate as false at ingestion time, so flagging early avoids the silent-mismatch case.

The Rules card surfaces the source of the sample (server + when) so operators know which push the editor is calibrating against.