### PR TITLE
ui(serverdetail): rank-group the 'Other servers in this group' section

### DIFF
--- a/private-web/src/routes/DeviceDetail.tsx
+++ b/private-web/src/routes/DeviceDetail.tsx
@@ -23,11 +23,12 @@ import { deviceDisplayName } from "../components/DeviceShorty";
 import TimeAgo from "../components/TimeAgo";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { humanDuration } from "../lib/humanDuration";
-import type {
-	DeviceConnectionData,
-	DeviceInfo,
-	DeviceKeyInfo,
-	DeviceRole,
+import {
+	compareServersByRankThenKind,
+	type DeviceConnectionData,
+	type DeviceInfo,
+	type DeviceKeyInfo,
+	type DeviceRole,
 } from "../types";
 
 const TRUSTABLE_ROLES: DeviceRole[] = ["server", "releaser", "admin"];
@@ -390,6 +391,7 @@ function AssociatedServersSection({ deviceId }: { deviceId: string }) {
 			title="Associated servers"
 			result={result}
 			emptyText="No servers are associated with this device."
+			sort
 		/>
 	);
 }
@@ -414,11 +416,19 @@ function ServersListSection({
 	title,
 	result,
 	emptyText,
+	sort = false,
 }: {
 	title: string;
 	result: ApiState<ServerShortyInfo[]> & { reload: () => void };
 	emptyText: string;
+	sort?: boolean;
 }) {
+	const items =
+		result.status === "ok" && sort
+			? [...result.data].sort(compareServersByRankThenKind)
+			: result.status === "ok"
+				? result.data
+				: [];
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
 			<Stack
@@ -441,11 +451,11 @@ function ServersListSection({
 				<LinearProgress />
 			) : result.status === "error" ? (
 				<Alert severity="error">{result.error.message}</Alert>
-			) : result.data.length === 0 ? (
+			) : items.length === 0 ? (
 				<Alert severity="info">{emptyText}</Alert>
 			) : (
 				<Stack spacing={1}>
-					{result.data.map((s) => (
+					{items.map((s) => (
 						<ServerShorty key={s.id} server={s} />
 					))}
 				</Stack>

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -44,6 +44,7 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import { humanSeconds } from "../lib/humanDuration";
 import ServerNameWithGroup from "../components/ServerNameWithGroup";
 import {
+	SERVER_RANK_ORDER,
 	compareServersByRankThenKind,
 	type DeviceInfo,
 	type HealthState,
@@ -52,6 +53,7 @@ import {
 	type ServerGroupSilencedRef,
 	type ServerInfo,
 	type ServerLastStatusData,
+	type ServerRank,
 	type ServerSilencedRef,
 	type ShortStatus,
 } from "../types";
@@ -1183,70 +1185,106 @@ function SiblingServers({
 	hasOpenIncident: boolean;
 	onEventSubmitted: () => void;
 }) {
+	// Same rank-then-kind grouping as the GroupDetail server list, so a
+	// reader scanning ServerDetail's sibling section sees the production
+	// peers up top and the dev scratch at the bottom in a predictable
+	// order. Unranked servers fall into a trailing `null` bucket.
+	const buckets = new Map<ServerRank | null, ServerDetailData["siblings"]>();
+	for (const sib of siblings) {
+		const rank = sib.rank ?? null;
+		const list = buckets.get(rank);
+		if (list) list.push(sib);
+		else buckets.set(rank, [sib]);
+	}
+	const order: Array<ServerRank | null> = [...SERVER_RANK_ORDER, null];
+	const groups: Array<[ServerRank | null, ServerDetailData["siblings"]]> = [];
+	for (const rank of order) {
+		const list = buckets.get(rank);
+		if (list && list.length > 0) {
+			list.sort(compareServersByRankThenKind);
+			groups.push([rank, list]);
+		}
+	}
+
 	return (
 		<Box>
 			<Typography variant="h5" component="h2" gutterBottom>
 				Other servers in this group ({siblings.length})
 			</Typography>
-			<Stack spacing={1}>
-				{siblings.map((sib) => (
-					<Stack
-						key={sib.id}
-						direction="row"
-						spacing={1}
-						sx={{
-							p: 1.5,
-							border: 1,
-							borderColor: "divider",
-							borderRadius: 1,
-							alignItems: "center",
-						}}
-					>
-						<Tooltip title={sib.host}>
-							<IconButton
-								component="a"
-								href={sib.host}
-								target="_blank"
-								rel="noopener noreferrer"
-								size="small"
-								aria-label={`Open ${sib.name ?? "server"} (${sib.host})`}
+			<Stack spacing={2}>
+				{groups.map(([rank, members]) => (
+					<Box key={rank ?? "_unranked"}>
+						{rank && (
+							<Typography
+								variant="overline"
+								color="text.secondary"
+								sx={{ display: "block", mb: 0.5 }}
 							>
-								<LanguageIcon fontSize="small" />
-							</IconButton>
-						</Tooltip>
-						<StatusDot
-							up={sib.up ?? "gone"}
-							health={sib.health ?? undefined}
-						/>
-						<MuiLink
-							component={RouterLink}
-							to={`/servers/${sib.id}`}
-							underline="hover"
-							color="text.primary"
-							sx={{ fontWeight: 500 }}
-						>
-							{sib.name ?? "Unnamed"}
-						</MuiLink>
-						{sib.rank && <ServerRankChip rank={sib.rank} />}
-						<ServerKindChip kind={sib.kind} />
-						{!sib.is_monitored && (
-							<Tooltip title="Status alerts are off for this server — canopy isn't watching it.">
-								<Chip
-									size="small"
-									variant="outlined"
-									label="unmonitored"
-								/>
-							</Tooltip>
+								{rank}
+							</Typography>
 						)}
-						<Box sx={{ flex: 1 }} />
-						{isAdmin && (
-							<ManualEventButton
-								serverId={sib.id}
-								hasOpenIncident={hasOpenIncident}
-								onSubmitted={onEventSubmitted}
-							/>
-						)}
-					</Stack>
+						<Stack spacing={1}>
+							{members.map((sib) => (
+								<Stack
+									key={sib.id}
+									direction="row"
+									spacing={1}
+									sx={{
+										p: 1.5,
+										border: 1,
+										borderColor: "divider",
+										borderRadius: 1,
+										alignItems: "center",
+									}}
+								>
+									<Tooltip title={sib.host}>
+										<IconButton
+											component="a"
+											href={sib.host}
+											target="_blank"
+											rel="noopener noreferrer"
+											size="small"
+											aria-label={`Open ${sib.name ?? "server"} (${sib.host})`}
+										>
+											<LanguageIcon fontSize="small" />
+										</IconButton>
+									</Tooltip>
+									<StatusDot
+										up={sib.up ?? "gone"}
+										health={sib.health ?? undefined}
+									/>
+									<MuiLink
+										component={RouterLink}
+										to={`/servers/${sib.id}`}
+										underline="hover"
+										color="text.primary"
+										sx={{ fontWeight: 500 }}
+									>
+										{sib.name ?? "Unnamed"}
+									</MuiLink>
+									{sib.rank && <ServerRankChip rank={sib.rank} />}
+									<ServerKindChip kind={sib.kind} />
+									{!sib.is_monitored && (
+										<Tooltip title="Status alerts are off for this server — canopy isn't watching it.">
+											<Chip
+												size="small"
+												variant="outlined"
+												label="unmonitored"
+											/>
+										</Tooltip>
+									)}
+									<Box sx={{ flex: 1 }} />
+									{isAdmin && (
+										<ManualEventButton
+											serverId={sib.id}
+											hasOpenIncident={hasOpenIncident}
+											onSubmitted={onEventSubmitted}
+										/>
+									)}
+								</Stack>
+							))}
+						</Stack>
+					</Box>
 				))}
 			</Stack>
 		</Box>

--- a/private-web/src/routes/UngroupedServersList.tsx
+++ b/private-web/src/routes/UngroupedServersList.tsx
@@ -2,6 +2,7 @@ import { Alert, LinearProgress, Stack } from "@mui/material";
 import ServerShorty from "../components/ServerShorty";
 import { useApi } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
+import { compareServersByRankThenKind } from "../types";
 
 export default function UngroupedServersList() {
 	usePageTitle("Ungrouped servers");
@@ -20,9 +21,10 @@ export default function UngroupedServersList() {
 			</Alert>
 		);
 	}
+	const sorted = [...result.data.items].sort(compareServersByRankThenKind);
 	return (
 		<Stack spacing={1}>
-			{result.data.items.map((s) => (
+			{sorted.map((s) => (
 				<ServerShorty key={s.id} server={s} />
 			))}
 		</Stack>


### PR DESCRIPTION
🤖

Follow-up to #196. The rank-then-kind grouping landed for the group detail server list and the status-dot strips, but the sibling-servers section on ServerDetail still rendered as one flat list. This PR extends the same grouping there: rank headers (production / clone / demo / test / dev), each bucket internally sorted by kind (centrals first) then name. Unranked servers fall into a trailing unnamed bucket.