### PR TITLE
Sort servers by rank then kind in group views + status-dot strips

### DIFF
--- a/crates/commons-types/src/server/cards.rs
+++ b/crates/commons-types/src/server/cards.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
+	server::{kind::ServerKind, rank::ServerRank},
 	status::{HealthState, ShortStatus},
 	version::VersionStr,
 };
@@ -12,6 +13,12 @@ pub struct FacilityServerStatus {
 	pub name: String,
 	pub up: ShortStatus,
 	pub health: HealthState,
+	/// Server's rank, when set. Surfaced so the UI can group dots by
+	/// rank (production first, then clone, demo, …) in a stable order.
+	pub rank: Option<ServerRank>,
+	/// Server's kind (central / facility / canopy). UI breaks ties
+	/// within a rank by kind, centrals first.
+	pub kind: ServerKind,
 }
 
 /// Status-page card for a server group. Replaces the old per-central-server

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -197,6 +197,8 @@ pub async fn group_details(
 				name: s.name.clone().unwrap_or_default(),
 				up: st.map(|s| s.short_status()).unwrap_or_default(),
 				health: st.map(|s| s.health_state()).unwrap_or_default(),
+				rank: s.rank,
+				kind: s.kind,
 			}
 		})
 		.collect();

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4202,7 +4202,8 @@
           "id",
           "name",
           "up",
-          "health"
+          "health",
+          "kind"
         ],
         "properties": {
           "health": {
@@ -4212,8 +4213,23 @@
             "type": "string",
             "format": "uuid"
           },
+          "kind": {
+            "$ref": "#/components/schemas/ServerKind",
+            "description": "Server's kind (central / facility / canopy). UI breaks ties\nwithin a rank by kind, centrals first."
+          },
           "name": {
             "type": "string"
+          },
+          "rank": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ServerRank",
+                "description": "Server's rank, when set. Surfaced so the UI can group dots by\nrank (production first, then clone, demo, …) in a stable order."
+              }
+            ]
           },
           "up": {
             "$ref": "#/components/schemas/ShortStatus"

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1661,7 +1661,13 @@ export interface components {
             health: components["schemas"]["HealthState"];
             /** Format: uuid */
             id: string;
+            /**
+             * @description Server's kind (central / facility / canopy). UI breaks ties
+             *     within a rank by kind, centrals first.
+             */
+            kind: components["schemas"]["ServerKind"];
             name: string;
+            rank?: null | components["schemas"]["ServerRank"];
             up: components["schemas"]["ShortStatus"];
         };
         GeoPoint: {

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -17,7 +17,13 @@ import TimeAgo from "../components/TimeAgo";
 import { useApi } from "../api";
 import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 import { usePageTitle } from "../hooks/usePageTitle";
-import type { IncidentData } from "../types";
+import {
+	SERVER_RANK_ORDER,
+	compareServersByRankThenKind,
+	type IncidentData,
+	type ServerInfo,
+	type ServerRank,
+} from "../types";
 
 export default function GroupDetail() {
 	const { id = "" } = useParams<{ id: string }>();
@@ -111,9 +117,24 @@ export default function GroupDetail() {
 						from the group selector.
 					</Alert>
 				) : (
-					<Stack spacing={1}>
-						{servers.map((s) => (
-							<ServerShorty key={s.id} server={s} />
+					<Stack spacing={2}>
+						{groupServersByRank(servers).map(([rank, members]) => (
+							<Box key={rank ?? "_unranked"}>
+								{rank && (
+									<Typography
+										variant="overline"
+										color="text.secondary"
+										sx={{ display: "block", mb: 0.5 }}
+									>
+										{rank}
+									</Typography>
+								)}
+								<Stack spacing={1}>
+									{members.map((s) => (
+										<ServerShorty key={s.id} server={s} />
+									))}
+								</Stack>
+							</Box>
 						))}
 					</Stack>
 				)}
@@ -180,4 +201,29 @@ function ActiveIncidentCard({ incident }: { incident: IncidentData }) {
 			</Stack>
 		</Paper>
 	);
+}
+
+/// Group a flat server list into rank buckets in display order, with
+/// each bucket internally sorted by kind (centrals first) then name.
+/// Servers without a rank land in a trailing `null` bucket.
+function groupServersByRank(
+	servers: ServerInfo[],
+): Array<[ServerRank | null, ServerInfo[]]> {
+	const buckets = new Map<ServerRank | null, ServerInfo[]>();
+	for (const s of servers) {
+		const rank = s.rank ?? null;
+		const list = buckets.get(rank);
+		if (list) list.push(s);
+		else buckets.set(rank, [s]);
+	}
+	const order: Array<ServerRank | null> = [...SERVER_RANK_ORDER, null];
+	const result: Array<[ServerRank | null, ServerInfo[]]> = [];
+	for (const rank of order) {
+		const list = buckets.get(rank);
+		if (list && list.length > 0) {
+			list.sort(compareServersByRankThenKind);
+			result.push([rank, list]);
+		}
+	}
+	return result;
 }

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -43,15 +43,17 @@ import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { humanSeconds } from "../lib/humanDuration";
 import ServerNameWithGroup from "../components/ServerNameWithGroup";
-import type {
-	DeviceInfo,
-	ServerDetailData,
-	ServerGroup,
-	ServerGroupSilencedRef,
-	ServerInfo,
-	ServerLastStatusData,
-	ServerSilencedRef,
-	ShortStatus,
+import {
+	compareServersByRankThenKind,
+	type DeviceInfo,
+	type HealthState,
+	type ServerDetailData,
+	type ServerGroup,
+	type ServerGroupSilencedRef,
+	type ServerInfo,
+	type ServerLastStatusData,
+	type ServerSilencedRef,
+	type ShortStatus,
 } from "../types";
 
 export default function ServerDetail() {
@@ -188,22 +190,12 @@ function Header({
 				{data.server.rank && <ServerRankChip rank={data.server.rank} />}
 				<ServerKindChip kind={data.server.kind} />
 				<Typography variant="h4" component="h1" sx={{ ml: 1 }}>
-					<StatusDot
-						up={data.up}
-						health={data.health}
-						title={data.server.name ?? ""}
-						size="0.8em"
+					<SiblingDotStrip
+						focused={data.server}
+						focusedUp={data.up}
+						focusedHealth={data.health}
+						siblings={data.siblings}
 					/>
-					{data.siblings.map((sib) => (
-						<StatusDot
-							key={sib.id}
-							up={sib.up ?? "gone"}
-							health={sib.health ?? undefined}
-							title={sib.name ?? ""}
-							dim
-							size="0.8em"
-						/>
-					))}
 					<ServerNameWithGroup
 						groupName={data.server.group_name}
 						serverName={data.server.name ?? "Unnamed"}
@@ -1335,5 +1327,92 @@ function NotesAndTagsSection({
 				</Stack>
 			)}
 		</Paper>
+	);
+}
+
+/// Header strip of StatusDots: the focused server (full-colour) plus its
+/// siblings (dimmed), sorted by rank then kind. A thin grey vertical bar
+/// separates adjacent ranks. The focused server's dot is the only one
+/// without `dim`, so it visually pops regardless of where in the strip
+/// rank+kind ordering places it.
+function SiblingDotStrip({
+	focused,
+	focusedUp,
+	focusedHealth,
+	siblings,
+}: {
+	focused: ServerInfo & { name?: string | null };
+	focusedUp: ShortStatus;
+	focusedHealth: HealthState;
+	siblings: Array<
+		ServerInfo & {
+			up?: ShortStatus | null;
+			health?: HealthState | null;
+			name?: string | null;
+		}
+	>;
+}) {
+	// Combine + sort. The focused server keeps a marker so we can render
+	// it without `dim` once the order is established.
+	const combined: Array<{
+		entry: ServerInfo & {
+			up?: ShortStatus | null;
+			health?: HealthState | null;
+		};
+		focused: boolean;
+	}> = [
+		{
+			entry: { ...focused, up: focusedUp, health: focusedHealth },
+			focused: true,
+		},
+		...siblings.map((sib) => ({ entry: sib, focused: false })),
+	];
+	combined.sort((a, b) => compareServersByRankThenKind(a.entry, b.entry));
+
+	const chunks: Array<{
+		rank: string;
+		entries: typeof combined;
+	}> = [];
+	for (const m of combined) {
+		const key = m.entry.rank ?? "_unranked";
+		const last = chunks[chunks.length - 1];
+		if (last && last.rank === key) last.entries.push(m);
+		else chunks.push({ rank: key, entries: [m] });
+	}
+
+	return (
+		<Box component="span" sx={{ display: "inline-flex", alignItems: "center" }}>
+			{chunks.map((chunk, idx) => (
+				<Box
+					key={chunk.rank}
+					component="span"
+					sx={{ display: "inline-flex", alignItems: "center" }}
+				>
+					{idx > 0 && (
+						<Box
+							component="span"
+							aria-hidden
+							sx={{
+								display: "inline-block",
+								width: "2px",
+								height: "0.7em",
+								mx: 0.5,
+								bgcolor: "text.disabled",
+							}}
+						/>
+					)}
+					{chunk.entries.map((m) => (
+						<StatusDot
+							key={m.entry.id}
+							up={(m.entry.up as ShortStatus | undefined) ?? "gone"}
+							health={(m.entry.health as HealthState | undefined) ?? undefined}
+							title={m.entry.name ?? ""}
+							dim={!m.focused}
+							size="0.8em"
+						/>
+					))}
+				</Box>
+			))}
+		</Box>
 	);
 }

--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -17,7 +17,12 @@ import { HealthLegend, StatusLegend, VersionLegend } from "../components/Legends
 import { useApi } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { useReloadInterval } from "../hooks/useReloadInterval";
-import { type ServerGroupCard, SERVER_RANK_ORDER } from "../types";
+import {
+	type FacilityServerStatus,
+	type ServerGroupCard,
+	SERVER_RANK_ORDER,
+	compareServersByRankThenKind,
+} from "../types";
 
 /// Held vs loud: a group has an open incident, but the Slack notice is
 /// still inside the per-group cooldown window (held) or has already fired
@@ -257,9 +262,61 @@ function GroupCard({
 				spacing={1}
 				sx={{ alignItems: "center", justifyContent: "space-between" }}
 			>
-				<Stack direction="row" spacing={0} sx={{ flexWrap: "wrap" }}>
-					{group.members.map((m) => (
-						<Tooltip key={m.id} title={m.name || "(unnamed)"}>
+				<RankedDotStrip members={group.members} />
+				{openIncident === "loud" && (
+					<Chip label="incident" color="error" size="small" />
+				)}
+				{openIncident === "held" && (
+					<Tooltip title="Open incident; Slack notice is still inside the per-group cooldown window">
+						<Chip label="incident (held)" color="warning" size="small" />
+					</Tooltip>
+				)}
+			</Stack>
+		</Stack>
+	);
+}
+
+/// Strip of StatusDots for a group's members, sorted by rank then kind
+/// (centrals first within a rank). A thin grey vertical bar separates
+/// adjacent ranks, so operators can see at a glance how the group
+/// breaks down without naming each dot.
+export function RankedDotStrip({ members }: { members: FacilityServerStatus[] }) {
+	const sorted = [...members].sort(compareServersByRankThenKind);
+	const chunks: Array<{ rank: string; entries: FacilityServerStatus[] }> = [];
+	for (const m of sorted) {
+		const key = m.rank ?? "_unranked";
+		const last = chunks[chunks.length - 1];
+		if (last && last.rank === key) last.entries.push(m);
+		else chunks.push({ rank: key, entries: [m] });
+	}
+	return (
+		<Stack direction="row" spacing={0} sx={{ flexWrap: "wrap", alignItems: "center" }}>
+			{chunks.map((chunk, idx) => (
+				<Box
+					key={chunk.rank}
+					component="span"
+					sx={{ display: "inline-flex", alignItems: "center" }}
+				>
+					{idx > 0 && (
+						<Box
+							component="span"
+							aria-hidden
+							sx={{
+								display: "inline-block",
+								width: "1px",
+								height: "0.9em",
+								mx: 0.5,
+								bgcolor: "text.disabled",
+							}}
+						/>
+					)}
+					{chunk.entries.map((m) => (
+						<Tooltip
+							key={m.id}
+							title={`${m.name || "(unnamed)"}${
+								m.rank ? ` · ${m.rank}` : ""
+							} · ${m.kind}`}
+						>
 							<Box component="span" sx={{ display: "inline-flex" }}>
 								<StatusDot
 									up={m.up}
@@ -271,16 +328,8 @@ function GroupCard({
 							</Box>
 						</Tooltip>
 					))}
-				</Stack>
-				{openIncident === "loud" && (
-					<Chip label="incident" color="error" size="small" />
-				)}
-				{openIncident === "held" && (
-					<Tooltip title="Open incident; Slack notice is still inside the per-group cooldown window">
-						<Chip label="incident (held)" color="warning" size="small" />
-					</Tooltip>
-				)}
-			</Stack>
+				</Box>
+			))}
 		</Stack>
 	);
 }

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -155,6 +155,38 @@ export const SERVER_RANK_ORDER: ServerRank[] = [
 	"dev",
 ];
 
+/// Display order for server kinds — centrals first, then facilities,
+/// then canopy's own. Used as a tiebreak within a single rank in
+/// status-dot lists / group detail views.
+export const SERVER_KIND_ORDER: ServerKind[] = ["central", "facility", "canopy"];
+
+/// Sort key combining rank index (with `null` ranks pushed last) and
+/// kind index. Stable per-rank ordering matches what the UI grouping
+/// expects.
+export function serverSortKey(s: {
+	rank?: ServerRank | null;
+	kind: ServerKind;
+}): [number, number] {
+	const rankIndex =
+		s.rank == null ? Infinity : SERVER_RANK_ORDER.indexOf(s.rank);
+	const rankKey = rankIndex === -1 ? SERVER_RANK_ORDER.length : rankIndex;
+	const kindIndex = SERVER_KIND_ORDER.indexOf(s.kind);
+	const kindKey = kindIndex === -1 ? SERVER_KIND_ORDER.length : kindIndex;
+	return [rankKey, kindKey];
+}
+
+export function compareServersByRankThenKind<
+	T extends { rank?: ServerRank | null; kind: ServerKind; name?: string | null },
+>(a: T, b: T): number {
+	const [ar, ak] = serverSortKey(a);
+	const [br, bk] = serverSortKey(b);
+	if (ar !== br) return ar - br;
+	if (ak !== bk) return ak - bk;
+	const an = a.name ?? "";
+	const bn = b.name ?? "";
+	return an.localeCompare(bn);
+}
+
 /// Operator-facing severity vocabulary, loud → quiet. Used for both
 /// display and selection (the API now restricts severities to these
 /// five — see commons-types::issue::Severity and the


### PR DESCRIPTION
🤖

Two small UI improvements to make server lists scannable at a glance:

## Group detail view (`/groups/<id>`)

The server list is now grouped under rank headers (`production`, `clone`, `demo`, `test`, `dev`), with each bucket internally ordered by kind (centrals first, then facility, then canopy) and then by name. Servers without a rank land in a trailing unnamed bucket.

## Status-dot strips

The dot strips on the `/status` page cards and at the top of `/servers/<id>` apply the same rank-then-kind ordering. A thin grey vertical bar between adjacent ranks signals the boundary so operators can see the breakdown without naming each dot.

## Mechanics

- `commons_types::server::cards::FacilityServerStatus` gains `rank` and `kind` so the `/api/statuses/group_details` response carries the data the UI needs for the dot strip on group cards.
- `private-web/src/types.ts` adds `SERVER_KIND_ORDER`, `serverSortKey`, and `compareServersByRankThenKind` helpers.
- `GroupDetail.tsx` groups under rank headers via a local `groupServersByRank`.
- `Status.tsx` and `ServerDetail.tsx` each introduce a small `*DotStrip` component to render the chunked dots with separators. `ServerDetail`'s variant keeps the focused server full-colour (siblings dimmed) regardless of where rank+kind ordering places it in the strip.

No new tests — backend change is one struct field passthrough, frontend is presentational. Existing test packages all still pass.