### PR TITLE
Severity: restrict to 5 levels with explicit incident semantics

### DIFF
--- a/crates/commons-types/src/issue.rs
+++ b/crates/commons-types/src/issue.rs
@@ -7,12 +7,25 @@ use diesel::{
 };
 use serde::{Deserialize, Serialize};
 
-/// RFC 5424 syslog severities.
+/// Canopy's severity vocabulary, narrowed from RFC 5424 to a five-level
+/// set with operator semantics:
+///
+/// - `Debug`: never participates in incidents (filed for the audit
+///   trail / per-server view only).
+/// - `Info`, `Warning`: join an open incident for context but don't
+///   open one or keep one open on their own.
+/// - `Error`: opens an incident; sits in the per-group `slack_open_delay`
+///   holding window before the Slack notification ships.
+/// - `Critical`: opens an incident and bypasses the holding window —
+///   the Slack notification is enqueued for immediate delivery.
 ///
 /// Stored as text in Postgres; validated as this enum at the API layer.
-/// Default is `Error` (incidents only open at severity ≥ Error, so the
-/// default is intentionally above the floor — most devices that bother
-/// pushing an event mean it).
+/// Default is `Error` (the most common severity for a deliberately
+/// filed event). The legacy syslog severities `emergency` / `alert` /
+/// `notice` have been retired — see the
+/// `2026-05-29-000000-0000_restrict_severities` migration; the
+/// `FromStr` impl still accepts them as aliases for forward-compat with
+/// any device that hasn't been updated.
 #[derive(
 	Debug,
 	Clone,
@@ -28,24 +41,20 @@ use serde::{Deserialize, Serialize};
 #[diesel(sql_type = Text)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
-	Emergency,
-	Alert,
 	Critical,
 	#[default]
 	Error,
 	Warning,
-	Notice,
 	Info,
 	Debug,
 }
 
 impl Severity {
 	/// Severities that may open an incident on their own and may keep one
-	/// open. Low-severity issues (warning and below) join an already-open
+	/// open. Lower-severity issues (warning and below) join an already-open
 	/// incident for context but don't hold it open — see
 	/// `database::issues::re_evaluate_incident_membership`.
-	pub const OPENS_INCIDENT: &'static [Severity] =
-		&[Self::Emergency, Self::Alert, Self::Critical, Self::Error];
+	pub const OPENS_INCIDENT: &'static [Severity] = &[Self::Critical, Self::Error];
 
 	/// Issues at or above this severity open incidents.
 	pub fn opens_incident(self) -> bool {
@@ -55,7 +64,7 @@ impl Severity {
 
 #[derive(Debug, Clone, Copy, thiserror::Error)]
 #[error(
-	"invalid severity; expected one of: emergency, alert, critical, error, warning, notice, info, debug"
+	"invalid severity; expected one of: critical, error, warning, info, debug"
 )]
 pub struct SeverityFromStringError;
 
@@ -64,13 +73,14 @@ impl std::str::FromStr for Severity {
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		match s.to_ascii_lowercase().as_ref() {
-			"emergency" | "emerg" | "panic" => Ok(Self::Emergency),
-			"alert" => Ok(Self::Alert),
-			"critical" | "crit" => Ok(Self::Critical),
+			// Retired severities still parse — emergency/alert collapse into
+			// critical and notice collapses into info, matching the migration.
+			"emergency" | "emerg" | "panic" | "alert" | "critical" | "crit" => {
+				Ok(Self::Critical)
+			}
 			"error" | "err" => Ok(Self::Error),
 			"warning" | "warn" => Ok(Self::Warning),
-			"notice" => Ok(Self::Notice),
-			"info" | "informational" => Ok(Self::Info),
+			"notice" | "info" | "informational" => Ok(Self::Info),
 			"debug" => Ok(Self::Debug),
 			_ => Err(SeverityFromStringError),
 		}
@@ -88,12 +98,9 @@ impl TryFrom<String> for Severity {
 impl std::fmt::Display for Severity {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let s = match self {
-			Self::Emergency => "emergency",
-			Self::Alert => "alert",
 			Self::Critical => "critical",
 			Self::Error => "error",
 			Self::Warning => "warning",
-			Self::Notice => "notice",
 			Self::Info => "info",
 			Self::Debug => "debug",
 		};

--- a/crates/database/src/healthcheck_severities.rs
+++ b/crates/database/src/healthcheck_severities.rs
@@ -112,8 +112,8 @@ impl HealthcheckSeverity {
 	) -> Result<Self> {
 		use crate::schema::healthcheck_severities::dsl;
 		let now = Timestamp::now();
-		let rules_json: Option<JsonValue> = rules
-			.map(|l| serde_json::to_value(l).expect("IfLadder always serialises"));
+		let rules_json: Option<JsonValue> =
+			rules.map(|l| serde_json::to_value(l).expect("IfLadder always serialises"));
 		diesel::update(dsl::healthcheck_severities.filter(dsl::check_name.eq(check_name)))
 			.set((
 				dsl::rules.eq(rules_json),
@@ -271,7 +271,9 @@ impl Condition {
 			Self::Gt(_, rhs) => json_compare(lhs, rhs, |a, b| a > b).unwrap_or(false),
 			Self::Gte(_, rhs) => json_compare(lhs, rhs, |a, b| a >= b).unwrap_or(false),
 			Self::InRange(_, range_str) => {
-				let Some(lhs_str) = lhs.as_str() else { return false };
+				let Some(lhs_str) = lhs.as_str() else {
+					return false;
+				};
 				let Ok(version) = lhs_str.parse::<node_semver::Version>() else {
 					return false;
 				};
@@ -335,10 +337,7 @@ impl std::str::FromStr for Var {
 		if field.is_empty() {
 			return Err(format!("var path '{s}' has an empty field name"));
 		}
-		if !field
-			.chars()
-			.all(|c| c.is_ascii_alphanumeric() || c == '_')
-		{
+		if !field.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
 			return Err(format!(
 				"var field '{field}' must be ASCII alphanumeric or underscore"
 			));
@@ -424,9 +423,9 @@ impl<'de> Deserialize<'de> for Condition {
 				let range = rhs
 					.as_str()
 					.ok_or_else(|| de::Error::custom("'in_range' value must be a string"))?;
-				range
-					.parse::<node_semver::Range>()
-					.map_err(|e| de::Error::custom(format!("invalid semver range '{range}': {e}")))?;
+				range.parse::<node_semver::Range>().map_err(|e| {
+					de::Error::custom(format!("invalid semver range '{range}': {e}"))
+				})?;
 				Ok(Self::InRange(var, range.to_string()))
 			}
 			other => Err(de::Error::custom(format!(
@@ -454,7 +453,9 @@ impl<'de> Deserialize<'de> for IfLadder {
 			.as_object()
 			.ok_or_else(|| de::Error::custom("rules must be a JSON object"))?;
 		if obj.len() != 1 {
-			return Err(de::Error::custom("rules must be a single-key {\"if\": …} object"));
+			return Err(de::Error::custom(
+				"rules must be a single-key {\"if\": …} object",
+			));
 		}
 		let (key, args) = obj.iter().next().expect("len == 1");
 		if key != "if" {

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -419,9 +419,19 @@ async fn re_evaluate_incident_membership(
 	.await?;
 	let group_open = group_has_open_incident(conn, server_group_id).await?;
 
-	let should_leave =
-		!issue.active || issue.resolved_at.is_some() || snoozed || silenced || !monitored;
-	let should_join = monitored
+	// Debug-severity issues are intentionally invisible to the incident
+	// workflow: they don't join, and any that are currently attached
+	// (because their catalog/rule severity dropped to Debug after they
+	// joined) get treated as a leave on next re-evaluation.
+	let is_debug = issue.severity == Severity::Debug;
+	let should_leave = is_debug
+		|| !issue.active
+		|| issue.resolved_at.is_some()
+		|| snoozed
+		|| silenced
+		|| !monitored;
+	let should_join = !is_debug
+		&& monitored
 		&& !silenced
 		&& issue.active
 		&& issue.resolved_at.is_none()
@@ -442,6 +452,12 @@ async fn re_evaluate_incident_membership(
 				.await?;
 			if newly_opened {
 				enqueue_slack_open(conn, incident_id, server_group_id, issue).await?;
+			} else if issue.severity == Severity::Critical {
+				// Critical joining an existing incident whose open is
+				// still inside its holding window: pull the delivery
+				// forward to now. enqueue_slack_open already does this
+				// for newly-opened incidents.
+				accelerate_pending_open(conn, incident_id).await?;
 			}
 		}
 		(true, _, true) => {
@@ -805,11 +821,17 @@ async fn enqueue_slack_open(
 		&issue.r#ref,
 		&issue.message,
 	);
-	// Sit in the outbox for the group's `slack_open_delay` before the
-	// drainer is allowed to pick the row up. If the incident closes within
-	// that window the resolve path will cancel this row outright (see
-	// `enqueue_slack_resolve_inner`), and Slack never hears about a flap.
-	let deliver_after = Timestamp::now() + group.slack_open_delay.0;
+	// Normally the row sits in the outbox for the group's
+	// `slack_open_delay` before the drainer can ship it — that's the
+	// flap-suppression window, so a transient open/close pair never
+	// reaches Slack. Critical bypasses this: it's the
+	// "stop-the-world" tier where operators have signalled they don't
+	// want any delay.
+	let deliver_after = if issue.severity == Severity::Critical {
+		Timestamp::now()
+	} else {
+		Timestamp::now() + group.slack_open_delay.0
+	};
 	crate::slack_outbox::SlackOutbox::enqueue(
 		conn,
 		crate::slack_outbox::KIND_INCIDENT_OPEN,
@@ -820,6 +842,32 @@ async fn enqueue_slack_open(
 		deliver_after,
 	)
 	.await?;
+	Ok(())
+}
+
+/// Pull forward the `deliver_after` of any pending `incident_open` row
+/// for `incident_id` to now. Used when a Critical-severity issue joins
+/// an incident whose open was originally enqueued by a lower-severity
+/// contributor — the operator's signal is "no more delay".
+///
+/// Affects only rows that are still in their delay window
+/// (`delivered_at IS NULL`, `gave_up_at IS NULL`, `deliver_after > now`).
+/// Already-shipped or cancelled rows are left alone.
+async fn accelerate_pending_open(conn: &mut AsyncPgConnection, incident_id: Uuid) -> Result<()> {
+	use crate::schema::slack_outbox::dsl;
+	let now = Timestamp::now();
+	diesel::update(
+		dsl::slack_outbox
+			.filter(dsl::incident_id.eq(incident_id))
+			.filter(dsl::kind.eq(crate::slack_outbox::KIND_INCIDENT_OPEN))
+			.filter(dsl::delivered_at.is_null())
+			.filter(dsl::gave_up_at.is_null())
+			.filter(dsl::deliver_after.gt(jiff_diesel::Timestamp::from(now))),
+	)
+	.set(dsl::deliver_after.eq(jiff_diesel::Timestamp::from(now)))
+	.execute(conn)
+	.await
+	.map_err(AppError::from)?;
 	Ok(())
 }
 

--- a/crates/database/tests/healthcheck_severity_rules.rs
+++ b/crates/database/tests/healthcheck_severity_rules.rs
@@ -26,8 +26,7 @@ fn empty_ctx<'a>(
 fn deserialise_accepts_all_supported_ops() {
 	for op in ["==", "!=", "<", "<=", ">", ">="] {
 		let json = json!({"if": [{op: [{"var": "check.x"}, 10]}, "error"]});
-		serde_json::from_value::<IfLadder>(json)
-			.unwrap_or_else(|e| panic!("op {op} failed: {e}"));
+		serde_json::from_value::<IfLadder>(json).unwrap_or_else(|e| panic!("op {op} failed: {e}"));
 	}
 	let in_range = json!({"if": [
 		{"in_range": [{"var": "status.bestoolVersion"}, ">=2.4.0 <2.5.4"]},
@@ -43,7 +42,10 @@ fn deserialise_rejects_composition_and_unknown_ops() {
 		(json!({"if": [{"or": [true, true]}, "error"]}), "or"),
 		(json!({"if": [{"!": [true]}, "error"]}), "not"),
 		(json!({"if": [{"if": [true, true]}, "error"]}), "nested if"),
-		(json!({"if": [{"foo": [{"var": "check.x"}, 1]}, "error"]}), "unknown"),
+		(
+			json!({"if": [{"foo": [{"var": "check.x"}, 1]}, "error"]}),
+			"unknown",
+		),
 	];
 	for (val, label) in cases {
 		serde_json::from_value::<IfLadder>(val.clone())
@@ -56,8 +58,14 @@ fn deserialise_rejects_composition_and_unknown_ops() {
 fn deserialise_rejects_malformed_shapes() {
 	let cases: &[(serde_json::Value, &str)] = &[
 		(json!({"if": []}), "empty args"),
-		(json!({"if": [{"==": [{"var": "check.x"}, 1]}]}), "odd-length"),
-		(json!({"if": [{"==": [{"var": "check.x"}, 1]}, "warning", "trailing"]}), "trailing else"),
+		(
+			json!({"if": [{"==": [{"var": "check.x"}, 1]}]}),
+			"odd-length",
+		),
+		(
+			json!({"if": [{"==": [{"var": "check.x"}, 1]}, "warning", "trailing"]}),
+			"trailing else",
+		),
 		(json!({"not_if": []}), "wrong top-level op"),
 		(
 			json!({"if": [{"==": [{"var": "check.x"}, 1]}, "not_a_severity"]}),
@@ -161,10 +169,7 @@ fn numeric_ops_coerce_string_of_digits() {
 
 	// Missing field → false.
 	let missing = serde_json::Map::new();
-	assert_eq!(
-		ladder.evaluate(&empty_ctx(&missing, &status, &tags)),
-		None,
-	);
+	assert_eq!(ladder.evaluate(&empty_ctx(&missing, &status, &tags)), None,);
 }
 
 #[test]
@@ -175,7 +180,12 @@ fn eq_neq_handle_bool_string_numeric() {
 		(json!("prod"), json!("prod"), true, "string eq"),
 		(json!("prod"), json!("staging"), false, "string neq"),
 		(json!(5), json!(5.0), true, "numeric coercion 5 == 5.0"),
-		(json!("21608625"), json!(21_608_625), true, "string-of-digits eq number"),
+		(
+			json!("21608625"),
+			json!(21_608_625),
+			true,
+			"string-of-digits eq number",
+		),
 	];
 	for (lhs, rhs, want_eq, label) in cases {
 		let ladder: IfLadder = serde_json::from_value(json!({"if": [
@@ -203,7 +213,10 @@ fn tag_namespace_resolves_against_tag_map() {
 	let status = serde_json::Map::new();
 
 	let mut tags = HashMap::new();
-	tags.insert("environment".to_string(), serde_json::Value::String("prod".into()));
+	tags.insert(
+		"environment".to_string(),
+		serde_json::Value::String("prod".into()),
+	);
 	assert_eq!(
 		ladder.evaluate(&empty_ctx(&check, &status, &tags)),
 		Some(Severity::Error),
@@ -298,7 +311,11 @@ async fn severity_for_uses_rules_or_falls_back_to_base() {
 		)
 		.await
 		.expect("severity_for");
-		assert_eq!(sev, Severity::Error, "falls back to base when no branch matches");
+		assert_eq!(
+			sev,
+			Severity::Error,
+			"falls back to base when no branch matches"
+		);
 	})
 	.await
 }
@@ -354,10 +371,9 @@ async fn update_rules_clears_column_when_passed_none() {
 				.expect("save");
 		assert!(saved.rules.is_some(), "rules should be populated");
 
-		let cleared =
-			HealthcheckSeverity::update_rules(&mut conn, "disk_space", None, "ops")
-				.await
-				.expect("clear");
+		let cleared = HealthcheckSeverity::update_rules(&mut conn, "disk_space", None, "ops")
+			.await
+			.expect("clear");
 		assert!(cleared.rules.is_none(), "rules should be cleared by None");
 	})
 	.await

--- a/crates/database/tests/incident_severity_semantics.rs
+++ b/crates/database/tests/incident_severity_semantics.rs
@@ -1,0 +1,396 @@
+//! Severity semantics for the incident workflow:
+//!
+//! - **Debug** never participates in incidents — neither joining a new
+//!   one nor staying attached if a contributor's severity drops to
+//!   Debug after the fact.
+//! - **Critical** opens the incident (or joins it) without sitting in
+//!   the per-group `slack_open_delay` holding window: the outbox row's
+//!   `deliver_after` is pulled forward to NOW().
+
+use commons_types::issue::{ResolvedReason, Severity};
+use database::issues::{Incident, NewEvent};
+use database::slack_outbox::{KIND_INCIDENT_OPEN, SlackOutbox};
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_grouped_server(conn: &mut diesel_async::AsyncPgConnection, host: &str) -> Uuid {
+	let group: RowId =
+		sql_query("INSERT INTO server_groups (name) VALUES ('test-group') RETURNING id")
+			.get_result(conn)
+			.await
+			.expect("group");
+	let row: RowId = sql_query("INSERT INTO servers (host, group_id) VALUES ($1, $2) RETURNING id")
+		.bind::<sql_types::Text, _>(host)
+		.bind::<sql_types::Uuid, _>(group.id)
+		.get_result(conn)
+		.await
+		.expect("server");
+	row.id
+}
+
+async fn save_event(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	r#ref: &str,
+	severity: Severity,
+	active: bool,
+	message: &str,
+) {
+	NewEvent {
+		source: "test".into(),
+		r#ref: r#ref.into(),
+		severity: Some(severity),
+		description: None,
+		message: message.into(),
+		active: Some(active),
+		occurred_at: None,
+	}
+	.save(conn, server_id, None)
+	.await
+	.expect("save event");
+}
+
+#[derive(QueryableByName)]
+struct OpenLinkCount {
+	#[diesel(sql_type = sql_types::BigInt)]
+	n: i64,
+}
+async fn open_link_count(conn: &mut diesel_async::AsyncPgConnection, issue_ref: &str) -> i64 {
+	let row: OpenLinkCount = sql_query(
+		"SELECT COUNT(*) AS n FROM incident_issues ii \
+		 JOIN issues i ON i.id = ii.issue_id \
+		 WHERE i.ref = $1 AND ii.left_at IS NULL",
+	)
+	.bind::<sql_types::Text, _>(issue_ref)
+	.get_result(conn)
+	.await
+	.expect("count");
+	row.n
+}
+
+/// Pending-incident_open row summarised so we can assert on its delivery
+/// timing without round-tripping the underlying timestamps (which need a
+/// jiff_diesel wrapper that isn't worth pulling in for tests).
+#[derive(QueryableByName, Debug)]
+struct OpenInfo {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+	/// Seconds until (positive) or since (negative) `deliver_after`.
+	#[diesel(sql_type = sql_types::Double)]
+	delay_secs: f64,
+	#[diesel(sql_type = sql_types::Bool)]
+	is_delivered: bool,
+}
+
+async fn pending_open(conn: &mut diesel_async::AsyncPgConnection, incident_id: Uuid) -> OpenInfo {
+	sql_query(
+		"SELECT id, \
+				EXTRACT(EPOCH FROM (deliver_after - NOW()))::float8 AS delay_secs, \
+				delivered_at IS NOT NULL AS is_delivered \
+		 FROM slack_outbox WHERE incident_id = $1 AND kind = $2 LIMIT 1",
+	)
+	.bind::<sql_types::Uuid, _>(incident_id)
+	.bind::<sql_types::Text, _>(KIND_INCIDENT_OPEN)
+	.get_result(conn)
+	.await
+	.expect("pending open row")
+}
+
+// ── Debug ────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn debug_issue_does_not_join_open_incidents() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn, "http://debug-shy.invalid/").await;
+		// Open an incident with an Error-severity issue.
+		save_event(
+			&mut conn,
+			server_id,
+			"real-error",
+			Severity::Error,
+			true,
+			"boom",
+		)
+		.await;
+		assert!(
+			!Incident::list_for_server(&mut conn, server_id, false, 10)
+				.await
+				.expect("list")
+				.is_empty(),
+			"incident open"
+		);
+		// File a Debug issue on the same server.
+		save_event(
+			&mut conn,
+			server_id,
+			"debug-noise",
+			Severity::Debug,
+			true,
+			"low signal",
+		)
+		.await;
+		// The Debug issue's link should NOT be in incident_issues.
+		assert_eq!(
+			open_link_count(&mut conn, "debug-noise").await,
+			0,
+			"debug never joins"
+		);
+		// The Error contributor is still attached.
+		assert_eq!(open_link_count(&mut conn, "real-error").await, 1);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_downgraded_to_debug_leaves_incident_on_next_evaluation() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id =
+			insert_grouped_server(&mut conn, "http://downgrade-to-debug.invalid/").await;
+		// Joins at Warning while another Error issue holds the incident open.
+		save_event(
+			&mut conn,
+			server_id,
+			"main-error",
+			Severity::Error,
+			true,
+			"boom",
+		)
+		.await;
+		save_event(
+			&mut conn,
+			server_id,
+			"noisy",
+			Severity::Warning,
+			true,
+			"noise",
+		)
+		.await;
+		assert_eq!(open_link_count(&mut conn, "noisy").await, 1);
+		// Now an operator (or rule edit) drops it to Debug. The next event push
+		// runs re_evaluate_incident_membership, which should detach it.
+		save_event(
+			&mut conn,
+			server_id,
+			"noisy",
+			Severity::Debug,
+			true,
+			"demoted",
+		)
+		.await;
+		assert_eq!(
+			open_link_count(&mut conn, "noisy").await,
+			0,
+			"debug-downgraded issue must leave the incident"
+		);
+	})
+	.await
+}
+
+// ── Critical ─────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn critical_open_sets_deliver_after_to_now() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn, "http://critical-now.invalid/").await;
+		save_event(
+			&mut conn,
+			server_id,
+			"crit",
+			Severity::Critical,
+			true,
+			"red alert",
+		)
+		.await;
+		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list")
+			.into_iter()
+			.next()
+			.expect("incident");
+		let open = pending_open(&mut conn, incident.id).await;
+		assert!(
+			open.delay_secs.abs() <= 5.0,
+			"Critical bypasses the holding window — deliver_after should be ~now, delay={}s",
+			open.delay_secs,
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn non_critical_open_still_honours_holding_window() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn, "http://error-delayed.invalid/").await;
+		save_event(
+			&mut conn,
+			server_id,
+			"boom",
+			Severity::Error,
+			true,
+			"less urgent",
+		)
+		.await;
+		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list")
+			.into_iter()
+			.next()
+			.expect("incident");
+		let open = pending_open(&mut conn, incident.id).await;
+		// Default group `slack_open_delay` is 3 minutes; should be well above 30s.
+		assert!(
+			open.delay_secs > 30.0,
+			"Error severity sits in the holding window; got delay={}s",
+			open.delay_secs,
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn critical_joining_existing_open_accelerates_pending_delivery() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id =
+			insert_grouped_server(&mut conn, "http://crit-join-accelerate.invalid/").await;
+		// Open the incident with a non-Critical issue → deliver_after is in the future.
+		save_event(
+			&mut conn,
+			server_id,
+			"warmup",
+			Severity::Error,
+			true,
+			"boom",
+		)
+		.await;
+		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list")
+			.into_iter()
+			.next()
+			.expect("incident");
+		let initial = pending_open(&mut conn, incident.id).await;
+		assert!(
+			initial.delay_secs > 30.0,
+			"preconditions: delay > 30s, got {}s",
+			initial.delay_secs,
+		);
+
+		// A Critical-severity issue now joins the same group's open incident.
+		save_event(
+			&mut conn,
+			server_id,
+			"crit",
+			Severity::Critical,
+			true,
+			"red alert",
+		)
+		.await;
+
+		// The existing pending open row was pulled forward to ~now.
+		let after = pending_open(&mut conn, incident.id).await;
+		assert!(
+			after.delay_secs.abs() <= 5.0,
+			"Critical join pulls deliver_after forward; delay={}s",
+			after.delay_secs,
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn critical_join_does_not_disturb_already_delivered_open() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id =
+			insert_grouped_server(&mut conn, "http://crit-after-delivered.invalid/").await;
+		save_event(
+			&mut conn,
+			server_id,
+			"warmup",
+			Severity::Error,
+			true,
+			"boom",
+		)
+		.await;
+		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list")
+			.into_iter()
+			.next()
+			.expect("incident");
+		// Simulate the drainer having shipped the open already.
+		let pending = pending_open(&mut conn, incident.id).await;
+		SlackOutbox::mark_delivered(&mut conn, pending.id, "ok")
+			.await
+			.expect("mark delivered");
+
+		// A Critical issue now joins. There's no pending open to accelerate,
+		// so the call is a no-op and crucially doesn't re-enqueue Slack noise.
+		save_event(
+			&mut conn,
+			server_id,
+			"crit",
+			Severity::Critical,
+			true,
+			"red alert",
+		)
+		.await;
+
+		// The (now-delivered) outbox row still has its delivered_at set; no
+		// duplicate incident_open rows have been created.
+		#[derive(QueryableByName)]
+		struct Count {
+			#[diesel(sql_type = sql_types::BigInt)]
+			n: i64,
+		}
+		let count: Count = sql_query(
+			"SELECT COUNT(*) AS n FROM slack_outbox \
+			 WHERE incident_id = $1 AND kind = $2",
+		)
+		.bind::<sql_types::Uuid, _>(incident.id)
+		.bind::<sql_types::Text, _>(KIND_INCIDENT_OPEN)
+		.get_result(&mut conn)
+		.await
+		.expect("count");
+		assert_eq!(count.n, 1);
+		let row = pending_open(&mut conn, incident.id).await;
+		assert!(row.is_delivered);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn debug_filing_still_records_the_issue_row() {
+	// Audit-trail guarantee: Debug doesn't participate in incidents, but
+	// the issue row itself is still written so the per-server / global
+	// issues lists can show low-severity context.
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn, "http://debug-audit.invalid/").await;
+		save_event(
+			&mut conn,
+			server_id,
+			"logspam",
+			Severity::Debug,
+			true,
+			"verbose",
+		)
+		.await;
+		let issue: RowId =
+			sql_query("SELECT id FROM issues WHERE ref = 'logspam' AND server_id = $1")
+				.bind::<sql_types::Uuid, _>(server_id)
+				.get_result(&mut conn)
+				.await
+				.expect("debug issue row exists despite no incident participation");
+		// Belt-and-suspenders: the resolution path on a debug issue must not panic.
+		database::issues::Issue::resolve(&mut conn, issue.id, "ops", ResolvedReason::Fixed)
+			.await
+			.expect("resolve a debug issue");
+	})
+	.await
+}

--- a/crates/private-server/tests/healthchecks.rs
+++ b/crates/private-server/tests/healthchecks.rs
@@ -248,10 +248,7 @@ async fn update_rules_rejects_malformed_shapes() {
 		.unwrap();
 		let cases: &[(serde_json::Value, &str)] = &[
 			(json!({"and": [true]}), "AND composition"),
-			(
-				json!({"if": [{"if": [true, true]}, "error"]}),
-				"nested if",
-			),
+			(json!({"if": [{"if": [true, true]}, "error"]}), "nested if"),
 			(
 				json!({"if": [{"==": [{"var": "BAD.x"}, 1]}, "error"]}),
 				"unknown var namespace",

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -1365,14 +1365,11 @@
       },
       "Severity": {
         "type": "string",
-        "description": "RFC 5424 syslog severities.\n\nStored as text in Postgres; validated as this enum at the API layer.\nDefault is `Error` (incidents only open at severity ≥ Error, so the\ndefault is intentionally above the floor — most devices that bother\npushing an event mean it).",
+        "description": "Canopy's severity vocabulary, narrowed from RFC 5424 to a five-level\nset with operator semantics:\n\n- `Debug`: never participates in incidents (filed for the audit\n  trail / per-server view only).\n- `Info`, `Warning`: join an open incident for context but don't\n  open one or keep one open on their own.\n- `Error`: opens an incident; sits in the per-group `slack_open_delay`\n  holding window before the Slack notification ships.\n- `Critical`: opens an incident and bypasses the holding window —\n  the Slack notification is enqueued for immediate delivery.\n\nStored as text in Postgres; validated as this enum at the API layer.\nDefault is `Error` (the most common severity for a deliberately\nfiled event). The legacy syslog severities `emergency` / `alert` /\n`notice` have been retired — see the\n`2026-05-29-000000-0000_restrict_severities` migration; the\n`FromStr` impl still accepts them as aliases for forward-compat with\nany device that hasn't been updated.",
         "enum": [
-          "emergency",
-          "alert",
           "critical",
           "error",
           "warning",
-          "notice",
           "info",
           "debug"
         ]

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -1647,7 +1647,10 @@ async fn submit_status_rule_on_server_tag() {
 			let issue = fetch_issue(&mut conn, server_id, "status", "health/cert_expiry")
 				.await
 				.expect("per-check issue filed");
-			assert_eq!(issue.severity, "error", "tag.environment=prod fires the rule");
+			assert_eq!(
+				issue.severity, "error",
+				"tag.environment=prod fires the rule"
+			);
 		},
 	)
 	.await

--- a/migrations/2026-05-29-000000-0000_restrict_severities/down.sql
+++ b/migrations/2026-05-29-000000-0000_restrict_severities/down.sql
@@ -1,0 +1,11 @@
+-- Best-effort revert: restore the 8-severity CHECK constraint on
+-- healthcheck_severities.severity. The data normalization (emergency /
+-- alert → critical, notice → info) is not reversed — the original
+-- distinctions are lost.
+
+ALTER TABLE healthcheck_severities
+	DROP CONSTRAINT healthcheck_severities_severity_check;
+
+ALTER TABLE healthcheck_severities
+	ADD CONSTRAINT healthcheck_severities_severity_check
+	CHECK (severity IN ('emergency','alert','critical','error','warning','notice','info','debug'));

--- a/migrations/2026-05-29-000000-0000_restrict_severities/up.sql
+++ b/migrations/2026-05-29-000000-0000_restrict_severities/up.sql
@@ -1,0 +1,68 @@
+-- Severity catalog restricted to debug / info / warning / error / critical.
+-- emergency and alert collapse into critical; notice collapses into info.
+-- See docs note in commons-types::issue::Severity.
+--
+-- The five tables/columns carrying a severity value:
+--   - issues.severity           (TEXT)
+--   - events.severity           (TEXT, append-only log)
+--   - healthcheck_severities.severity (TEXT, has a CHECK constraint)
+--   - healthcheck_severities.rules     (JSONB if-ladder, severities at odd indices)
+--   - slack_outbox.payload      (JSONB, the rendered notification — left as-is;
+--                                already-delivered rows are historical, the
+--                                drainer doesn't re-read severities from them)
+
+-- Data migration.
+
+UPDATE issues
+SET severity = CASE severity
+	WHEN 'emergency' THEN 'critical'
+	WHEN 'alert' THEN 'critical'
+	WHEN 'notice' THEN 'info'
+	ELSE severity
+END
+WHERE severity IN ('emergency', 'alert', 'notice');
+
+UPDATE events
+SET severity = CASE severity
+	WHEN 'emergency' THEN 'critical'
+	WHEN 'alert' THEN 'critical'
+	WHEN 'notice' THEN 'info'
+	ELSE severity
+END
+WHERE severity IN ('emergency', 'alert', 'notice');
+
+UPDATE healthcheck_severities
+SET severity = CASE severity
+	WHEN 'emergency' THEN 'critical'
+	WHEN 'alert' THEN 'critical'
+	WHEN 'notice' THEN 'info'
+	ELSE severity
+END
+WHERE severity IN ('emergency', 'alert', 'notice');
+
+-- Migrate severity strings embedded in the rules JsonLogic if-ladder.
+-- Severities appear at odd indices of the `if` array; lower-severity
+-- string-typed *values* in conditions could theoretically also be
+-- "emergency"/"alert"/"notice", but in practice operators predicate on
+-- bestool fields (semver, numbers, hostnames) — not on the severity
+-- vocabulary itself — so the textual replace is safe.
+UPDATE healthcheck_severities
+SET rules = regexp_replace(
+	regexp_replace(
+		regexp_replace(rules::text, '"emergency"', '"critical"', 'g'),
+		'"alert"', '"critical"', 'g'
+	),
+	'"notice"', '"info"', 'g'
+)::jsonb
+WHERE rules IS NOT NULL
+	AND rules::text ~ '"(emergency|alert|notice)"';
+
+-- Drop the existing CHECK constraint on healthcheck_severities.severity
+-- and replace with the narrower set.
+
+ALTER TABLE healthcheck_severities
+	DROP CONSTRAINT healthcheck_severities_severity_check;
+
+ALTER TABLE healthcheck_severities
+	ADD CONSTRAINT healthcheck_severities_severity_check
+	CHECK (severity IN ('debug', 'info', 'warning', 'error', 'critical'));

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6253,14 +6253,11 @@
       },
       "Severity": {
         "type": "string",
-        "description": "RFC 5424 syslog severities.\n\nStored as text in Postgres; validated as this enum at the API layer.\nDefault is `Error` (incidents only open at severity ≥ Error, so the\ndefault is intentionally above the floor — most devices that bother\npushing an event mean it).",
+        "description": "Canopy's severity vocabulary, narrowed from RFC 5424 to a five-level\nset with operator semantics:\n\n- `Debug`: never participates in incidents (filed for the audit\n  trail / per-server view only).\n- `Info`, `Warning`: join an open incident for context but don't\n  open one or keep one open on their own.\n- `Error`: opens an incident; sits in the per-group `slack_open_delay`\n  holding window before the Slack notification ships.\n- `Critical`: opens an incident and bypasses the holding window —\n  the Slack notification is enqueued for immediate delivery.\n\nStored as text in Postgres; validated as this enum at the API layer.\nDefault is `Error` (the most common severity for a deliberately\nfiled event). The legacy syslog severities `emergency` / `alert` /\n`notice` have been retired — see the\n`2026-05-29-000000-0000_restrict_severities` migration; the\n`FromStr` impl still accepts them as aliases for forward-compat with\nany device that hasn't been updated.",
         "enum": [
-          "emergency",
-          "alert",
           "critical",
           "error",
           "warning",
-          "notice",
           "info",
           "debug"
         ]

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2390,15 +2390,28 @@ export interface components {
             source: string;
         };
         /**
-         * @description RFC 5424 syslog severities.
+         * @description Canopy's severity vocabulary, narrowed from RFC 5424 to a five-level
+         *     set with operator semantics:
+         *
+         *     - `Debug`: never participates in incidents (filed for the audit
+         *       trail / per-server view only).
+         *     - `Info`, `Warning`: join an open incident for context but don't
+         *       open one or keep one open on their own.
+         *     - `Error`: opens an incident; sits in the per-group `slack_open_delay`
+         *       holding window before the Slack notification ships.
+         *     - `Critical`: opens an incident and bypasses the holding window —
+         *       the Slack notification is enqueued for immediate delivery.
          *
          *     Stored as text in Postgres; validated as this enum at the API layer.
-         *     Default is `Error` (incidents only open at severity ≥ Error, so the
-         *     default is intentionally above the floor — most devices that bother
-         *     pushing an event mean it).
+         *     Default is `Error` (the most common severity for a deliberately
+         *     filed event). The legacy syslog severities `emergency` / `alert` /
+         *     `notice` have been retired — see the
+         *     `2026-05-29-000000-0000_restrict_severities` migration; the
+         *     `FromStr` impl still accepts them as aliases for forward-compat with
+         *     any device that hasn't been updated.
          * @enum {string}
          */
-        Severity: "emergency" | "alert" | "critical" | "error" | "warning" | "notice" | "info" | "debug";
+        Severity: "critical" | "error" | "warning" | "info" | "debug";
         /** @enum {string} */
         ShortStatus: "up" | "down" | "away" | "blip" | "gone";
         SilenceGroupArgs: {

--- a/private-web/src/components/SeverityChip.tsx
+++ b/private-web/src/components/SeverityChip.tsx
@@ -1,19 +1,20 @@
-import { Chip } from "@mui/material";
-import type { Severity } from "../types";
+import { Chip, Tooltip } from "@mui/material";
+import { SEVERITY_INTENT, type Severity } from "../types";
 
 type Color = "error" | "warning" | "info" | "default";
 
 const COLOR: Record<Severity, Color> = {
-	emergency: "error",
-	alert: "error",
 	critical: "error",
 	error: "error",
 	warning: "warning",
-	notice: "info",
 	info: "info",
 	debug: "default",
 };
 
 export default function SeverityChip({ severity }: { severity: Severity }) {
-	return <Chip label={severity} color={COLOR[severity]} size="small" />;
+	return (
+		<Tooltip title={SEVERITY_INTENT[severity]} arrow>
+			<Chip label={severity} color={COLOR[severity]} size="small" />
+		</Tooltip>
+	);
 }

--- a/private-web/src/routes/HealthcheckDetail.tsx
+++ b/private-web/src/routes/HealthcheckDetail.tsx
@@ -33,7 +33,12 @@ import SeverityChip from "../components/SeverityChip";
 import TimeAgo from "../components/TimeAgo";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { SEVERITIES, type HealthcheckSeverityData, type Severity } from "../types";
+import {
+	SEVERITIES,
+	SEVERITY_INTENT,
+	type HealthcheckSeverityData,
+	type Severity,
+} from "../types";
 
 // ── Constrained JsonLogic shape ───────────────────────────────────────────
 //
@@ -265,11 +270,16 @@ function BaseSeverityCard({
 						value={severity}
 						onChange={(e) => setSeverity(e.target.value as Severity)}
 						disabled={update.pending}
-						sx={{ minWidth: 140 }}
+						sx={{ minWidth: 320 }}
 					>
 						{SEVERITIES.map((s) => (
 							<MenuItem key={s} value={s}>
-								<SeverityChip severity={s} />
+								<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+									<SeverityChip severity={s} />
+									<Typography variant="caption" color="text.secondary">
+										{SEVERITY_INTENT[s]}
+									</Typography>
+								</Stack>
 							</MenuItem>
 						))}
 					</Select>
@@ -606,10 +616,16 @@ function BranchDialog({
 						size="small"
 						value={severity}
 						onChange={(e) => setSeverity(e.target.value as Severity)}
+						sx={{ minWidth: 320 }}
 					>
 						{SEVERITIES.map((s) => (
 							<MenuItem key={s} value={s}>
-								<SeverityChip severity={s} />
+								<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+									<SeverityChip severity={s} />
+									<Typography variant="caption" color="text.secondary">
+										{SEVERITY_INTENT[s]}
+									</Typography>
+								</Stack>
 							</MenuItem>
 						))}
 					</Select>

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -153,16 +153,29 @@ export const SERVER_RANK_ORDER: ServerRank[] = [
 	"dev",
 ];
 
+/// Operator-facing severity vocabulary, loud → quiet. Used for both
+/// display and selection (the API now restricts severities to these
+/// five — see commons-types::issue::Severity and the
+/// 2026-05-29-restrict_severities migration).
 export const SEVERITIES: Severity[] = [
-	"emergency",
-	"alert",
 	"critical",
 	"error",
 	"warning",
-	"notice",
 	"info",
 	"debug",
 ];
+
+/// Short one-line description of how each severity participates in the
+/// incident workflow. Used in dropdown helper text and as the
+/// SeverityChip tooltip so operators see the semantic meaning at the
+/// point of choice.
+export const SEVERITY_INTENT: Record<Severity, string> = {
+	critical: "Opens an incident immediately (no holding period)",
+	error: "Opens an incident (after the group's holding period)",
+	warning: "Joins an open incident; doesn't open one on its own",
+	info: "Joins an open incident; doesn't open one on its own",
+	debug: "Not shown in incidents",
+};
 
 export const RESOLVED_REASONS: ResolvedReason[] = [
 	"fixed",


### PR DESCRIPTION
🤖

Trims the severity vocabulary from RFC 5424's 8 levels to 5, and gives each level a clear operator-facing meaning in the incident workflow:

| Severity | Behaviour |
|---|---|
| `critical` | Opens an incident immediately (bypasses the group's holding period). |
| `error` | Opens an incident, with the normal `slack_open_delay` flap-suppression window. |
| `warning` | Joins an open incident for context; doesn't open one on its own. |
| `info` | Joins an open incident for context; doesn't open one on its own. |
| `debug` | Not shown in incidents at all — filed only for the per-server / audit trail. |

## Backend

- The Rust `Severity` enum drops `Emergency`, `Alert`, `Notice`. `FromStr` still parses them as aliases (`emergency` / `alert` → `Critical`, `notice` → `Info`) for forward-compat with any device that hasn't been updated yet.
- Migration `2026-05-29-000000-0000_restrict_severities` normalises any existing rows in `issues`, `events`, `healthcheck_severities.severity`, and the JsonLogic ladder in `healthcheck_severities.rules`, then tightens the `CHECK` constraint to the five values.
- `re_evaluate_incident_membership` treats Debug as an unconditional leave: Debug never joins an incident, and any issue downgraded to Debug detaches on its next event.
- `enqueue_slack_open` sets `deliver_after = NOW()` when the triggering issue is Critical; a new `accelerate_pending_open` helper pulls forward the pending Slack open when a Critical issue joins an incident whose open is still in its holding window.

## Frontend

- `SeverityChip` wraps in a tooltip showing the intent.
- Severity dropdowns now render the chip plus a caption summarising the intent, so the meaning is visible at the point of choice.
- The TypeScript `Severity` type (regenerated) is the 5-value set; `SEVERITIES` and `SEVERITY_INTENT` are aligned.

## Tests

Seven new database tests under `crates/database/tests/incident_severity_semantics.rs`:
- `debug_issue_does_not_join_open_incidents`
- `issue_downgraded_to_debug_leaves_incident_on_next_evaluation`
- `critical_open_sets_deliver_after_to_now`
- `non_critical_open_still_honours_holding_window`
- `critical_joining_existing_open_accelerates_pending_delivery`
- `critical_join_does_not_disturb_already_delivered_open`
- `debug_filing_still_records_the_issue_row`