### PR TITLE
Reword 'resolved by automation' as 'the healthcheck recovering'

### DIFF
--- a/crates/commons-types/src/issue.rs
+++ b/crates/commons-types/src/issue.rs
@@ -131,7 +131,7 @@ where
 	}
 }
 
-/// Reason an issue or incident was resolved by a human.
+/// Reason an issue or incident was resolved by an operator.
 ///
 /// Stored as text in Postgres, validated as this enum at the API layer.
 /// Categories follow common operational practice (PagerDuty/Sentry/Opsgenie):

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -253,8 +253,8 @@ impl NewEvent {
 				} else {
 					existing.last_seen
 				};
-				// Sentry-style reopen: a device event with `active = true` against a
-				// human-resolved issue clears the resolved_* fields (issue is back
+				// Sentry-style reopen: a device event with `active = true` against an
+				// operator-resolved issue clears the resolved_* fields (issue is back
 				// in unresolved state).
 				let clear_resolved = active && existing.resolved_at.is_some();
 				let issue = diesel::update(issues::table.filter(issues::id.eq(existing.id)))
@@ -397,8 +397,8 @@ impl NewEvent {
 /// human action (e.g. resolving an issue or incident). It's threaded
 /// through so a cascade close caused by that action can attribute the
 /// resulting Slack `incident_resolve` row to the operator rather than
-/// "automation". `None` for device-driven flows (event push with
-/// `active:false`).
+/// "the healthcheck recovering". `None` for device-driven flows (event
+/// push with `active:false`).
 async fn re_evaluate_incident_membership(
 	conn: &mut AsyncPgConnection,
 	issue: &Issue,
@@ -1117,7 +1117,7 @@ impl Issue {
 			.map_err(AppError::from)
 	}
 
-	/// Mark an issue as human-resolved. Triggers incident-membership
+	/// Mark an issue as operator-resolved. Triggers incident-membership
 	/// re-evaluation (typically: leaves the incident).
 	pub async fn resolve(
 		db: &mut AsyncPgConnection,
@@ -1184,9 +1184,9 @@ impl Issue {
 	/// can't open or join incidents. Triggers re-evaluation.
 	///
 	/// Snooze doesn't carry an operator login today, so a cascade close
-	/// triggered by snoozing the last live issue still attributes to
-	/// "automation" in Slack. Worth revisiting if/when snooze records its
-	/// `by`.
+	/// triggered by snoozing the last live issue still attributes the
+	/// Slack resolve to "the healthcheck recovering" rather than the
+	/// operator. Worth revisiting if/when snooze records its `by`.
 	pub async fn snooze(
 		db: &mut AsyncPgConnection,
 		issue_id: Uuid,
@@ -1540,7 +1540,7 @@ impl Incident {
 		Ok((incident, rows))
 	}
 
-	/// Mark an incident as human-resolved. This is metadata only — it does
+	/// Mark an incident as operator-resolved. This is metadata only — it does
 	/// *not* force `closed_at` (that's still driven by auto rules). An
 	/// open incident can be resolved (the cause is dealt with) and a closed
 	/// incident can be resolved retroactively.

--- a/crates/database/src/slack_outbox/vars.rs
+++ b/crates/database/src/slack_outbox/vars.rs
@@ -8,7 +8,10 @@
 //!
 //! Two workflows, one per outbox kind:
 //! - `incident_open`: variables `server`, `severity`, `source_ref`, `message`, `link`
-//! - `incident_resolve`: variables `server`, `by`, `link`
+//! - `incident_resolve`: variables `server`, `by`, `link`. `by` is either the
+//!   resolving operator's login, or — when the incident retired on its own —
+//!   "the healthcheck recovering" (it describes the event, not an actor: the
+//!   check went healthy again, which does not imply nobody intervened).
 //!
 //! Note: `link` is **not** rendered here. It's pure config (incident_id is
 //! already on the row, and `PRIVATE_URL` is operator-set), so the drainer
@@ -46,6 +49,11 @@ pub fn incident_open(
 pub fn incident_resolve(server_label: &str, by: Option<&str>) -> Value {
 	json!({
 		"server": server_label,
-		"by": by.unwrap_or("automation"),
+		// `None` means no operator was attached to the close: the incident
+		// retired because its healthcheck started reporting healthy again.
+		// Phrase it as the triggering event, not an actor — "automation"
+		// was read as "a bot decided to close this", when in practice an
+		// operator was usually involved; canopy just can't attribute it.
+		"by": by.unwrap_or("the healthcheck recovering"),
 	})
 }

--- a/private-web/e2e/resolver-attribution.spec.ts
+++ b/private-web/e2e/resolver-attribution.spec.ts
@@ -1,0 +1,76 @@
+import {
+	resetSeededTables,
+	seedIssue,
+	seedServer,
+	seedServerGroup,
+	seedTailscaleUser,
+} from "./seed";
+import { expect, test } from "./test-fixtures";
+
+// The resolver avatar on a resolved issue distinguishes an operator-attributed
+// close from one with no operator attached. The latter is *not* phrased as an
+// actor ("automation") — it says the healthcheck recovered, which is what
+// canopy actually observed and doesn't claim nobody intervened.
+test.describe("resolver attribution", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("an unattributed resolve reads as the healthcheck recovering", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "Recovery Group" });
+		const server = await seedServer(sql, {
+			name: "recovery-srv",
+			groupId: group.id,
+		});
+		await seedIssue(sql, {
+			serverId: server.id,
+			message: "auto-cleared issue",
+			resolved: true,
+			resolvedBy: null,
+		});
+
+		// showAll=1 turns off the active-only filter so resolved issues show.
+		await page.goto("/incidents?showAll=1");
+		await expect(page.getByText("auto-cleared issue")).toBeVisible();
+
+		// The resolver avatar is the only avatar on the page (no incidents
+		// seeded). Hover it to reveal the MUI tooltip.
+		await page.locator(".MuiAvatar-root").first().hover();
+		const tooltip = page.getByRole("tooltip");
+		await expect(tooltip).toContainText("the healthcheck recovering");
+		await expect(tooltip).not.toContainText("automation");
+	});
+
+	test("an operator-attributed resolve names the operator", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "Operator Group" });
+		const server = await seedServer(sql, {
+			name: "operator-srv",
+			groupId: group.id,
+		});
+		await seedTailscaleUser(sql, {
+			login: "ada@example.test",
+			name: "Ada Lovelace",
+		});
+		await seedIssue(sql, {
+			serverId: server.id,
+			message: "hand-resolved issue",
+			resolved: true,
+			resolvedBy: "ada@example.test",
+			resolvedReason: "fixed",
+		});
+
+		await page.goto("/incidents?showAll=1");
+		await expect(page.getByText("hand-resolved issue")).toBeVisible();
+
+		await page.locator(".MuiAvatar-root").first().hover();
+		const tooltip = page.getByRole("tooltip");
+		await expect(tooltip).toContainText("Ada Lovelace");
+		await expect(tooltip).not.toContainText("the healthcheck recovering");
+	});
+});

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -264,13 +264,21 @@ export async function seedIssue(
 		description?: string | null;
 		active?: boolean;
 		deviceId?: string | null;
+		/** Mark the issue resolved. `resolvedBy` null (with `resolved: true`)
+		 * is the "retired on its own" case — the healthcheck recovered with
+		 * no operator attributed. A login string attributes it to that
+		 * operator (seed a matching tailscale_user for the name lookup). */
+		resolved?: boolean;
+		resolvedBy?: string | null;
+		resolvedReason?: string | null;
 	},
 ): Promise<SeededIssue> {
 	const id = randomUUID();
+	const resolved = opts.resolved ?? false;
 	await sql.query(
 		`INSERT INTO issues
-		 (id, server_id, device_id, source, ref, severity, message, description, active, first_seen, last_seen)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())`,
+		 (id, server_id, device_id, source, ref, severity, message, description, active, first_seen, last_seen, resolved_at, resolved_by, resolved_reason)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW(), $10, $11, $12)`,
 		[
 			id,
 			opts.serverId,
@@ -280,7 +288,10 @@ export async function seedIssue(
 			opts.severity ?? "error",
 			opts.message ?? "Issue message",
 			opts.description ?? null,
-			opts.active ?? true,
+			resolved ? false : (opts.active ?? true),
+			resolved ? new Date().toISOString() : null,
+			resolved ? (opts.resolvedBy ?? null) : null,
+			resolved ? (opts.resolvedReason ?? null) : null,
 		],
 	);
 	return { id };

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6426,7 +6426,7 @@
       },
       "ResolvedReason": {
         "type": "string",
-        "description": "Reason an issue or incident was resolved by a human.\n\nStored as text in Postgres, validated as this enum at the API layer.\nCategories follow common operational practice (PagerDuty/Sentry/Opsgenie):\n\n- `Fixed` — the underlying problem was addressed.\n- `WontFix` — won't fix; not worth doing, or not actually a problem.\n- `Expected` — known/expected behaviour (e.g. planned maintenance window).\n- `Duplicate` — a duplicate of another issue.\n- `Flapping` — too noisy; suppressed rather than fixed (often paired with\n  a snooze).",
+        "description": "Reason an issue or incident was resolved by an operator.\n\nStored as text in Postgres, validated as this enum at the API layer.\nCategories follow common operational practice (PagerDuty/Sentry/Opsgenie):\n\n- `Fixed` — the underlying problem was addressed.\n- `WontFix` — won't fix; not worth doing, or not actually a problem.\n- `Expected` — known/expected behaviour (e.g. planned maintenance window).\n- `Duplicate` — a duplicate of another issue.\n- `Flapping` — too noisy; suppressed rather than fixed (often paired with\n  a snooze).",
         "enum": [
           "fixed",
           "wont_fix",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2565,7 +2565,7 @@ export interface components {
             matched?: null | components["schemas"]["TailnetLiveInfo"];
         };
         /**
-         * @description Reason an issue or incident was resolved by a human.
+         * @description Reason an issue or incident was resolved by an operator.
          *
          *     Stored as text in Postgres, validated as this enum at the API layer.
          *     Categories follow common operational practice (PagerDuty/Sentry/Opsgenie):

--- a/private-web/src/components/IssueRow.tsx
+++ b/private-web/src/components/IssueRow.tsx
@@ -8,7 +8,6 @@ import {
 	Pagination,
 	Stack,
 	TextField,
-	Tooltip,
 	Typography,
 } from "@mui/material";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
@@ -23,11 +22,11 @@ import { useIsAdmin } from "../hooks/useIsAdmin";
 import { humanDuration } from "../lib/humanDuration";
 import MessageView from "./MessageView";
 import NotesList, { AddNoteButton } from "./NotesList";
+import ResolverAvatar from "./ResolverAvatar";
 import ServerNameWithGroup from "./ServerNameWithGroup";
 import SeverityChip from "./SeverityChip";
 import StatusSnapshotPanel, { StatusSnapshotButton } from "./StatusSnapshot";
 import TimeAgo from "./TimeAgo";
-import UserAvatar from "./UserAvatar";
 import {
 	RESOLVED_REASONS,
 	RESOLVED_REASON_LABEL,
@@ -212,7 +211,7 @@ function Header({
 }
 
 /** Header time slot. For closed issues, gives the closure context — reason
- * (human-resolved) or "on its own" (device sent inactive) — plus the
+ * (operator-resolved) or "on its own" (device sent inactive) — plus the
  * lifetime. For still-active issues, falls back to last-seen. */
 function ClosureOrTime({ issue }: { issue: IssueData }) {
 	if (issue.resolved_at) {
@@ -245,19 +244,12 @@ function ClosureOrTime({ issue }: { issue: IssueData }) {
 function HeaderActor({ issue }: { issue: IssueData }) {
 	if (!issue.resolved_at) return null;
 	return (
-		<Tooltip
-			title={`resolved (${issue.resolved_reason ?? "?"}) by ${
-				issue.resolved_by_name ?? issue.resolved_by ?? "?"
-			}`}
-		>
-			<span>
-				<UserAvatar
-					login={issue.resolved_by}
-					name={issue.resolved_by_name}
-					profilePic={issue.resolved_by_pic}
-				/>
-			</span>
-		</Tooltip>
+		<ResolverAvatar
+			resolvedBy={issue.resolved_by}
+			resolvedByName={issue.resolved_by_name}
+			resolvedByPic={issue.resolved_by_pic}
+			resolvedReason={issue.resolved_reason}
+		/>
 	);
 }
 

--- a/private-web/src/components/ResolverAvatar.tsx
+++ b/private-web/src/components/ResolverAvatar.tsx
@@ -1,0 +1,58 @@
+import MonitorHeartOutlinedIcon from "@mui/icons-material/MonitorHeartOutlined";
+import { Avatar, Tooltip } from "@mui/material";
+import { AUTOMATION_RESOLVER_LABEL } from "../types";
+import UserAvatar from "./UserAvatar";
+
+/** Avatar for whoever (or whatever) resolved an issue/incident.
+ *
+ * When an operator login is attached, this is their {@link UserAvatar}. When
+ * it's absent the incident retired on its own — the healthcheck started
+ * reporting healthy again — so we show a heartbeat icon and say so, rather
+ * than a blank "?". The label describes the event, not an actor: it does not
+ * claim nobody intervened, only that canopy can't attribute the close. */
+export default function ResolverAvatar({
+	resolvedBy,
+	resolvedByName,
+	resolvedByPic,
+	resolvedReason,
+	size = 24,
+}: {
+	resolvedBy: string | null;
+	resolvedByName?: string | null;
+	resolvedByPic?: string | null;
+	resolvedReason?: string | null;
+	size?: number;
+}) {
+	const reasonPart = resolvedReason ? `(${resolvedReason}) ` : "";
+
+	if (resolvedBy == null) {
+		return (
+			<Tooltip title={`resolved ${reasonPart}by ${AUTOMATION_RESOLVER_LABEL}`}>
+				<Avatar
+					sx={{
+						width: size,
+						height: size,
+						bgcolor: "action.selected",
+						color: "text.secondary",
+					}}
+				>
+					<MonitorHeartOutlinedIcon sx={{ fontSize: size * 0.6 }} />
+				</Avatar>
+			</Tooltip>
+		);
+	}
+
+	return (
+		<Tooltip title={`resolved ${reasonPart}by ${resolvedByName ?? resolvedBy}`}>
+			<span>
+				<UserAvatar
+					login={resolvedBy}
+					name={resolvedByName}
+					profilePic={resolvedByPic}
+					size={size}
+					tooltip={false}
+				/>
+			</span>
+		</Tooltip>
+	);
+}

--- a/private-web/src/components/UserAvatar.tsx
+++ b/private-web/src/components/UserAvatar.tsx
@@ -1,29 +1,34 @@
 import { Avatar, Tooltip } from "@mui/material";
 
 /** Small circular avatar for a Tailscale user. Falls back to the first
- * letter of the login or name when no profile picture is available. */
+ * letter of the login or name when no profile picture is available.
+ *
+ * Pass `tooltip={false}` when a parent already wraps this in its own tooltip,
+ * to avoid stacking two tooltips on the same element. */
 export default function UserAvatar({
 	login,
 	name,
 	profilePic,
 	size = 24,
+	tooltip = true,
 }: {
 	login: string | null;
 	name?: string | null;
 	profilePic?: string | null;
 	size?: number;
+	tooltip?: boolean;
 }) {
 	const display = name ?? login ?? "?";
 	const initial = (display.trim()[0] ?? "?").toUpperCase();
-	return (
-		<Tooltip title={display}>
-			<Avatar
-				src={profilePic ?? undefined}
-				alt={display}
-				sx={{ width: size, height: size, fontSize: size * 0.55 }}
-			>
-				{initial}
-			</Avatar>
-		</Tooltip>
+	const avatar = (
+		<Avatar
+			src={profilePic ?? undefined}
+			alt={display}
+			sx={{ width: size, height: size, fontSize: size * 0.55 }}
+		>
+			{initial}
+		</Avatar>
 	);
+	if (!tooltip) return avatar;
+	return <Tooltip title={display}>{avatar}</Tooltip>;
 }

--- a/private-web/src/routes/IncidentDetail.tsx
+++ b/private-web/src/routes/IncidentDetail.tsx
@@ -27,7 +27,7 @@ import { AddNoteButton } from "../components/NotesList";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 import TimeAgo from "../components/TimeAgo";
-import UserAvatar from "../components/UserAvatar";
+import ResolverAvatar from "../components/ResolverAvatar";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { humanDuration } from "../lib/humanDuration";
 import {
@@ -245,20 +245,13 @@ function Header({
 				</Box>
 				<Box sx={{ flexShrink: 0 }}>
 					{incident.resolved_at && (
-						<Tooltip
-							title={`resolved (${incident.resolved_reason ?? "?"}) by ${
-								incident.resolved_by_name ?? incident.resolved_by ?? "?"
-							}`}
-						>
-							<span>
-								<UserAvatar
-									login={incident.resolved_by}
-									name={incident.resolved_by_name}
-									profilePic={incident.resolved_by_pic}
-									size={36}
-								/>
-							</span>
-						</Tooltip>
+						<ResolverAvatar
+							resolvedBy={incident.resolved_by}
+							resolvedByName={incident.resolved_by_name}
+							resolvedByPic={incident.resolved_by_pic}
+							resolvedReason={incident.resolved_reason}
+							size={36}
+						/>
 					)}
 				</Box>
 			</Stack>

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -309,3 +309,11 @@ export const RESOLVED_REASON_LABEL: Record<ResolvedReason, string> = {
 	duplicate: "Duplicate",
 	flapping: "Flapping",
 };
+
+// Shown wherever a resolver is named but no operator login is attached: the
+// incident/issue retired because its healthcheck started reporting healthy
+// again. Phrased as the triggering event, not an actor — it describes what
+// canopy observed, and does not imply that nobody intervened. Keep in sync
+// with the Slack `incident_resolve` default in
+// crates/database/src/slack_outbox/vars.rs.
+export const AUTOMATION_RESOLVER_LABEL = "the healthcheck recovering";


### PR DESCRIPTION
🤖 "Resolved by automation" answers "by whom?" with a fake actor — people and agents read it as "canopy auto-resolved this", when it only means the healthcheck started reporting healthy again. An operator was usually involved; canopy just can't attribute the close. This reframes the wording as the triggering event rather than an actor.

- Slack `incident_resolve`: the `by` variable now defaults to "the healthcheck recovering" instead of "automation" when no operator login is attached. (The message template itself lives in Slack Workflow Builder — we only control the variable.)
- New `ResolverAvatar` component (issues + incidents): the unattributed case shows a heartbeat icon with a matching tooltip instead of a blank "?". `UserAvatar` grows a `tooltip` toggle so the parent can own the tooltip without stacking two.
- `ResolvedReason` doc/schema and assorted comments now say "operator" rather than "human".
- Playwright coverage for both the unattributed and operator-attributed resolver tooltips.