### PR TITLE
Status snapshot: compute and surface per-check severity

### DIFF
--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -231,6 +231,15 @@ pub struct StatusSnapshotData {
 	pub healthy: bool,
 	pub health: serde_json::Value,
 	pub extra: serde_json::Value,
+	/// For each unhealthy check on this push, the severity the
+	/// catalog + rules engine would file at. Healthy checks are
+	/// absent; absence on an unhealthy check means the catalog has
+	/// no row yet (treat as the default Warning) — the UI surfaces
+	/// the explicit severity when one is known so operators see
+	/// all five levels, not just the legacy "warning/error" pair
+	/// derived from `healthy`.
+	pub check_severities:
+		std::collections::HashMap<String, commons_types::issue::Severity>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -300,6 +309,12 @@ pub async fn snapshot(
 	let platform = status.platform();
 	let postgres = status.postgres_version();
 
+	// Compute the per-unhealthy-check severity the rules engine would
+	// file at given this push. Healthy checks are omitted; the UI
+	// renders them with its 'passing' affordance regardless.
+	let check_severities =
+		compute_check_severities(&mut conn, args.server_id, &status).await?;
+
 	Ok(Json(Some(StatusSnapshotData {
 		id: status.id,
 		created_at: status.created_at,
@@ -315,7 +330,66 @@ pub async fn snapshot(
 		healthy: status.healthy,
 		health: status.health,
 		extra: status.extra,
+		check_severities,
 	})))
+}
+
+/// For every unhealthy check on `status`, resolve the catalog + rules
+/// severity given the snapshot's actual extras and the server's
+/// resolved tag map. Mirrors the public-server ingestion path
+/// (`file_health_events`) so the UI displays what *would* be filed.
+async fn compute_check_severities(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	status: &Status,
+) -> commons_errors::Result<std::collections::HashMap<String, commons_types::issue::Severity>> {
+	use database::healthcheck_severities::{EvaluationContext, HealthcheckSeverity};
+	use database::servers::Server as DbServer;
+
+	let Some(arr) = status.health.as_array() else {
+		return Ok(Default::default());
+	};
+	// Walk the health array once, collect (check_name, check_extra) for
+	// every unhealthy entry. Healthy entries don't drive the rules
+	// engine on the ingestion path either, so we skip them.
+	let mut failing: Vec<(String, serde_json::Map<String, serde_json::Value>)> = Vec::new();
+	for raw in arr {
+		let Some(obj) = raw.as_object() else { continue };
+		let Some(check_name) = obj.get("check").and_then(|v| v.as_str()) else { continue };
+		let Some(healthy) = obj.get("healthy").and_then(|v| v.as_bool()) else { continue };
+		if healthy {
+			continue;
+		}
+		let mut extra = obj.clone();
+		extra.remove("check");
+		extra.remove("healthy");
+		failing.push((check_name.to_string(), extra));
+	}
+	if failing.is_empty() {
+		return Ok(Default::default());
+	}
+
+	let server = DbServer::get_by_id(conn, server_id).await?;
+	let tag_map = server.tags_merged_with_group(conn).await?;
+	let tags: std::collections::HashMap<String, serde_json::Value> = tag_map
+		.0
+		.into_iter()
+		.map(|(k, v)| (k, serde_json::Value::String(v)))
+		.collect();
+	let empty_map = serde_json::Map::new();
+	let status_extra = status.extra.as_object().unwrap_or(&empty_map);
+
+	let mut out = std::collections::HashMap::with_capacity(failing.len());
+	for (name, check_extra) in failing {
+		let ctx = EvaluationContext {
+			status_extra,
+			check_extra: &check_extra,
+			tags: &tags,
+		};
+		let sev = HealthcheckSeverity::severity_for(conn, &name, &ctx).await?;
+		out.insert(name, sev);
+	}
+	Ok(out)
 }
 
 // Touch `Server` so the unused-import warning doesn't fire when this module

--- a/crates/private-server/tests/private_statuses.rs
+++ b/crates/private-server/tests/private_statuses.rs
@@ -937,3 +937,60 @@ async fn snapshot_server_without_statuses_returns_null() {
 	})
 	.await
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_surfaces_per_check_severity() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		// Seed catalog: catalog_only stays at the default warning;
+		// elevated has its base severity bumped to error so the snapshot
+		// returns the operator-set value, not the legacy heuristic;
+		// version_gated has a rules ladder firing on a specific
+		// status.bestoolVersion.
+		conn.batch_execute(
+			"INSERT INTO healthcheck_severities (check_name, severity) VALUES \
+				('catalog_only', 'warning'), \
+				('elevated', 'error'), \
+				('version_gated', 'warning'); \
+			 UPDATE healthcheck_severities \
+				SET rules = '{\"if\":[{\"in_range\":[{\"var\":\"status.bestoolVersion\"},\">=1.0.0 <2.0.0\"]},\"critical\"]}'::jsonb \
+				WHERE check_name = 'version_gated';",
+		)
+		.await
+		.unwrap();
+
+		conn.batch_execute(
+			"INSERT INTO servers (id, host, kind) VALUES \
+				('30000000-0000-0000-0000-000000000001', 'https://snap-sev.example.com', 'central'); \
+			 INSERT INTO statuses (server_id, healthy, health, extra) VALUES \
+				('30000000-0000-0000-0000-000000000001', false, \
+				 '[{\"check\":\"catalog_only\",\"healthy\":false}, \
+				   {\"check\":\"elevated\",\"healthy\":false}, \
+				   {\"check\":\"version_gated\",\"healthy\":false}, \
+				   {\"check\":\"passing\",\"healthy\":true}]'::jsonb, \
+				 '{\"bestoolVersion\":\"1.5.0\"}'::jsonb);",
+		)
+		.await
+		.unwrap();
+
+		let r = private
+			.post("/api/statuses/snapshot")
+			.json(&serde_json::json!({
+				"server_id": "30000000-0000-0000-0000-000000000001"
+			}))
+			.await;
+		r.assert_status_ok();
+		let body: serde_json::Value = r.json();
+		let severities = &body["check_severities"];
+		assert_eq!(severities["catalog_only"], "warning");
+		assert_eq!(severities["elevated"], "error");
+		// version_gated's rule fires because bestoolVersion 1.5.0 is in
+		// the >=1.0.0 <2.0.0 range — Critical wins over the base.
+		assert_eq!(severities["version_gated"], "critical");
+		// Passing checks must not appear in the map.
+		assert!(
+			severities.get("passing").is_none(),
+			"healthy checks are omitted; got {severities}",
+		);
+	})
+	.await
+}

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6427,9 +6427,20 @@
           "server_id",
           "healthy",
           "health",
-          "extra"
+          "extra",
+          "check_severities"
         ],
         "properties": {
+          "check_severities": {
+            "type": "object",
+            "description": "For each unhealthy check on this push, the severity the\ncatalog + rules engine would file at. Healthy checks are\nabsent; absence on an unhealthy check means the catalog has\nno row yet (treat as the default Warning) — the UI surfaces\nthe explicit severity when one is known so operators see\nall five levels, not just the legacy \"warning/error\" pair\nderived from `healthy`.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Severity"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
           "created_at": {
             "type": "string",
             "format": "date-time"

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2468,6 +2468,18 @@ export interface components {
          *     the raw `extra` blob for forward-compat as the contract expands.
          */
         StatusSnapshotData: {
+            /**
+             * @description For each unhealthy check on this push, the severity the
+             *     catalog + rules engine would file at. Healthy checks are
+             *     absent; absence on an unhealthy check means the catalog has
+             *     no row yet (treat as the default Warning) — the UI surfaces
+             *     the explicit severity when one is known so operators see
+             *     all five levels, not just the legacy "warning/error" pair
+             *     derived from `healthy`.
+             */
+            check_severities: {
+                [key: string]: components["schemas"]["Severity"];
+            };
             /** Format: date-time */
             created_at: string;
             /** Format: uuid */

--- a/private-web/src/components/StatusSnapshot.tsx
+++ b/private-web/src/components/StatusSnapshot.tsx
@@ -11,6 +11,9 @@ import {
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CloseIcon from "@mui/icons-material/Close";
+import CircleIcon from "@mui/icons-material/Circle";
+import ErrorIcon from "@mui/icons-material/Error";
+import InfoIcon from "@mui/icons-material/Info";
 import PreviewIcon from "@mui/icons-material/Preview";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Fragment } from "react";
@@ -18,7 +21,11 @@ import { useApi, type ApiState } from "../api";
 import TimeAgo from "./TimeAgo";
 import TimezoneTooltip from "./TimezoneTooltip";
 import VersionIndicator from "./VersionIndicator";
-import type { StatusSnapshotData } from "../types";
+import {
+	SEVERITY_INTENT,
+	type Severity,
+	type StatusSnapshotData,
+} from "../types";
 
 /** Inline panel rendering the server's status at a given point in time.
  * Hits `/api/statuses/snapshot` lazily on mount; each (serverId, at)
@@ -109,7 +116,7 @@ function PanelBody({
 	return (
 		<Stack spacing={2}>
 			<CuratedFields snap={snap} />
-			<ChecksBlock health={snap.health} overallHealthy={snap.healthy} />
+			<ChecksBlock health={snap.health} severities={snap.check_severities} />
 			<ExtrasBlock extra={snap.extra} />
 		</Stack>
 	);
@@ -175,10 +182,10 @@ function Field({
 
 function ChecksBlock({
 	health,
-	overallHealthy,
+	severities,
 }: {
 	health: StatusSnapshotData["health"];
-	overallHealthy: boolean;
+	severities: StatusSnapshotData["check_severities"];
 }) {
 	const entries = parseChecks(health);
 	if (entries.length === 0) return null;
@@ -202,13 +209,10 @@ function ChecksBlock({
 							bgcolor: entry.healthy ? undefined : "action.hover",
 						}}
 					>
-						{entry.healthy ? (
-							<CheckCircleIcon fontSize="small" color="success" />
-						) : overallHealthy ? (
-							<WarningAmberIcon fontSize="small" color="warning" />
-						) : (
-							<CancelIcon fontSize="small" color="error" />
-						)}
+						<CheckIcon
+							healthy={entry.healthy}
+							severity={severities[entry.check] ?? null}
+						/>
 						<Box sx={{ flex: 1, minWidth: 0 }}>
 							<Typography variant="body2" sx={{ fontFamily: "monospace" }}>
 								{entry.check}
@@ -304,6 +308,63 @@ function parseChecks(health: StatusSnapshotData["health"]): ParsedCheck[] {
 		return a.check.localeCompare(b.check);
 	});
 	return parsed;
+}
+
+/// Per-check status indicator. Healthy checks always render as a green
+/// tick. Unhealthy checks render the icon for the rules engine's
+/// computed severity (debug → grey dot, info → blue i, warning →
+/// yellow triangle, error → red ⊘, critical → red filled exclamation).
+/// Falls back to the warning icon when the severity is absent — the
+/// catalog hasn't been touched for this check yet, so we surface it
+/// at the default level rather than miscolouring it.
+function CheckIcon({
+	healthy,
+	severity,
+}: {
+	healthy: boolean;
+	severity: Severity | null;
+}) {
+	if (healthy) {
+		return (
+			<Tooltip title="Passing" arrow>
+				<CheckCircleIcon fontSize="small" color="success" />
+			</Tooltip>
+		);
+	}
+	const sev: Severity = severity ?? "warning";
+	const tooltip = `${sev} — ${SEVERITY_INTENT[sev]}`;
+	switch (sev) {
+		case "critical":
+			return (
+				<Tooltip title={tooltip} arrow>
+					<ErrorIcon fontSize="small" color="error" />
+				</Tooltip>
+			);
+		case "error":
+			return (
+				<Tooltip title={tooltip} arrow>
+					<CancelIcon fontSize="small" color="error" />
+				</Tooltip>
+			);
+		case "warning":
+			return (
+				<Tooltip title={tooltip} arrow>
+					<WarningAmberIcon fontSize="small" color="warning" />
+				</Tooltip>
+			);
+		case "info":
+			return (
+				<Tooltip title={tooltip} arrow>
+					<InfoIcon fontSize="small" color="info" />
+				</Tooltip>
+			);
+		case "debug":
+			return (
+				<Tooltip title={tooltip} arrow>
+					<CircleIcon fontSize="small" color="disabled" sx={{ fontSize: 12 }} />
+				</Tooltip>
+			);
+	}
 }
 
 function renderValue(v: unknown): string {


### PR DESCRIPTION
🤖

Stacks on #194 (severity-semantics).

The per-check icons in the status snapshot were driven by the legacy `healthy: bool` rollup flag — green tick for passing, yellow triangle if the check was unhealthy while overall was healthy, red ⊘ if overall was unhealthy too. That ignored the new rules engine: an operator could elevate a check to `critical` or downgrade to `debug` and the UI would still show one of the three legacy colours.

This PR routes the icons through the rules engine.

## Backend

`StatusSnapshotData` grows a `check_severities: Map<String, Severity>` field. For each unhealthy check on the push, the handler builds the same `EvaluationContext` that `file_health_events` uses (status extras, the check's own extras, the server's merged tag map) and calls `HealthcheckSeverity::severity_for` to compute the severity that would be filed. Healthy checks are omitted from the map.

## Frontend

`StatusSnapshot.tsx`'s `ChecksBlock` replaces the 3-state heuristic with a per-severity icon:

- passing  → green CheckCircleIcon (unchanged)
- critical → red ErrorIcon (filled !)
- error    → red CancelIcon (unchanged)
- warning  → yellow WarningAmberIcon (unchanged)
- info     → blue InfoIcon
- debug    → grey CircleIcon (small dot)

Each icon carries a tooltip with the severity and its incident intent (from `SEVERITY_INTENT`).

## Test

`snapshot_surfaces_per_check_severity` exercises the four interesting cases in one push: catalog default surfaces as-is, operator elevation surfaces, a rules ladder predicating on `status.bestoolVersion` wins over the base, and healthy checks are correctly omitted.