### PR TITLE
fix(healthcheck): repair variable Autocomplete in the rule editor dialog

### DIFF
--- a/private-web/src/routes/HealthcheckDetail.tsx
+++ b/private-web/src/routes/HealthcheckDetail.tsx
@@ -650,7 +650,7 @@ function BranchDialog({
 					<Autocomplete
 						freeSolo
 						options={options}
-						value={varPath}
+						inputValue={varPath}
 						onInputChange={(_, v) => setVarPath(v)}
 						renderInput={(params) => (
 							<TextField
@@ -660,6 +660,7 @@ function BranchDialog({
 								error={!varValid}
 								size="small"
 								slotProps={{
+									...params.slotProps,
 									input: {
 										...params.slotProps.input,
 										endAdornment: (


### PR DESCRIPTION
🤖

Two bugs in the Add/Edit rule dialog made the form unusable:

- **Validation never passed.** The variable Autocomplete bound `value={varPath}` while only updating via `onInputChange`. In freeSolo mode `value` is the *selection*; `inputValue` is the typed text. Each keystroke updated `varPath`, but on re-render `value` snapped the underlying selection back to the initial `"status."`, so the regex check kept failing and Save stayed blocked. Switched to `inputValue` + `onInputChange`.
- **Console crash on focus.** MUI v9's `params.slotProps` carries three keys (`input`, `htmlInput`, `inputLabel`); we passed only `{ input }` through to TextField, dropping `htmlInput` — which holds the input ref Autocomplete uses to call `.focus()`. The "fe.current is null" error fired the moment the field gained focus. Spread `...params.slotProps` to preserve the other slots.