### PR TITLE
Archive UX: redirect to group, archive empty groups from detail

### DIFF
--- a/private-web/e2e/servers.spec.ts
+++ b/private-web/e2e/servers.spec.ts
@@ -150,6 +150,21 @@ test.describe("archived view", () => {
 		// The archived server is still listed.
 		await expect(page.getByText(/arch-server/)).toBeVisible();
 	});
+
+	test("an empty group can be archived from its detail page", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "empty-grp" });
+		page.on("dialog", (d) => d.accept());
+
+		await page.goto(`/groups/${group.id}`);
+		await page.getByRole("button", { name: "Archive" }).click();
+		// Redirects to the servers list, and the group now shows under Archived.
+		await expect(page).toHaveURL(/\/servers$/);
+		await page.goto("/servers/archived");
+		await expect(page.getByRole("link", { name: "empty-grp" })).toBeVisible();
+	});
 });
 
 test.describe("server create → setup → archive flow", () => {
@@ -184,11 +199,12 @@ test.describe("server create → setup → archive flow", () => {
 		await expect(page.getByText(/hasn't checked in yet/i)).toBeVisible();
 		await expect(page.getByText(/bestool canopy register/)).toBeVisible();
 
-		// Archive — confirm the dialog and return to the servers list.
+		// Archive — confirm the dialog; since the server is in a group, it
+		// redirects to that group's page (not the servers list).
 		await page.getByRole("button", { name: "Archive", exact: true }).click();
 		const dialog = page.getByRole("dialog");
 		await expect(dialog).toBeVisible();
 		await dialog.getByRole("button", { name: "Archive", exact: true }).click();
-		await expect(page).toHaveURL(/\/servers$/);
+		await expect(page).toHaveURL(new RegExp(`/groups/${group.id}$`));
 	});
 });

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -9,10 +9,11 @@ import {
 	Typography,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
+import ArchiveIcon from "@mui/icons-material/ArchiveOutlined";
 import EditIcon from "@mui/icons-material/Edit";
 import RestoreIcon from "@mui/icons-material/RestoreFromTrash";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import { Link as RouterLink, useParams } from "react-router-dom";
+import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
 import ServerShorty from "../components/ServerShorty";
 import SilencedRefsSection from "../components/SilencedRefsSection";
 import TimeAgo from "../components/TimeAgo";
@@ -29,8 +30,10 @@ import {
 
 export default function GroupDetail() {
 	const { id = "" } = useParams<{ id: string }>();
+	const navigate = useNavigate();
 	const detail = useApi("server_groups", "get", { server_group_id: id }, [id]);
 	const isAdmin = useApi("commons", "is_current_user_admin");
+	const archive = useApiAction("server_groups", "delete");
 	// Only the currently-open incident matters for the active-incident
 	// section; closed ones live behind the /incidents filter route.
 	const activeIncidents = useApi(
@@ -55,6 +58,21 @@ export default function GroupDetail() {
 		activeIncidents.status === "ok" && activeIncidents.data.length > 0
 			? activeIncidents.data[0]
 			: null;
+
+	const onArchive = async () => {
+		if (
+			!confirm(
+				`Archive group "${group.name}"? It's hidden from listings but can be restored from the Archived tab.`,
+			)
+		)
+			return;
+		try {
+			await archive.call({ server_group_id: group.id });
+			navigate("/servers");
+		} catch {
+			/* surfaced via archive.error */
+		}
+	};
 
 	return (
 		<Stack spacing={3}>
@@ -84,9 +102,24 @@ export default function GroupDetail() {
 						>
 							Edit
 						</Button>
+						{servers.length === 0 && !group.deleted_at && (
+							<Button
+								variant="outlined"
+								color="error"
+								startIcon={<ArchiveIcon />}
+								onClick={onArchive}
+								disabled={archive.pending}
+							>
+								Archive
+							</Button>
+						)}
 					</Stack>
 				)}
 			</Stack>
+
+			{archive.error && (
+				<Alert severity="error">{archive.error.message}</Alert>
+			)}
 
 			{group.deleted_at && (
 				<ArchivedGroupBanner

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -258,6 +258,7 @@ function Header({
 							<DeleteServerButton
 								serverId={data.server.id}
 								serverName={data.server.name ?? "this server"}
+								groupId={data.server.group_id ?? null}
 								onArchived={onArchived}
 							/>
 						)}
@@ -269,14 +270,16 @@ function Header({
 }
 
 /// Inline admin action: archive (soft-delete) the server behind a confirm
-/// dialog, then navigate back to the servers list.
+/// dialog, then navigate back to its group (if it had one) or the server list.
 function DeleteServerButton({
 	serverId,
 	serverName,
+	groupId,
 	onArchived,
 }: {
 	serverId: string;
 	serverName: string;
+	groupId: string | null;
 	onArchived: () => void;
 }) {
 	const navigate = useNavigate();
@@ -288,7 +291,7 @@ function DeleteServerButton({
 			await action.call({ server_id: serverId });
 			setOpen(false);
 			onArchived();
-			navigate("/servers");
+			navigate(groupId ? `/groups/${groupId}` : "/servers");
 		} catch {
 			/* surfaced via action.error */
 		}


### PR DESCRIPTION
🤖 Two small archival-UX fixes:

- **Archiving a server that's in a group** now redirects to that group's page rather than the servers list (falls back to `/servers` for ungrouped servers). You stay in context instead of being bounced to the top-level list.
- **Group detail gains an Archive button for empty groups** (no live members), so an empty group can be archived directly instead of digging into Edit. Still restorable from the Archived tab.

e2e: the create→setup→archive flow now asserts it lands on the group page; a new test archives an empty group from its detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)