### PR TITLE
fix: status card version from highest-ranked/-kind member

### DIFF
--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -204,6 +204,8 @@ diesel::table! {
 		notes -> Text,
 		tags -> Jsonb,
 		slack_open_delay -> Interval,
+		version_server_id -> Nullable<Uuid>,
+		effective_version -> Nullable<Text>,
 	}
 }
 
@@ -338,7 +340,6 @@ diesel::joinable!(issues -> servers (server_id));
 diesel::joinable!(server_group_silenced_refs -> server_groups (server_group_id));
 diesel::joinable!(server_silenced_refs -> servers (server_id));
 diesel::joinable!(servers -> devices (device_id));
-diesel::joinable!(servers -> server_groups (group_id));
 diesel::joinable!(slack_outbox -> incident_notes (note_id));
 diesel::joinable!(slack_outbox -> incidents (incident_id));
 diesel::joinable!(slack_outbox -> issues (issue_id));

--- a/crates/database/src/server_groups.rs
+++ b/crates/database/src/server_groups.rs
@@ -2,7 +2,8 @@
 //! purposes of incident roll-up, shared tags, and shared operator notes.
 
 use commons_errors::{AppError, Result};
-use commons_types::server::{TagMap, rank::ServerRank};
+use commons_types::server::{TagMap, kind::ServerKind, rank::ServerRank};
+use commons_types::version::VersionStr;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use jiff::Timestamp;
@@ -11,16 +12,38 @@ use uuid::Uuid;
 
 use crate::pg_duration::PgDuration;
 use crate::servers::Server;
+use crate::statuses::Status;
+
+/// Ordering key for a server's rank — lower is higher priority. Used to pick a
+/// group's canonical member (and to bucket groups on the status page). `None`
+/// (unranked) sorts last.
+pub fn rank_priority(rank: Option<ServerRank>) -> u8 {
+	match rank {
+		Some(ServerRank::Production) => 0,
+		Some(ServerRank::Clone) => 1,
+		Some(ServerRank::Demo) => 2,
+		Some(ServerRank::Test) => 3,
+		Some(ServerRank::Dev) => 4,
+		None => 5,
+	}
+}
+
+/// Ordering key for a server's kind — lower is higher priority. Central servers
+/// are the headline of a group; facility ties below them, canopy-kind last.
+pub fn kind_priority(kind: ServerKind) -> u8 {
+	match kind {
+		ServerKind::Central => 0,
+		ServerKind::Facility => 1,
+		ServerKind::Canopy => 2,
+	}
+}
 
 fn higher_rank(a: ServerRank, b: ServerRank) -> ServerRank {
-	let order = |r: ServerRank| match r {
-		ServerRank::Production => 0u8,
-		ServerRank::Clone => 1,
-		ServerRank::Demo => 2,
-		ServerRank::Test => 3,
-		ServerRank::Dev => 4,
-	};
-	if order(a) <= order(b) { a } else { b }
+	if rank_priority(Some(a)) <= rank_priority(Some(b)) {
+		a
+	} else {
+		b
+	}
 }
 
 #[derive(
@@ -54,6 +77,15 @@ pub struct ServerGroup {
 	/// keep Slack quiet without losing the underlying incident record.
 	#[schema(value_type = i64, format = "int64")]
 	pub slack_open_delay: PgDuration,
+	/// The group's canonical member (highest rank, then highest kind) whose
+	/// version is cached in `effective_version`. Maintained by
+	/// [`ServerGroup::recompute_version`] on membership/rank/kind/delete
+	/// changes. `None` when the group has no members.
+	pub version_server_id: Option<Uuid>,
+	/// The canonical member's last reported version. Maintained by the
+	/// `statuses` AFTER INSERT trigger (canonical member reports a new version)
+	/// and by [`ServerGroup::recompute_version`] (membership changes).
+	pub effective_version: Option<VersionStr>,
 }
 
 #[derive(Debug, Clone, Deserialize, Insertable, utoipa::ToSchema)]
@@ -209,6 +241,56 @@ impl ServerGroup {
 			out.insert(gid, better);
 		}
 		Ok(out)
+	}
+
+	/// Recompute the cached canonical member and its version for `group_id`.
+	///
+	/// Loads every member of the group, picks the canonical one (lowest
+	/// `(rank_priority, kind_priority)`, tie-broken by `id`), and caches that
+	/// member's last version-bearing status. No members → both cache columns
+	/// are cleared. Runs only on infrequent membership/rank/kind/delete
+	/// changes, so the unbounded `last_with_version_for_server` query is fine
+	/// here. The `statuses` trigger handles the hot path (canonical member
+	/// reporting a new version) without touching this.
+	pub async fn recompute_version(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<()> {
+		use crate::schema::server_groups::dsl;
+
+		let members: Vec<Server> = {
+			use crate::schema::servers::dsl as servers_dsl;
+			servers_dsl::servers
+				.select(Server::as_select())
+				.filter(servers_dsl::group_id.eq(group_id))
+				.load(db)
+				.await?
+		};
+
+		let canonical = members.into_iter().min_by(|a, b| {
+			(rank_priority(a.rank), kind_priority(a.kind), a.id).cmp(&(
+				rank_priority(b.rank),
+				kind_priority(b.kind),
+				b.id,
+			))
+		});
+
+		let (version_server_id, effective_version) = match canonical {
+			None => (None, None),
+			Some(server) => {
+				let version = Status::last_with_version_for_server(db, server.id)
+					.await?
+					.and_then(|s| s.version);
+				(Some(server.id), version)
+			}
+		};
+
+		diesel::update(dsl::server_groups.filter(dsl::id.eq(group_id)))
+			.set((
+				dsl::version_server_id.eq(version_server_id),
+				dsl::effective_version.eq(effective_version),
+			))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
 	}
 
 	/// Loose search by UUID or name substring, capped at 50 results, used by

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -15,6 +15,23 @@ use super::url_field::UrlField;
 
 const TEN_MINUTES: PgDuration = PgDuration(SignedDuration::from_secs(600));
 
+/// Recompute each distinct, present group id, deduping repeats and skipping
+/// `None`. Used by the server write paths that can change a group's canonical
+/// member (membership/rank/kind/delete).
+async fn recompute_groups(
+	db: &mut AsyncPgConnection,
+	groups: impl IntoIterator<Item = Option<Uuid>>,
+) -> Result<()> {
+	let mut seen: Vec<Uuid> = Vec::new();
+	for gid in groups.into_iter().flatten() {
+		if !seen.contains(&gid) {
+			seen.push(gid);
+			crate::server_groups::ServerGroup::recompute_version(db, gid).await?;
+		}
+	}
+	Ok(())
+}
+
 #[derive(
 	Debug,
 	Clone,
@@ -255,7 +272,7 @@ impl Server {
 		// (kind, rank, cloud) re-apply on update; operator-edited state
 		// (public_name, geolocation, alert_when_down_for, group_id, notes,
 		// tags) is preserved.
-		diesel::insert_into(servers::table)
+		let server: Self = diesel::insert_into(servers::table)
 			.values((
 				servers::id.eq(ticket.server_id),
 				servers::name.eq(&Some(ticket.hostname.clone())),
@@ -278,7 +295,11 @@ impl Server {
 			.returning(Self::as_select())
 			.get_result(db)
 			.await
-			.map_err(AppError::from)
+			.map_err(AppError::from)?;
+
+		// kind/rank/membership may have changed, shifting the canonical member.
+		recompute_groups(db, [server.group_id]).await?;
+		Ok(server)
 	}
 
 	pub async fn get_by_device_id(db: &mut AsyncPgConnection, dev_id: Uuid) -> Result<Vec<Self>> {
@@ -473,13 +494,25 @@ impl Server {
 	) -> Result<Self> {
 		use crate::schema::servers::dsl;
 
+		// Capture the old group before the update: rank/kind/group_id may all
+		// change, so both the old and new group's canonical member can shift.
+		// Non-fatal: a missing server (or read error) just means "no old group
+		// to recompute" and leaves the update's own error handling — e.g. the
+		// empty-changeset path — to set the response, unchanged by us.
+		let old_group_id = Self::get_by_id(db, server_id)
+			.await
+			.ok()
+			.and_then(|s| s.group_id);
+
 		diesel::update(dsl::servers.filter(dsl::id.eq(server_id)))
 			.set(updates)
 			.execute(db)
 			.await
 			.map_err(AppError::from)?;
 
-		Self::get_by_id(db, server_id).await
+		let after = Self::get_by_id(db, server_id).await?;
+		recompute_groups(db, [old_group_id, after.group_id]).await?;
+		Ok(after)
 	}
 
 	/// Set or clear the server's group. On a `None → Some(group)` transition,
@@ -508,6 +541,8 @@ impl Server {
 			// to attach an incident to.
 			crate::issues::reevaluate_open_issues_for_server(db, server_id).await?;
 		}
+
+		recompute_groups(db, [before.group_id, new_group_id]).await?;
 
 		Ok(after)
 	}

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -367,6 +367,31 @@ impl Status {
 			.map_err(AppError::from)
 	}
 
+	/// The most recent status for `server` that carries a version — **not**
+	/// bounded by the live 7-day window. Used for the status card's headline
+	/// version, which should reflect the last version a server ever reported
+	/// even if it's currently down (and hence has no recent status).
+	pub async fn last_with_version_for_server(
+		db: &mut AsyncPgConnection,
+		server: Uuid,
+	) -> Result<Option<Status>> {
+		use crate::schema::statuses::dsl::*;
+
+		statuses
+			.select(Status::as_select())
+			.filter(
+				server_id
+					.eq(server)
+					.and(version.is_not_null())
+					.and(id.ne(Uuid::nil())),
+			)
+			.order(created_at.desc())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
 	pub async fn latest_for_servers(
 		db: &mut AsyncPgConnection,
 		server_ids: &[Uuid],

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -503,12 +503,16 @@ impl Status {
 	}
 
 	pub fn distance_from_version(&self, version: &Version) -> Option<u64> {
-		let Some(current) = &self.version.as_ref().map(|v| &v.0) else {
-			return None;
-		};
-
-		let minor_distance = version.minor.saturating_sub(current.minor);
-		let major_distance = version.major.saturating_sub(current.major);
-		Some(major_distance * 1000 + minor_distance)
+		let current = self.version.as_ref().map(|v| &v.0)?;
+		Some(version_distance(current, version))
 	}
+}
+
+/// How far `current` lags behind `latest`, as `major_distance * 1000 +
+/// minor_distance` with saturating subtraction (a newer-than-latest `current`
+/// yields 0). Used for the status snapshot and the group card's headline.
+pub fn version_distance(current: &Version, latest: &Version) -> u64 {
+	let minor_distance = latest.minor.saturating_sub(current.minor);
+	let major_distance = latest.major.saturating_sub(current.major);
+	major_distance * 1000 + minor_distance
 }

--- a/crates/database/tests/server_group_version_cache.rs
+++ b/crates/database/tests/server_group_version_cache.rs
@@ -1,0 +1,188 @@
+//! The `server_groups` version cache: `recompute_version` picks the canonical
+//! member and caches its last version-bearing status, and the `statuses` AFTER
+//! INSERT trigger keeps `effective_version` fresh for the canonical member only.
+
+use commons_tests::db::TestDb;
+use database::server_groups::ServerGroup;
+use diesel::{ExpressionMethods, QueryDsl, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+/// Insert a group, returning its id.
+async fn insert_group(conn: &mut database::diesel_async::AsyncPgConnection, name: &str) -> Uuid {
+	#[derive(diesel::QueryableByName)]
+	struct RowId {
+		#[diesel(sql_type = sql_types::Uuid)]
+		id: Uuid,
+	}
+	let row: RowId = sql_query("INSERT INTO server_groups (name) VALUES ($1) RETURNING id")
+		.bind::<sql_types::Text, _>(name)
+		.get_result(conn)
+		.await
+		.expect("insert group");
+	row.id
+}
+
+/// Insert a server with the given kind/rank into a group, returning its id.
+async fn insert_server(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	group_id: Uuid,
+	kind: &str,
+	rank: Option<&str>,
+) -> Uuid {
+	#[derive(diesel::QueryableByName)]
+	struct RowId {
+		#[diesel(sql_type = sql_types::Uuid)]
+		id: Uuid,
+	}
+	let host = format!("http://test.invalid/{}", Uuid::new_v4());
+	let row: RowId = sql_query(
+		"INSERT INTO servers (host, kind, rank, group_id) VALUES ($1, $2, $3, $4) RETURNING id",
+	)
+	.bind::<sql_types::Text, _>(host)
+	.bind::<sql_types::Text, _>(kind)
+	.bind::<sql_types::Nullable<sql_types::Text>, _>(rank)
+	.bind::<sql_types::Uuid, _>(group_id)
+	.get_result(conn)
+	.await
+	.expect("insert server");
+	row.id
+}
+
+/// Insert a status row (fires the trigger). `created_at` is `now()` offset by
+/// `offset_secs` so all rows land in a partition the fresh test DB has.
+async fn insert_status(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	version: Option<&str>,
+	offset_secs: i64,
+) {
+	sql_query(
+		"INSERT INTO statuses (server_id, created_at, version, healthy, health)
+		 VALUES ($1, now() + ($2 || ' seconds')::interval, $3, true, '[]'::jsonb)",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(offset_secs.to_string())
+	.bind::<sql_types::Nullable<sql_types::Text>, _>(version)
+	.execute(conn)
+	.await
+	.expect("insert status");
+}
+
+async fn cache(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	group_id: Uuid,
+) -> (Option<Uuid>, Option<String>) {
+	use database::schema::server_groups::dsl;
+	dsl::server_groups
+		.select((dsl::version_server_id, dsl::effective_version))
+		.filter(dsl::id.eq(group_id))
+		.first(conn)
+		.await
+		.expect("load cache")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recompute_picks_canonical_and_trigger_updates_only_it() {
+	TestDb::run(async |mut conn, _| {
+		let group_id = insert_group(&mut conn, "Group").await;
+		// dev-facility is the only member at first.
+		let dev = insert_server(&mut conn, group_id, "facility", Some("dev")).await;
+		insert_status(&mut conn, dev, Some("1.0.0"), -60).await;
+
+		// (a) recompute picks the (lone) canonical member.
+		ServerGroup::recompute_version(&mut conn, group_id)
+			.await
+			.unwrap();
+		let (vsid, ver) = cache(&mut conn, group_id).await;
+		assert_eq!(vsid, Some(dev));
+		assert_eq!(ver.as_deref(), Some("1.0.0"));
+
+		// (b) a higher-ranked server added to the group flips the cache after
+		// recompute.
+		let prod = insert_server(&mut conn, group_id, "central", Some("production")).await;
+		insert_status(&mut conn, prod, Some("2.0.0"), -50).await;
+		ServerGroup::recompute_version(&mut conn, group_id)
+			.await
+			.unwrap();
+		let (vsid, ver) = cache(&mut conn, group_id).await;
+		assert_eq!(vsid, Some(prod), "production-central is now canonical");
+		assert_eq!(ver.as_deref(), Some("2.0.0"));
+
+		// (c) the trigger updates effective_version only for the canonical
+		// server, and only for version-bearing statuses.
+		insert_status(&mut conn, prod, Some("2.1.0"), -10).await;
+		let (_, ver) = cache(&mut conn, group_id).await;
+		assert_eq!(
+			ver.as_deref(),
+			Some("2.1.0"),
+			"canonical server's new version updates the cache"
+		);
+
+		// A later status from the non-canonical dev server is ignored.
+		insert_status(&mut conn, dev, Some("9.9.9"), -5).await;
+		let (_, ver) = cache(&mut conn, group_id).await;
+		assert_eq!(
+			ver.as_deref(),
+			Some("2.1.0"),
+			"non-canonical member's version does not touch the cache"
+		);
+
+		// A NULL-version (down/error) status from the canonical server is
+		// ignored, so the cached version is never blanked.
+		insert_status(&mut conn, prod, None, -1).await;
+		let (_, ver) = cache(&mut conn, group_id).await;
+		assert_eq!(
+			ver.as_deref(),
+			Some("2.1.0"),
+			"a NULL-version status from the canonical server does not blank the cache"
+		);
+
+		// (d) deleting the canonical member then recomputing falls back to the
+		// next-ranked member.
+		sql_query("DELETE FROM servers WHERE id = $1")
+			.bind::<sql_types::Uuid, _>(prod)
+			.execute(&mut conn)
+			.await
+			.expect("delete canonical server");
+		ServerGroup::recompute_version(&mut conn, group_id)
+			.await
+			.unwrap();
+		let (vsid, ver) = cache(&mut conn, group_id).await;
+		assert_eq!(vsid, Some(dev), "falls back to the remaining dev member");
+		assert_eq!(
+			ver.as_deref(),
+			Some("9.9.9"),
+			"dev member's last version-bearing status"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recompute_clears_cache_when_no_members() {
+	TestDb::run(async |mut conn, _| {
+		let group_id = insert_group(&mut conn, "Empty").await;
+		let server = insert_server(&mut conn, group_id, "central", Some("production")).await;
+		insert_status(&mut conn, server, Some("3.0.0"), -10).await;
+		ServerGroup::recompute_version(&mut conn, group_id)
+			.await
+			.unwrap();
+		let (vsid, ver) = cache(&mut conn, group_id).await;
+		assert_eq!(vsid, Some(server));
+		assert_eq!(ver.as_deref(), Some("3.0.0"));
+
+		sql_query("DELETE FROM servers WHERE id = $1")
+			.bind::<sql_types::Uuid, _>(server)
+			.execute(&mut conn)
+			.await
+			.expect("delete server");
+		ServerGroup::recompute_version(&mut conn, group_id)
+			.await
+			.unwrap();
+		let (vsid, ver) = cache(&mut conn, group_id).await;
+		assert_eq!(vsid, None, "no members → cache cleared");
+		assert_eq!(ver, None);
+	})
+	.await
+}

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -7,6 +7,7 @@ use commons_servers::tailscale_auth::TailscaleUser;
 use commons_types::{
 	server::{
 		cards::{FacilityServerStatus, ServerGroupCard},
+		kind::ServerKind,
 		rank::ServerRank,
 	},
 	version::VersionStr,
@@ -148,6 +149,31 @@ pub struct GroupDetailsArgs {
 	pub server_group_id: Uuid,
 }
 
+/// Ordering key for "most canonical rank" — lower is higher priority. Mirrors
+/// the public mobile list's rank ordering.
+fn rank_priority(rank: Option<ServerRank>) -> u8 {
+	match rank {
+		Some(ServerRank::Production) => 0,
+		Some(ServerRank::Clone) => 1,
+		Some(ServerRank::Demo) => 2,
+		Some(ServerRank::Test) => 3,
+		Some(ServerRank::Dev) => 4,
+		None => 5,
+	}
+}
+
+/// Ordering key for "most canonical kind" — lower is higher priority. Central
+/// servers are the headline of a group; facility servers tie-break below them.
+fn kind_priority(kind: ServerKind) -> u8 {
+	match kind {
+		ServerKind::Central => 0,
+		ServerKind::Facility => 1,
+		// Canopy-kind servers represent canopy itself, not a Tamanu deployment;
+		// they're the least likely headline for a group card.
+		ServerKind::Canopy => 2,
+	}
+}
+
 #[utoipa::path(
 	post,
 	path = "/group_details",
@@ -178,15 +204,24 @@ pub async fn group_details(
 		.map(|s| (s.server_id, s))
 		.collect();
 
-	// Pick a representative server to provide the card's headline version:
-	// the one with the most recent status. Ties (no status anywhere) fall
-	// back to the first server by name.
+	// The card's headline version is the last reported version of the group's
+	// most "canonical" member: highest rank first (production > clone > demo >
+	// test > dev > unranked), then highest kind (central > facility). This is a
+	// property of the member, not of who reported most recently. We use that
+	// member's last *version-bearing* status from history (not the 7-day live
+	// window), so a currently-down canonical server still shows the last version
+	// it reported rather than borrowing another member's.
 	let representative = servers
 		.iter()
-		.max_by_key(|s| status_map.get(&s.id).map(|st| st.created_at))
+		.min_by_key(|s| (rank_priority(s.rank), kind_priority(s.kind)))
 		.cloned();
-	let rep_status = representative.as_ref().and_then(|s| status_map.get(&s.id));
-	let version_distance = rep_status.and_then(|s| s.distance_from_version(&latest_version));
+	let rep_status = match &representative {
+		Some(s) => Status::last_with_version_for_server(&mut conn, s.id).await?,
+		None => None,
+	};
+	let version_distance = rep_status
+		.as_ref()
+		.and_then(|s| s.distance_from_version(&latest_version));
 
 	let members = servers
 		.into_iter()

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -7,7 +7,6 @@ use commons_servers::tailscale_auth::TailscaleUser;
 use commons_types::{
 	server::{
 		cards::{FacilityServerStatus, ServerGroupCard},
-		kind::ServerKind,
 		rank::ServerRank,
 	},
 	version::VersionStr,
@@ -149,31 +148,6 @@ pub struct GroupDetailsArgs {
 	pub server_group_id: Uuid,
 }
 
-/// Ordering key for "most canonical rank" — lower is higher priority. Mirrors
-/// the public mobile list's rank ordering.
-fn rank_priority(rank: Option<ServerRank>) -> u8 {
-	match rank {
-		Some(ServerRank::Production) => 0,
-		Some(ServerRank::Clone) => 1,
-		Some(ServerRank::Demo) => 2,
-		Some(ServerRank::Test) => 3,
-		Some(ServerRank::Dev) => 4,
-		None => 5,
-	}
-}
-
-/// Ordering key for "most canonical kind" — lower is higher priority. Central
-/// servers are the headline of a group; facility servers tie-break below them.
-fn kind_priority(kind: ServerKind) -> u8 {
-	match kind {
-		ServerKind::Central => 0,
-		ServerKind::Facility => 1,
-		// Canopy-kind servers represent canopy itself, not a Tamanu deployment;
-		// they're the least likely headline for a group card.
-		ServerKind::Canopy => 2,
-	}
-}
-
 #[utoipa::path(
 	post,
 	path = "/group_details",
@@ -204,24 +178,14 @@ pub async fn group_details(
 		.map(|s| (s.server_id, s))
 		.collect();
 
-	// The card's headline version is the last reported version of the group's
-	// most "canonical" member: highest rank first (production > clone > demo >
-	// test > dev > unranked), then highest kind (central > facility). This is a
-	// property of the member, not of who reported most recently. We use that
-	// member's last *version-bearing* status from history (not the 7-day live
-	// window), so a currently-down canonical server still shows the last version
-	// it reported rather than borrowing another member's.
-	let representative = servers
-		.iter()
-		.min_by_key(|s| (rank_priority(s.rank), kind_priority(s.kind)))
-		.cloned();
-	let rep_status = match &representative {
-		Some(s) => Status::last_with_version_for_server(&mut conn, s.id).await?,
-		None => None,
-	};
-	let version_distance = rep_status
+	// The card's headline version is the cached last reported version of the
+	// group's canonical member (highest rank, then highest kind), maintained by
+	// the `statuses` trigger and `ServerGroup::recompute_version`. The distance
+	// is computed against the latest published version.
+	let card_version = group.effective_version.clone();
+	let version_distance = card_version
 		.as_ref()
-		.and_then(|s| s.distance_from_version(&latest_version));
+		.map(|v| database::statuses::version_distance(&v.0, &latest_version));
 
 	let members = servers
 		.into_iter()
@@ -242,7 +206,7 @@ pub async fn group_details(
 		id: group.id,
 		name: group.name,
 		notes: group.notes,
-		version: rep_status.and_then(|s| s.version.clone()),
+		version: card_version,
 		version_distance,
 		members,
 	}))

--- a/crates/private-server/tests/group_card_version.rs
+++ b/crates/private-server/tests/group_card_version.rs
@@ -1,0 +1,47 @@
+//! The status group card's headline version must come from the highest-ranked,
+//! highest-kind member (e.g. the production central), not whichever member
+//! reported most recently.
+
+use commons_tests::diesel_async::SimpleAsyncConnection;
+use serde_json::{Value, json};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn group_card_version_is_from_highest_rank_kind_member() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (major, minor, patch, changelog, status)
+				VALUES (2, 10, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name)
+				VALUES ('aaaaaaaa-0000-0000-0000-000000000001', 'Group');
+			INSERT INTO servers (id, name, host, kind, rank, group_id) VALUES
+				('aaaaaaaa-0000-0000-0000-0000000000c0', 'prod-central',
+				 'https://prod.example.com', 'central', 'production',
+				 'aaaaaaaa-0000-0000-0000-000000000001'),
+				('aaaaaaaa-0000-0000-0000-0000000000d0', 'dev-facility',
+				 'https://dev.example.com', 'facility', 'dev',
+				 'aaaaaaaa-0000-0000-0000-000000000001');
+			-- The dev/facility server reported MORE recently, with a different
+			-- version; the prod/central reported earlier. The card must show the
+			-- prod/central version regardless of recency.
+			INSERT INTO statuses (server_id, created_at, version, healthy, health) VALUES
+				('aaaaaaaa-0000-0000-0000-0000000000c0', NOW() - INTERVAL '1 hour',
+				 '2.10.0', true, '[]'::jsonb),
+				('aaaaaaaa-0000-0000-0000-0000000000d0', NOW() - INTERVAL '1 minute',
+				 '2.99.0', true, '[]'::jsonb);",
+		)
+		.await
+		.unwrap();
+
+		let resp = private
+			.post("/api/statuses/group_details")
+			.json(&json!({ "server_group_id": "aaaaaaaa-0000-0000-0000-000000000001" }))
+			.await;
+		resp.assert_status_ok();
+		let card: Value = resp.json();
+		assert_eq!(
+			card["version"], "2.10.0",
+			"card shows the production-central version, not the most-recent (dev) one",
+		);
+	})
+	.await;
+}

--- a/crates/private-server/tests/group_card_version.rs
+++ b/crates/private-server/tests/group_card_version.rs
@@ -8,6 +8,11 @@ use serde_json::{Value, json};
 #[tokio::test(flavor = "multi_thread")]
 async fn group_card_version_is_from_highest_rank_kind_member() {
 	commons_tests::server::run(async |mut conn, _, private| {
+		let group_id = "aaaaaaaa-0000-0000-0000-000000000001".parse().unwrap();
+
+		// Set up the group and its members, then recompute the cache through the
+		// real path (raw INSERTs alone bypass `recompute_version`, leaving
+		// `version_server_id` NULL and the trigger a no-op).
 		conn.batch_execute(
 			"INSERT INTO versions (major, minor, patch, changelog, status)
 				VALUES (2, 10, 0, 'x', 'published');
@@ -19,11 +24,21 @@ async fn group_card_version_is_from_highest_rank_kind_member() {
 				 'aaaaaaaa-0000-0000-0000-000000000001'),
 				('aaaaaaaa-0000-0000-0000-0000000000d0', 'dev-facility',
 				 'https://dev.example.com', 'facility', 'dev',
-				 'aaaaaaaa-0000-0000-0000-000000000001');
-			-- The dev/facility server reported MORE recently, with a different
-			-- version; the prod/central reported earlier. The card must show the
-			-- prod/central version regardless of recency.
-			INSERT INTO statuses (server_id, created_at, version, healthy, health) VALUES
+				 'aaaaaaaa-0000-0000-0000-000000000001');",
+		)
+		.await
+		.unwrap();
+
+		database::server_groups::ServerGroup::recompute_version(&mut conn, group_id)
+			.await
+			.unwrap();
+
+		// The dev/facility server reports MORE recently, with a different
+		// version; the prod/central reports earlier. The card must show the
+		// prod/central version regardless of recency: the trigger only updates
+		// the cache for the cached canonical member (prod-central).
+		conn.batch_execute(
+			"INSERT INTO statuses (server_id, created_at, version, healthy, health) VALUES
 				('aaaaaaaa-0000-0000-0000-0000000000c0', NOW() - INTERVAL '1 hour',
 				 '2.10.0', true, '[]'::jsonb),
 				('aaaaaaaa-0000-0000-0000-0000000000d0', NOW() - INTERVAL '1 minute',

--- a/crates/private-server/tests/private_statuses.rs
+++ b/crates/private-server/tests/private_statuses.rs
@@ -184,6 +184,16 @@ async fn status_json_server_with_recent_status() {
 		.await
 		.unwrap();
 
+		// Raw INSERTs bypass `recompute_version`, which in production runs from
+		// the server create/edit paths and seeds the group's cached headline
+		// version. Run it explicitly so `group_details` has a cache to read.
+		database::server_groups::ServerGroup::recompute_version(
+			&mut conn,
+			"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".parse().unwrap(),
+		)
+		.await
+		.unwrap();
+
 		// Get server IDs
 		let server_ids_response = private.post("/api/statuses/server_grouped_ids").json(&serde_json::json!({})).await;
 		server_ids_response.assert_status_ok();

--- a/crates/public-server/src/servers.rs
+++ b/crates/public-server/src/servers.rs
@@ -96,6 +96,11 @@ pub async fn create(
 		.get_result(&mut db)
 		.await?;
 
+	// A new member can shift the group's canonical member, so refresh the cache.
+	if let Some(group_id) = server.group_id {
+		database::server_groups::ServerGroup::recompute_version(&mut db, group_id).await?;
+	}
+
 	Ok(Json(server))
 }
 
@@ -123,6 +128,13 @@ pub async fn edit(
 	let input_id = input.id;
 	let dev_id = device.0.0.id;
 
+	// Capture the old group before the update: rank/kind/group_id may all
+	// change, so both the old and new group's canonical member can shift.
+	let old_group_id = Server::get_by_id(&mut db, input_id)
+		.await
+		.ok()
+		.and_then(|s| s.group_id);
+
 	// Scope to the calling device's own server: a device may only edit the
 	// server it is bound to, never an arbitrary server id from the body.
 	diesel::update(servers)
@@ -132,14 +144,22 @@ pub async fn edit(
 		.execute(&mut db)
 		.await?;
 
-	Ok(Json(
-		servers
-			.filter(id.eq(input_id))
-			.filter(device_id.eq(dev_id))
-			.select(Server::as_select())
-			.first(&mut db)
-			.await?,
-	))
+	let updated: Server = servers
+		.filter(id.eq(input_id))
+		.filter(device_id.eq(dev_id))
+		.select(Server::as_select())
+		.first(&mut db)
+		.await?;
+
+	for gid in [old_group_id, updated.group_id]
+		.into_iter()
+		.flatten()
+		.collect::<std::collections::BTreeSet<_>>()
+	{
+		database::server_groups::ServerGroup::recompute_version(&mut db, gid).await?;
+	}
+
+	Ok(Json(updated))
 }
 
 #[utoipa::path(
@@ -163,10 +183,22 @@ pub async fn remove(
 
 	let mut db = db.get().await?;
 
+	// Capture the group before the delete: the FK auto-nulls
+	// `version_server_id`, but we must repopulate the cache from the remaining
+	// members.
+	let removed_group_id = Server::get_by_id(&mut db, input.id)
+		.await
+		.ok()
+		.and_then(|s| s.group_id);
+
 	diesel::delete(servers)
 		.filter(id.eq(input.id))
 		.execute(&mut db)
 		.await?;
+
+	if let Some(gid) = removed_group_id {
+		database::server_groups::ServerGroup::recompute_version(&mut db, gid).await?;
+	}
 
 	Ok(())
 }

--- a/migrations/2026-06-02-071412-0000_add_server_group_version_cache/down.sql
+++ b/migrations/2026-06-02-071412-0000_add_server_group_version_cache/down.sql
@@ -1,0 +1,6 @@
+DROP TRIGGER IF EXISTS statuses_update_server_group_effective_version ON statuses;
+DROP FUNCTION IF EXISTS update_server_group_effective_version();
+DROP INDEX IF EXISTS server_groups_version_server_id;
+ALTER TABLE server_groups
+    DROP COLUMN IF EXISTS effective_version,
+    DROP COLUMN IF EXISTS version_server_id;

--- a/migrations/2026-06-02-071412-0000_add_server_group_version_cache/up.sql
+++ b/migrations/2026-06-02-071412-0000_add_server_group_version_cache/up.sql
@@ -1,0 +1,75 @@
+-- Hybrid cache for a group card's headline version: the last reported version
+-- of the group's canonical member (highest rank, then highest kind). Replaces a
+-- per-render unbounded query that fanned out across every weekly partition of
+-- the partitioned `statuses` table.
+--
+-- `version_server_id` is the canonical member whose version is cached;
+-- `effective_version` is that member's last version-bearing status.
+
+ALTER TABLE server_groups
+    ADD COLUMN version_server_id UUID REFERENCES servers(id) ON DELETE SET NULL,
+    ADD COLUMN effective_version TEXT;
+
+CREATE INDEX server_groups_version_server_id ON server_groups (version_server_id);
+
+-- AFTER INSERT trigger on statuses: when the canonical member reports a new
+-- version, push it into the cache. No rank/kind logic — membership/rank changes
+-- are handled by the app-level recompute. Only version-bearing statuses update
+-- it, so a down/error (NULL-version) status never blanks the cached version.
+CREATE OR REPLACE FUNCTION update_server_group_effective_version() RETURNS TRIGGER
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.version IS NOT NULL THEN
+        UPDATE server_groups
+        SET effective_version = NEW.version, updated_at = now()
+        WHERE version_server_id = NEW.server_id;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+-- Row-level triggers on a partitioned parent propagate to all current and
+-- future partitions in PG13+, so cron-created weekly partitions inherit it.
+CREATE TRIGGER statuses_update_server_group_effective_version
+    AFTER INSERT ON statuses
+    FOR EACH ROW
+    EXECUTE FUNCTION update_server_group_effective_version();
+
+-- One-time backfill: for each group, pick the canonical member (lowest rank
+-- priority, then kind priority, tie-broken by id) and cache its last
+-- version-bearing status. Priority mappings mirror the Rust helpers.
+WITH canonical AS (
+    SELECT DISTINCT ON (group_id)
+        group_id,
+        id AS server_id
+    FROM servers
+    WHERE group_id IS NOT NULL
+    ORDER BY
+        group_id,
+        CASE rank
+            WHEN 'production' THEN 0
+            WHEN 'clone' THEN 1
+            WHEN 'demo' THEN 2
+            WHEN 'test' THEN 3
+            WHEN 'dev' THEN 4
+            ELSE 5
+        END,
+        CASE kind
+            WHEN 'central' THEN 0
+            WHEN 'facility' THEN 1
+            WHEN 'canopy' THEN 2
+            ELSE 3
+        END,
+        id
+)
+UPDATE server_groups g
+SET version_server_id = c.server_id,
+    effective_version = (
+        SELECT version
+        FROM statuses
+        WHERE server_id = c.server_id AND version IS NOT NULL
+        ORDER BY created_at DESC
+        LIMIT 1
+    )
+FROM canonical c
+WHERE g.id = c.group_id;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6086,6 +6086,17 @@
             "type": "string",
             "format": "date-time"
           },
+          "effective_version": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VersionStr",
+                "description": "The canonical member's last reported version. Maintained by the\n`statuses` AFTER INSERT trigger (canonical member reports a new version)\nand by [`ServerGroup::recompute_version`] (membership changes)."
+              }
+            ]
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -6107,6 +6118,14 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "version_server_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The group's canonical member (highest rank, then highest kind) whose\nversion is cached in `effective_version`. Maintained by\n[`ServerGroup::recompute_version`] on membership/rank/kind/delete\nchanges. `None` when the group has no members."
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2348,6 +2348,7 @@ export interface components {
         ServerGroup: {
             /** Format: date-time */
             created_at: string;
+            effective_version?: null | components["schemas"]["VersionStr"];
             /** Format: uuid */
             id: string;
             name: string;
@@ -2364,6 +2365,14 @@ export interface components {
             tags?: components["schemas"]["TagMap"];
             /** Format: date-time */
             updated_at: string;
+            /**
+             * Format: uuid
+             * @description The group's canonical member (highest rank, then highest kind) whose
+             *     version is cached in `effective_version`. Maintained by
+             *     [`ServerGroup::recompute_version`] on membership/rank/kind/delete
+             *     changes. `None` when the group has no members.
+             */
+            version_server_id?: string | null;
         };
         /**
          * @description Status-page card for a server group. Replaces the old per-central-server


### PR DESCRIPTION
🤖 The status page group card showed the version of whichever member reported its status *most recently*, so a dev/test/facility member checking in last could set the card's headline version.

It now uses the group's most canonical member: highest rank (production > clone > demo > test > dev > unranked), then highest kind (central > facility > canopy), and shows **that member's last reported version from history** — not just the live 7-day window, so a currently-down canonical server still shows the version it last reported (it only blanks if that server has never reported a version).

**Performance.** Computing that per render meant an unbounded last-version-bearing-status query, and `statuses` is partitioned by week with no `(server_id, created_at)` index, so it fanned out across every partition and would degrade as history grows. The headline version is now cached on `server_groups` (`version_server_id` + `effective_version`):

- a cheap `AFTER INSERT` trigger on `statuses` refreshes `effective_version` when the canonical member reports a new version-bearing status (NULL-version statuses never blank it);
- `ServerGroup::recompute_version` repicks the canonical member on every write path that can change group membership or a member's rank/kind (create, edit, remove, update, assign-to-group, ticket upsert);
- a migration backfills existing groups.

`group_details` now reads the cached column, so the card render is O(1) per group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)