### PR TITLE
healthchecks: aggregate tag keys for the rule editor autocomplete

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -19,6 +19,7 @@ pub mod silenced_refs;
 pub mod slack_outbox;
 pub mod sql_playground_history;
 pub mod statuses;
+pub mod tags;
 pub mod tailscale_users;
 pub mod url_field;
 pub mod version_known_issues;

--- a/crates/database/src/tags.rs
+++ b/crates/database/src/tags.rs
@@ -1,0 +1,26 @@
+use commons_errors::Result;
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+
+/// Distinct top-level tag keys across all servers and server groups,
+/// sorted. Used by the admin rule editor to populate autocomplete
+/// suggestions for `tag.*` variables — a key that exists on any
+/// server or group is a valid thing to predicate on, even if the
+/// sampled server doesn't carry it.
+pub async fn all_known_keys(conn: &mut AsyncPgConnection) -> Result<Vec<String>> {
+	#[derive(QueryableByName)]
+	struct Row {
+		#[diesel(sql_type = sql_types::Text)]
+		key: String,
+	}
+	let rows: Vec<Row> = sql_query(
+		"SELECT key FROM ( \
+		    SELECT jsonb_object_keys(tags) AS key FROM servers \
+		    UNION SELECT jsonb_object_keys(tags) AS key FROM server_groups \
+		 ) k ORDER BY key",
+	)
+	.get_results(conn)
+	.await
+	.map_err(commons_errors::AppError::from)?;
+	Ok(rows.into_iter().map(|r| r.key).collect())
+}

--- a/crates/private-server/src/fns/healthchecks.rs
+++ b/crates/private-server/src/fns/healthchecks.rs
@@ -26,6 +26,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(update))
 		.routes(routes!(update_rules))
 		.routes(routes!(sample))
+		.routes(routes!(tag_keys))
 }
 
 /// Catalog row enriched with `pending_review` and `rule_count` derivations
@@ -304,4 +305,31 @@ pub async fn sample(
 			seen_at: status.created_at,
 		}),
 	}))
+}
+
+/// Distinct tag keys known anywhere in the system — union across all
+/// servers and server groups, sorted. Feeds the rule editor's
+/// Autocomplete so operators can pick `tag.<key>` even when the
+/// sampled server doesn't carry that key. The sample-based pass/warn
+/// badge still reflects the sample only; this list only widens the
+/// completion menu.
+#[utoipa::path(
+	post,
+	path = "/tag_keys",
+	operation_id = "healthcheck_tag_keys",
+	tag = "healthchecks",
+	security(("tailscale-admin" = [])),
+	responses(
+		(status = 200, description = "Sorted, distinct tag keys.", body = Vec<String>),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn tag_keys(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+) -> Result<Json<Vec<String>>> {
+	let mut conn = state.db.get().await?;
+	let keys = database::tags::all_known_keys(&mut conn).await?;
+	Ok(Json(keys))
 }

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1202,6 +1202,55 @@
         ]
       }
     },
+    "/api/healthchecks/tag_keys": {
+      "post": {
+        "tags": [
+          "healthchecks"
+        ],
+        "summary": "Distinct tag keys known anywhere in the system — union across all\nservers and server groups, sorted. Feeds the rule editor's\nAutocomplete so operators can pick `tag.<key>` even when the\nsampled server doesn't carry that key. The sample-based pass/warn\nbadge still reflects the sample only; this list only widens the\ncompletion menu.",
+        "operationId": "healthcheck_tag_keys",
+        "responses": {
+          "200": {
+            "description": "Sorted, distinct tag keys.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/healthchecks/update": {
       "post": {
         "tags": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -474,6 +474,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/healthchecks/tag_keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Distinct tag keys known anywhere in the system — union across all
+         *     servers and server groups, sorted. Feeds the rule editor's
+         *     Autocomplete so operators can pick `tag.<key>` even when the
+         *     sampled server doesn't carry that key. The sample-based pass/warn
+         *     badge still reflects the sample only; this list only widens the
+         *     completion menu.
+         */
+        post: operations["healthcheck_tag_keys"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/healthchecks/update": {
         parameters: {
             query?: never;
@@ -3561,6 +3585,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HealthcheckSampleResponse"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    healthcheck_tag_keys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sorted, distinct tag keys. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
                 };
             };
             401: {

--- a/private-web/src/routes/HealthcheckDetail.tsx
+++ b/private-web/src/routes/HealthcheckDetail.tsx
@@ -385,6 +385,12 @@ function RulesCard({
 	const sample: HealthcheckSample | null =
 		sampleResp.status === "ok" ? (sampleResp.data.sample ?? null) : null;
 
+	// Widen the autocomplete with every `tag.*` key known to canopy. The
+	// sample-resolved tag map only covers one server; a rule may want to
+	// predicate on a tag that exists on a different server or group.
+	const tagKeysResp = useApi("healthchecks", "tag_keys");
+	const knownTagKeys = tagKeysResp.status === "ok" ? tagKeysResp.data : [];
+
 	const dirty = useMemo(
 		() => JSON.stringify(branches) !== JSON.stringify(parsed.branches),
 		[branches, parsed.branches],
@@ -547,6 +553,7 @@ function RulesCard({
 				<BranchDialog
 					initial={dialog.index != null ? branches[dialog.index] : null}
 					sample={sample}
+					knownTagKeys={knownTagKeys}
 					onCancel={() => setDialog(null)}
 					onSave={(b) => {
 						setBranches((bs) => {
@@ -582,11 +589,13 @@ function sampleVarOptions(sample: HealthcheckSample | null): string[] {
 function BranchDialog({
 	initial,
 	sample,
+	knownTagKeys,
 	onCancel,
 	onSave,
 }: {
 	initial: Branch | null;
 	sample: HealthcheckSample | null;
+	knownTagKeys: string[];
 	onCancel: () => void;
 	onSave: (b: Branch) => void;
 }) {
@@ -600,9 +609,20 @@ function BranchDialog({
 
 	// Did the sample carry a value for this exact var path? Powers the
 	// pass/warn badge: green when the operator's predicating on a field
-	// the most recent push actually had, yellow otherwise.
-	const options = useMemo(() => sampleVarOptions(sample), [sample]);
-	const varInSample = varValid && options.includes(varPath);
+	// the most recent push actually had, yellow otherwise. A tag that
+	// exists on some *other* server is fine to predicate on but stays
+	// yellow here — at evaluation time the sampled server's tag map
+	// won't carry it, so the rule branch would be false.
+	const sampleKeys = useMemo(() => sampleVarOptions(sample), [sample]);
+	const varInSample = varValid && sampleKeys.includes(varPath);
+
+	// Autocomplete suggestions widen the sample with every known tag
+	// key across the system. Sorted, de-duplicated.
+	const options = useMemo(() => {
+		const merged = new Set<string>(sampleKeys);
+		for (const k of knownTagKeys) merged.add(`tag.${k}`);
+		return [...merged].sort();
+	}, [sampleKeys, knownTagKeys]);
 
 	const submit = () => {
 		if (!varValid) return;


### PR DESCRIPTION
🤖

The variable Autocomplete in the rule editor previously only suggested keys from the sampled server's resolved tag map. That meant an operator wanting to predicate on `tag.environment` couldn't see it in the dropdown unless the sampled server happened to carry that tag.

This PR widens the suggestions with every distinct top-level tag key across all servers and server_groups:

- New `database::tags::all_known_keys()` helper running a single `jsonb_object_keys` UNION query.
- New admin endpoint `POST /api/healthchecks/tag_keys` returning the sorted, de-duplicated list.
- React side fetches it alongside the sample and unions `tag.<k>` suggestions into the existing options.

The pass/warn badge semantics are unchanged: a tag that exists on some other server but not the sampled one still shows yellow, because at evaluation time the sampled server's tag map wouldn't carry it (the branch would be false).