### PR TITLE
Result-driven HealthState rollup; headline chips stop trusting top-level healthy

### DIFF
--- a/crates/commons-types/src/status.rs
+++ b/crates/commons-types/src/status.rs
@@ -157,8 +157,9 @@ mod tests {
 }
 
 /// Server's self-reported health state, derived from the most
-/// recent status row's `healthy` field and `health[]` array.
-/// Orthogonal to [`ShortStatus`]: a server can be reachable
+/// recent status row's per-check results (and, as legacy input, its
+/// top-level `healthy` field — that flag is being retired from the
+/// wire). Orthogonal to [`ShortStatus`]: a server can be reachable
 /// (`up`) and reporting itself unhealthy at the same time.
 ///
 /// The UI renders this as the *border* of `<StatusDot>` so both
@@ -168,17 +169,19 @@ mod tests {
 )]
 #[serde(rename_all = "lowercase")]
 pub enum HealthState {
-	/// Top-level `healthy: true` and every entry in `health[]` is
-	/// also healthy. Also the default for servers with no status row
-	/// at all — there's no signal that says otherwise. (Reachability
-	/// covers the "we haven't heard from this server" case
-	/// separately.)
+	/// Every `health[]` entry passed or was skipped (and the legacy
+	/// top-level `healthy` flag, if sent, was `true`). Also the
+	/// default for servers with no status row at all — there's no
+	/// signal that says otherwise. (Reachability covers the "we
+	/// haven't heard from this server" case separately.)
 	#[default]
 	Healthy,
-	/// Top-level `healthy: true` but at least one `health[]` entry
-	/// reports `healthy: false`. Operator should investigate but
-	/// it's not an incident.
+	/// At least one `health[]` entry reports warning or broken — or,
+	/// in the legacy form, `healthy: false` under top-level `true`
+	/// (old bestool's warning encoding). Operator should investigate
+	/// but it's not an incident.
 	Warning,
-	/// Top-level `healthy: false`. Incident-class.
+	/// At least one `health[]` entry reports `result: failed`, or the
+	/// legacy top-level `healthy` flag was `false`. Incident-class.
 	Unhealthy,
 }

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -471,32 +471,46 @@ impl Status {
 	}
 
 	/// Server's self-reported health state derived from this status
-	/// row. Returns [`HealthState::Unhealthy`] if top-level is
-	/// `false`, [`HealthState::Warning`] if any `health[]` entry
-	/// reports warning, failed, or broken while top-level is `true`,
-	/// and [`HealthState::Healthy`] otherwise (passed and skipped
-	/// entries don't count against the server).
+	/// row's per-check results. The top-level `healthy` bool is being
+	/// retired from the wire (absent ⇒ true on ingestion), so this
+	/// rollup is primarily result-driven, consulting top-level only
+	/// as legacy input:
+	///
+	/// - top-level `false` ⇒ [`HealthState::Unhealthy`] (legacy
+	///   self-report; new bestool doesn't send it)
+	/// - any entry with an explicit `result: failed` ⇒ `Unhealthy` —
+	///   this is exactly what legacy bestool folded into top-level
+	///   `healthy: false`
+	/// - any warning/broken entry, or a legacy `healthy: false` entry
+	///   under top-level `true` (legacy bestool's warning encoding) ⇒
+	///   [`HealthState::Warning`]
+	/// - otherwise [`HealthState::Healthy`] (passed and skipped
+	///   entries don't count against the server)
 	pub fn health_state(&self) -> HealthState {
 		if !self.healthy {
 			return HealthState::Unhealthy;
 		}
-		let any_failing = self.health.as_array().is_some_and(|arr| {
-			arr.iter().any(|e| {
-				e.as_object()
-					.and_then(CheckResult::from_entry)
-					.is_some_and(|r| {
-						matches!(
-							r,
-							CheckResult::Warning | CheckResult::Failed | CheckResult::Broken
-						)
-					})
-			})
-		});
-		if any_failing {
-			HealthState::Warning
-		} else {
-			HealthState::Healthy
+		let mut state = HealthState::Healthy;
+		if let Some(arr) = self.health.as_array() {
+			for entry in arr {
+				let Some(obj) = entry.as_object() else {
+					continue;
+				};
+				let Some(result) = CheckResult::from_entry(obj) else {
+					continue;
+				};
+				match result {
+					CheckResult::Failed if obj.contains_key("result") => {
+						return HealthState::Unhealthy;
+					}
+					CheckResult::Failed | CheckResult::Warning | CheckResult::Broken => {
+						state = HealthState::Warning;
+					}
+					CheckResult::Passed | CheckResult::Skipped => {}
+				}
+			}
 		}
+		state
 	}
 
 	pub fn short_status(&self) -> ShortStatus {

--- a/crates/database/tests/status_health_state.rs
+++ b/crates/database/tests/status_health_state.rs
@@ -35,6 +35,9 @@ fn no_entries_is_healthy() {
 	);
 }
 
+/// Legacy bestool encoded a per-check *warning* as `healthy: false`
+/// under top-level `true` (real failures flipped top-level to false),
+/// so the legacy bool form rolls up to Warning, not Unhealthy.
 #[test]
 fn legacy_failing_entry_is_warning() {
 	assert_eq!(
@@ -51,8 +54,8 @@ fn legacy_failing_entry_is_warning() {
 }
 
 #[test]
-fn result_warning_failed_broken_count_toward_warning() {
-	for result in ["warning", "failed", "broken"] {
+fn result_warning_and_broken_count_toward_warning() {
+	for result in ["warning", "broken"] {
 		assert_eq!(
 			status(
 				true,
@@ -63,6 +66,24 @@ fn result_warning_failed_broken_count_toward_warning() {
 			"{result}",
 		);
 	}
+}
+
+/// An explicit `result: failed` is what legacy bestool folded into
+/// top-level `healthy: false` — incident-class, regardless of the
+/// (retiring, absent ⇒ true) top-level flag.
+#[test]
+fn result_failed_is_unhealthy() {
+	assert_eq!(
+		status(
+			true,
+			serde_json::json!([
+				{"check": "a", "result": "warning"},
+				{"check": "b", "result": "failed"},
+			])
+		)
+		.health_state(),
+		HealthState::Unhealthy,
+	);
 }
 
 #[test]

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -229,7 +229,15 @@ pub struct StatusSnapshotData {
 	pub postgres: Option<String>,
 	pub nodejs: Option<String>,
 	pub timezone: Option<String>,
+	/// Raw legacy top-level self-report. Being retired from the wire
+	/// (absent ⇒ true on ingestion); UI display should use
+	/// `health_state` instead.
 	pub healthy: bool,
+	/// Rollup over the per-check results (and the legacy top-level
+	/// flag) — same derivation as the status-dot border. The UI's
+	/// headline chip uses this so a failing check can't hide behind
+	/// a self-reported (or defaulted) top-level `healthy: true`.
+	pub health_state: commons_types::status::HealthState,
 	pub health: serde_json::Value,
 	pub extra: serde_json::Value,
 	/// For each unhealthy check on this push, the severity the
@@ -313,6 +321,7 @@ pub async fn snapshot(
 	// file at given this push. Healthy checks are omitted; the UI
 	// renders them with its 'passing' affordance regardless.
 	let check_severities = compute_check_severities(&mut conn, args.server_id, &status).await?;
+	let health_state = status.health_state();
 
 	Ok(Json(Some(StatusSnapshotData {
 		id: status.id,
@@ -327,6 +336,7 @@ pub async fn snapshot(
 		nodejs,
 		timezone,
 		healthy: status.healthy,
+		health_state,
 		health: status.health,
 		extra: status.extra,
 		check_severities,

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4917,7 +4917,7 @@
       },
       "HealthState": {
         "type": "string",
-        "description": "Server's self-reported health state, derived from the most\nrecent status row's `healthy` field and `health[]` array.\nOrthogonal to [`ShortStatus`]: a server can be reachable\n(`up`) and reporting itself unhealthy at the same time.\n\nThe UI renders this as the *border* of `<StatusDot>` so both\ndimensions (reachability and self-report) show in one glyph.",
+        "description": "Server's self-reported health state, derived from the most\nrecent status row's per-check results (and, as legacy input, its\ntop-level `healthy` field — that flag is being retired from the\nwire). Orthogonal to [`ShortStatus`]: a server can be reachable\n(`up`) and reporting itself unhealthy at the same time.\n\nThe UI renders this as the *border* of `<StatusDot>` so both\ndimensions (reachability and self-report) show in one glyph.",
         "enum": [
           "healthy",
           "warning",
@@ -7228,6 +7228,7 @@
           "created_at",
           "server_id",
           "healthy",
+          "health_state",
           "health",
           "extra",
           "check_severities"
@@ -7256,8 +7257,13 @@
           },
           "extra": {},
           "health": {},
+          "health_state": {
+            "$ref": "#/components/schemas/HealthState",
+            "description": "Rollup over the per-check results (and the legacy top-level\nflag) — same derivation as the status-dot border. The UI's\nheadline chip uses this so a failing check can't hide behind\na self-reported (or defaulted) top-level `healthy: true`."
+          },
           "healthy": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Raw legacy top-level self-report. Being retired from the wire\n(absent ⇒ true on ingestion); UI display should use\n`health_state` instead."
           },
           "id": {
             "type": "string",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1965,8 +1965,9 @@ export interface components {
         };
         /**
          * @description Server's self-reported health state, derived from the most
-         *     recent status row's `healthy` field and `health[]` array.
-         *     Orthogonal to [`ShortStatus`]: a server can be reachable
+         *     recent status row's per-check results (and, as legacy input, its
+         *     top-level `healthy` field — that flag is being retired from the
+         *     wire). Orthogonal to [`ShortStatus`]: a server can be reachable
          *     (`up`) and reporting itself unhealthy at the same time.
          *
          *     The UI renders this as the *border* of `<StatusDot>` so both
@@ -2855,6 +2856,18 @@ export interface components {
             device_id?: string | null;
             extra: unknown;
             health: unknown;
+            /**
+             * @description Rollup over the per-check results (and the legacy top-level
+             *     flag) — same derivation as the status-dot border. The UI's
+             *     headline chip uses this so a failing check can't hide behind
+             *     a self-reported (or defaulted) top-level `healthy: true`.
+             */
+            health_state: components["schemas"]["HealthState"];
+            /**
+             * @description Raw legacy top-level self-report. Being retired from the wire
+             *     (absent ⇒ true on ingestion); UI display should use
+             *     `health_state` instead.
+             */
             healthy: boolean;
             /** Format: uuid */
             id: string;

--- a/private-web/src/components/HealthChip.tsx
+++ b/private-web/src/components/HealthChip.tsx
@@ -1,0 +1,66 @@
+import { Chip, Tooltip } from "@mui/material";
+import CancelIcon from "@mui/icons-material/Cancel";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import type { HealthState } from "../types";
+
+const LABEL: Record<HealthState, string> = {
+	healthy: "Healthy",
+	warning: "Warning",
+	unhealthy: "Unhealthy",
+};
+
+const TOOLTIP: Record<HealthState, string> = {
+	healthy: "Server reports OK",
+	warning: "Some check is warning, failing, or broken while the server reports overall OK",
+	unhealthy: "Server reports problems",
+};
+
+const COLOR: Record<HealthState, "success" | "warning" | "error"> = {
+	healthy: "success",
+	warning: "warning",
+	unhealthy: "error",
+};
+
+/** Headline health chip derived from the `HealthState` rollup (top-level
+ * self-report AND per-check results), not the raw top-level `healthy`
+ * bool — a server saying "healthy" while a check fails shows as Warning,
+ * matching the status-dot border and `<HealthLegend>`.
+ *
+ * `stale` recolours to an outlined variant for servers that aren't
+ * currently reporting, so an operator isn't misled into thinking a stale
+ * "Healthy" still holds. */
+export default function HealthChip({
+	health,
+	stale = false,
+}: {
+	health: HealthState;
+	stale?: boolean;
+}) {
+	if (stale) {
+		return (
+			<Tooltip title="Server isn't currently reporting status; this reflects its most recent received report.">
+				<Chip
+					size="small"
+					variant="outlined"
+					color="warning"
+					icon={<WarningAmberIcon />}
+					label={`Last reported ${LABEL[health].toLowerCase()}`}
+				/>
+			</Tooltip>
+		);
+	}
+	const icon =
+		health === "healthy" ? (
+			<CheckCircleIcon />
+		) : health === "warning" ? (
+			<WarningAmberIcon />
+		) : (
+			<CancelIcon />
+		);
+	return (
+		<Tooltip title={TOOLTIP[health]}>
+			<Chip size="small" color={COLOR[health]} icon={icon} label={LABEL[health]} />
+		</Tooltip>
+	);
+}

--- a/private-web/src/components/StatusSnapshot.tsx
+++ b/private-web/src/components/StatusSnapshot.tsx
@@ -1,7 +1,6 @@
 import {
 	Alert,
 	Box,
-	Chip,
 	IconButton,
 	LinearProgress,
 	Stack,
@@ -20,6 +19,7 @@ import RemoveCircleOutlinedIcon from "@mui/icons-material/RemoveCircleOutlined";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Fragment } from "react";
 import { useApi, type ApiState } from "../api";
+import HealthChip from "./HealthChip";
 import TimeAgo from "./TimeAgo";
 import TimezoneTooltip from "./TimezoneTooltip";
 import VersionIndicator from "./VersionIndicator";
@@ -74,14 +74,7 @@ export default function StatusSnapshotPanel({
 				</Typography>
 				{result.status === "ok" && result.data && (
 					<>
-						<Chip
-							size="small"
-							color={result.data.healthy ? "success" : "error"}
-							icon={
-								result.data.healthy ? <CheckCircleIcon /> : <CancelIcon />
-							}
-							label={result.data.healthy ? "Healthy" : "Unhealthy"}
-						/>
+						<HealthChip health={result.data.health_state} />
 						<Typography variant="body2" color="text.secondary">
 							<TimeAgo timestamp={result.data.created_at} />
 						</Typography>

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -36,6 +36,7 @@ import NotificationsOffOutlinedIcon from "@mui/icons-material/NotificationsOffOu
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Fragment, useEffect, useState } from "react";
 import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
+import HealthChip from "../components/HealthChip";
 import IncidentsLink from "../components/IncidentsLink";
 import ManualEventButton from "../components/ManualEventButton";
 import SilencedRefsSection from "../components/SilencedRefsSection";
@@ -150,6 +151,7 @@ export default function ServerDetail() {
 			<InfoSection
 				server={data.server}
 				status={data.last_status}
+				health={data.health}
 				onSilenced={bumpRefresh}
 				up={data.up}
 				refreshTick={refreshTick}
@@ -687,19 +689,21 @@ function deviceShortName(info: DeviceInfo): string {
 function InfoSection({
 	server,
 	status,
+	health,
 	onSilenced,
 	up,
 	refreshTick,
 }: {
 	server: ServerInfo;
 	status: ServerLastStatusData | null;
+	health: HealthState;
 	onSilenced: () => void;
 	up: ShortStatus;
 	refreshTick: number;
 }) {
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
-			{status && <HealthIndicator healthy={status.healthy} up={up} />}
+			{status && <HealthIndicator health={health} up={up} />}
 			<Stack
 				direction="row"
 				spacing={4}
@@ -764,39 +768,22 @@ function InfoSection({
 
 /** Global health chip rendered at the top of the InfoSection. The
  * server's per-check breakdown is shown by `<ChecksTable>` below — this
- * is the "headline" answer to "does the server think it's OK".
- *
- * When the server isn't currently reporting (anything other than `up` or
- * `blip`), the chip is recoloured to a stale variant so an operator
- * isn't misled into thinking a stale "Healthy" still holds — the data
- * is whatever the server last said before going quiet. */
+ * is the "headline" answer to "is the server OK", derived from the
+ * `HealthState` rollup rather than the raw top-level `healthy` bool so
+ * a failing check can't hide behind a self-reported "healthy". */
 function HealthIndicator({
-	healthy,
+	health,
 	up,
 }: {
-	healthy: boolean;
+	health: HealthState;
 	up: ShortStatus;
 }) {
 	const reporting = up === "up" || up === "blip";
-	const chip = reporting ? (
-		<Chip
-			size="small"
-			color={healthy ? "success" : "error"}
-			icon={healthy ? <CheckCircleIcon /> : <CancelIcon />}
-			label={healthy ? "Healthy" : "Unhealthy"}
-		/>
-	) : (
-		<Tooltip title="Server isn't currently reporting status; this reflects its most recent received report.">
-			<Chip
-				size="small"
-				variant="outlined"
-				color="warning"
-				icon={<WarningAmberIcon />}
-				label={healthy ? "Last reported healthy" : "Last reported unhealthy"}
-			/>
-		</Tooltip>
+	return (
+		<Box sx={{ mb: 1.5 }}>
+			<HealthChip health={health} stale={!reporting} />
+		</Box>
 	);
-	return <Box sx={{ mb: 1.5 }}>{chip}</Box>;
 }
 
 /** Per-check table from the most recent status push. Failing entries


### PR DESCRIPTION
🤖

Follow-up to #211. A server can currently show a green "Healthy" headline chip while a check right below it files an error-severity issue and holds an incident open — the chip renders bestool's raw top-level `healthy` self-report, which says `true` in exactly the legacy warning/failure-under-healthy encodings. And that field is being retired from the wire entirely (absent ⇒ true on ingestion), so anything relying on it is on borrowed time.

- `Status::health_state()` is now result-driven: an explicit `result: failed` rolls up to **Unhealthy** (that's precisely what legacy bestool folded into top-level `healthy: false`), warning/broken roll up to **Warning**, and a legacy `healthy: false` entry under top-level `true` keeps meaning Warning (old bestool's warning encoding — so no behaviour change for the legacy fleet). The top-level flag is consulted only as legacy input.
- The snapshot endpoint exposes the rollup as `health_state`.
- Both headline chips (server detail info section, status snapshot panel) render the rollup via a shared `HealthChip` component instead of the raw bool, matching the status-dot border semantics and `HealthLegend`.