### PR TITLE
perf: stop reading whole partition windows for latest-row lookups on the server detail page

### DIFF
--- a/crates/database/src/devices.rs
+++ b/crates/database/src/devices.rs
@@ -1243,7 +1243,7 @@ impl NewDeviceConnection {
 	}
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Queryable, Selectable)]
+#[derive(Clone, Debug, Serialize, Deserialize, Queryable, QueryableByName, Selectable)]
 #[diesel(table_name = crate::schema::device_connections)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct DeviceConnection {
@@ -1260,23 +1260,31 @@ impl DeviceConnection {
 		db: &mut AsyncPgConnection,
 		device_ids: impl Iterator<Item = Uuid>,
 	) -> Result<Vec<Self>> {
-		use crate::schema::device_connections::dsl as dc;
-
 		let ids: Vec<Uuid> = device_ids.collect();
-		// Bounded by created_at so partition pruning can engage; otherwise every
-		// weekly partition is scanned and sorted to find one row per device.
-		dc::device_connections
-			.select(Self::as_select())
-			.distinct_on(dc::device_id)
-			.filter(
-				dc::device_id
-					.eq_any(ids)
-					.and(dc::created_at.ge(diesel::dsl::sql("NOW() - INTERVAL '90 days'"))),
-			)
-			.order((dc::device_id, dc::created_at.desc()))
-			.load(db)
-			.await
-			.map_err(AppError::from)
+		if ids.is_empty() {
+			return Ok(Vec::new());
+		}
+
+		// One LATERAL probe per device rather than DISTINCT ON over the
+		// window: DISTINCT ON can't terminate early, so it reads every
+		// connection row in the window for each device — and a row is
+		// written per authenticated request, so that's ~all of a healthy
+		// device's traffic for 90 days. The LIMIT 1 under the lateral join
+		// reads one row per partition via the (device_id, created_at DESC)
+		// composite index. Still bounded by created_at so partition pruning
+		// engages.
+		diesel::sql_query(
+			"SELECT dc.* FROM unnest($1) AS d(id) \
+			 CROSS JOIN LATERAL ( \
+				SELECT * FROM device_connections \
+				WHERE device_id = d.id AND created_at >= NOW() - INTERVAL '90 days' \
+				ORDER BY created_at DESC LIMIT 1 \
+			 ) dc",
+		)
+		.bind::<diesel::sql_types::Array<diesel::sql_types::Uuid>, _>(ids)
+		.load(db)
+		.await
+		.map_err(AppError::from)
 	}
 
 	/// Get connection history for a device, newest first, optionally starting

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -405,14 +405,20 @@ impl Status {
 			return Ok(Vec::new());
 		}
 
-		// Get the latest status for each server using DISTINCT ON
+		// One LATERAL probe per server rather than DISTINCT ON over the
+		// window: DISTINCT ON can't terminate early, so it reads every
+		// status row in the 7-day window for each server. The LIMIT 1 under
+		// the lateral join reads one row per weekly partition through the
+		// (server_id, created_at DESC) composite index.
 		let query = diesel::sql_query(
-			"SELECT DISTINCT ON (server_id) id, created_at, server_id, device_id, version, extra, healthy, health
-				FROM statuses
-				WHERE server_id = ANY($1)
-				AND created_at >= NOW() - INTERVAL '7 days'
-				AND id != '00000000-0000-0000-0000-000000000000'
-				ORDER BY server_id, created_at DESC",
+			"SELECT st.* FROM unnest($1) AS s(id) \
+			 CROSS JOIN LATERAL ( \
+				SELECT * FROM statuses \
+				WHERE server_id = s.id \
+				AND created_at >= NOW() - INTERVAL '7 days' \
+				AND id != '00000000-0000-0000-0000-000000000000' \
+				ORDER BY created_at DESC LIMIT 1 \
+			 ) st",
 		)
 		.bind::<diesel::sql_types::Array<diesel::sql_types::Uuid>, _>(server_ids);
 
@@ -421,7 +427,6 @@ impl Status {
 
 	pub async fn production_versions(db: &mut AsyncPgConnection) -> Result<Vec<VersionStr>> {
 		use crate::schema::servers::dsl as servers_dsl;
-		use crate::schema::statuses::dsl as statuses_dsl;
 
 		let production_server_ids: Vec<Uuid> = servers_dsl::servers
 			.select(servers_dsl::id)
@@ -429,25 +434,11 @@ impl Status {
 			.load(db)
 			.await?;
 
-		statuses_dsl::statuses
-			.select((statuses_dsl::version,))
-			.filter(
-				statuses_dsl::server_id
-					.eq_any(&production_server_ids)
-					.and(statuses_dsl::created_at.ge(diesel::dsl::sql("NOW() - INTERVAL '7 days'")))
-					.and(statuses_dsl::id.ne(Uuid::nil())),
-			)
-			.order((statuses_dsl::server_id, statuses_dsl::created_at.desc()))
-			.distinct_on(statuses_dsl::server_id)
-			.load::<(Option<VersionStr>,)>(db)
-			.await
-			.map(|results| {
-				results
-					.into_iter()
-					.filter_map(|(version,)| version)
-					.collect()
-			})
-			.map_err(AppError::from)
+		Ok(Self::latest_for_servers(db, &production_server_ids)
+			.await?
+			.into_iter()
+			.filter_map(|s| s.version)
+			.collect())
 	}
 
 	pub fn platform(&self) -> Option<String> {

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -482,19 +482,32 @@ pub async fn get_detail(
 		.map(|s| s.health_state())
 		.unwrap_or_default();
 
+	let device_with_info = if let Some(device_id) = device_id {
+		Some(Device::get_with_info(&mut conn, device_id).await?)
+	} else {
+		None
+	};
+
 	let last_status = if let Some(st) = status.as_ref() {
-		let device = if let Some(device_id) = st.device_id {
-			DeviceConnection::get_latest_from_device_ids(&mut conn, [device_id].into_iter())
-				.await?
-				.into_iter()
-				.next()
-		} else {
-			None
+		// The status usually comes from the server's own device, whose
+		// latest connection was just fetched — only fall back to a
+		// dedicated lookup when the status was pushed by a different one.
+		let connection = match st.device_id {
+			Some(did) if Some(did) == device_id => device_with_info
+				.as_ref()
+				.and_then(|d| d.latest_connection.clone()),
+			Some(did) => {
+				DeviceConnection::get_latest_from_device_ids(&mut conn, [did].into_iter())
+					.await?
+					.into_iter()
+					.next()
+			}
+			None => None,
 		};
 
 		let platform = st.platform();
 		let postgres = st.postgres_version();
-		let nodejs = device.and_then(|d| d.nodejs_version());
+		let nodejs = connection.and_then(|d| d.nodejs_version());
 		let version_distance = st.distance_from_version(&latest_version);
 		let min_chrome_version = if let Some(ref version) = st.version {
 			compute_min_chrome_version(&mut conn, version).await
@@ -522,11 +535,9 @@ pub async fn get_detail(
 		None
 	};
 
-	let device_info = if let Some(device_id) = device_id {
-		let device_with_info = Device::get_with_info(&mut conn, device_id).await?;
-		Some(super::devices::DeviceInfo::from_db(device_with_info, &state).await)
-	} else {
-		None
+	let device_info = match device_with_info {
+		Some(dwi) => Some(super::devices::DeviceInfo::from_db(dwi, &state).await),
+		None => None,
 	};
 
 	let siblings = if let Some(g) = group.as_ref() {

--- a/migrations/2026-06-04-010558-0000_statuses_server_id_created_at_index/down.sql
+++ b/migrations/2026-06-04-010558-0000_statuses_server_id_created_at_index/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX statuses_server_id_created_at;
+
+CREATE INDEX statuses_server_id ON statuses USING btree (server_id);

--- a/migrations/2026-06-04-010558-0000_statuses_server_id_created_at_index/up.sql
+++ b/migrations/2026-06-04-010558-0000_statuses_server_id_created_at_index/up.sql
@@ -1,0 +1,12 @@
+-- Replace the single-column server_id btree with a composite
+-- (server_id, created_at DESC), mirroring what device_connections got in
+-- 2026-05-07. Lets latest-status-per-server lookups do an index-driven
+-- Limit and stop early, instead of fetching every matching row across
+-- all partitions and sorting in memory. The composite still serves
+-- server_id-only equality lookups (leading column), so the prior
+-- single-column index is redundant.
+
+CREATE INDEX statuses_server_id_created_at
+    ON statuses USING btree (server_id, created_at DESC);
+
+DROP INDEX statuses_server_id;


### PR DESCRIPTION
🤖 The server detail page could take a long time on its blocking `get_detail` call. The culprits were two `DISTINCT ON` queries over the partitioned tables: `DISTINCT ON` can't terminate early, so it reads *every* row in the time window for each requested id.

- `DeviceConnection::get_latest_from_device_ids` read all of a device's connection rows in the 90-day window — one row exists per authenticated request, so ~130k rows for a device pushing every minute — and `get_detail` called it twice (nodejs version + `Device::get_with_info`), usually for the same device.
- `Status::latest_for_servers` (sibling status dots, also the server list and group pages via `decorate_with_status`) read every status row in the 7-day window for each server, with the `health`/`extra` jsonb payloads along for the ride.

Changes:

1. Rewrite both lookups as `LATERAL ... ORDER BY created_at DESC LIMIT 1` probes, which read one row per weekly partition through a composite index instead.
2. New migration gives `statuses` the composite `(server_id, created_at DESC)` index, replacing the single-column `server_id` one — the same fix `device_connections` got in 2026-05. (A composite index alone does not help the `DISTINCT ON` plan shape; the query rewrite is what unlocks it.)
3. `get_detail` fetches the device info once and reuses its latest connection for the status's nodejs version; only a status pushed by a different device pays for a second lookup.
4. `production_versions` had the same `DISTINCT ON` pattern and now reuses `latest_for_servers`.

Benchmarked on a RAM-backed Postgres seeded with a 10-server group pushing every minute for 7 days and one device with 90 days of per-minute connections (i.e. best-case timings; prod disk with cold cache is far worse):

| query | before | after |
|---|---|---|
| latest connection, 1 device | 33.5 ms | 0.30 ms |
| latest statuses, 9 siblings | 61 ms | 0.30 ms |