### PR TITLE
Show live server count on the group list

### DIFF
--- a/crates/database/src/server_groups.rs
+++ b/crates/database/src/server_groups.rs
@@ -280,6 +280,28 @@ impl ServerGroup {
 		Ok(out)
 	}
 
+	/// Count of live (non-archived) servers in each group, keyed by group id.
+	/// Groups with no live members are absent (callers default to 0).
+	pub async fn live_server_counts(
+		db: &mut AsyncPgConnection,
+	) -> Result<std::collections::HashMap<Uuid, i64>> {
+		use crate::schema::servers::dsl;
+		use std::collections::HashMap;
+
+		let group_ids: Vec<Uuid> = dsl::servers
+			.select(dsl::group_id.assume_not_null())
+			.filter(dsl::group_id.is_not_null())
+			.filter(dsl::deleted_at.is_null())
+			.load(db)
+			.await?;
+
+		let mut counts: HashMap<Uuid, i64> = HashMap::new();
+		for gid in group_ids {
+			*counts.entry(gid).or_insert(0) += 1;
+		}
+		Ok(counts)
+	}
+
 	/// Recompute the cached canonical member and its version for `group_id`.
 	///
 	/// Loads every member of the group, picks the canonical one (lowest

--- a/crates/database/tests/server_group_archival.rs
+++ b/crates/database/tests/server_group_archival.rs
@@ -133,3 +133,21 @@ async fn server_list_archived_only_returns_archived() {
 	})
 	.await
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn live_server_counts_excludes_archived() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "G").await;
+		insert_server(&mut conn, group, false).await; // live
+		insert_server(&mut conn, group, false).await; // live
+		insert_server(&mut conn, group, true).await; // archived — excluded
+
+		let counts = ServerGroup::live_server_counts(&mut conn).await.unwrap();
+		assert_eq!(
+			counts.get(&group).copied(),
+			Some(2),
+			"counts only live (non-archived) members",
+		);
+	})
+	.await
+}

--- a/crates/private-server/src/fns/server_groups.rs
+++ b/crates/private-server/src/fns/server_groups.rs
@@ -19,6 +19,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(delete))
 		.routes(routes!(restore))
 		.routes(routes!(list_archived))
+		.routes(routes!(server_counts))
 		.routes(routes!(search))
 }
 
@@ -39,6 +40,41 @@ pub async fn list(
 	let mut conn = state.db.get().await?;
 	let groups = ServerGroup::list_all(&mut conn).await?;
 	Ok(Json(groups))
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct GroupServerCount {
+	pub server_group_id: Uuid,
+	pub server_count: i64,
+}
+
+/// Live (non-archived) server count per group, for the groups list. Groups with
+/// no live members are omitted (the client defaults missing entries to 0).
+#[utoipa::path(
+	post,
+	path = "/server_counts",
+	operation_id = "server_groups_server_counts",
+	tag = "server_groups",
+	security(("tailscale-user" = [])),
+	responses(
+		(status = 200, body = Vec<GroupServerCount>),
+	),
+)]
+pub async fn server_counts(
+	State(state): State<AppState>,
+	_body: Json<serde_json::Value>,
+) -> Result<Json<Vec<GroupServerCount>>> {
+	let mut conn = state.db.get().await?;
+	let counts = ServerGroup::live_server_counts(&mut conn).await?;
+	Ok(Json(
+		counts
+			.into_iter()
+			.map(|(server_group_id, server_count)| GroupServerCount {
+				server_group_id,
+				server_count,
+			})
+			.collect(),
+	))
 }
 
 #[derive(Deserialize, ToSchema)]

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -2434,6 +2434,43 @@
         ]
       }
     },
+    "/api/server_groups/server_counts": {
+      "post": {
+        "tags": [
+          "server_groups"
+        ],
+        "summary": "Live (non-archived) server count per group, for the groups list. Groups with\nno live members are omitted (the client defaults missing entries to 0).",
+        "operationId": "server_groups_server_counts",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GroupServerCount"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
     "/api/server_groups/update": {
       "post": {
         "tags": [
@@ -4855,6 +4892,23 @@
           "server_group_id"
         ],
         "properties": {
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "GroupServerCount": {
+        "type": "object",
+        "required": [
+          "server_group_id",
+          "server_count"
+        ],
+        "properties": {
+          "server_count": {
+            "type": "integer",
+            "format": "int64"
+          },
           "server_group_id": {
             "type": "string",
             "format": "uuid"

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -984,6 +984,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/server_groups/server_counts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Live (non-archived) server count per group, for the groups list. Groups with
+         *     no live members are omitted (the client defaults missing entries to 0).
+         */
+        post: operations["server_groups_server_counts"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/server_groups/update": {
         parameters: {
             query?: never;
@@ -1934,6 +1954,12 @@ export interface components {
             server_group_id: string;
         };
         GroupScopeArgs: {
+            /** Format: uuid */
+            server_group_id: string;
+        };
+        GroupServerCount: {
+            /** Format: int64 */
+            server_count: number;
             /** Format: uuid */
             server_group_id: string;
         };
@@ -4682,6 +4708,29 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ServerGroup"][];
+                };
+            };
+        };
+    };
+    server_groups_server_counts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": unknown;
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupServerCount"][];
                 };
             };
         };

--- a/private-web/src/routes/GroupsList.tsx
+++ b/private-web/src/routes/GroupsList.tsx
@@ -8,6 +8,7 @@ import { usePageTitle } from "../hooks/usePageTitle";
 export default function GroupsList() {
 	usePageTitle("Server groups");
 	const groups = useApi("server_groups", "list", {}, []);
+	const counts = useApi("server_groups", "server_counts", {}, []);
 	const isAdmin = useApi("commons", "is_current_user_admin");
 	const admin = isAdmin.status === "ok" && isAdmin.data;
 
@@ -17,6 +18,13 @@ export default function GroupsList() {
 	if (groups.status === "error") {
 		return <Alert severity="error">{groups.error.message}</Alert>;
 	}
+
+	// Live-member counts keyed by group id. Null until loaded (so no chip
+	// flashes a premature 0); once loaded, groups absent from the map are 0.
+	const countById =
+		counts.status === "ok"
+			? new Map(counts.data.map((c) => [c.server_group_id, c.server_count]))
+			: null;
 
 	return (
 		<Stack spacing={2}>
@@ -40,7 +48,11 @@ export default function GroupsList() {
 			) : (
 				<Stack spacing={1}>
 					{groups.data.map((g) => (
-						<GroupShorty key={g.id} group={g} />
+						<GroupShorty
+							key={g.id}
+							group={g}
+							memberCount={countById ? (countById.get(g.id) ?? 0) : undefined}
+						/>
 					))}
 				</Stack>
 			)}


### PR DESCRIPTION
🤖 The groups list now shows how many (live) servers each group contains.

`GroupShorty` already had a `memberCount` chip; this just supplies it. Adds a `server_groups/server_counts` endpoint (`ServerGroup::live_server_counts` — live members per group) that `GroupsList` fetches alongside the list. The shared `list` endpoint (used by the group picker) is left untouched. Counts exclude archived members; a group with none shows 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)