### PR TITLE
private-web(healthchecks): live rule preview in the add/edit dialog

### DIFF
--- a/private-web/package-lock.json
+++ b/private-web/package-lock.json
@@ -21,7 +21,8 @@
 				"rehype-raw": "^7.0.0",
 				"rehype-sanitize": "^6.0.0",
 				"remark-breaks": "^4.0.0",
-				"remark-gfm": "^4.0.1"
+				"remark-gfm": "^4.0.1",
+				"semver": "^7.8.1"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.60.0",
@@ -31,6 +32,7 @@
 				"@types/pg": "^8.20.0",
 				"@types/react": "^19.2.14",
 				"@types/react-dom": "^19.2.3",
+				"@types/semver": "^7.7.1",
 				"@vitejs/plugin-react": "^6.0.2",
 				"jsdom": "^29.1.1",
 				"openapi-typescript": "^7.13.0",
@@ -1552,6 +1554,13 @@
 			"peerDependencies": {
 				"@types/react": "*"
 			}
+		},
+		"node_modules/@types/semver": {
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
@@ -4756,6 +4765,18 @@
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
 			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
 			"license": "MIT"
+		},
+		"node_modules/semver": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.2",

--- a/private-web/package.json
+++ b/private-web/package.json
@@ -26,7 +26,8 @@
 		"rehype-raw": "^7.0.0",
 		"rehype-sanitize": "^6.0.0",
 		"remark-breaks": "^4.0.0",
-		"remark-gfm": "^4.0.1"
+		"remark-gfm": "^4.0.1",
+		"semver": "^7.8.1"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",
@@ -36,6 +37,7 @@
 		"@types/pg": "^8.20.0",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
+		"@types/semver": "^7.7.1",
 		"@vitejs/plugin-react": "^6.0.2",
 		"jsdom": "^29.1.1",
 		"openapi-typescript": "^7.13.0",

--- a/private-web/src/lib/healthcheck-rule-eval.ts
+++ b/private-web/src/lib/healthcheck-rule-eval.ts
@@ -1,0 +1,179 @@
+// Client-side mirror of the Rust IfLadder evaluator (see
+// crates/database/src/healthcheck_severities.rs). Used by the rule
+// editor to preview whether a candidate rule would match a sampled
+// status push.
+//
+// The Rust side is the source of truth. Behaviours that must stay in
+// sync:
+//   - Missing field → condition false (not an error).
+//   - `==` / `!=` compare strict-equal first; numeric-string and
+//     number compare numerically when both sides are numeric-coercible.
+//   - `<` / `<=` / `>` / `>=` are numeric; non-numeric → false.
+//   - `in_range` parses lhs as a semver Version, value as a semver Range.
+
+import semver from "semver";
+import type { HealthcheckSample } from "../types";
+
+export type RuleOp = "==" | "!=" | "<" | "<=" | ">" | ">=" | "in_range";
+
+export interface Condition {
+	varPath: string;
+	op: RuleOp;
+	value: unknown;
+}
+
+export interface PreviewResult {
+	/** True if the var path resolves in the sample. */
+	varResolved: boolean;
+	/** The resolved lhs value (when varResolved). */
+	lhs: unknown;
+	/** True if the condition matches the sample. */
+	matched: boolean;
+	/** Per-piece diagnostics — what we tried, why we said yes/no. */
+	notes: string;
+}
+
+function resolveVar(varPath: string, sample: HealthcheckSample): { found: boolean; value: unknown } {
+	const dot = varPath.indexOf(".");
+	if (dot <= 0) return { found: false, value: undefined };
+	const kind = varPath.slice(0, dot);
+	const field = varPath.slice(dot + 1);
+	let map: Record<string, unknown>;
+	if (kind === "check") map = sample.check_extra;
+	else if (kind === "status") map = sample.status_extra;
+	else if (kind === "tag") map = sample.tags;
+	else return { found: false, value: undefined };
+	if (!(field in map)) return { found: false, value: undefined };
+	return { found: true, value: map[field] };
+}
+
+function toNumber(v: unknown): number | null {
+	if (typeof v === "number") return Number.isFinite(v) ? v : null;
+	if (typeof v === "string") {
+		const trimmed = v.trim();
+		if (trimmed === "") return null;
+		const n = Number(trimmed);
+		return Number.isFinite(n) ? n : null;
+	}
+	return null;
+}
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+	// Strict structural equality (JSON-level).
+	if (a === b) return true;
+	if (typeof a === "number" && typeof b === "number") return a === b;
+	// Numeric coercion: same as Rust evaluator.
+	const an = toNumber(a);
+	const bn = toNumber(b);
+	if (an !== null && bn !== null) return an === bn;
+	return false;
+}
+
+export function evaluate(condition: Condition, sample: HealthcheckSample): PreviewResult {
+	const { varPath, op, value } = condition;
+	const { found, value: lhs } = resolveVar(varPath, sample);
+	if (!found) {
+		return {
+			varResolved: false,
+			lhs: undefined,
+			matched: false,
+			notes: `${varPath} is not present in the sample, so the condition evaluates to false.`,
+		};
+	}
+	const fmt = (v: unknown) =>
+		typeof v === "string" ? JSON.stringify(v) : JSON.stringify(v);
+	switch (op) {
+		case "==": {
+			const matched = jsonEqual(lhs, value);
+			return {
+				varResolved: true,
+				lhs,
+				matched,
+				notes: `${fmt(lhs)} ${matched ? "==" : "!="} ${fmt(value)}`,
+			};
+		}
+		case "!=": {
+			const matched = !jsonEqual(lhs, value);
+			return {
+				varResolved: true,
+				lhs,
+				matched,
+				notes: `${fmt(lhs)} ${matched ? "!=" : "=="} ${fmt(value)}`,
+			};
+		}
+		case "<":
+		case "<=":
+		case ">":
+		case ">=": {
+			const ln = toNumber(lhs);
+			const rn = toNumber(value);
+			if (ln === null || rn === null) {
+				return {
+					varResolved: true,
+					lhs,
+					matched: false,
+					notes: `${fmt(lhs)} or ${fmt(value)} is not numeric — comparison evaluates to false.`,
+				};
+			}
+			const matched =
+				op === "<"
+					? ln < rn
+					: op === "<="
+						? ln <= rn
+						: op === ">"
+							? ln > rn
+							: ln >= rn;
+			return {
+				varResolved: true,
+				lhs,
+				matched,
+				notes: `${ln} ${op} ${rn}`,
+			};
+		}
+		case "in_range": {
+			if (typeof lhs !== "string") {
+				return {
+					varResolved: true,
+					lhs,
+					matched: false,
+					notes: `${fmt(lhs)} is not a string, so it can't be a semver version.`,
+				};
+			}
+			if (typeof value !== "string") {
+				return {
+					varResolved: true,
+					lhs,
+					matched: false,
+					notes: `value ${fmt(value)} is not a string, so it can't be a semver range.`,
+				};
+			}
+			const ver = semver.valid(semver.coerce(lhs)?.version ?? lhs);
+			const range = semver.validRange(value);
+			if (!ver) {
+				return {
+					varResolved: true,
+					lhs,
+					matched: false,
+					notes: `'${lhs}' is not a valid semver version.`,
+				};
+			}
+			if (!range) {
+				return {
+					varResolved: true,
+					lhs,
+					matched: false,
+					notes: `'${value}' is not a valid semver range.`,
+				};
+			}
+			const matched = semver.satisfies(ver, range);
+			return {
+				varResolved: true,
+				lhs,
+				matched,
+				notes: matched
+					? `${ver} satisfies ${value}.`
+					: `${ver} does not satisfy ${value}.`,
+			};
+		}
+	}
+}

--- a/private-web/src/routes/HealthcheckDetail.tsx
+++ b/private-web/src/routes/HealthcheckDetail.tsx
@@ -37,6 +37,7 @@ import SeverityChip from "../components/SeverityChip";
 import TimeAgo from "../components/TimeAgo";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
+import { evaluate as evalCondition } from "../lib/healthcheck-rule-eval";
 import {
 	SEVERITIES,
 	SEVERITY_INTENT,
@@ -719,6 +720,15 @@ function BranchDialog({
 							</MenuItem>
 						))}
 					</TextField>
+					{varValid && sample && (
+						<PreviewBox
+							sample={sample}
+							varPath={varPath}
+							op={op}
+							valueText={valueText}
+							severity={severity}
+						/>
+					)}
 				</Stack>
 			</DialogContent>
 			<DialogActions>
@@ -728,6 +738,58 @@ function BranchDialog({
 				</Button>
 			</DialogActions>
 		</Dialog>
+	);
+}
+
+function PreviewBox({
+	sample,
+	varPath,
+	op,
+	valueText,
+	severity,
+}: {
+	sample: HealthcheckSample;
+	varPath: string;
+	op: RuleOp;
+	valueText: string;
+	severity: Severity;
+}) {
+	const result = useMemo(
+		() =>
+			evalCondition(
+				{ varPath, op, value: parseValueInput(valueText) },
+				sample,
+			),
+		[varPath, op, valueText, sample],
+	);
+	return (
+		<Alert
+			severity={result.matched ? "success" : "info"}
+			variant="outlined"
+			sx={{ alignItems: "center" }}
+		>
+			<Stack direction="row" spacing={1} sx={{ alignItems: "center", flexWrap: "wrap" }}>
+				<Typography variant="body2">
+					Against the sample push (
+					<code>{sample.server_name ?? sample.server_host}</code>):
+				</Typography>
+				{result.matched ? (
+					<Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+						<Typography variant="body2">would file at</Typography>
+						<SeverityChip severity={severity} />
+					</Stack>
+				) : (
+					<Typography variant="body2">would not match → base severity used</Typography>
+				)}
+			</Stack>
+			<Typography
+				variant="caption"
+				color="text.secondary"
+				sx={{ display: "block", mt: 0.5 }}
+			>
+				{result.notes}
+			</Typography>
+		</Alert>
 	);
 }
 


### PR DESCRIPTION
🤖

Stacks on #192 (sample endpoint).

The add/edit rule dialog now evaluates the candidate (var, op, value) live against the most recent status push that reported this check, and shows the result inline:

- Match → `would file at <severity-chip>`
- No match → `would not match → base severity used`
- A short diagnostic line under each, e.g. `1.4.2 satisfies >=1.4.0 <1.5.0`, `97 > 95`, `"abc" is not numeric — comparison evaluates to false`, `'10 (17763)' is not a valid semver version`.

The evaluator is a small TS mirror of the Rust `IfLadder` evaluator in `crates/database/src/healthcheck_severities.rs`. It uses the npm `semver` package for `in_range` parsing/matching, and matches the Rust side's numeric-coercion (numeric-coercible strings compare numerically) and missing-field semantics (absent var → condition false, never an error).

Preview only renders when the var path is syntactically valid and a sample is available; otherwise the dialog quietly skips it.