### PR TITLE
Cascade-archive a group whose servers are all gone

### DIFF
--- a/crates/database/src/server_groups.rs
+++ b/crates/database/src/server_groups.rs
@@ -193,42 +193,82 @@ impl ServerGroup {
 		Self::get_by_id(db, group_id).await
 	}
 
-	/// Archive (soft-delete) a group: hide it from live listings while keeping
-	/// it (and its archived members) and allowing restore. Refuses if the group
-	/// still has *live* servers attached — operators move those out (or archive
-	/// them) first. Archived members don't block it; they're already hidden.
+	/// Archive (soft-delete) a group, hiding it from live listings while keeping
+	/// it (and its members) and allowing restore.
+	///
+	/// An empty group archives outright. A group with live members archives only
+	/// if *every* live member is **gone** (no status in the last 7 days — the
+	/// same notion the UI shows): in that case the archive **cascades**, also
+	/// archiving those members. If any live member reported recently, it refuses
+	/// (409) — you don't bulk-archive a group with active servers.
 	pub async fn soft_delete(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<()> {
 		use crate::schema::{server_groups::dsl, servers};
+		use diesel_async::AsyncConnection;
 
-		let live_members: i64 = servers::table
-			.count()
-			.filter(servers::group_id.eq(group_id))
-			.filter(servers::deleted_at.is_null())
-			.get_result(db)
-			.await?;
-		if live_members > 0 {
-			return Err(AppError::Conflict(format!(
-				"group {group_id} still has {live_members} live server(s); move them out first",
-			)));
-		}
+		db.transaction::<_, AppError, _>(async |conn| {
+			let member_ids: Vec<Uuid> = servers::table
+				.select(servers::id)
+				.filter(servers::group_id.eq(group_id))
+				.filter(servers::deleted_at.is_null())
+				.load(conn)
+				.await
+				.map_err(AppError::from)?;
 
-		diesel::update(dsl::server_groups.filter(dsl::id.eq(group_id)))
-			.set(dsl::deleted_at.eq(jiff_diesel::NullableTimestamp::from(Some(Timestamp::now()))))
-			.execute(db)
-			.await
-			.map_err(AppError::from)?;
-		Ok(())
+			if !member_ids.is_empty() {
+				// A member is "gone" iff it's absent from `latest_for_servers`
+				// (no status in the last 7 days). Allow the cascade only when
+				// every live member is gone; any recent reporter blocks it.
+				let recent = Status::latest_for_servers(conn, &member_ids).await?;
+				if !recent.is_empty() {
+					return Err(AppError::Conflict(format!(
+						"group {group_id} has {} server(s) that reported within the last \
+						 week; only a group whose servers are all gone can be archived",
+						recent.len(),
+					)));
+				}
+				for id in &member_ids {
+					Server::soft_delete(conn, *id).await?;
+				}
+			}
+
+			diesel::update(dsl::server_groups.filter(dsl::id.eq(group_id)))
+				.set(
+					dsl::deleted_at.eq(jiff_diesel::NullableTimestamp::from(Some(Timestamp::now()))),
+				)
+				.execute(conn)
+				.await
+				.map_err(AppError::from)?;
+			Ok(())
+		})
+		.await
 	}
 
-	/// Un-archive a group.
+	/// Un-archive a group, cascading to restore its archived members (the
+	/// inverse of [`ServerGroup::soft_delete`]'s cascade).
 	pub async fn restore(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<()> {
-		use crate::schema::server_groups::dsl;
-		diesel::update(dsl::server_groups.filter(dsl::id.eq(group_id)))
-			.set(dsl::deleted_at.eq(None::<jiff_diesel::Timestamp>))
-			.execute(db)
-			.await
-			.map_err(AppError::from)?;
-		Ok(())
+		use crate::schema::{server_groups::dsl, servers};
+		use diesel_async::AsyncConnection;
+
+		db.transaction::<_, AppError, _>(async |conn| {
+			let archived_members: Vec<Uuid> = servers::table
+				.select(servers::id)
+				.filter(servers::group_id.eq(group_id))
+				.filter(servers::deleted_at.is_not_null())
+				.load(conn)
+				.await
+				.map_err(AppError::from)?;
+			for id in &archived_members {
+				Server::restore(conn, *id).await?;
+			}
+
+			diesel::update(dsl::server_groups.filter(dsl::id.eq(group_id)))
+				.set(dsl::deleted_at.eq(None::<jiff_diesel::Timestamp>))
+				.execute(conn)
+				.await
+				.map_err(AppError::from)?;
+			Ok(())
+		})
+		.await
 	}
 
 	pub async fn list_servers(&self, db: &mut AsyncPgConnection) -> Result<Vec<Server>> {

--- a/crates/database/tests/server_group_archival.rs
+++ b/crates/database/tests/server_group_archival.rs
@@ -1,6 +1,8 @@
-//! Group archival (soft-delete): a group can be archived only when it has no
-//! *live* members; archived groups drop out of live listings and show up in the
-//! archived listing; restore reverses it. Also covers `Server::list_archived`.
+//! Group archival (soft-delete): an empty group, or one whose live members are
+//! all "gone" (no status in 7 days), can be archived — the latter cascades,
+//! archiving those members too; a group with a recently-reporting server is
+//! refused. Restore cascades back. Archived groups drop out of live listings.
+//! Also covers `Server::list_archived`.
 
 use commons_tests::db::TestDb;
 use database::server_groups::ServerGroup;
@@ -48,59 +50,96 @@ async fn insert_server(
 	row.id
 }
 
+/// Give a server a recent status so it counts as live (not "gone").
+async fn insert_recent_status(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+) {
+	sql_query(
+		"INSERT INTO statuses (server_id, created_at, version, healthy, health)
+		 VALUES ($1, now(), '1.0.0', true, '[]'::jsonb)",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.execute(conn)
+	.await
+	.expect("insert status");
+}
+
 #[tokio::test(flavor = "multi_thread")]
-async fn group_archival_round_trips_and_guards_live_members() {
+async fn archiving_a_group_with_a_recent_server_is_refused() {
 	TestDb::run(async |mut conn, _| {
 		let group = insert_group(&mut conn, "Group").await;
+		let server = insert_server(&mut conn, group, false).await;
+		insert_recent_status(&mut conn, server).await; // reported now → not gone
 
-		// A live member blocks archival.
-		let live = insert_server(&mut conn, group, false).await;
 		assert!(
 			ServerGroup::soft_delete(&mut conn, group).await.is_err(),
-			"a group with a live member can't be archived",
+			"a group with a recently-reporting server can't be archived",
 		);
+		// Neither the group nor the server was touched.
+		assert!(
+			ServerGroup::get_by_id(&mut conn, group)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_none(),
+		);
+		assert!(
+			Server::get_by_id(&mut conn, server)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_none(),
+		);
+	})
+	.await
+}
 
-		// Archive that member; now the group has only-archived members → allowed.
-		Server::soft_delete(&mut conn, live).await.unwrap();
+#[tokio::test(flavor = "multi_thread")]
+async fn archiving_an_all_gone_group_cascades_and_restore_reverses() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "Group").await;
+		// Two live members with no status → both "gone".
+		let a = insert_server(&mut conn, group, false).await;
+		let b = insert_server(&mut conn, group, false).await;
+
+		// Archive cascades to the gone members.
 		ServerGroup::soft_delete(&mut conn, group).await.unwrap();
-
-		// (a) live listings exclude it; (b) archived listing includes it.
-		let live_ids: Vec<Uuid> = ServerGroup::list_all(&mut conn)
-			.await
-			.unwrap()
-			.into_iter()
-			.map(|g| g.id)
-			.collect();
-		assert!(!live_ids.contains(&group), "archived group hidden from list_all");
-		let archived_ids: Vec<Uuid> = ServerGroup::list_archived(&mut conn)
-			.await
-			.unwrap()
-			.into_iter()
-			.map(|g| g.id)
-			.collect();
-		assert!(archived_ids.contains(&group), "archived group shows in list_archived");
-
-		// get_by_id still finds it (detail page needs it to offer Restore).
 		assert!(
 			ServerGroup::get_by_id(&mut conn, group)
 				.await
 				.unwrap()
 				.deleted_at
 				.is_some(),
+			"group archived",
 		);
-
-		// Restore: back in live listings, gone from archived.
-		ServerGroup::restore(&mut conn, group).await.unwrap();
-		let live_ids: Vec<Uuid> = ServerGroup::list_all(&mut conn)
-			.await
-			.unwrap()
-			.into_iter()
-			.map(|g| g.id)
-			.collect();
-		assert!(live_ids.contains(&group), "restored group back in list_all");
 		assert!(
-			ServerGroup::list_archived(&mut conn).await.unwrap().is_empty(),
-			"nothing archived after restore",
+			Server::get_by_id(&mut conn, a).await.unwrap().deleted_at.is_some(),
+			"member a cascade-archived",
+		);
+		assert!(
+			Server::get_by_id(&mut conn, b).await.unwrap().deleted_at.is_some(),
+			"member b cascade-archived",
+		);
+		assert!(!ServerGroup::list_all(&mut conn).await.unwrap().iter().any(|g| g.id == group));
+
+		// Restore cascades back.
+		ServerGroup::restore(&mut conn, group).await.unwrap();
+		assert!(
+			ServerGroup::get_by_id(&mut conn, group)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_none(),
+			"group restored",
+		);
+		assert!(
+			Server::get_by_id(&mut conn, a).await.unwrap().deleted_at.is_none(),
+			"member a restored",
+		);
+		assert!(
+			Server::get_by_id(&mut conn, b).await.unwrap().deleted_at.is_none(),
+			"member b restored",
 		);
 	})
 	.await

--- a/private-web/e2e/servers.spec.ts
+++ b/private-web/e2e/servers.spec.ts
@@ -165,6 +165,28 @@ test.describe("archived view", () => {
 		await page.goto("/servers/archived");
 		await expect(page.getByRole("link", { name: "empty-grp" })).toBeVisible();
 	});
+
+	test("a group whose servers are all gone archives, cascading to them", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "gone-grp" });
+		// No statuses seeded → both servers are "gone".
+		await seedServer(sql, { name: "gone-1", kind: "central", groupId: group.id });
+		await seedServer(sql, { name: "gone-2", kind: "facility", groupId: group.id });
+		page.on("dialog", (d) => d.accept());
+
+		await page.goto(`/groups/${group.id}`);
+		// The Archive button is offered because every member is gone.
+		await page.getByRole("button", { name: "Archive" }).click();
+		await expect(page).toHaveURL(/\/servers$/);
+
+		// The group and both servers are now archived.
+		await page.goto("/servers/archived");
+		await expect(page.getByRole("link", { name: "gone-grp" })).toBeVisible();
+		await expect(page.getByText(/gone-1/)).toBeVisible();
+		await expect(page.getByText(/gone-2/)).toBeVisible();
+	});
 });
 
 test.describe("server create → setup → archive flow", () => {

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -59,10 +59,17 @@ export default function GroupDetail() {
 			? activeIncidents.data[0]
 			: null;
 
+	// A group archives when empty, or when all its members are "gone" (no
+	// recent status) — in which case archiving cascades to those servers.
+	const allGone = servers.every((s) => s.up === "gone");
 	const onArchive = async () => {
+		const cascade =
+			servers.length > 0
+				? ` This also archives its ${servers.length} gone server${servers.length === 1 ? "" : "s"}.`
+				: "";
 		if (
 			!confirm(
-				`Archive group "${group.name}"? It's hidden from listings but can be restored from the Archived tab.`,
+				`Archive group "${group.name}"?${cascade} It's hidden from listings but can be restored from the Archived tab.`,
 			)
 		)
 			return;
@@ -102,7 +109,7 @@ export default function GroupDetail() {
 						>
 							Edit
 						</Button>
-						{servers.length === 0 && !group.deleted_at && (
+						{allGone && !group.deleted_at && (
 							<Button
 								variant="outlined"
 								color="error"


### PR DESCRIPTION
🤖 **Stacked on #208** (depends on its GroupDetail Archive button — will retarget to main when #208 merges).

Archiving a group used to require it to be empty of live members. Now a group can also be archived when **all its live members are "gone"** (no status in the last 7 days — the same state the UI shows), and the archive **cascades**, soft-deleting those servers too. A group with any recently-reporting server is still refused (409). **Restore cascades back**, un-archiving the group's archived members.

- `ServerGroup::soft_delete`: empty → archive; all-gone → cascade-archive; any recent reporter → refuse. `ServerGroup::restore` cascade-restores members. Both transactional.
- GroupDetail's Archive button now appears when every member is gone (not only when empty), with a confirm that notes the cascade.
- Tests: refuse-on-recent, all-gone cascade, and cascade-restore (DB); a gone group archives (cascading) from its detail page (e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)