### PR TITLE
Backup credentials: database layer

### DIFF
--- a/crates/commons-servers/src/tailnet_sweeps.rs
+++ b/crates/commons-servers/src/tailnet_sweeps.rs
@@ -44,8 +44,12 @@ pub async fn sweep_key_expiry(
 	let server_ids: Vec<Uuid> = pairs.iter().map(|(_, s, _)| *s).collect();
 	let existing =
 		Issue::list_by_source_ref(db, TAILSCALE_SOURCE, KEY_EXPIRY_REF, &server_ids).await?;
-	let issue_map: std::collections::HashMap<Uuid, &Issue> =
-		existing.iter().map(|i| (i.server_id, i)).collect();
+	// `list_by_source_ref` is filtered by `server_ids`, so every row is
+	// server-scoped (`server_id` is `Some`); drop any defensively.
+	let issue_map: std::collections::HashMap<Uuid, &Issue> = existing
+		.iter()
+		.filter_map(|i| i.server_id.map(|sid| (sid, i)))
+		.collect();
 
 	let now = Timestamp::now();
 	let mut filed = 0usize;

--- a/crates/commons-types/src/backup.rs
+++ b/crates/commons-types/src/backup.rs
@@ -1,0 +1,318 @@
+//! Shared vocabulary for the backup-credentials system.
+//!
+//! These enums are stored as `TEXT` in Postgres and flow through
+//! public-server, the `jobs` crate, and the private-web wire types (via the
+//! generated `api-types.ts`), so they live here in `commons-types` rather than
+//! being re-declared per component. The closed sets (`BackupPurpose`,
+//! `RunOutcome`, `MaintenanceKind`, `BackupConfigStatus`) mirror the
+//! `Severity`/`ServerKind` pattern and back DB `CHECK (… IN …)` constraints.
+//! `BackupType` is deliberately open — bestool registers arbitrary type names
+//! and unknown ones land in `Custom`.
+
+use std::{fmt::Display, str::FromStr};
+
+use diesel::{
+	backend::Backend,
+	deserialize::{self, FromSql, FromSqlRow},
+	expression::AsExpression,
+	serialize::{self, Output, ToSql},
+	sql_types::Text,
+};
+use serde::{Deserialize, Serialize};
+
+/// Generate a closed string-valued enum stored as Postgres `TEXT`, with the
+/// `Display`/`FromStr`/`FromSql`/`ToSql` plumbing the `Severity` pattern uses.
+/// The string literal per variant is the single source of truth for the wire
+/// form, the `Display` form, and the DB value (which the `CHECK` constraint
+/// must match).
+macro_rules! text_enum {
+	(
+		$(#[$meta:meta])*
+		$vis:vis enum $name:ident {
+			$( $(#[doc = $doc:literal])* $variant:ident = $str:literal ),+ $(,)?
+		}
+		default = $default:ident;
+		error $err:ident = $errmsg:literal;
+	) => {
+		$(#[$meta])*
+		#[derive(
+			Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, AsExpression, FromSqlRow,
+			utoipa::ToSchema,
+		)]
+		#[diesel(sql_type = Text)]
+		$vis enum $name {
+			// `serde(rename)` sets the wire string; `schema(rename)` mirrors it
+			// into the utoipa-generated OpenAPI schema, since utoipa v5 doesn't
+			// pick up per-variant serde renames on its own (it only honours a
+			// container-level `rename_all`). Without the schema rename the
+			// generated TS union would carry the PascalCase variant names while
+			// the actual JSON is the lowercase string — a wire/type mismatch.
+			$( $(#[doc = $doc])* #[serde(rename = $str)] #[schema(rename = $str)] $variant ),+
+		}
+
+		#[derive(Debug, Clone, Copy, thiserror::Error)]
+		#[error($errmsg)]
+		$vis struct $err;
+
+		impl Default for $name {
+			fn default() -> Self { Self::$default }
+		}
+
+		impl Display for $name {
+			fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+				let s = match self { $( Self::$variant => $str ),+ };
+				write!(f, "{s}")
+			}
+		}
+
+		impl FromStr for $name {
+			type Err = $err;
+			fn from_str(s: &str) -> Result<Self, Self::Err> {
+				match s { $( $str => Ok(Self::$variant), )+ _ => Err($err) }
+			}
+		}
+
+		impl TryFrom<String> for $name {
+			type Error = $err;
+			fn try_from(value: String) -> Result<Self, Self::Error> { value.parse() }
+		}
+
+		impl From<$name> for String {
+			fn from(v: $name) -> Self { v.to_string() }
+		}
+
+		impl<DB> FromSql<Text, DB> for $name
+		where
+			DB: Backend,
+			String: FromSql<Text, DB>,
+		{
+			fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+				Ok(Self::try_from(String::from_sql(bytes)?)?)
+			}
+		}
+
+		impl ToSql<Text, diesel::pg::Pg> for $name
+		where
+			String: ToSql<Text, diesel::pg::Pg>,
+		{
+			fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, diesel::pg::Pg>) -> serialize::Result {
+				let v = String::from(*self);
+				<String as ToSql<Text, diesel::pg::Pg>>::to_sql(&v, &mut out.reborrow())
+			}
+		}
+	};
+}
+
+text_enum! {
+	/// Why a credential was issued / a run executed. A real capability gate
+	/// on the issued S3 creds, not just audit metadata: `Backup` grants
+	/// write-without-delete, `Restore` grants read-only.
+	pub enum BackupPurpose {
+		Backup = "backup",
+		Restore = "restore",
+	}
+	default = Backup;
+	error BackupPurposeFromStringError = "invalid backup purpose; expected one of: backup, restore";
+}
+
+text_enum! {
+	/// Outcome of a reported backup/restore run.
+	pub enum RunOutcome {
+		Success = "success",
+		Failure = "failure",
+	}
+	default = Success;
+	error RunOutcomeFromStringError = "invalid run outcome; expected one of: success, failure";
+}
+
+text_enum! {
+	/// Which kopia maintenance cycle a Canopy maintenance Job ran.
+	pub enum MaintenanceKind {
+		Quick = "quick",
+		Full = "full",
+	}
+	default = Quick;
+	error MaintenanceKindFromStringError = "invalid maintenance kind; expected one of: quick, full";
+}
+
+text_enum! {
+	/// How a group's repo passphrase is sourced. `FromBirth` means Canopy
+	/// generates the passphrase + names the Secret (operator must escrow it →
+	/// the reveal-once flow); `Import` means the operator already holds the
+	/// passphrase and points `repo_password_ref` at a pre-existing Secret (skips
+	/// escrow, goes straight to `Ready`).
+	pub enum BackupRepoMode {
+		FromBirth = "from_birth",
+		Import = "import",
+	}
+	default = FromBirth;
+	error BackupRepoModeFromStringError = "invalid backup repo mode; expected one of: from_birth, import";
+}
+
+text_enum! {
+	/// Lifecycle state of a group's backup repo. Backups stay dormant (the
+	/// endpoints 412/409) until `Ready`.
+	pub enum BackupConfigStatus {
+		/// Init Job running.
+		Provisioning = "provisioning",
+		/// Repo created, awaiting the operator's Bitwarden-escrow ack.
+		EscrowPending = "escrow_pending",
+		/// Authorized: config set + repo created + escrow acknowledged.
+		Ready = "ready",
+	}
+	default = Provisioning;
+	error BackupConfigStatusFromStringError = "invalid backup config status; expected one of: provisioning, escrow_pending, ready";
+}
+
+/// A named, client-side backup procedure that ends in a type-tagged kopia
+/// snapshot (e.g. `tamanu-postgres`). Open by design: bestool advertises
+/// whatever types its server can run, and Canopy is type-agnostic for
+/// execution, so any unrecognised name is preserved verbatim in `Custom`
+/// rather than rejected. Stored as `TEXT`; serializes as a plain string (no
+/// DB `CHECK`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, AsExpression, FromSqlRow)]
+#[diesel(sql_type = Text)]
+pub enum BackupType {
+	/// The first well-known type — a quiesced Postgres snapshot (also what
+	/// PGRO restores).
+	TamanuPostgres,
+	/// Any other type name, preserved as advertised.
+	Custom(String),
+}
+
+impl BackupType {
+	const TAMANU_POSTGRES: &'static str = "tamanu-postgres";
+
+	/// The wire/DB string for this type.
+	pub fn as_str(&self) -> &str {
+		match self {
+			Self::TamanuPostgres => Self::TAMANU_POSTGRES,
+			Self::Custom(s) => s,
+		}
+	}
+}
+
+impl Display for BackupType {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
+}
+
+impl FromStr for BackupType {
+	type Err = std::convert::Infallible;
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(match s {
+			Self::TAMANU_POSTGRES => Self::TamanuPostgres,
+			other => Self::Custom(other.to_owned()),
+		})
+	}
+}
+
+impl From<&str> for BackupType {
+	fn from(s: &str) -> Self {
+		// FromStr is infallible.
+		s.parse().unwrap()
+	}
+}
+
+impl From<String> for BackupType {
+	fn from(s: String) -> Self {
+		match s.as_str() {
+			Self::TAMANU_POSTGRES => Self::TamanuPostgres,
+			_ => Self::Custom(s),
+		}
+	}
+}
+
+impl From<BackupType> for String {
+	fn from(v: BackupType) -> Self {
+		match v {
+			BackupType::TamanuPostgres => BackupType::TAMANU_POSTGRES.to_owned(),
+			BackupType::Custom(s) => s,
+		}
+	}
+}
+
+impl Serialize for BackupType {
+	fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+		s.serialize_str(self.as_str())
+	}
+}
+
+impl<'de> Deserialize<'de> for BackupType {
+	fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+		Ok(Self::from(String::deserialize(d)?))
+	}
+}
+
+impl<DB> FromSql<Text, DB> for BackupType
+where
+	DB: Backend,
+	String: FromSql<Text, DB>,
+{
+	fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+		Ok(Self::from(String::from_sql(bytes)?))
+	}
+}
+
+impl ToSql<Text, diesel::pg::Pg> for BackupType
+where
+	String: ToSql<Text, diesel::pg::Pg>,
+{
+	fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, diesel::pg::Pg>) -> serialize::Result {
+		<str as ToSql<Text, diesel::pg::Pg>>::to_sql(self.as_str(), &mut out.reborrow())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn closed_enum_roundtrips_match_db_strings() {
+		assert_eq!(BackupPurpose::Backup.to_string(), "backup");
+		assert_eq!(
+			"restore".parse::<BackupPurpose>().unwrap(),
+			BackupPurpose::Restore
+		);
+		assert_eq!(
+			BackupConfigStatus::EscrowPending.to_string(),
+			"escrow_pending"
+		);
+		assert!("nope".parse::<RunOutcome>().is_err());
+	}
+
+	#[test]
+	fn closed_enum_serde_is_the_db_string() {
+		assert_eq!(
+			serde_json::to_string(&MaintenanceKind::Full).unwrap(),
+			"\"full\""
+		);
+		assert_eq!(
+			serde_json::from_str::<BackupConfigStatus>("\"provisioning\"").unwrap(),
+			BackupConfigStatus::Provisioning,
+		);
+	}
+
+	#[test]
+	fn backup_type_known_and_custom() {
+		assert_eq!(
+			BackupType::from("tamanu-postgres"),
+			BackupType::TamanuPostgres
+		);
+		assert_eq!(
+			BackupType::from("weird"),
+			BackupType::Custom("weird".into())
+		);
+		assert_eq!(BackupType::TamanuPostgres.to_string(), "tamanu-postgres");
+		// Round-trips through the wire as a plain string.
+		assert_eq!(
+			serde_json::to_string(&BackupType::TamanuPostgres).unwrap(),
+			"\"tamanu-postgres\""
+		);
+		assert_eq!(
+			serde_json::from_str::<BackupType>("\"custom-x\"").unwrap(),
+			BackupType::Custom("custom-x".into()),
+		);
+	}
+}

--- a/crates/commons-types/src/lib.rs
+++ b/crates/commons-types/src/lib.rs
@@ -1,5 +1,6 @@
 pub use uuid::Uuid;
 
+pub mod backup;
 pub mod device;
 pub mod geo;
 pub mod issue;

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -1,0 +1,1182 @@
+//! Persistent state for the backup-credentials system: the control plane that
+//! issues short-lived S3 creds to devices and owns repo maintenance. Backups
+//! are keyed `(server, type)` — the repo/bucket is per-group and shared by all
+//! the group's backup *types*, while the type (e.g. `tamanu-postgres`) is a
+//! dimension on runs / issuances / requests / snapshots.
+//!
+//! This module owns the diesel models and the DB-layer helpers; the calling
+//! logic (STS issuance, scheduler loops, operator UI) lives in the
+//! public-server, `jobs`, and private-server components.
+
+use std::collections::HashMap;
+
+use commons_errors::{AppError, Result};
+use commons_types::backup::{
+	BackupConfigStatus, BackupPurpose, BackupRepoMode, BackupType, MaintenanceKind, RunOutcome,
+};
+use diesel::{
+	dsl::now,
+	prelude::*,
+	result::{DatabaseErrorKind, Error as DieselError},
+};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+
+use crate::pg_duration::PgDuration;
+
+// ---------------------------------------------------------------------------
+// RetentionPolicy — the kopia keep-* policy, modelled as a typed struct so the
+// wire/openapi shape is concrete (not a raw JSON blob). Stored as JSONB on the
+// per-(group,type) schedule and on the type defaults.
+// ---------------------------------------------------------------------------
+
+/// kopia `keep-*` retention policy. Org-minimum floors
+/// (`keep_daily ≥ 7, keep_weekly ≥ 4, keep_monthly ≥ 6`) are enforced by
+/// [`RetentionPolicy::validate_floor`] on create/update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct RetentionPolicy {
+	#[serde(default = "RetentionPolicy::default_keep_latest")]
+	pub keep_latest: i32,
+	pub keep_daily: i32,
+	pub keep_weekly: i32,
+	pub keep_monthly: i32,
+	#[serde(default)]
+	pub keep_annual: i32,
+}
+
+impl RetentionPolicy {
+	pub const FLOOR_DAILY: i32 = 7;
+	pub const FLOOR_WEEKLY: i32 = 4;
+	pub const FLOOR_MONTHLY: i32 = 6;
+
+	fn default_keep_latest() -> i32 {
+		1
+	}
+
+	/// Reject a policy below the org-minimum floor. Returns
+	/// [`AppError::BadRequest`] (→ 400) listing the violated field(s).
+	pub fn validate_floor(&self) -> Result<()> {
+		let mut violations = Vec::new();
+		if self.keep_daily < Self::FLOOR_DAILY {
+			violations.push(format!("keep_daily must be ≥ {}", Self::FLOOR_DAILY));
+		}
+		if self.keep_weekly < Self::FLOOR_WEEKLY {
+			violations.push(format!("keep_weekly must be ≥ {}", Self::FLOOR_WEEKLY));
+		}
+		if self.keep_monthly < Self::FLOOR_MONTHLY {
+			violations.push(format!("keep_monthly must be ≥ {}", Self::FLOOR_MONTHLY));
+		}
+		if violations.is_empty() {
+			Ok(())
+		} else {
+			Err(AppError::BadRequest(format!(
+				"retention below org minimum: {}",
+				violations.join(", ")
+			)))
+		}
+	}
+
+	/// Parse a stored JSONB retention into the typed policy. Returns `None` for
+	/// a JSON value that doesn't fit the shape (forward-compatible: a future
+	/// extra key is ignored by serde, but a structurally wrong blob is dropped
+	/// rather than erroring the whole listing).
+	pub fn from_json(value: &JsonValue) -> Option<Self> {
+		serde_json::from_value(value.clone()).ok()
+	}
+
+	pub fn to_json(&self) -> JsonValue {
+		serde_json::to_value(self).expect("RetentionPolicy serializes")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// server_group_backup_config — repo-level config, one row per configured group
+// ---------------------------------------------------------------------------
+
+#[derive(
+	Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, utoipa::ToSchema,
+)]
+#[diesel(table_name = crate::schema::server_group_backup_config)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ServerGroupBackupConfig {
+	pub group_id: Uuid,
+	pub bucket: String,
+	pub prefix: String,
+	pub target_role_arn: String,
+	pub region: Option<String>,
+	pub repo_password_ref: String,
+	pub status: BackupConfigStatus,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub created_at: Timestamp,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub updated_at: Timestamp,
+	#[schema(value_type = String)]
+	pub mode: BackupRepoMode,
+	pub last_init_error: Option<String>,
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	pub escrow_acked_at: Option<Timestamp>,
+	pub escrow_acked_by: Option<String>,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = crate::schema::server_group_backup_config)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewServerGroupBackupConfig {
+	pub group_id: Uuid,
+	pub bucket: String,
+	pub prefix: String,
+	pub target_role_arn: String,
+	pub region: Option<String>,
+	pub repo_password_ref: String,
+	pub status: BackupConfigStatus,
+	pub mode: BackupRepoMode,
+}
+
+impl ServerGroupBackupConfig {
+	/// Fetch a group's backup config (absent → caller maps to 409).
+	pub async fn get(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<Option<Self>> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		dsl::server_group_backup_config
+			.filter(dsl::group_id.eq(group_id))
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
+	/// Fetch a group's backup config, mapping absent → 404
+	/// (`AppError::DatabaseQuery(NotFound)`). For mutation handlers that
+	/// require an existing config; `get` keeps the `Option` for the zero-state.
+	pub async fn get_required(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<Self> {
+		Self::get(db, group_id)
+			.await?
+			.ok_or(AppError::DatabaseQuery(DieselError::NotFound))
+	}
+
+	/// All configured groups (the onboarding/stats listing).
+	pub async fn list(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		dsl::server_group_backup_config
+			.order(dsl::created_at.desc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Create or replace a group's config (the operator onboarding write path).
+	/// `created_at`/`updated_at` keep their DB defaults / auto-touch.
+	pub async fn upsert(
+		db: &mut AsyncPgConnection,
+		new: NewServerGroupBackupConfig,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::insert_into(dsl::server_group_backup_config)
+			.values(&new)
+			.on_conflict(dsl::group_id)
+			.do_update()
+			.set((
+				dsl::bucket.eq(&new.bucket),
+				dsl::prefix.eq(&new.prefix),
+				dsl::target_role_arn.eq(&new.target_role_arn),
+				dsl::region.eq(new.region.as_deref()),
+				dsl::repo_password_ref.eq(&new.repo_password_ref),
+				dsl::status.eq(new.status),
+				dsl::mode.eq(new.mode),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Insert a fresh config row (the operator onboarding *create* path). A
+	/// second create for the same group violates the PK and is surfaced as
+	/// [`AppError::Conflict`] so the handler can return 409 ("already
+	/// configured") rather than silently overwriting a live repo's config.
+	pub async fn insert(
+		db: &mut AsyncPgConnection,
+		new: NewServerGroupBackupConfig,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		match diesel::insert_into(dsl::server_group_backup_config)
+			.values(&new)
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+		{
+			Ok(row) => Ok(row),
+			Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => Err(
+				AppError::Conflict("group already has a backup config".into()),
+			),
+			Err(e) => Err(AppError::from(e)),
+		}
+	}
+
+	/// Edit the non-structural config fields (region only — interval/retention
+	/// live on the per-(group,type) schedule). Structural fields
+	/// (bucket/role/mode) are immutable post-creation; the handler rejects
+	/// those before calling here.
+	pub async fn update_region(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		region: Option<&str>,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::update(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.set((dsl::region.eq(region), dsl::updated_at.eq(now)))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Advance (or reset) the lifecycle status (repo-init / escrow flow).
+	pub async fn set_status(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		status: BackupConfigStatus,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::update(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.set(dsl::status.eq(status))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Record intent for the init Job: set `status='provisioning'` and clear
+	/// any prior `last_init_error`. Idempotent — re-running it on an already-
+	/// provisioning row is a no-op retry. The jobs-side init Job observes the
+	/// `provisioning` status and drives the row to `escrow_pending`/`ready`.
+	pub async fn mark_provisioning(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::update(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.set((
+				dsl::status.eq(BackupConfigStatus::Provisioning),
+				dsl::last_init_error.eq(None::<String>),
+				dsl::updated_at.eq(now),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Record an init-Job failure: keep `status='provisioning'` and surface the
+	/// error for the operator. (The jobs component calls this; included here so
+	/// the operator-UI and tests can simulate the failure branch.)
+	pub async fn set_last_init_error(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		error: &str,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::update(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.set((
+				dsl::status.eq(BackupConfigStatus::Provisioning),
+				dsl::last_init_error.eq(Some(error)),
+				dsl::updated_at.eq(now),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Flip `escrow_pending → ready`, stamping who acknowledged the Bitwarden
+	/// escrow and when. The handler guards that the row is in `escrow_pending`
+	/// before calling.
+	pub async fn ack_escrow(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		acked_by: &str,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::update(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.set((
+				dsl::status.eq(BackupConfigStatus::Ready),
+				dsl::escrow_acked_at.eq(now),
+				dsl::escrow_acked_by.eq(Some(acked_by)),
+				dsl::updated_at.eq(now),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Delete a group's config row (decommission). Audit tables intentionally
+	/// have no CASCADE here and the bucket persists (object-locked).
+	pub async fn delete(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<()> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::delete(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backup_type_defaults — canopy-wide per-type defaults
+// ---------------------------------------------------------------------------
+
+#[derive(
+	Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, utoipa::ToSchema,
+)]
+#[diesel(table_name = crate::schema::backup_type_defaults)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupTypeDefault {
+	#[diesel(column_name = type_)]
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	#[schema(value_type = Option<i64>, format = "int64")]
+	pub default_interval: Option<PgDuration>,
+	pub default_retention: JsonValue,
+	pub auto_enable: bool,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = crate::schema::backup_type_defaults)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewBackupTypeDefault {
+	#[diesel(column_name = type_)]
+	pub r#type: BackupType,
+	pub default_interval: Option<PgDuration>,
+	pub default_retention: JsonValue,
+	pub auto_enable: bool,
+}
+
+impl BackupTypeDefault {
+	pub async fn get(db: &mut AsyncPgConnection, r#type: &BackupType) -> Result<Option<Self>> {
+		use crate::schema::backup_type_defaults::dsl;
+
+		dsl::backup_type_defaults
+			.filter(dsl::type_.eq(r#type.as_str()))
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
+	pub async fn list(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::backup_type_defaults::dsl;
+
+		dsl::backup_type_defaults
+			.order(dsl::type_)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	pub async fn upsert(db: &mut AsyncPgConnection, new: NewBackupTypeDefault) -> Result<Self> {
+		use crate::schema::backup_type_defaults::dsl;
+
+		diesel::insert_into(dsl::backup_type_defaults)
+			.values(&new)
+			.on_conflict(dsl::type_)
+			.do_update()
+			.set((
+				dsl::default_interval.eq(new.default_interval),
+				dsl::default_retention.eq(&new.default_retention),
+				dsl::auto_enable.eq(new.auto_enable),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// server_backup_capabilities — what a server advertises it can back up
+// ---------------------------------------------------------------------------
+
+#[derive(
+	Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, utoipa::ToSchema,
+)]
+#[diesel(table_name = crate::schema::server_backup_capabilities)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ServerBackupCapability {
+	pub server_id: Uuid,
+	#[diesel(column_name = type_)]
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	pub enabled: bool,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub registered_at: Timestamp,
+}
+
+impl ServerBackupCapability {
+	/// Register a capability advertised by bestool. `enabled_seed` is the
+	/// type's `auto_enable` default and is applied only when the row is first
+	/// created — an existing row keeps its operator-set `enabled`.
+	pub async fn register(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+		r#type: &BackupType,
+		enabled_seed: bool,
+	) -> Result<Self> {
+		use crate::schema::server_backup_capabilities::dsl;
+
+		diesel::insert_into(dsl::server_backup_capabilities)
+			.values((
+				dsl::server_id.eq(server_id),
+				dsl::type_.eq(r#type.as_str()),
+				dsl::enabled.eq(enabled_seed),
+			))
+			.on_conflict((dsl::server_id, dsl::type_))
+			// Keep the existing (operator-set) enabled; no-op update so we can
+			// RETURNING the existing row.
+			.do_update()
+			.set(dsl::server_id.eq(server_id))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Operator toggle for a `(server, type)`; durable, not re-seeded by the
+	/// type default.
+	pub async fn set_enabled(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+		r#type: &BackupType,
+		enabled: bool,
+	) -> Result<Self> {
+		use crate::schema::server_backup_capabilities::dsl;
+
+		diesel::update(
+			dsl::server_backup_capabilities
+				.filter(dsl::server_id.eq(server_id))
+				.filter(dsl::type_.eq(r#type.as_str())),
+		)
+		.set(dsl::enabled.eq(enabled))
+		.returning(Self::as_select())
+		.get_result(db)
+		.await
+		.map_err(AppError::from)
+	}
+
+	pub async fn list_for_server(db: &mut AsyncPgConnection, server_id: Uuid) -> Result<Vec<Self>> {
+		use crate::schema::server_backup_capabilities::dsl;
+
+		dsl::server_backup_capabilities
+			.filter(dsl::server_id.eq(server_id))
+			.order(dsl::type_)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// All enabled `(server, type)` capabilities fleet-wide — the candidate set
+	/// the scheduler / staleness scan starts from.
+	pub async fn list_enabled(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::server_backup_capabilities::dsl;
+
+		dsl::server_backup_capabilities
+			.filter(dsl::enabled.eq(true))
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Distinct backup types that are **enabled** on any non-archived server in
+	/// the group — i.e. the types the group's repo is actively expected to
+	/// hold. The scheduler resolves a per-type retention/cadence for each of
+	/// these.
+	pub async fn enabled_types_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<Vec<BackupType>> {
+		use crate::schema::{server_backup_capabilities as cap, servers};
+
+		cap::table
+			.inner_join(servers::table.on(servers::id.eq(cap::server_id)))
+			.filter(servers::group_id.eq(group_id))
+			.filter(servers::deleted_at.is_null())
+			.filter(cap::enabled.eq(true))
+			.select(cap::type_)
+			.distinct()
+			.load::<BackupType>(db)
+			.await
+			.map_err(AppError::from)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// server_group_backup_schedule — per-(group,type) schedule/retention overrides
+// ---------------------------------------------------------------------------
+
+#[derive(
+	Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, utoipa::ToSchema,
+)]
+#[diesel(table_name = crate::schema::server_group_backup_schedule)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ServerGroupBackupSchedule {
+	pub group_id: Uuid,
+	#[diesel(column_name = type_)]
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	#[schema(value_type = Option<i64>, format = "int64")]
+	pub expected_interval: Option<PgDuration>,
+	pub retention: Option<JsonValue>,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub created_at: Timestamp,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub updated_at: Timestamp,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = crate::schema::server_group_backup_schedule)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewServerGroupBackupSchedule {
+	pub group_id: Uuid,
+	#[diesel(column_name = type_)]
+	pub r#type: BackupType,
+	pub expected_interval: Option<PgDuration>,
+	pub retention: Option<JsonValue>,
+}
+
+impl ServerGroupBackupSchedule {
+	pub async fn get(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		r#type: &BackupType,
+	) -> Result<Option<Self>> {
+		use crate::schema::server_group_backup_schedule::dsl;
+
+		dsl::server_group_backup_schedule
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::type_.eq(r#type.as_str()))
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
+	pub async fn list_for_group(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<Vec<Self>> {
+		use crate::schema::server_group_backup_schedule::dsl;
+
+		dsl::server_group_backup_schedule
+			.filter(dsl::group_id.eq(group_id))
+			.order(dsl::type_)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	pub async fn upsert(
+		db: &mut AsyncPgConnection,
+		new: NewServerGroupBackupSchedule,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_schedule::dsl;
+
+		diesel::insert_into(dsl::server_group_backup_schedule)
+			.values(&new)
+			.on_conflict((dsl::group_id, dsl::type_))
+			.do_update()
+			.set((
+				dsl::expected_interval.eq(new.expected_interval),
+				dsl::retention.eq(&new.retention),
+				dsl::updated_at.eq(now),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backup_credential_issuances — audit log of every STS issuance
+// ---------------------------------------------------------------------------
+
+#[derive(
+	Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, utoipa::ToSchema,
+)]
+#[diesel(table_name = crate::schema::backup_credential_issuances)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupCredentialIssuance {
+	pub id: i64,
+	pub device_id: Uuid,
+	pub group_id: Uuid,
+	#[diesel(column_name = type_)]
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub issued_at: Timestamp,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub expires_at: Timestamp,
+	pub purpose: BackupPurpose,
+	pub sts_assumed_role: String,
+	pub sts_request_id: Option<String>,
+	pub access_key_id: Option<String>,
+	pub bucket: String,
+	pub prefix: String,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = crate::schema::backup_credential_issuances)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewBackupCredentialIssuance {
+	pub device_id: Uuid,
+	pub group_id: Uuid,
+	#[diesel(column_name = type_)]
+	pub r#type: BackupType,
+	#[diesel(serialize_as = jiff_diesel::Timestamp)]
+	pub expires_at: Timestamp,
+	pub purpose: BackupPurpose,
+	pub sts_assumed_role: String,
+	pub sts_request_id: Option<String>,
+	pub access_key_id: Option<String>,
+	/// Snapshot of `bucket` at issuance time (not an FK back to config).
+	pub bucket: String,
+	/// Snapshot of `prefix` at issuance time.
+	pub prefix: String,
+}
+
+impl BackupCredentialIssuance {
+	/// Record an issuance (public-server, after a successful AssumeRole).
+	/// `device_id`/`group_id`/bucket/prefix are resolved by the caller, not
+	/// read from a client body.
+	pub async fn record(
+		db: &mut AsyncPgConnection,
+		new: NewBackupCredentialIssuance,
+	) -> Result<Self> {
+		use crate::schema::backup_credential_issuances::dsl;
+
+		diesel::insert_into(dsl::backup_credential_issuances)
+			.values(new)
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Recent issuances for a device, newest-first (served by the
+	/// `(device_id, issued_at DESC)` index).
+	pub async fn list_for_device(
+		db: &mut AsyncPgConnection,
+		device_id: Uuid,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::backup_credential_issuances::dsl;
+
+		dsl::backup_credential_issuances
+			.filter(dsl::device_id.eq(device_id))
+			.order(dsl::issued_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Recent issuances for a group, newest-first.
+	pub async fn list_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::backup_credential_issuances::dsl;
+
+		dsl::backup_credential_issuances
+			.filter(dsl::group_id.eq(group_id))
+			.order(dsl::issued_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backup_runs — what bestool reported per run (client-minted UUID PK)
+// ---------------------------------------------------------------------------
+
+#[derive(
+	Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, utoipa::ToSchema,
+)]
+#[diesel(table_name = crate::schema::backup_runs)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupRun {
+	pub id: Uuid,
+	pub device_id: Uuid,
+	pub group_id: Uuid,
+	pub server_id: Option<Uuid>,
+	#[diesel(column_name = type_)]
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	pub purpose: BackupPurpose,
+	pub outcome: RunOutcome,
+	pub error: Option<String>,
+	pub bytes_uploaded: Option<i64>,
+	pub snapshot_id: Option<String>,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub reported_at: Timestamp,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = crate::schema::backup_runs)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewBackupRun {
+	/// The run-uuid bestool minted at run start (becomes the PK).
+	pub id: Uuid,
+	pub device_id: Uuid,
+	pub group_id: Uuid,
+	pub server_id: Option<Uuid>,
+	#[diesel(column_name = type_)]
+	pub r#type: BackupType,
+	pub purpose: BackupPurpose,
+	pub outcome: RunOutcome,
+	pub error: Option<String>,
+	pub bytes_uploaded: Option<i64>,
+	pub snapshot_id: Option<String>,
+}
+
+impl BackupRun {
+	/// Record a reported run. A duplicate `id` (the client-minted run-uuid)
+	/// fails its own insert; that PK violation is surfaced as
+	/// [`AppError::Conflict`] so the endpoint can choose 409 vs idempotent 204.
+	pub async fn record(db: &mut AsyncPgConnection, new: NewBackupRun) -> Result<Self> {
+		use crate::schema::backup_runs::dsl;
+
+		let id = new.id;
+		match diesel::insert_into(dsl::backup_runs)
+			.values(&new)
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+		{
+			Ok(run) => Ok(run),
+			Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => Err(
+				AppError::Conflict(format!("backup run {id} already reported")),
+			),
+			Err(e) => Err(AppError::from(e)),
+		}
+	}
+
+	/// Latest successful *backup* (never restore) for a `(server, type)` — the
+	/// staleness anchor. Filters `purpose='backup'` + `outcome='success'` so a
+	/// recent successful restore can't reset backup staleness.
+	pub async fn latest_success_for_server(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+		r#type: &BackupType,
+	) -> Result<Option<Self>> {
+		use crate::schema::backup_runs::dsl;
+
+		dsl::backup_runs
+			.filter(dsl::server_id.eq(server_id))
+			.filter(dsl::type_.eq(r#type.as_str()))
+			.filter(dsl::purpose.eq(BackupPurpose::Backup))
+			.filter(dsl::outcome.eq(RunOutcome::Success))
+			.order(dsl::reported_at.desc())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
+	/// Latest successful backup per `(server, type)` within a group — the bulk
+	/// staleness-scan input. Keyed `(server_id, type)`; rows with a NULL
+	/// `server_id` are skipped (they can't be attributed to a server).
+	pub async fn latest_success_by_server_type_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<HashMap<(Uuid, BackupType), Self>> {
+		use crate::schema::backup_runs::dsl;
+
+		let rows: Vec<Self> = dsl::backup_runs
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::purpose.eq(BackupPurpose::Backup))
+			.filter(dsl::outcome.eq(RunOutcome::Success))
+			.filter(dsl::server_id.is_not_null())
+			.distinct_on((dsl::server_id, dsl::type_))
+			.order_by((dsl::server_id, dsl::type_, dsl::reported_at.desc()))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+
+		Ok(rows
+			.into_iter()
+			.filter_map(|r| r.server_id.map(|sid| ((sid, r.r#type.clone()), r)))
+			.collect())
+	}
+
+	/// Recent runs for a group, newest-first (stats panel).
+	pub async fn list_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::backup_runs::dsl;
+
+		dsl::backup_runs
+			.filter(dsl::group_id.eq(group_id))
+			.order(dsl::reported_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backup_maintenance_runs — Canopy-owned maintenance outcomes (per-group)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::backup_maintenance_runs)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupMaintenanceRun {
+	pub id: i64,
+	pub group_id: Uuid,
+	pub kind: MaintenanceKind,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub started_at: Timestamp,
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	pub finished_at: Option<Timestamp>,
+	/// NULL while running.
+	pub outcome: Option<RunOutcome>,
+	pub error: Option<String>,
+	pub bytes_reclaimed: Option<i64>,
+}
+
+impl BackupMaintenanceRun {
+	/// Open a maintenance-run row at Job start; returns the new id for the
+	/// matching [`finish`](Self::finish).
+	pub async fn start(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		kind: MaintenanceKind,
+	) -> Result<i64> {
+		use crate::schema::backup_maintenance_runs::dsl;
+
+		diesel::insert_into(dsl::backup_maintenance_runs)
+			.values((dsl::group_id.eq(group_id), dsl::kind.eq(kind)))
+			.returning(dsl::id)
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Close a maintenance run with its outcome.
+	pub async fn finish(
+		db: &mut AsyncPgConnection,
+		id: i64,
+		outcome: RunOutcome,
+		error: Option<String>,
+		bytes_reclaimed: Option<i64>,
+	) -> Result<()> {
+		use crate::schema::backup_maintenance_runs::dsl;
+
+		diesel::update(dsl::backup_maintenance_runs.filter(dsl::id.eq(id)))
+			.set((
+				dsl::finished_at.eq(now),
+				dsl::outcome.eq(Some(outcome)),
+				dsl::error.eq(error),
+				dsl::bytes_reclaimed.eq(bytes_reclaimed),
+			))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
+	}
+
+	pub async fn list_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::backup_maintenance_runs::dsl;
+
+		dsl::backup_maintenance_runs
+			.filter(dsl::group_id.eq(group_id))
+			.order(dsl::started_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Whether a run row still exists and is open (`outcome IS NULL`). Used by
+	/// the scheduler's crash-detection to mark a run failed when its Job
+	/// finished without ever reporting.
+	pub async fn is_open(db: &mut AsyncPgConnection, id: i64) -> Result<bool> {
+		use crate::schema::backup_maintenance_runs::dsl;
+
+		let open: Option<bool> = dsl::backup_maintenance_runs
+			.filter(dsl::id.eq(id))
+			.select(dsl::outcome.is_null())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)?;
+		Ok(open.unwrap_or(false))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backup_repo_snapshots — ground-truth inventory from the inspection Job
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::backup_repo_snapshots)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupRepoSnapshot {
+	pub group_id: Uuid,
+	pub source: String,
+	pub server_id: Option<Uuid>,
+	#[diesel(column_name = type_)]
+	#[serde(rename = "type")]
+	#[schema(value_type = Option<String>)]
+	pub r#type: Option<BackupType>,
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	pub latest_snapshot_at: Option<Timestamp>,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub observed_at: Timestamp,
+}
+
+impl BackupRepoSnapshot {
+	/// Upsert the inventory for one kopia source (the inspection Job calls this
+	/// per source, refreshing `latest_snapshot_at`/`observed_at` in place).
+	pub async fn upsert(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		source: &str,
+		server_id: Option<Uuid>,
+		r#type: Option<&BackupType>,
+		latest_snapshot_at: Option<Timestamp>,
+	) -> Result<()> {
+		use crate::schema::backup_repo_snapshots::dsl;
+
+		let type_str = r#type.map(BackupType::as_str);
+		let latest = jiff_diesel::NullableTimestamp::from(latest_snapshot_at);
+
+		diesel::insert_into(dsl::backup_repo_snapshots)
+			.values((
+				dsl::group_id.eq(group_id),
+				dsl::source.eq(source),
+				dsl::server_id.eq(server_id),
+				dsl::type_.eq(type_str),
+				dsl::latest_snapshot_at.eq(latest),
+			))
+			.on_conflict((dsl::group_id, dsl::source))
+			.do_update()
+			.set((
+				dsl::server_id.eq(server_id),
+				dsl::type_.eq(type_str),
+				dsl::latest_snapshot_at.eq(latest),
+				dsl::observed_at.eq(now),
+			))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
+	}
+
+	pub async fn list_for_group(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<Vec<Self>> {
+		use crate::schema::backup_repo_snapshots::dsl;
+
+		dsl::backup_repo_snapshots
+			.filter(dsl::group_id.eq(group_id))
+			.order(dsl::source)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backup_repo_stats — cached repo + bucket stats (per-group, two writers)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::backup_repo_stats)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupRepoStats {
+	pub group_id: Uuid,
+	pub snapshot_count: Option<i32>,
+	pub source_count: Option<i32>,
+	pub logical_bytes: Option<i64>,
+	pub physical_bytes: Option<i64>,
+	pub bucket_bytes: Option<i64>,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub observed_at: Timestamp,
+}
+
+impl BackupRepoStats {
+	pub async fn get(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<Option<Self>> {
+		use crate::schema::backup_repo_stats::dsl;
+
+		dsl::backup_repo_stats
+			.filter(dsl::group_id.eq(group_id))
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
+	/// Writer 1: the read-only inspection Job. Touches only the repo-derived
+	/// fields (+ `observed_at`), never `bucket_bytes`.
+	pub async fn upsert_repo_fields(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		snapshot_count: Option<i32>,
+		source_count: Option<i32>,
+		logical_bytes: Option<i64>,
+		physical_bytes: Option<i64>,
+	) -> Result<()> {
+		use crate::schema::backup_repo_stats::dsl;
+
+		diesel::insert_into(dsl::backup_repo_stats)
+			.values((
+				dsl::group_id.eq(group_id),
+				dsl::snapshot_count.eq(snapshot_count),
+				dsl::source_count.eq(source_count),
+				dsl::logical_bytes.eq(logical_bytes),
+				dsl::physical_bytes.eq(physical_bytes),
+			))
+			.on_conflict(dsl::group_id)
+			.do_update()
+			.set((
+				dsl::snapshot_count.eq(snapshot_count),
+				dsl::source_count.eq(source_count),
+				dsl::logical_bytes.eq(logical_bytes),
+				dsl::physical_bytes.eq(physical_bytes),
+				dsl::observed_at.eq(now),
+			))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
+	}
+
+	/// Writer 2: the S3-metrics task. Touches only `bucket_bytes`
+	/// (+ `observed_at`), never the repo-derived fields.
+	pub async fn upsert_bucket_bytes(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		bucket_bytes: Option<i64>,
+	) -> Result<()> {
+		use crate::schema::backup_repo_stats::dsl;
+
+		diesel::insert_into(dsl::backup_repo_stats)
+			.values((
+				dsl::group_id.eq(group_id),
+				dsl::bucket_bytes.eq(bucket_bytes),
+			))
+			.on_conflict(dsl::group_id)
+			.do_update()
+			.set((dsl::bucket_bytes.eq(bucket_bytes), dsl::observed_at.eq(now)))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backup_requests — pending operator one-off "backup now" flags
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::backup_requests)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupRequest {
+	pub server_id: Uuid,
+	#[diesel(column_name = type_)]
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	pub purpose: BackupPurpose,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub requested_at: Timestamp,
+	pub requested_by: Option<String>,
+}
+
+impl BackupRequest {
+	/// Enqueue (or refresh) a one-off request for a `(server, type, purpose)`.
+	pub async fn enqueue(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+		r#type: &BackupType,
+		purpose: BackupPurpose,
+		requested_by: Option<&str>,
+	) -> Result<()> {
+		use crate::schema::backup_requests::dsl;
+
+		diesel::insert_into(dsl::backup_requests)
+			.values((
+				dsl::server_id.eq(server_id),
+				dsl::type_.eq(r#type.as_str()),
+				dsl::purpose.eq(purpose),
+				dsl::requested_by.eq(requested_by),
+			))
+			.on_conflict((dsl::server_id, dsl::type_, dsl::purpose))
+			.do_update()
+			.set((
+				dsl::requested_at.eq(now),
+				dsl::requested_by.eq(requested_by),
+			))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
+	}
+
+	/// Clear a pending request (called when the run is reported).
+	pub async fn clear(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+		r#type: &BackupType,
+		purpose: BackupPurpose,
+	) -> Result<()> {
+		use crate::schema::backup_requests::dsl;
+
+		diesel::delete(
+			dsl::backup_requests
+				.filter(dsl::server_id.eq(server_id))
+				.filter(dsl::type_.eq(r#type.as_str()))
+				.filter(dsl::purpose.eq(purpose)),
+		)
+		.execute(db)
+		.await
+		.map_err(AppError::from)?;
+		Ok(())
+	}
+
+	pub async fn pending_for_server(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+	) -> Result<Vec<Self>> {
+		use crate::schema::backup_requests::dsl;
+
+		dsl::backup_requests
+			.filter(dsl::server_id.eq(server_id))
+			.order((dsl::type_, dsl::purpose))
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+}

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -26,7 +26,14 @@ pub struct Issue {
 	pub created_at: Timestamp,
 	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
 	pub updated_at: Timestamp,
-	pub server_id: Uuid,
+	/// `NULL` for a group-scoped issue (see [`server_group_id`](Self::server_group_id)).
+	/// Exactly one of `server_id` / `server_group_id` is set (DB CHECK).
+	pub server_id: Option<Uuid>,
+	/// `NULL` for an ordinary server-scoped issue; `Some` for a group-scoped
+	/// control-plane issue (backup corruption, preflight, …) raised via
+	/// [`raise_group_event`]. Group-scoped issues bypass the per-server
+	/// `is_monitored` gate.
+	pub server_group_id: Option<Uuid>,
 	pub device_id: Option<Uuid>,
 	pub source: String,
 	#[diesel(column_name = "ref_")]
@@ -363,6 +370,166 @@ impl NewEvent {
 	}
 }
 
+/// Open (or recover) a **group-scoped** issue, bypassing the per-server
+/// `is_monitored` gate. This is the single entrypoint for control-plane
+/// concerns that are not attributable to any one server — backup corruption,
+/// upstream preflight failures, reconcile-missing, restore-verification.
+///
+/// Mirrors [`NewEvent::save`] but keys the issue on
+/// `(server_group_id, source, ref)` instead of `(server_id, …)`:
+/// 1. find-or-create the group-scoped issue (server_id = NULL),
+/// 2. append the event or coalesce into the latest matching one,
+/// 3. run incident membership evaluation with `monitored = true` so the
+///    incident opens/pages regardless of any member server's monitored flag.
+///
+/// Recovery is the same `(source, ref)` with `active = false` at a lower
+/// severity, which lets the issue leave the incident and auto-close —
+/// identical lifecycle to the per-server path.
+///
+/// `description` is an optional single-line headline (rejected if multi-line);
+/// `message` is the body. Both feed the dedup hash, so a repeated identical
+/// alert coalesces into one event with a bumped occurrence count.
+pub async fn raise_group_event(
+	conn: &mut AsyncPgConnection,
+	group_id: Uuid,
+	r#ref: &str,
+	severity: Severity,
+	description: Option<&str>,
+	message: &str,
+	active: bool,
+) -> Result<Issue> {
+	use crate::schema::{events, issues};
+
+	if let Some(d) = description
+		&& d.contains('\n')
+	{
+		return Err(AppError::BadRequest(
+			"description must be a single line (no newlines); use `message` for body text".into(),
+		));
+	}
+
+	let source = crate::statuses::CANOPY_SOURCE;
+	let now = Timestamp::now();
+	let hash = hash_event(severity, active, message, description);
+
+	conn.transaction::<_, AppError, _>(async |conn| {
+		// 1. find-or-create the group-scoped issue.
+		let existing: Option<Issue> = issues::table
+			.select(Issue::as_select())
+			.filter(
+				issues::server_group_id
+					.eq(group_id)
+					.and(issues::source.eq(source))
+					.and(issues::ref_.eq(r#ref)),
+			)
+			.for_update()
+			.first(conn)
+			.await
+			.optional()?;
+
+		let issue: Issue = if let Some(existing) = existing {
+			let new_last_seen = if now > existing.last_seen {
+				now
+			} else {
+				existing.last_seen
+			};
+			let clear_resolved = active && existing.resolved_at.is_some();
+			diesel::update(issues::table.filter(issues::id.eq(existing.id)))
+				.set((
+					issues::severity.eq(severity),
+					issues::description.eq(description),
+					issues::message.eq(message),
+					issues::active.eq(active),
+					issues::last_seen.eq(jiff_diesel::Timestamp::from(new_last_seen)),
+					issues::resolved_at.eq(diesel::dsl::sql::<
+						diesel::sql_types::Nullable<diesel::sql_types::Timestamptz>,
+					>(if clear_resolved {
+						"NULL"
+					} else {
+						"issues.resolved_at"
+					})),
+					issues::resolved_by.eq(diesel::dsl::sql::<
+						diesel::sql_types::Nullable<diesel::sql_types::Text>,
+					>(if clear_resolved {
+						"NULL"
+					} else {
+						"issues.resolved_by"
+					})),
+					issues::resolved_reason.eq(diesel::dsl::sql::<
+						diesel::sql_types::Nullable<diesel::sql_types::Text>,
+					>(if clear_resolved {
+						"NULL"
+					} else {
+						"issues.resolved_reason"
+					})),
+				))
+				.returning(Issue::as_select())
+				.get_result(conn)
+				.await?
+		} else {
+			diesel::insert_into(issues::table)
+				.values((
+					issues::server_group_id.eq(group_id),
+					issues::source.eq(source),
+					issues::ref_.eq(r#ref),
+					issues::severity.eq(severity),
+					issues::description.eq(description),
+					issues::message.eq(message),
+					issues::active.eq(active),
+					issues::first_seen.eq(jiff_diesel::Timestamp::from(now)),
+					issues::last_seen.eq(jiff_diesel::Timestamp::from(now)),
+				))
+				.returning(Issue::as_select())
+				.get_result(conn)
+				.await?
+		};
+
+		// 2. coalesce into latest event or insert new.
+		let latest_event: Option<Event> = events::table
+			.select(Event::as_select())
+			.filter(events::issue_id.eq(issue.id))
+			.order(events::created_at.desc())
+			.first(conn)
+			.await
+			.optional()?;
+
+		let coalesce = matches!(&latest_event, Some(e) if e.hash == hash);
+		if let (true, Some(latest)) = (coalesce, latest_event) {
+			let new_last = if now > latest.last_seen {
+				now
+			} else {
+				latest.last_seen
+			};
+			diesel::update(events::table.filter(events::id.eq(latest.id)))
+				.set((
+					events::occurrences.eq(latest.occurrences + 1),
+					events::last_seen.eq(jiff_diesel::Timestamp::from(new_last)),
+				))
+				.execute(conn)
+				.await?;
+		} else {
+			diesel::insert_into(events::table)
+				.values((
+					events::issue_id.eq(issue.id),
+					events::severity.eq(severity),
+					events::description.eq(description),
+					events::message.eq(message),
+					events::active.eq(active),
+					events::hash.eq(&hash),
+					events::last_seen.eq(jiff_diesel::Timestamp::from(now)),
+				))
+				.execute(conn)
+				.await?;
+		}
+
+		// 3. group-aware incident evaluation — monitored = true unconditionally.
+		re_evaluate_incident_membership(conn, &issue, group_id, true, now, None).await?;
+
+		Ok(issue)
+	})
+	.await
+}
+
 /// Compute whether the issue *should* currently be contributing to an
 /// open incident, and apply join/leave accordingly. The rules:
 ///
@@ -411,9 +578,11 @@ async fn re_evaluate_incident_membership(
 
 	let was_in = is_issue_in_open_incident(conn, issue.id).await?;
 	let snoozed = issue.snoozed_until.map_or(false, |t| t > Timestamp::now());
+	// A group-scoped issue (server_id = None) can only be silenced at the
+	// group level; pass the nil server so only the group list is consulted.
 	let silenced = crate::silenced_refs::is_silenced(
 		conn,
-		issue.server_id,
+		issue.server_id.unwrap_or(Uuid::nil()),
 		Some(server_group_id),
 		&issue.source,
 		&issue.r#ref,
@@ -570,6 +739,29 @@ async fn re_evaluate_incident_membership(
 	Ok(())
 }
 
+/// Resolve the `(server_group_id, monitored)` pair an issue should be
+/// re-evaluated against, handling both server-scoped and group-scoped issues.
+///
+/// - Server-scoped (`server_id = Some`): look the server up; its `group_id`
+///   and `is_monitored` drive the evaluation. `None` group → ungrouped, no
+///   incident path.
+/// - Group-scoped (`server_group_id = Some`): use the group directly and force
+///   `monitored = true` so the per-server gate never silences a control-plane
+///   issue.
+async fn issue_group_and_monitored(
+	conn: &mut AsyncPgConnection,
+	issue: &Issue,
+) -> Result<Option<(Uuid, bool)>> {
+	match (issue.server_id, issue.server_group_id) {
+		(_, Some(gid)) => Ok(Some((gid, true))),
+		(Some(sid), None) => {
+			let server = Server::get_by_id(conn, sid).await?;
+			Ok(server.group_id.map(|gid| (gid, server.is_monitored)))
+		}
+		(None, None) => Ok(None),
+	}
+}
+
 /// Re-evaluate every currently-open issue on `server_id` against incident
 /// membership. Used as a catch-up when the operator flips a property of
 /// the server that changes its incident eligibility — currently:
@@ -655,13 +847,16 @@ pub async fn reevaluate_open_issues_for_group_ref(
 		.filter(servers::group_id.eq(server_group_id))
 		.load(db)
 		.await?;
-	if server_ids.is_empty() {
-		return Ok(());
-	}
 
+	// Both the group's server-scoped issues and any group-scoped issues
+	// (server_group_id = this group) that match the silenced (source, ref).
 	let open_issues: Vec<Issue> = issues::table
 		.select(Issue::as_select())
-		.filter(issues::server_id.eq_any(&server_ids))
+		.filter(
+			issues::server_id
+				.eq_any(&server_ids)
+				.or(issues::server_group_id.eq(server_group_id)),
+		)
 		.filter(issues::source.eq(source))
 		.filter(issues::ref_.eq(r#ref))
 		.filter(issues::active.eq(true))
@@ -679,10 +874,11 @@ pub async fn reevaluate_open_issues_for_group_ref(
 		monitored_by_server.insert(*sid, s.is_monitored);
 	}
 	for issue in open_issues {
-		let monitored = monitored_by_server
-			.get(&issue.server_id)
-			.copied()
-			.unwrap_or(true);
+		// Group-scoped issues bypass the per-server monitored gate.
+		let monitored = match issue.server_id {
+			Some(sid) => monitored_by_server.get(&sid).copied().unwrap_or(true),
+			None => true,
+		};
 		re_evaluate_incident_membership(db, &issue, server_group_id, monitored, now, None).await?;
 	}
 	Ok(())
@@ -723,7 +919,7 @@ pub async fn reconcile_open_incidents(db: &mut AsyncPgConnection) -> Result<(usi
 
 		let server_ids: Vec<Uuid> = {
 			let mut s: std::collections::HashSet<Uuid> =
-				open_issues.iter().map(|i| i.server_id).collect();
+				open_issues.iter().filter_map(|i| i.server_id).collect();
 			s.drain().collect()
 		};
 		let servers = Server::get_by_ids(conn, &server_ids).await?;
@@ -733,16 +929,28 @@ pub async fn reconcile_open_incidents(db: &mut AsyncPgConnection) -> Result<(usi
 		let now = Timestamp::now();
 		let mut evaluated = 0usize;
 		for issue in open_issues {
-			let Some(server) = by_id.get(&issue.server_id) else {
-				continue;
-			};
-			let Some(gid) = server.group_id else {
-				// Ungrouped servers can't have incidents; nothing to reconcile.
-				continue;
-			};
-			re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
-				.await?;
-			evaluated += 1;
+			match (issue.server_id, issue.server_group_id) {
+				// Group-scoped issue: resolve its group directly, bypass the
+				// per-server is_monitored gate (monitored = true).
+				(None, Some(gid)) => {
+					re_evaluate_incident_membership(conn, &issue, gid, true, now, None).await?;
+					evaluated += 1;
+				}
+				// Server-scoped issue: look up the server and its group.
+				(Some(sid), _) => {
+					let Some(server) = by_id.get(&sid) else {
+						continue;
+					};
+					let Some(gid) = server.group_id else {
+						// Ungrouped servers can't have incidents; nothing to reconcile.
+						continue;
+					};
+					re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
+						.await?;
+					evaluated += 1;
+				}
+				(None, None) => continue,
+			}
 		}
 		Ok((by_id.len(), evaluated))
 	})
@@ -835,8 +1043,11 @@ async fn enqueue_slack_open(
 	issue: &Issue,
 ) -> Result<()> {
 	let group = ServerGroup::get_by_id(conn, server_group_id).await?;
-	let server = Server::get_by_id(conn, issue.server_id).await?;
-	let label = format_group_label(&group, Some(&server));
+	let server = match issue.server_id {
+		Some(sid) => Some(Server::get_by_id(conn, sid).await?),
+		None => None,
+	};
+	let label = format_group_label(&group, server.as_ref());
 	let payload = crate::slack_outbox::vars::incident_open(
 		&label,
 		issue.severity,
@@ -1138,17 +1349,8 @@ impl Issue {
 				.returning(Self::as_select())
 				.get_result(conn)
 				.await?;
-			let server = Server::get_by_id(conn, issue.server_id).await?;
-			if let Some(gid) = server.group_id {
-				re_evaluate_incident_membership(
-					conn,
-					&issue,
-					gid,
-					server.is_monitored,
-					now,
-					Some(by),
-				)
-				.await?;
+			if let Some((gid, monitored)) = issue_group_and_monitored(conn, &issue).await? {
+				re_evaluate_incident_membership(conn, &issue, gid, monitored, now, Some(by)).await?;
 			}
 			Ok(issue)
 		})
@@ -1169,11 +1371,9 @@ impl Issue {
 				.returning(Self::as_select())
 				.get_result(conn)
 				.await?;
-			let server = Server::get_by_id(conn, issue.server_id).await?;
-			if let Some(gid) = server.group_id {
-				// Unresolve rejoins; cascade close path doesn't fire here.
-				re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
-					.await?;
+			// Unresolve rejoins; cascade close path doesn't fire here.
+			if let Some((gid, monitored)) = issue_group_and_monitored(conn, &issue).await? {
+				re_evaluate_incident_membership(conn, &issue, gid, monitored, now, None).await?;
 			}
 			Ok(issue)
 		})
@@ -1201,10 +1401,8 @@ impl Issue {
 				.returning(Self::as_select())
 				.get_result(conn)
 				.await?;
-			let server = Server::get_by_id(conn, issue.server_id).await?;
-			if let Some(gid) = server.group_id {
-				re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
-					.await?;
+			if let Some((gid, monitored)) = issue_group_and_monitored(conn, &issue).await? {
+				re_evaluate_incident_membership(conn, &issue, gid, monitored, now, None).await?;
 			}
 			Ok(issue)
 		})
@@ -1221,10 +1419,8 @@ impl Issue {
 				.returning(Self::as_select())
 				.get_result(conn)
 				.await?;
-			let server = Server::get_by_id(conn, issue.server_id).await?;
-			if let Some(gid) = server.group_id {
-				re_evaluate_incident_membership(conn, &issue, gid, server.is_monitored, now, None)
-					.await?;
+			if let Some((gid, monitored)) = issue_group_and_monitored(conn, &issue).await? {
+				re_evaluate_incident_membership(conn, &issue, gid, monitored, now, None).await?;
 			}
 			Ok(issue)
 		})
@@ -1600,17 +1796,13 @@ impl Incident {
 					.await?;
 				// The issue is now resolved so the leave path fires
 				// regardless of `monitored`; pass the live value
-				// anyway so the function never sees stale state.
-				let server = Server::get_by_id(conn, issue.server_id).await?;
-				re_evaluate_incident_membership(
-					conn,
-					&issue,
-					gid,
-					server.is_monitored,
-					now,
-					Some(by),
-				)
-				.await?;
+				// anyway so the function never sees stale state. Group-scoped
+				// issues (server_id = None) bypass the per-server gate.
+				let monitored = match issue.server_id {
+					Some(sid) => Server::get_by_id(conn, sid).await?.is_monitored,
+					None => true,
+				};
+				re_evaluate_incident_membership(conn, &issue, gid, monitored, now, Some(by)).await?;
 			}
 
 			let incident: Incident =

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -5,6 +5,7 @@ use diesel_async::{
 
 pub mod admins;
 pub mod artifacts;
+pub mod backups;
 pub mod bestool_snippets;
 pub mod chrome_releases;
 pub mod devices;
@@ -28,7 +29,16 @@ pub mod version_known_issues;
 pub mod versions;
 pub mod views;
 
+pub use backups::{
+	BackupCredentialIssuance, BackupMaintenanceRun, BackupRepoSnapshot, BackupRepoStats,
+	BackupRequest, BackupRun, BackupTypeDefault, NewBackupCredentialIssuance, NewBackupRun,
+	NewBackupTypeDefault, NewServerGroupBackupConfig, NewServerGroupBackupSchedule,
+	ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
+};
 pub use bestool_snippets::{BestoolSnippet, NewBestoolSnippet};
+pub use commons_types::backup::{
+	BackupConfigStatus, BackupPurpose, BackupType, MaintenanceKind, RunOutcome,
+};
 pub use devices::{Device, DeviceConnection, DeviceKey, DeviceWithInfo};
 
 pub type Db = Pool<AsyncPgConnection>;

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -22,6 +22,99 @@ diesel::table! {
 }
 
 diesel::table! {
+	backup_credential_issuances (id) {
+		id -> Int8,
+		device_id -> Uuid,
+		group_id -> Uuid,
+		#[sql_name = "type"]
+		type_ -> Text,
+		issued_at -> Timestamptz,
+		expires_at -> Timestamptz,
+		purpose -> Text,
+		sts_assumed_role -> Text,
+		sts_request_id -> Nullable<Text>,
+		access_key_id -> Nullable<Text>,
+		bucket -> Text,
+		prefix -> Text,
+	}
+}
+
+diesel::table! {
+	backup_maintenance_runs (id) {
+		id -> Int8,
+		group_id -> Uuid,
+		kind -> Text,
+		started_at -> Timestamptz,
+		finished_at -> Nullable<Timestamptz>,
+		outcome -> Nullable<Text>,
+		error -> Nullable<Text>,
+		bytes_reclaimed -> Nullable<Int8>,
+	}
+}
+
+diesel::table! {
+	backup_repo_snapshots (group_id, source) {
+		group_id -> Uuid,
+		source -> Text,
+		server_id -> Nullable<Uuid>,
+		#[sql_name = "type"]
+		type_ -> Nullable<Text>,
+		latest_snapshot_at -> Nullable<Timestamptz>,
+		observed_at -> Timestamptz,
+	}
+}
+
+diesel::table! {
+	backup_repo_stats (group_id) {
+		group_id -> Uuid,
+		snapshot_count -> Nullable<Int4>,
+		source_count -> Nullable<Int4>,
+		logical_bytes -> Nullable<Int8>,
+		physical_bytes -> Nullable<Int8>,
+		bucket_bytes -> Nullable<Int8>,
+		observed_at -> Timestamptz,
+	}
+}
+
+diesel::table! {
+	backup_requests (server_id, type_, purpose) {
+		server_id -> Uuid,
+		#[sql_name = "type"]
+		type_ -> Text,
+		purpose -> Text,
+		requested_at -> Timestamptz,
+		requested_by -> Nullable<Text>,
+	}
+}
+
+diesel::table! {
+	backup_runs (id) {
+		id -> Uuid,
+		device_id -> Uuid,
+		group_id -> Uuid,
+		server_id -> Nullable<Uuid>,
+		#[sql_name = "type"]
+		type_ -> Text,
+		purpose -> Text,
+		outcome -> Text,
+		error -> Nullable<Text>,
+		bytes_uploaded -> Nullable<Int8>,
+		snapshot_id -> Nullable<Text>,
+		reported_at -> Timestamptz,
+	}
+}
+
+diesel::table! {
+	backup_type_defaults (type_) {
+		#[sql_name = "type"]
+		type_ -> Text,
+		default_interval -> Nullable<Interval>,
+		default_retention -> Jsonb,
+		auto_enable -> Bool,
+	}
+}
+
+diesel::table! {
 	bestool_snippets (id) {
 		id -> Uuid,
 		created_at -> Timestamptz,
@@ -166,7 +259,7 @@ diesel::table! {
 		id -> Uuid,
 		created_at -> Timestamptz,
 		updated_at -> Timestamptz,
-		server_id -> Uuid,
+		server_id -> Nullable<Uuid>,
 		device_id -> Nullable<Uuid>,
 		source -> Text,
 		#[sql_name = "ref"]
@@ -181,6 +274,17 @@ diesel::table! {
 		resolved_by -> Nullable<Text>,
 		resolved_reason -> Nullable<Text>,
 		snoozed_until -> Nullable<Timestamptz>,
+		server_group_id -> Nullable<Uuid>,
+	}
+}
+
+diesel::table! {
+	server_backup_capabilities (server_id, type_) {
+		server_id -> Uuid,
+		#[sql_name = "type"]
+		type_ -> Text,
+		enabled -> Bool,
+		registered_at -> Timestamptz,
 	}
 }
 
@@ -205,6 +309,36 @@ diesel::table! {
 		created_at -> Timestamptz,
 		expires_at -> Timestamptz,
 		consumed_at -> Nullable<Timestamptz>,
+	}
+}
+
+diesel::table! {
+	server_group_backup_config (group_id) {
+		group_id -> Uuid,
+		bucket -> Text,
+		prefix -> Text,
+		target_role_arn -> Text,
+		region -> Nullable<Text>,
+		repo_password_ref -> Text,
+		status -> Text,
+		created_at -> Timestamptz,
+		updated_at -> Timestamptz,
+		mode -> Text,
+		last_init_error -> Nullable<Text>,
+		escrow_acked_at -> Nullable<Timestamptz>,
+		escrow_acked_by -> Nullable<Text>,
+	}
+}
+
+diesel::table! {
+	server_group_backup_schedule (group_id, type_) {
+		group_id -> Uuid,
+		#[sql_name = "type"]
+		type_ -> Text,
+		expected_interval -> Nullable<Interval>,
+		retention -> Nullable<Jsonb>,
+		created_at -> Timestamptz,
+		updated_at -> Timestamptz,
 	}
 }
 
@@ -352,6 +486,16 @@ diesel::table! {
 
 diesel::joinable!(artifacts -> devices (device_id));
 diesel::joinable!(artifacts -> versions (version_id));
+diesel::joinable!(backup_credential_issuances -> devices (device_id));
+diesel::joinable!(backup_credential_issuances -> server_groups (group_id));
+diesel::joinable!(backup_maintenance_runs -> server_groups (group_id));
+diesel::joinable!(backup_repo_snapshots -> server_groups (group_id));
+diesel::joinable!(backup_repo_snapshots -> servers (server_id));
+diesel::joinable!(backup_repo_stats -> server_groups (group_id));
+diesel::joinable!(backup_requests -> servers (server_id));
+diesel::joinable!(backup_runs -> devices (device_id));
+diesel::joinable!(backup_runs -> server_groups (group_id));
+diesel::joinable!(backup_runs -> servers (server_id));
 diesel::joinable!(device_connections -> devices (device_id));
 diesel::joinable!(device_keys -> devices (device_id));
 diesel::joinable!(device_server_associations -> devices (device_id));
@@ -363,9 +507,13 @@ diesel::joinable!(incident_notes -> incidents (incident_id));
 diesel::joinable!(incidents -> server_groups (server_group_id));
 diesel::joinable!(issue_notes -> issues (issue_id));
 diesel::joinable!(issues -> devices (device_id));
+diesel::joinable!(issues -> server_groups (server_group_id));
 diesel::joinable!(issues -> servers (server_id));
+diesel::joinable!(server_backup_capabilities -> servers (server_id));
 diesel::joinable!(server_enrollment_challenges -> servers (server_id));
 diesel::joinable!(server_enrollment_tokens -> servers (server_id));
+diesel::joinable!(server_group_backup_config -> server_groups (group_id));
+diesel::joinable!(server_group_backup_schedule -> server_groups (group_id));
 diesel::joinable!(server_group_silenced_refs -> server_groups (server_group_id));
 diesel::joinable!(server_silenced_refs -> servers (server_id));
 diesel::joinable!(servers -> devices (device_id));
@@ -379,6 +527,13 @@ diesel::joinable!(versions -> devices (device_id));
 diesel::allow_tables_to_appear_in_same_query!(
 	admins,
 	artifacts,
+	backup_credential_issuances,
+	backup_maintenance_runs,
+	backup_repo_snapshots,
+	backup_repo_stats,
+	backup_requests,
+	backup_runs,
+	backup_type_defaults,
 	bestool_snippets,
 	chrome_releases,
 	device_connections,
@@ -392,8 +547,11 @@ diesel::allow_tables_to_appear_in_same_query!(
 	incidents,
 	issue_notes,
 	issues,
+	server_backup_capabilities,
 	server_enrollment_challenges,
 	server_enrollment_tokens,
+	server_group_backup_config,
+	server_group_backup_schedule,
 	server_group_silenced_refs,
 	server_groups,
 	server_silenced_refs,

--- a/crates/database/src/server_groups.rs
+++ b/crates/database/src/server_groups.rs
@@ -47,14 +47,7 @@ fn higher_rank(a: ServerRank, b: ServerRank) -> ServerRank {
 }
 
 #[derive(
-	Debug,
-	Clone,
-	Serialize,
-	Deserialize,
-	Queryable,
-	Selectable,
-	Insertable,
-	utoipa::ToSchema,
+	Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, utoipa::ToSchema,
 )]
 #[diesel(table_name = crate::schema::server_groups)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
@@ -233,7 +226,8 @@ impl ServerGroup {
 
 			diesel::update(dsl::server_groups.filter(dsl::id.eq(group_id)))
 				.set(
-					dsl::deleted_at.eq(jiff_diesel::NullableTimestamp::from(Some(Timestamp::now()))),
+					dsl::deleted_at
+						.eq(jiff_diesel::NullableTimestamp::from(Some(Timestamp::now()))),
 				)
 				.execute(conn)
 				.await

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -232,8 +232,12 @@ impl Status {
 			statuses.into_iter().map(|s| (s.server_id, s)).collect();
 		let existing_issues =
 			Issue::list_by_source_ref(db, CANOPY_SOURCE, REACHABILITY_REF, &server_ids).await?;
-		let issue_map: std::collections::HashMap<Uuid, &Issue> =
-			existing_issues.iter().map(|i| (i.server_id, i)).collect();
+		// `list_by_source_ref` is filtered by `server_ids`, so every row is
+		// server-scoped (`server_id` is `Some`); drop any defensively.
+		let issue_map: std::collections::HashMap<Uuid, &Issue> = existing_issues
+			.iter()
+			.filter_map(|i| i.server_id.map(|sid| (sid, i)))
+			.collect();
 
 		let now = Timestamp::now();
 		let mut filed = 0usize;

--- a/crates/database/tests/backfill_registered_at_migration.rs
+++ b/crates/database/tests/backfill_registered_at_migration.rs
@@ -22,12 +22,11 @@ async fn registered_at(
 	conn: &mut diesel_async::AsyncPgConnection,
 	server_id: Uuid,
 ) -> Option<jiff::Timestamp> {
-	let row: RegisteredRow =
-		diesel::sql_query("SELECT registered_at FROM servers WHERE id = $1")
-			.bind::<sql_types::Uuid, _>(server_id)
-			.get_result(conn)
-			.await
-			.expect("fetch registered_at");
+	let row: RegisteredRow = diesel::sql_query("SELECT registered_at FROM servers WHERE id = $1")
+		.bind::<sql_types::Uuid, _>(server_id)
+		.get_result(conn)
+		.await
+		.expect("fetch registered_at");
 	row.registered_at.map(Into::into)
 }
 
@@ -40,10 +39,7 @@ struct MatchRow {
 /// True when the server's `registered_at` equals its earliest status
 /// `created_at` (compared in SQL — statuses are seeded relative to
 /// NOW(), so there's no literal to compare against on the Rust side).
-async fn matches_first_status(
-	conn: &mut diesel_async::AsyncPgConnection,
-	server_id: Uuid,
-) -> bool {
+async fn matches_first_status(conn: &mut diesel_async::AsyncPgConnection, server_id: Uuid) -> bool {
 	let row: MatchRow = diesel::sql_query(
 		"SELECT s.registered_at = \
 			(SELECT MIN(st.created_at) FROM statuses st WHERE st.server_id = s.id) AS matches \

--- a/crates/database/tests/backups.rs
+++ b/crates/database/tests/backups.rs
@@ -1,0 +1,693 @@
+//! DB-layer tests for the backup-credentials models (`database::backups`).
+//! Exercises the model helpers directly against a fresh migrated DB — no HTTP.
+
+use commons_errors::AppError;
+use commons_tests::db::TestDb;
+use database::diesel_async::AsyncPgConnection;
+use database::pg_duration::PgDuration;
+use database::{
+	BackupConfigStatus, BackupCredentialIssuance, BackupPurpose, BackupRepoSnapshot,
+	BackupRepoStats, BackupRequest, BackupRun, BackupType, BackupTypeDefault, MaintenanceKind,
+	NewBackupCredentialIssuance, NewBackupRun, NewBackupTypeDefault, NewServerGroupBackupConfig,
+	NewServerGroupBackupSchedule, RunOutcome, ServerBackupCapability, ServerGroupBackupConfig,
+	ServerGroupBackupSchedule, backups::BackupMaintenanceRun,
+};
+use diesel::{sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use jiff::{SignedDuration, Timestamp};
+use uuid::Uuid;
+
+// --- seeding helpers (raw SQL, matching the existing test style) -----------
+
+#[derive(diesel::QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_group(conn: &mut AsyncPgConnection, name: &str) -> Uuid {
+	sql_query("INSERT INTO server_groups (name) VALUES ($1) RETURNING id")
+		.bind::<sql_types::Text, _>(name)
+		.get_result::<RowId>(conn)
+		.await
+		.expect("insert group")
+		.id
+}
+
+async fn insert_server(conn: &mut AsyncPgConnection, group_id: Uuid) -> Uuid {
+	let host = format!("http://test.invalid/{}", Uuid::new_v4());
+	sql_query("INSERT INTO servers (host, kind, group_id) VALUES ($1, 'central', $2) RETURNING id")
+		.bind::<sql_types::Text, _>(host)
+		.bind::<sql_types::Uuid, _>(group_id)
+		.get_result::<RowId>(conn)
+		.await
+		.expect("insert server")
+		.id
+}
+
+async fn insert_device(conn: &mut AsyncPgConnection) -> Uuid {
+	sql_query("INSERT INTO devices (role) VALUES ('server') RETURNING id")
+		.get_result::<RowId>(conn)
+		.await
+		.expect("insert device")
+		.id
+}
+
+fn retention() -> serde_json::Value {
+	serde_json::json!({"keep_daily": 7, "keep_weekly": 4, "keep_monthly": 6})
+}
+
+fn new_config(group_id: Uuid, region: Option<&str>) -> NewServerGroupBackupConfig {
+	NewServerGroupBackupConfig {
+		group_id,
+		bucket: "bes-kopia-backups-test".into(),
+		prefix: String::new(),
+		target_role_arn: "arn:aws:iam::123456789012:role/canopy-backups-test".into(),
+		region: region.map(Into::into),
+		repo_password_ref: "kopia-repo-pw-test".into(),
+		status: BackupConfigStatus::Provisioning,
+		mode: commons_types::backup::BackupRepoMode::FromBirth,
+	}
+}
+
+// --- config -----------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn config_upsert_roundtrip_and_status() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+
+		// Insert with NULL region.
+		let cfg = ServerGroupBackupConfig::upsert(&mut conn, new_config(group_id, None))
+			.await
+			.expect("insert config");
+		assert_eq!(cfg.region, None);
+		assert_eq!(cfg.status, BackupConfigStatus::Provisioning);
+		assert_eq!(
+			cfg.created_at, cfg.updated_at,
+			"fresh row: created == updated"
+		);
+
+		// Upsert replaces mutable fields (region now set).
+		let cfg = ServerGroupBackupConfig::upsert(
+			&mut conn,
+			new_config(group_id, Some("ap-southeast-2")),
+		)
+		.await
+		.expect("upsert config");
+		assert_eq!(cfg.region.as_deref(), Some("ap-southeast-2"));
+
+		// Status transition + updated_at auto-touch.
+		tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+		let cfg =
+			ServerGroupBackupConfig::set_status(&mut conn, group_id, BackupConfigStatus::Ready)
+				.await
+				.expect("set status");
+		assert_eq!(cfg.status, BackupConfigStatus::Ready);
+		assert!(
+			cfg.updated_at > cfg.created_at,
+			"updated_at auto-touched on update"
+		);
+
+		assert!(
+			ServerGroupBackupConfig::get(&mut conn, group_id)
+				.await
+				.unwrap()
+				.is_some()
+		);
+		assert!(
+			ServerGroupBackupConfig::get(&mut conn, Uuid::new_v4())
+				.await
+				.unwrap()
+				.is_none()
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn type_defaults_retention_must_be_object() {
+	TestDb::run(|mut conn, _url| async move {
+		// Valid object retention round-trips.
+		let td = BackupTypeDefault::upsert(
+			&mut conn,
+			NewBackupTypeDefault {
+				r#type: BackupType::TamanuPostgres,
+				default_interval: Some(PgDuration(SignedDuration::from_hours(24))),
+				default_retention: retention(),
+				auto_enable: true,
+			},
+		)
+		.await
+		.expect("insert type default");
+		assert_eq!(td.r#type, BackupType::TamanuPostgres);
+		assert!(td.auto_enable);
+
+		// A non-object retention is rejected by the jsonb_typeof CHECK.
+		let err = BackupTypeDefault::upsert(
+			&mut conn,
+			NewBackupTypeDefault {
+				r#type: BackupType::from("bad"),
+				default_interval: None,
+				default_retention: serde_json::json!([1, 2, 3]),
+				auto_enable: false,
+			},
+		)
+		.await;
+		assert!(err.is_err(), "array retention must violate the CHECK");
+	})
+	.await;
+}
+
+// --- FK semantics: plain references, no cascade (archival model) ------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hard_deleting_a_group_with_backup_rows_is_blocked() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let device_id = insert_device(&mut conn).await;
+
+		ServerGroupBackupConfig::upsert(&mut conn, new_config(group_id, None))
+			.await
+			.unwrap();
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.unwrap();
+
+		// Groups/servers are archived, never hard-deleted; the FKs are plain
+		// references (no cascade), so a hard DELETE is blocked rather than
+		// silently cascading the config/audit away.
+		let res = sql_query("DELETE FROM server_groups WHERE id = $1")
+			.bind::<sql_types::Uuid, _>(group_id)
+			.execute(&mut conn)
+			.await;
+		assert!(
+			res.is_err(),
+			"FK restrict must block deleting a referenced group"
+		);
+	})
+	.await;
+}
+
+// --- backup_runs ------------------------------------------------------------
+
+fn new_run(
+	id: Uuid,
+	device_id: Uuid,
+	group_id: Uuid,
+	server_id: Option<Uuid>,
+	purpose: BackupPurpose,
+	outcome: RunOutcome,
+) -> NewBackupRun {
+	NewBackupRun {
+		id,
+		device_id,
+		group_id,
+		server_id,
+		r#type: BackupType::TamanuPostgres,
+		purpose,
+		outcome,
+		error: None,
+		bytes_uploaded: Some(42),
+		snapshot_id: Some("kopia-snap-1".into()),
+	}
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backup_run_client_uuid_and_duplicate_is_conflict() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let device_id = insert_device(&mut conn).await;
+
+		let run_id = Uuid::new_v4();
+		let run = BackupRun::record(
+			&mut conn,
+			new_run(
+				run_id,
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.expect("first insert");
+		assert_eq!(run.id, run_id, "client-supplied UUID is the PK");
+
+		// Re-inserting the same UUID is a clean Conflict, not a panic.
+		let err = BackupRun::record(
+			&mut conn,
+			new_run(
+				run_id,
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Failure,
+			),
+		)
+		.await
+		.expect_err("duplicate must error");
+		assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn latest_success_ignores_restore_and_failure() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let device_id = insert_device(&mut conn).await;
+		let pg = BackupType::TamanuPostgres;
+
+		// Oldest: a real successful backup.
+		let good = Uuid::new_v4();
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				good,
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.unwrap();
+		// Newer: a successful *restore* — must NOT reset backup staleness.
+		tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Restore,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.unwrap();
+		// Newer still: a *failed* backup — also must not count.
+		tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Failure,
+			),
+		)
+		.await
+		.unwrap();
+
+		let latest = BackupRun::latest_success_for_server(&mut conn, server_id, &pg)
+			.await
+			.unwrap()
+			.expect("a successful backup exists");
+		assert_eq!(
+			latest.id, good,
+			"latest successful *backup* is the original, not the restore/failure"
+		);
+
+		let map = BackupRun::latest_success_by_server_type_for_group(&mut conn, group_id)
+			.await
+			.unwrap();
+		assert_eq!(map.get(&(server_id, pg)).map(|r| r.id), Some(good));
+	})
+	.await;
+}
+
+// --- issuances --------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn issuance_snapshots_bucket_and_orders_newest_first() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let device_id = insert_device(&mut conn).await;
+
+		let mk = |bucket: &str| NewBackupCredentialIssuance {
+			device_id,
+			group_id,
+			r#type: BackupType::TamanuPostgres,
+			expires_at: Timestamp::now() + SignedDuration::from_hours(1),
+			purpose: BackupPurpose::Backup,
+			sts_assumed_role: "arn:aws:iam::123456789012:role/canopy-backups-test".into(),
+			sts_request_id: Some("req-1".into()),
+			access_key_id: Some("ASIAEXAMPLE".into()),
+			bucket: bucket.into(),
+			prefix: String::new(),
+		};
+
+		let first = BackupCredentialIssuance::record(&mut conn, mk("bucket-at-issue"))
+			.await
+			.unwrap();
+		tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+		let _second = BackupCredentialIssuance::record(&mut conn, mk("later-bucket"))
+			.await
+			.unwrap();
+
+		// The snapshot column holds what was passed, independent of any config.
+		assert_eq!(first.bucket, "bucket-at-issue");
+
+		let list = BackupCredentialIssuance::list_for_device(&mut conn, device_id, 10)
+			.await
+			.unwrap();
+		assert_eq!(list.len(), 2);
+		assert_eq!(list[0].bucket, "later-bucket", "newest first");
+		assert_eq!(list[1].bucket, "bucket-at-issue");
+	})
+	.await;
+}
+
+// --- maintenance runs -------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn maintenance_start_finish_bracket() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+
+		let id = BackupMaintenanceRun::start(&mut conn, group_id, MaintenanceKind::Full)
+			.await
+			.unwrap();
+		let running = &BackupMaintenanceRun::list_for_group(&mut conn, group_id, 10)
+			.await
+			.unwrap()[0];
+		assert_eq!(running.id, id);
+		assert_eq!(running.kind, MaintenanceKind::Full);
+		assert!(running.outcome.is_none(), "NULL outcome while running");
+		assert!(running.finished_at.is_none());
+
+		BackupMaintenanceRun::finish(&mut conn, id, RunOutcome::Success, None, Some(1024))
+			.await
+			.unwrap();
+		let done = &BackupMaintenanceRun::list_for_group(&mut conn, group_id, 10)
+			.await
+			.unwrap()[0];
+		assert_eq!(done.outcome, Some(RunOutcome::Success));
+		assert_eq!(done.bytes_reclaimed, Some(1024));
+		assert!(done.finished_at.is_some());
+	})
+	.await;
+}
+
+// --- repo snapshots ---------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn repo_snapshot_upsert_in_place() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let pg = BackupType::TamanuPostgres;
+		let source = format!("canopy@{server_id}:/data");
+
+		// Fixed microsecond-precision timestamps: Postgres timestamptz truncates
+		// to microseconds, so a nanosecond `Timestamp::now()` wouldn't round-trip
+		// to an equal value.
+		let t1: Timestamp = "2026-06-10T00:00:00.000001Z".parse().unwrap();
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&source,
+			Some(server_id),
+			Some(&pg),
+			Some(t1),
+		)
+		.await
+		.unwrap();
+		let rows = BackupRepoSnapshot::list_for_group(&mut conn, group_id)
+			.await
+			.unwrap();
+		assert_eq!(rows.len(), 1);
+		assert_eq!(rows[0].latest_snapshot_at, Some(t1));
+		assert_eq!(rows[0].r#type, Some(pg.clone()));
+
+		// Second observation of the same (group, source) updates in place.
+		let t2: Timestamp = "2026-06-11T12:34:56.654321Z".parse().unwrap();
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&source,
+			Some(server_id),
+			Some(&pg),
+			Some(t2),
+		)
+		.await
+		.unwrap();
+		let rows = BackupRepoSnapshot::list_for_group(&mut conn, group_id)
+			.await
+			.unwrap();
+		assert_eq!(rows.len(), 1, "still one row");
+		assert_eq!(rows[0].latest_snapshot_at, Some(t2));
+	})
+	.await;
+}
+
+// --- repo stats: two independent writers ------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn repo_stats_split_writers_do_not_clobber() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+
+		// Inspection writer first, then bucket-bytes writer.
+		BackupRepoStats::upsert_repo_fields(
+			&mut conn,
+			group_id,
+			Some(10),
+			Some(3),
+			Some(1000),
+			Some(500),
+		)
+		.await
+		.unwrap();
+		BackupRepoStats::upsert_bucket_bytes(&mut conn, group_id, Some(777))
+			.await
+			.unwrap();
+		let s = BackupRepoStats::get(&mut conn, group_id)
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(
+			(
+				s.snapshot_count,
+				s.source_count,
+				s.logical_bytes,
+				s.physical_bytes,
+				s.bucket_bytes
+			),
+			(Some(10), Some(3), Some(1000), Some(500), Some(777))
+		);
+
+		// Bucket-bytes writer must not clobber the repo fields.
+		BackupRepoStats::upsert_bucket_bytes(&mut conn, group_id, Some(888))
+			.await
+			.unwrap();
+		let s = BackupRepoStats::get(&mut conn, group_id)
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(s.bucket_bytes, Some(888));
+		assert_eq!(s.snapshot_count, Some(10), "repo fields preserved");
+
+		// And the inspection writer must not clobber bucket_bytes.
+		BackupRepoStats::upsert_repo_fields(
+			&mut conn,
+			group_id,
+			Some(11),
+			Some(3),
+			Some(1100),
+			Some(550),
+		)
+		.await
+		.unwrap();
+		let s = BackupRepoStats::get(&mut conn, group_id)
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(s.snapshot_count, Some(11));
+		assert_eq!(s.bucket_bytes, Some(888), "bucket_bytes preserved");
+	})
+	.await;
+}
+
+// --- capabilities -----------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn capability_register_seeds_once_then_operator_controls() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let pg = BackupType::TamanuPostgres;
+
+		// First registration seeds enabled from the type default.
+		let cap = ServerBackupCapability::register(&mut conn, server_id, &pg, true)
+			.await
+			.unwrap();
+		assert!(cap.enabled);
+
+		// Operator turns it off.
+		ServerBackupCapability::set_enabled(&mut conn, server_id, &pg, false)
+			.await
+			.unwrap();
+
+		// Re-registration must NOT re-seed enabled — operator's choice sticks.
+		let cap = ServerBackupCapability::register(&mut conn, server_id, &pg, true)
+			.await
+			.unwrap();
+		assert!(!cap.enabled, "re-register keeps the operator-set enabled");
+
+		assert!(
+			ServerBackupCapability::list_enabled(&mut conn)
+				.await
+				.unwrap()
+				.is_empty()
+		);
+		ServerBackupCapability::set_enabled(&mut conn, server_id, &pg, true)
+			.await
+			.unwrap();
+		assert_eq!(
+			ServerBackupCapability::list_enabled(&mut conn)
+				.await
+				.unwrap()
+				.len(),
+			1
+		);
+	})
+	.await;
+}
+
+// --- schedule ---------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn schedule_upsert_and_get() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let pg = BackupType::TamanuPostgres;
+
+		ServerGroupBackupSchedule::upsert(
+			&mut conn,
+			NewServerGroupBackupSchedule {
+				group_id,
+				r#type: pg.clone(),
+				expected_interval: Some(PgDuration(SignedDuration::from_hours(12))),
+				retention: Some(retention()),
+			},
+		)
+		.await
+		.unwrap();
+
+		let got = ServerGroupBackupSchedule::get(&mut conn, group_id, &pg)
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(
+			got.expected_interval,
+			Some(PgDuration(SignedDuration::from_hours(12)))
+		);
+		assert!(got.retention.is_some());
+
+		// Upsert overrides in place.
+		ServerGroupBackupSchedule::upsert(
+			&mut conn,
+			NewServerGroupBackupSchedule {
+				group_id,
+				r#type: pg.clone(),
+				expected_interval: None,
+				retention: None,
+			},
+		)
+		.await
+		.unwrap();
+		let got = ServerGroupBackupSchedule::get(&mut conn, group_id, &pg)
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(got.expected_interval, None);
+		assert_eq!(
+			ServerGroupBackupSchedule::list_for_group(&mut conn, group_id)
+				.await
+				.unwrap()
+				.len(),
+			1
+		);
+	})
+	.await;
+}
+
+// --- requests ---------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn requests_enqueue_clear_list() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let pg = BackupType::TamanuPostgres;
+
+		BackupRequest::enqueue(
+			&mut conn,
+			server_id,
+			&pg,
+			BackupPurpose::Backup,
+			Some("op@bes"),
+		)
+		.await
+		.unwrap();
+		// Re-enqueue is an upsert on (server, type, purpose) — still one row.
+		BackupRequest::enqueue(
+			&mut conn,
+			server_id,
+			&pg,
+			BackupPurpose::Backup,
+			Some("op2@bes"),
+		)
+		.await
+		.unwrap();
+		let pending = BackupRequest::pending_for_server(&mut conn, server_id)
+			.await
+			.unwrap();
+		assert_eq!(pending.len(), 1);
+		assert_eq!(pending[0].requested_by.as_deref(), Some("op2@bes"));
+
+		// A different purpose is a distinct row.
+		BackupRequest::enqueue(&mut conn, server_id, &pg, BackupPurpose::Restore, None)
+			.await
+			.unwrap();
+		assert_eq!(
+			BackupRequest::pending_for_server(&mut conn, server_id)
+				.await
+				.unwrap()
+				.len(),
+			2
+		);
+
+		BackupRequest::clear(&mut conn, server_id, &pg, BackupPurpose::Backup)
+			.await
+			.unwrap();
+		let pending = BackupRequest::pending_for_server(&mut conn, server_id)
+			.await
+			.unwrap();
+		assert_eq!(pending.len(), 1);
+		assert_eq!(pending[0].purpose, BackupPurpose::Restore);
+	})
+	.await;
+}

--- a/crates/database/tests/server_enrollment.rs
+++ b/crates/database/tests/server_enrollment.rs
@@ -143,7 +143,9 @@ async fn revoke_invalidates_the_active_token() {
 				.is_some()
 		);
 
-		ServerEnrollmentToken::revoke(&mut conn, server.id).await.unwrap();
+		ServerEnrollmentToken::revoke(&mut conn, server.id)
+			.await
+			.unwrap();
 
 		assert!(
 			ServerEnrollmentToken::active_for(&mut conn, server.id)

--- a/crates/database/tests/server_group_archival.rs
+++ b/crates/database/tests/server_group_archival.rs
@@ -114,14 +114,28 @@ async fn archiving_an_all_gone_group_cascades_and_restore_reverses() {
 			"group archived",
 		);
 		assert!(
-			Server::get_by_id(&mut conn, a).await.unwrap().deleted_at.is_some(),
+			Server::get_by_id(&mut conn, a)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_some(),
 			"member a cascade-archived",
 		);
 		assert!(
-			Server::get_by_id(&mut conn, b).await.unwrap().deleted_at.is_some(),
+			Server::get_by_id(&mut conn, b)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_some(),
 			"member b cascade-archived",
 		);
-		assert!(!ServerGroup::list_all(&mut conn).await.unwrap().iter().any(|g| g.id == group));
+		assert!(
+			!ServerGroup::list_all(&mut conn)
+				.await
+				.unwrap()
+				.iter()
+				.any(|g| g.id == group)
+		);
 
 		// Restore cascades back.
 		ServerGroup::restore(&mut conn, group).await.unwrap();
@@ -134,11 +148,19 @@ async fn archiving_an_all_gone_group_cascades_and_restore_reverses() {
 			"group restored",
 		);
 		assert!(
-			Server::get_by_id(&mut conn, a).await.unwrap().deleted_at.is_none(),
+			Server::get_by_id(&mut conn, a)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_none(),
 			"member a restored",
 		);
 		assert!(
-			Server::get_by_id(&mut conn, b).await.unwrap().deleted_at.is_none(),
+			Server::get_by_id(&mut conn, b)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_none(),
 			"member b restored",
 		);
 	})
@@ -159,7 +181,10 @@ async fn server_list_archived_only_returns_archived() {
 			.map(|s| s.id)
 			.collect();
 		assert!(archived_ids.contains(&archived), "archived server listed");
-		assert!(!archived_ids.contains(&live), "live server not in archived list");
+		assert!(
+			!archived_ids.contains(&live),
+			"live server not in archived list"
+		);
 
 		let live_ids: Vec<Uuid> = Server::get_all(&mut conn, 0, None)
 			.await
@@ -168,7 +193,10 @@ async fn server_list_archived_only_returns_archived() {
 			.map(|s| s.id)
 			.collect();
 		assert!(live_ids.contains(&live), "live server in get_all");
-		assert!(!live_ids.contains(&archived), "archived server excluded from get_all");
+		assert!(
+			!live_ids.contains(&archived),
+			"archived server excluded from get_all"
+		);
 	})
 	.await
 }

--- a/crates/database/tests/status_health_state.rs
+++ b/crates/database/tests/status_health_state.rs
@@ -57,11 +57,7 @@ fn legacy_failing_entry_is_warning() {
 fn result_warning_and_broken_count_toward_warning() {
 	for result in ["warning", "broken"] {
 		assert_eq!(
-			status(
-				true,
-				serde_json::json!([{"check": "a", "result": result}])
-			)
-			.health_state(),
+			status(true, serde_json::json!([{"check": "a", "result": result}])).health_state(),
 			HealthState::Warning,
 			"{result}",
 		);

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -25,7 +25,9 @@ const DEFAULT_LIMIT: i64 = 100;
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct IssueData {
 	pub id: Uuid,
-	pub server_id: Uuid,
+	/// `None` for group-scoped issues (backup control-plane alerts that point
+	/// at a group, not a server — see the group-scoped-issues migration).
+	pub server_id: Option<Uuid>,
 	/// The issue's server name (may be null — fall back to `server_host`).
 	pub server_name: Option<String>,
 	pub server_host: String,
@@ -152,7 +154,7 @@ pub(crate) async fn enrich_issues(
 	conn: &mut database::diesel_async::AsyncPgConnection,
 	issues: Vec<Issue>,
 ) -> Result<Vec<IssueData>> {
-	let server_ids: Vec<Uuid> = issues.iter().map(|i| i.server_id).collect();
+	let server_ids: Vec<Uuid> = issues.iter().filter_map(|i| i.server_id).collect();
 	let names = Server::names_by_ids(conn, &server_ids).await?;
 	let group_refs = Server::group_refs_by_server_ids(conn, &server_ids).await?;
 	let user_logins = collect_user_logins(&issues);
@@ -162,10 +164,13 @@ pub(crate) async fn enrich_issues(
 	Ok(issues
 		.into_iter()
 		.map(|i| {
-			let (name, host) = names.get(&i.server_id).cloned().unwrap_or((None, None));
-			let (group_id, group_name) = group_refs
-				.get(&i.server_id)
-				.cloned()
+			let (name, host) = i
+				.server_id
+				.and_then(|sid| names.get(&sid).cloned())
+				.unwrap_or((None, None));
+			let (group_id, group_name) = i
+				.server_id
+				.and_then(|sid| group_refs.get(&sid).cloned())
 				.unwrap_or((None, None));
 			let links = incidents
 				.remove(&i.id)
@@ -193,10 +198,17 @@ pub(crate) async fn enrich_issue(
 	conn: &mut database::diesel_async::AsyncPgConnection,
 	issue: Issue,
 ) -> Result<IssueData> {
-	let mut names = Server::names_by_ids(conn, &[issue.server_id]).await?;
-	let (name, host) = names.remove(&issue.server_id).unwrap_or((None, None));
-	let mut group_refs = Server::group_refs_by_server_ids(conn, &[issue.server_id]).await?;
-	let (group_id, group_name) = group_refs.remove(&issue.server_id).unwrap_or((None, None));
+	let server_ids: Vec<Uuid> = issue.server_id.into_iter().collect();
+	let mut names = Server::names_by_ids(conn, &server_ids).await?;
+	let (name, host) = issue
+		.server_id
+		.and_then(|sid| names.remove(&sid))
+		.unwrap_or((None, None));
+	let mut group_refs = Server::group_refs_by_server_ids(conn, &server_ids).await?;
+	let (group_id, group_name) = issue
+		.server_id
+		.and_then(|sid| group_refs.remove(&sid))
+		.unwrap_or((None, None));
 	let user_logins = collect_user_logins(std::slice::from_ref(&issue));
 	let users = CachedTailscaleUser::by_logins(conn, &user_logins).await?;
 	let mut incidents = Incident::for_issues(conn, &[issue.id]).await?;

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -501,12 +501,10 @@ pub async fn get_detail(
 			Some(did) if Some(did) == device_id => device_with_info
 				.as_ref()
 				.and_then(|d| d.latest_connection.clone()),
-			Some(did) => {
-				DeviceConnection::get_latest_from_device_ids(&mut conn, [did].into_iter())
-					.await?
-					.into_iter()
-					.next()
-			}
+			Some(did) => DeviceConnection::get_latest_from_device_ids(&mut conn, [did].into_iter())
+				.await?
+				.into_iter()
+				.next(),
 			None => None,
 		};
 

--- a/crates/private-server/tests/create_server.rs
+++ b/crates/private-server/tests/create_server.rs
@@ -13,7 +13,9 @@ async fn create_server_without_url_succeeds() {
 			.await;
 		response.assert_status_ok();
 		let id: String = response.json();
-		let server = Server::get_by_id(&mut conn, id.parse().unwrap()).await.unwrap();
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
 		assert!(server.host.is_none(), "created without a URL");
 
 		// Explicit whitespace-only string clears the URL too.
@@ -23,7 +25,9 @@ async fn create_server_without_url_succeeds() {
 			.await;
 		response.assert_status_ok();
 		let id: String = response.json();
-		let server = Server::get_by_id(&mut conn, id.parse().unwrap()).await.unwrap();
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
 		assert!(server.host.is_none(), "empty URL stored as null");
 	})
 	.await
@@ -38,7 +42,9 @@ async fn create_server_defaults_schemeless_url_to_https() {
 			.await;
 		response.assert_status_ok();
 		let id: String = response.json();
-		let server = Server::get_by_id(&mut conn, id.parse().unwrap()).await.unwrap();
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
 		assert_eq!(
 			server.host.unwrap().0.to_string(),
 			"https://foo.example.com/"

--- a/crates/private-server/tests/enrollment_ticket.rs
+++ b/crates/private-server/tests/enrollment_ticket.rs
@@ -38,7 +38,9 @@ async fn mint_enrollment_ticket_round_trips_to_active_token() {
 		let words: Vec<&str> = passphrase.split('-').collect();
 		assert_eq!(words.len(), 4, "passphrase is four words: {passphrase}");
 		assert!(
-			words.iter().all(|w| !w.is_empty() && w == &w.to_lowercase()),
+			words
+				.iter()
+				.all(|w| !w.is_empty() && w == &w.to_lowercase()),
 			"passphrase words are non-empty and lowercase: {passphrase}"
 		);
 

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -904,7 +904,6 @@
           "id",
           "created_at",
           "updated_at",
-          "server_id",
           "source",
           "ref",
           "severity",
@@ -974,9 +973,21 @@
             ],
             "description": "Stored as nullable text; validated as `ResolvedReason` at the API layer\n(avoids the diesel orphan-rules dance for nullable enum columns)."
           },
+          "server_group_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "`NULL` for an ordinary server-scoped issue; `Some` for a group-scoped\ncontrol-plane issue (backup corruption, preflight, …) raised via\n[`raise_group_event`]. Group-scoped issues bypass the per-server\n`is_monitored` gate."
+          },
           "server_id": {
-            "type": "string",
-            "format": "uuid"
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "`NULL` for a group-scoped issue (see [`server_group_id`](Self::server_group_id)).\nExactly one of `server_id` / `server_group_id` is set (DB CHECK)."
           },
           "severity": {
             "$ref": "#/components/schemas/Severity"

--- a/crates/public-server/tests/server_enrollment.rs
+++ b/crates/public-server/tests/server_enrollment.rs
@@ -134,34 +134,41 @@ async fn run_tailnet_handshake(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tailnet_enrollment_happy_path() {
-	run_with_tailnet_device_auth("server", async |mut conn, fwd_ip, _node, _dev, _public, private| {
-		use database::Device;
-		let (spki, _cert, key) = make_signing_certificate();
-		let server = Server::create(&mut conn, new_server("https://ts-enroll.example/"))
-			.await
-			.unwrap();
-		let (_t, token) =
-			ServerEnrollmentToken::mint(&mut conn, server.id, SignedDuration::from_hours(1))
+	run_with_tailnet_device_auth(
+		"server",
+		async |mut conn, fwd_ip, _node, _dev, _public, private| {
+			use database::Device;
+			let (spki, _cert, key) = make_signing_certificate();
+			let server = Server::create(&mut conn, new_server("https://ts-enroll.example/"))
 				.await
 				.unwrap();
+			let (_t, token) =
+				ServerEnrollmentToken::mint(&mut conn, server.id, SignedDuration::from_hours(1))
+					.await
+					.unwrap();
 
-		run_tailnet_handshake(&private, fwd_ip, server.id, &token, &spki, &key, None)
-			.await
-			.assert_status_ok();
-
-		// Registered + bound to a device carrying the body-supplied key; token spent.
-		let after = Server::get_by_id(&mut conn, server.id).await.unwrap();
-		assert!(after.registered_at.is_some(), "registered_at set");
-		assert!(after.device_id.is_some(), "device bound");
-		let bound = Device::from_key(&mut conn, &spki).await.unwrap().unwrap();
-		assert_eq!(bound.id, after.device_id.unwrap(), "body SPKI bound the device");
-		assert!(
-			ServerEnrollmentToken::find_active(&mut conn, server.id, &token)
+			run_tailnet_handshake(&private, fwd_ip, server.id, &token, &spki, &key, None)
 				.await
-				.is_err(),
-			"token consumed",
-		);
-	})
+				.assert_status_ok();
+
+			// Registered + bound to a device carrying the body-supplied key; token spent.
+			let after = Server::get_by_id(&mut conn, server.id).await.unwrap();
+			assert!(after.registered_at.is_some(), "registered_at set");
+			assert!(after.device_id.is_some(), "device bound");
+			let bound = Device::from_key(&mut conn, &spki).await.unwrap().unwrap();
+			assert_eq!(
+				bound.id,
+				after.device_id.unwrap(),
+				"body SPKI bound the device"
+			);
+			assert!(
+				ServerEnrollmentToken::find_active(&mut conn, server.id, &token)
+					.await
+					.is_err(),
+				"token consumed",
+			);
+		},
+	)
 	.await;
 }
 
@@ -194,44 +201,53 @@ async fn internet_path_rejects_body_spki() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tailnet_ignores_the_mtls_certificate_header() {
-	run_with_tailnet_device_auth("server", async |mut conn, fwd_ip, _node, _dev, _public, private| {
-		use database::Device;
-		// Real device key (carried in the body) and a *different*, attacker-style
-		// cert sent in the (forgeable) mtls-certificate header.
-		let (spki_real, _c, key_real) = make_signing_certificate();
-		let (spki_forged, cert_forged, _k) = make_signing_certificate();
-		let server = Server::create(&mut conn, new_server("https://ts-forge.example/"))
-			.await
-			.unwrap();
-		let (_t, token) =
-			ServerEnrollmentToken::mint(&mut conn, server.id, SignedDuration::from_hours(1))
+	run_with_tailnet_device_auth(
+		"server",
+		async |mut conn, fwd_ip, _node, _dev, _public, private| {
+			use database::Device;
+			// Real device key (carried in the body) and a *different*, attacker-style
+			// cert sent in the (forgeable) mtls-certificate header.
+			let (spki_real, _c, key_real) = make_signing_certificate();
+			let (spki_forged, cert_forged, _k) = make_signing_certificate();
+			let server = Server::create(&mut conn, new_server("https://ts-forge.example/"))
 				.await
 				.unwrap();
+			let (_t, token) =
+				ServerEnrollmentToken::mint(&mut conn, server.id, SignedDuration::from_hours(1))
+					.await
+					.unwrap();
 
-		// Body SPKI = real key; header cert = forged. The tailnet mount must use
-		// the body and ignore the header, so the handshake (signed by the real
-		// key) succeeds and binds the real key — not the forged one.
-		run_tailnet_handshake(
-			&private,
-			fwd_ip,
-			server.id,
-			&token,
-			&spki_real,
-			&key_real,
-			Some(&cert_forged),
-		)
-		.await
-		.assert_status_ok();
+			// Body SPKI = real key; header cert = forged. The tailnet mount must use
+			// the body and ignore the header, so the handshake (signed by the real
+			// key) succeeds and binds the real key — not the forged one.
+			run_tailnet_handshake(
+				&private,
+				fwd_ip,
+				server.id,
+				&token,
+				&spki_real,
+				&key_real,
+				Some(&cert_forged),
+			)
+			.await
+			.assert_status_ok();
 
-		assert!(
-			Device::from_key(&mut conn, &spki_real).await.unwrap().is_some(),
-			"the body-supplied (real) key was bound",
-		);
-		assert!(
-			Device::from_key(&mut conn, &spki_forged).await.unwrap().is_none(),
-			"the forged cert-header key was ignored, never bound",
-		);
-	})
+			assert!(
+				Device::from_key(&mut conn, &spki_real)
+					.await
+					.unwrap()
+					.is_some(),
+				"the body-supplied (real) key was bound",
+			);
+			assert!(
+				Device::from_key(&mut conn, &spki_forged)
+					.await
+					.unwrap()
+					.is_none(),
+				"the forged cert-header key was ignored, never bound",
+			);
+		},
+	)
 	.await;
 }
 
@@ -496,7 +512,11 @@ async fn re_enrollment_replaces_the_device() {
 			.unwrap();
 		assert_ne!(device_b, device_a, "re-enroll bound a new device");
 		assert_eq!(
-			Device::from_key(&mut conn, &spki_b).await.unwrap().unwrap().id,
+			Device::from_key(&mut conn, &spki_b)
+				.await
+				.unwrap()
+				.unwrap()
+				.id,
 			device_b,
 			"new box's key authenticates as the new device",
 		);
@@ -586,9 +606,17 @@ async fn channel_binding_happy_path() {
 
 		// Same EKM in the signed transcript and the proxy header → bound.
 		let ekm = [7u8; 32];
-		let (begin, complete) =
-			run_cb_handshake(&public, server.id, &token, &spki, &cert, &key, Some(&ekm), Some(&ekm))
-				.await;
+		let (begin, complete) = run_cb_handshake(
+			&public,
+			server.id,
+			&token,
+			&spki,
+			&cert,
+			&key,
+			Some(&ekm),
+			Some(&ekm),
+		)
+		.await;
 		assert_eq!(
 			begin["channel_binding_required"],
 			json!(true),
@@ -623,8 +651,17 @@ async fn channel_binding_missing_header_is_rejected() {
 		// The device folded the EKM into its signature, but the proxy header is
 		// absent → Canopy has nothing to bind against → rejected, token intact.
 		let ekm = [7u8; 32];
-		let (_begin, complete) =
-			run_cb_handshake(&public, server.id, &token, &spki, &cert, &key, Some(&ekm), None).await;
+		let (_begin, complete) = run_cb_handshake(
+			&public,
+			server.id,
+			&token,
+			&spki,
+			&cert,
+			&key,
+			Some(&ekm),
+			None,
+		)
+		.await;
 		complete.assert_status_forbidden();
 		assert!(
 			ServerEnrollmentToken::find_active(&mut conn, server.id, &token)
@@ -671,36 +708,39 @@ async fn channel_binding_mismatch_is_rejected() {
 #[tokio::test(flavor = "multi_thread")]
 async fn tailnet_path_skips_channel_binding() {
 	unsafe { std::env::set_var("CANOPY_ENROLL_EKM_HEADER", EKM_HEADER) };
-	run_with_tailnet_device_auth("server", async |mut conn, fwd_ip, _node, _dev, _public, private| {
-		let (spki, _cert, key) = make_signing_certificate();
-		let server = Server::create(&mut conn, new_server("https://cb-tailnet.example/"))
-			.await
-			.unwrap();
-		let (_t, token) =
-			ServerEnrollmentToken::mint(&mut conn, server.id, SignedDuration::from_hours(1))
+	run_with_tailnet_device_auth(
+		"server",
+		async |mut conn, fwd_ip, _node, _dev, _public, private| {
+			let (spki, _cert, key) = make_signing_certificate();
+			let server = Server::create(&mut conn, new_server("https://cb-tailnet.example/"))
 				.await
 				.unwrap();
+			let (_t, token) =
+				ServerEnrollmentToken::mint(&mut conn, server.id, SignedDuration::from_hours(1))
+					.await
+					.unwrap();
 
-		// Even with channel binding enabled globally, the tailnet mount has no
-		// TLS exporter, so it neither advertises nor requires it: begin reports
-		// false and complete succeeds with no EKM header and none in the
-		// signature.
-		let fwd = format!("for={fwd_ip}");
-		let begin = private
-			.post("/public/servers/register/begin")
-			.add_header("Forwarded", &fwd)
-			.json(&json!({"server_id": server.id, "token": token, "spki": b64().encode(&spki)}))
-			.await;
-		begin.assert_status_ok();
-		assert_eq!(
-			begin.json::<Value>()["channel_binding_required"],
-			json!(false),
-			"tailnet mount never requires channel binding",
-		);
+			// Even with channel binding enabled globally, the tailnet mount has no
+			// TLS exporter, so it neither advertises nor requires it: begin reports
+			// false and complete succeeds with no EKM header and none in the
+			// signature.
+			let fwd = format!("for={fwd_ip}");
+			let begin = private
+				.post("/public/servers/register/begin")
+				.add_header("Forwarded", &fwd)
+				.json(&json!({"server_id": server.id, "token": token, "spki": b64().encode(&spki)}))
+				.await;
+			begin.assert_status_ok();
+			assert_eq!(
+				begin.json::<Value>()["channel_binding_required"],
+				json!(false),
+				"tailnet mount never requires channel binding",
+			);
 
-		run_tailnet_handshake(&private, fwd_ip, server.id, &token, &spki, &key, None)
-			.await
-			.assert_status_ok();
-	})
+			run_tailnet_handshake(&private, fwd_ip, server.id, &token, &spki, &key, None)
+				.await
+				.assert_status_ok();
+		},
+	)
 	.await;
 }

--- a/docs/plans/backup-credentials-blind-relay.md
+++ b/docs/plans/backup-credentials-blind-relay.md
@@ -1,0 +1,78 @@
+# Backup credentials: blind-relay issuer isolation (STUB — stage 2)
+
+**Status: deferred.** This is a stage-2 hardening of the backup-credentials
+design in [`backup-credentials.md`](./backup-credentials.md). Stage 1
+knowingly accepts the risk this would close (see that plan's
+threat-boundary section: the internet-facing `public-server` holds the
+privileged issuer rights). This file is a placeholder to revisit, not a
+worked plan.
+
+## Problem it closes
+
+In stage 1, `public-server` — the internet-exposed surface — holds:
+- `sts:AssumeRole` on **every** group's per-bucket role → fleet-wide S3
+  **read + write** (write = the poisoning vector, see H1 in the main plan), and
+- Secret-read for **every** group's kopia repo password → which decrypts
+  all backups (so even read access to it is fleet-wide data exposure).
+
+So a single `public-server` RCE yields fleet-wide backup read + poison in
+one hop. Stage 1 accepts this (same trust as canopy's other internet
+surface); this plan removes it.
+
+## Goal
+
+Make `public-server` a **blind relay**: it authenticates the device (mTLS)
+and shuttles bytes, but holds **no** AWS rights and **never sees** creds or
+the repo password in plaintext. A `public-server` compromise should yield
+nothing usable.
+
+## Sketch
+
+- The privileged capability (STS assume + Secret-read) lives only in an
+  **internal, non-internet-facing** component (the jobs/scheduler side),
+  driven by Canopy's own backup schedule — minting follows the schedule
+  Canopy already owns, not arbitrary device requests.
+- That component mints the short-lived creds + fetches the password,
+  **envelope-encrypts the bundle to the requesting device's public key**
+  (we already have per-device mTLS identities / `device_keys`), and stages
+  the opaque blob.
+- `public-server` relays the blob to bestool; bestool decrypts with its
+  private key. `public-server` can't read it.
+
+Net: the front door holds no secrets and no mint rights; compromise gets
+opaque blobs it can't open.
+
+## Hard problems to solve on revisit
+
+1. **Long-backup refresh.** Stage 1's elegance is `credential_process`
+   pulling fresh creds on demand (chained STS caps at 1h). Staged delivery
+   needs the internal component to keep re-minting + re-staging for the
+   life of an active backup (it knows the run started from
+   `/backup-report`). Define that orchestration.
+2. **Device-initiated restore.** Restore is spontaneous (pre-prod restoring
+   from prod), not scheduled, so it doesn't fit pure pre-staging. Note
+   restore creds are **read-only** (lower stakes); the password is the part
+   that still needs the blind-relay treatment. Decide the restore path.
+3. **Creds + password at rest.** Staging puts secrets at rest between mint
+   and pickup — short TTL, delete-on-pickup, and the envelope encryption
+   (above) is what keeps them opaque to `public-server` and the stage store.
+4. **Envelope encryption mechanics.** Which device key (the mTLS cert key,
+   or a dedicated backup key?), key availability to bestool, crypto choice,
+   rotation, and what happens on device re-provisioning.
+5. **Request path without re-trusting `public-server`.** If any request
+   flows device → `public-server` → internal minter, the minter must not
+   blindly trust `public-server`'s assertion of device identity (else
+   compromise re-grants minting). Either drive everything from Canopy's
+   schedule (no device-asserted mint), or forward the raw device cert for
+   independent validation.
+
+## Relationship to the main plan
+
+Replaces only the *delivery* mechanism: the on-demand `/backup-credentials`
+minting and the `/backup-target` password-serving become staged,
+envelope-encrypted, blind-relayed delivery. Everything else in
+`backup-credentials.md` (per-bucket cross-account roles, the group model,
+GOVERNANCE object lock, Canopy-owned maintenance/retention/inspection,
+detection, preflight) is unchanged.
+
+See the M7 discussion that produced this split.

--- a/docs/plans/backup-credentials-implementation-order.md
+++ b/docs/plans/backup-credentials-implementation-order.md
@@ -74,6 +74,15 @@ against the agreed names and the two meet at deploy.
 
 ## The early blocker: kopia-behaviour verification spike
 
+> **Concluded (from kopia docs/source + S3 semantics) — Branch A:** device
+> creds = `AWS_S3_MULTIPART_ACTIONS` (no `PutObjectRetention`/no delete);
+> repo created **non-lock-aware**; rely on the bucket's default GOVERNANCE
+> retention + versioning + lifecycle. `--session-token`,
+> `--override-hostname`, and `--point-in-time` are all supported. Two items
+> still want a **live confirm** (the no-`PutObjectRetention` write path, and
+> PIT on real AWS S3 per issue #4346). Full verdict + test script:
+> [`backup-credentials-kopia-spike.md`](./backup-credentials-kopia-spike.md).
+
 **Do this first, in parallel with stage 0, before committing the ops action-set
 and the bestool kopia wiring.** It's cheap, it's a known unknown, and it
 changes two specs if it comes out the wrong way.

--- a/docs/plans/backup-credentials-implementation-order.md
+++ b/docs/plans/backup-credentials-implementation-order.md
@@ -1,0 +1,342 @@
+# Backup-credentials — cross-repo implementation order
+
+Direction / ordering doc for building the backup-credentials system across the
+four repos (`canopy`, `ops/pulumi`, `bestool`, `pgro`). It does **not** restate
+the design — read [`backup-credentials.md`](./backup-credentials.md) for that,
+and each component spec for the how. This document answers one question: **in
+what order, and on which tracks, do we build it so nothing waits on something
+that isn't there yet.**
+
+## The eight component specs
+
+| # | Component | Repo | Spec |
+|---|-----------|------|------|
+| 1 | canopy-database (tables, models, migrations) | canopy | [specs/canopy-database.md](./specs/canopy-database.md) |
+| 2 | canopy-public-server (device endpoints + AWS/kube on AppState) | canopy | [specs/canopy-public-server.md](./specs/canopy-public-server.md) |
+| 3 | canopy-jobs-maintenance-inspection (maintenance/inspection/S3-metrics/init Jobs) | canopy | [specs/canopy-jobs-maintenance-inspection.md](./specs/canopy-jobs-maintenance-inspection.md) |
+| 4 | canopy-jobs-detection-preflight (staleness, reconciliation, group-level alerting, preflight) | canopy | [specs/canopy-jobs-detection-preflight.md](./specs/canopy-jobs-detection-preflight.md) |
+| 5 | canopy-operator-ui (private-server fns + private-web) | canopy | [specs/canopy-operator-ui.md](./specs/canopy-operator-ui.md) |
+| 6 | ops (per-bucket roles, IRSA/ServiceAccounts, OIDC, scheduler Deployments) | ops/pulumi | [../../../ops/pulumi/docs/canopy-backup-credentials.md](../../../ops/pulumi/docs/canopy-backup-credentials.md) |
+| 7 | bestool (device `backup-credentials` / `backup` subcommands) | bestool | [../../../bestool/docs/canopy-backup-credentials.md](../../../bestool/docs/canopy-backup-credentials.md) |
+| 8 | pgro (restore consumer + signal-3 restore-verification) | pgro | [../../../pgro/docs/canopy-backup-integration.md](../../../pgro/docs/canopy-backup-integration.md) |
+
+---
+
+## Dependency graph (derived from each spec's provides / depends_on)
+
+Arrows mean "depends on / must exist or be stubbed first".
+
+```
+                         ┌─────────────────────────────────────────────┐
+                         │  SPIKE: kopia vs GOVERNANCE-default-retention │
+                         │  bucket, no client-side PutObjectRetention    │
+                         │  (gates ops A2 action-set + bestool kopia)    │
+                         └───────────────┬─────────────────────────────-┘
+                                         │ (verifies an assumption; doesn't block code start)
+                                         ▼
+   (1) canopy-database  ◄──────────────────────────── everything in canopy reads/writes these tables
+        │  tables, models, lib.rs re-exports, commons-types enums,
+        │  Option-B group-scoped-issues migration handled with (4)
+        │
+        ├──────────────┬───────────────────────┬──────────────────────┐
+        ▼              ▼                       ▼                      ▼
+   (2) public-server  (3) jobs-maint/insp   (4) jobs-detect/preflight  (5) operator-ui
+   AWS SDK + kube      kube client + Job-     group-level alerting       private-server fns
+   on AppState;        spawn lib; init Job;   (Option-B issues);         + private-web; reads
+   /backup-* endpoints maintenance/inspection staleness + reconcile;     status/stats; reveal
+        │              /S3-metrics schedulers preflight (AWS)            escrow (needs kube)
+        │                    │                      │
+        │   contracts: HTTP endpoint shapes, IRSA role ARNs / ServiceAccount subs, billing labels
+        ▼                    ▼                      ▼
+   (6) ops  ◄────────────────┴──────────────────────┘   provides per-bucket role ARNs, IRSA roles,
+        │   OIDC providers, scheduler Deployments; consumes canopy SA names + OIDC issuer URL
+        │
+   (7) bestool ◄── public-server endpoints (2) + the kopia spike
+        │
+   (8) pgro    ◄── restore endpoint + external-restore grant + first-party auth (canopy, later)
+                   + a non-chained / longer-lived restore-cred decision
+```
+
+Two cross-cutting net-new capabilities sit underneath most of canopy and are
+the real gate (see Critical path):
+
+- **AWS SDK + kube client** — first use anywhere in canopy. Lands on
+  `public-server` (component 2) and the `jobs` crate (components 3/4).
+- **ServiceAccount + IRSA + OIDC** — first ServiceAccount canopy has ever had.
+  Owned by ops (component 6), consumed by 2/3/4.
+
+The canopy↔ops boundary is **mutually dependent** and resolved by contract, not
+by serialising: canopy publishes the SA names + central-cluster OIDC issuer
+URL; ops publishes the per-bucket role ARNs + IRSA role ARNs. Each side codes
+against the agreed names and the two meet at deploy.
+
+---
+
+## The early blocker: kopia-behaviour verification spike
+
+**Do this first, in parallel with stage 0, before committing the ops action-set
+and the bestool kopia wiring.** It's cheap, it's a known unknown, and it
+changes two specs if it comes out the wrong way.
+
+The question (from ops spec A2 / bestool open-Q 2 / canopy-database H3): does
+kopia **write and maintain** against an S3 bucket with **GOVERNANCE 30-day
+default Object-Lock retention** when the client has **no `s3:PutObjectRetention`**
+(the device action set is `AWS_S3_MULTIPART_ACTIONS`, delete- and
+retention-free)? Also confirm:
+
+- kopia's S3 backend honours `AWS_SESSION_TOKEN` temporary creds (pgro open-Q 2;
+  bestool credential_process path).
+- `--override-hostname` exists on the installed kopia for source-host = server-id
+  (bestool open-Q 3).
+- which `BucketSizeBytes` `StorageType` dimension a versioned+locked bucket emits
+  (jobs-maint open-Q 6) — needed by the S3-metrics task, lower-stakes, can trail.
+
+Outcome drives:
+- **ops A2**: device role is exactly `AWS_S3_MULTIPART_ACTIONS`, or that **plus**
+  `s3:PutObjectRetention` (safe under GOVERNANCE-without-bypass — can only
+  lengthen a lock). Don't finalise the managed policy until this is known.
+- **bestool kopia helpers**: connect/snapshot wiring and how creds reach kopia.
+
+Run it against a throwaway dev bucket the ops `backups` stack can stand up. If it
+comes back "kopia insists on PutObjectRetention", the fallback is already
+specified — re-grant it — so this never blocks, it just picks a branch. Start
+the spike at day 0; it must conclude before ops merges the action-set change and
+before bestool finalises the kopia connect path.
+
+---
+
+## Critical path
+
+The longest chain of hard dependencies, and what unblocks the most downstream
+work, is:
+
+1. **Net-new enabling work** (the gate for all of canopy):
+   - **(1) canopy-database** — tables, models, `lib.rs` re-exports, and the
+     shared `commons-types` enums (`Purpose`/`Outcome`/`kind`). Nothing in
+     canopy compiles against these until they exist. This is the true
+     foundation; land it first.
+   - **AWS SDK + kube client deps + AppState wiring** (inside component 2) and
+     the **kube client + Job-spawn library** (inside component 3). First AWS/k8s
+     code in the repo; verify crate versions against the registry (no guessing),
+     pin `k8s-openapi` to the cluster's control-plane version.
+   - **(6) ops IRSA/ServiceAccount/OIDC + per-bucket role ARNs** — without the
+     ServiceAccount + IRSA trust, no canopy pod can `AssumeRole`, and without the
+     role ARNs there's no `target_role_arn` to put in config. This runs in
+     parallel with the canopy enabling work, joined by the ARN/SA-name contract.
+
+2. **The issuance hot path**: (1) → (2) public-server `/backup-credentials` +
+   `/backup-target` + `/backup-report`, against (6)'s role ARNs and Secret-read
+   RBAC. This is the contract bestool consumes.
+
+3. **bestool (7)** — needs (2)'s endpoint shapes live (or contract-frozen) and
+   the kopia spike concluded.
+
+4. **pgro (8)** — additive last stage; needs the restore endpoint, the
+   external-restore grant, first-party auth, and a longer-lived-cred decision,
+   none of which exist until canopy ships its restore surface.
+
+The single highest-leverage item is **canopy-database (1)**: components 2, 3, 4,
+and 5 all import its models. Land it, with the `commons-types` enums, before the
+four canopy tracks fan out. The second is the **ops IRSA/OIDC plumbing (6)**,
+because it's the longest-lead infra item and gates every AWS-touching code path
+at deploy time even though the code can be written against the contract earlier.
+
+---
+
+## Build order (stages)
+
+Stages are sequencing guidance, not hard gates — within a stage, tracks run in
+parallel. A later stage starts when its named dependencies from the earlier
+stage are merged (or contract-frozen and stubbed).
+
+### Stage 0 — foundations (must land first)
+
+- **Spike**: kopia-behaviour verification (above). Parallel, concludes before
+  ops action-set + bestool kopia.
+- **(1) canopy-database**: the `backup_credentials` migration (all 7 tables),
+  `backups.rs` models + `lib.rs` re-exports, the `commons-types`
+  `Purpose`/`Outcome`/`kind` enums. Resolve its open decisions up front because
+  they ripple: enum representation (shared enums vs validated String), the
+  `backup_runs` client-supplied-PK → `AppError::Conflict` mapping, cascade
+  policy for stats/requests vs the no-cascade audit rule, and the
+  `backup_repo_snapshots.server_id` on-delete behaviour. DB-only tests via
+  `TestDb::run`.
+- **(6) ops — contract freeze + long-lead infra**: agree the names/ARNs both
+  sides code against (`canopyIssuerRoleArn`, `canopyJobsRoleArn`,
+  `canopy-issuer`/`canopy-jobs` ServiceAccount subs, central-cluster OIDC issuer
+  URL, per-bucket `deviceRoleArn`/`maintenanceRoleArn`, the
+  `billing.{product,stage,deployment}` label keys). Then start the actual
+  Pulumi: Component B (central ServiceAccounts + IRSA + RBAC, `spec.ts`
+  `serviceAccountName`), Component A1/A3/A4/A6 (per-bucket trust, Object-Lock
+  read action, ARN exports, lifecycle rules), Component C (OIDC provider per
+  deployment account). A2 (action-set reduction) waits on the spike.
+
+The canopy↔ops contract is the coordination spine for everything after.
+
+### Stage 1 — issuance hot path + enabling clients (the device-facing MVP)
+
+Depends on Stage 0's (1) and the (6) contract.
+
+- **(2) canopy-public-server**: add the AWS SDK + kube deps, the
+  `AppState.sts` / `AppState.kube` fields + `FromRef` impls + async init,
+  `AppError::Upstream` (502) + ERRORS.md, and the three handlers
+  (`/backup-credentials`, `/backup-target`, `/backup-report`) with the restore
+  session-policy builder. This component **owns** the AWS/kube-on-AppState
+  capability the rest of canopy reuses. Tests: the 412/409/502 resolution
+  matrix with `None` clients, the session-policy unit test, a stubbed-STS 200
+  path.
+
+This is the first end-to-end slice: a device can mint creds and report a run.
+
+### Stage 2 — control-plane jobs (parallel canopy tracks)
+
+All depend on Stage 0 (1) and reuse the AWS/kube patterns from Stage 1 (2).
+These three run in parallel with each other and with bestool.
+
+- **(3) canopy-jobs-maintenance-inspection**: the shared Job-spawn library
+  (recommended `commons-servers::backup_jobs` so private-server can call the
+  init-Job spawn without depending on the `jobs` crate), the three scheduler
+  bins (maintenance / inspection / S3-metrics), the kopia-Job arg contract, and
+  the migrations it owns (`backup_maintenance_runs`, `backup_repo_snapshots`,
+  `backup_repo_stats`) — coordinate with (1) on single-vs-split migration
+  ownership.
+- **(4) canopy-jobs-detection-preflight**: the **Option-B group-scoped-issues
+  migration** + the thorough `issues.rs` sweep (this is the largest single
+  decision in the system and the central new shared plumbing —
+  `raise_group_event` is consumed by the inspection Job in (3) and PGRO ingest
+  in (8)), the `backup_staleness` and `backup_preflight` bins, and the shared
+  `jitter_slot` helper. Resolve Option A vs B before building; recommend B.
+- **(6) ops — scheduler Deployments**: B4 wires the
+  `backup-maintenance`/`backup-inspection`/`backup-preflight` (and possibly
+  `backup-s3-metrics`/`backup-staleness`) single-replica Deployments on the
+  `canopy-jobs` SA, once the bin names are pinned by (3)/(4).
+
+Cross-track coordination inside Stage 2:
+- (3) and (4) **share** `commons-servers` helpers (`jitter_slot`,
+  retention-floor) and the `(source, ref)` alert keys — agree these once.
+- The group-level alerting path from (4) is a **prerequisite** for (3)'s
+  corruption alert and (4)'s own group-level refs — (4) should land the Option-B
+  plumbing early in the stage so (3) can call `raise_group_event`.
+
+### Stage 3 — operator UI + device client (parallel)
+
+- **(5) canopy-operator-ui**: private-server `/api/backups/*` fns + the React
+  screens. Depends on (1) models, reuses (2)'s kube client for `reveal_escrow`
+  (resolve open-Q: private-server gets its own `canopy-issuer` SA + Secret-read
+  RBAC — coordinate with ops open-Q 2), and depends on (3)'s init-Job contract
+  for the `provisioning → escrow_pending/ready` lifecycle. `just gen-openapi` +
+  Playwright e2e in the same change.
+- **(7) bestool**: the two subcommands + `CanopyClient` methods, against (2)'s
+  frozen endpoint shapes and the concluded kopia spike. The "back up now"
+  command-channel transport is **deferred upstream** — build the
+  transport-independent subcommands now; wire the trigger when canopy defines
+  the status-response payload.
+
+(5) and (7) are independent and parallel. (7) can start as soon as (2)'s
+endpoint contract is frozen, even before (3)/(4) land.
+
+### Stage 4 — PGRO (additive, last)
+
+- **(8) pgro**: restore-consumer CRD (`canopyBackup.group`), `fetch_restore_creds`
+  / `report_restore`, signal-3 `RestoreReport` into a future
+  `backup_restore_checks` table + the `restore-verification` group-level alert
+  (routed through (4)'s `raise_group_event`).
+
+PGRO is explicitly last because it needs canopy-side surfaces that don't exist
+until the earlier stages ship:
+- a **restore-credentials** path (purpose=restore creds + target + repo
+  password) — built on (2);
+- the **external-restore grant** (operator-authorized, audited "consumer pgro
+  may read group X read-only") — net-new canopy authz surface;
+- a **first-party non-device auth** path (Tailscale now, OIDC later) — joint
+  canopy+ops design;
+- the **`backup_restore_checks` table + ingest endpoint + signal-3 detection**;
+- a **decision on longer-lived / non-chained restore creds** so restores >1h
+  survive (mirror the maintenance-Job direct web-identity). **This decision is
+  owed by canopy and should be made during Stage 2** (when the maintenance-Job
+  direct-web-identity path is built) so PGRO isn't blocked on it in Stage 4.
+
+---
+
+## Parallelizable tracks (one per repo)
+
+Once Stage 0's (1) + (6)-contract land, the repos proceed largely in parallel,
+coordinated only by the contracts named below.
+
+- **canopy track**: (1) → then (2), (3), (4), (5) fan out. (2) blocks (7) (HTTP
+  contract). (4)'s Option-B plumbing blocks (3)'s corruption alert. (5) needs
+  (3)'s init-Job contract and (2)'s kube client.
+- **ops track**: (6) runs alongside the canopy enabling work, joined by the
+  ARN/SA-name contract; its scheduler-Deployment piece (B4) trails (3)/(4)'s bin
+  names.
+- **bestool track**: (7) starts when (2)'s endpoint shapes are frozen and the
+  spike is done; otherwise independent of (3)/(4)/(5).
+- **pgro track**: (8) is last; nothing else depends on it.
+
+### The contracts that let the tracks run independently
+
+1. **HTTP endpoint shapes** (canopy public-server ⇆ bestool, and later ⇆ pgro):
+   `POST /backup-credentials`, `GET /backup-target`, `POST /backup-report` —
+   request/response bodies, the 412/409/502 semantics, and `backup_runs.id` =
+   client-minted UUID PK with `device_id`/`group_id` server-derived. Freeze
+   these from spec (2)/(7) before bestool starts; bestool's `canopy_contract.rs`
+   `#[ignore]`d suite is the drift detector.
+2. **IRSA role ARNs + ServiceAccount subs + OIDC issuer** (canopy ⇆ ops):
+   `target_role_arn` (= ops `deviceRoleArn`), `maintenanceRoleArn`,
+   `canopyIssuerRoleArn`, `canopyJobsRoleArn`, the central-cluster OIDC issuer
+   URL, and the `canopy-issuer`/`canopy-jobs` SA names in namespace
+   `tamanu-meta-<stack>`. The hard isolation invariant: the maintenance/
+   fullaccess role MUST NOT trust the issuer principal.
+3. **Billing label keys** (canopy ⇆ ops): `billing.{product,stage,deployment}`,
+   with `ServerRank::Production → "prod"` (the load-bearing mapping gotcha).
+4. **Shared `commons-types` enums** (canopy-internal, spec 1): `Purpose` /
+   `Outcome` / `kind` shared across public-server, jobs, and the generated
+   `api-types.ts`, so the three components don't drift.
+5. **`raise_group_event` group-level alert entrypoint** (spec 4, consumed by 3
+   and 8): the single place that opens a group-scoped incident bypassing
+   `is_monitored`.
+6. **Init-Job lifecycle contract** (spec 3 ⇆ spec 5): UI sets
+   `status='provisioning'` + clears `last_init_error`; the init Job transitions
+   to `escrow_pending`/`ready` or sets `last_init_error`. UI depends only on the
+   observable fields, not the handoff mechanism.
+7. **kopia Job image + entrypoint arg contract** (ops-built image ⇆ canopy jobs
+   ⇆ bestool source conventions): args (bucket/prefix/region/role/retention/
+   run-id), `secretKeyRef` password mount, source-host `canopy@<server-id>`,
+   snapshot tags `canopy-device`/`canopy-run`.
+
+---
+
+## Cross-cutting decisions to settle before the dependent stage
+
+These appear in multiple specs' open questions; resolving them early prevents
+rework. Each is tagged with the latest stage by which it must be decided.
+
+- **Enum representation** (`commons-types` shared vs validated String) — **Stage 0**,
+  blocks (1) and the generated `api-types.ts`.
+- **Migration ownership** (one `backup_credentials` migration vs split across
+  (1)/(3)) — **Stage 0/2**, coordinate (1) and (3).
+- **Group-level alerting Option A vs B** — **Stage 2**, recommend B; blocks (3)'s
+  corruption alert and all group-level refs in (4).
+- **Where `reveal_escrow` reads the Secret** (private-server own kube client) —
+  **Stage 3**, ties to ops open-Q 2 (does private-server get `canopy-issuer`).
+- **Longer-lived / non-chained restore creds for first-party consumers** —
+  **Stage 2** (decided when the maintenance-Job direct-web-identity lands), so
+  (8) isn't blocked.
+- **"Back up now" command-channel transport** — deferred upstream; **does not
+  block** Stage 3's bestool subcommands, which are transport-independent.
+- **kopia + default-retention without PutObjectRetention** — the **spike**;
+  blocks ops A2 and bestool kopia wiring.
+
+---
+
+## Summary one-liner per stage
+
+- **Stage 0**: land the DB layer + shared enums (1); freeze the canopy↔ops
+  contract and start the long-lead IRSA/OIDC infra (6); run the kopia spike.
+- **Stage 1**: build the issuance hot path + the AWS/kube-on-AppState
+  capability (2) — first end-to-end device slice.
+- **Stage 2**: the control-plane Jobs (3) + detection/preflight + group-level
+  alerting (4) in parallel, plus ops scheduler Deployments; decide restore-cred
+  lifetime here.
+- **Stage 3**: operator UI (5) and the bestool device client (7) in parallel.
+- **Stage 4**: PGRO restore-verification (8), additive and last.

--- a/docs/plans/backup-credentials-kopia-spike.md
+++ b/docs/plans/backup-credentials-kopia-spike.md
@@ -1,0 +1,166 @@
+# kopia-behaviour verification spike (day-0 blocker)
+
+Resolves the spike named in
+[`backup-credentials-implementation-order.md`](./backup-credentials-implementation-order.md).
+Its job: pick the device IAM action-set branch and confirm the kopia
+assumptions, so ops can finalize the managed policy and bestool can wire
+the kopia connect/snapshot path.
+
+**Method:** authoritative from kopia docs + source and S3 semantics (no
+live test was runnable in-session — no kopia binary, no valid AWS creds).
+A gold-standard live-test script is at the end; the *decision* doesn't wait
+on it, but two items (PIT on real AWS, the bucket-default-retention write
+path) warrant a live confirm before relying on them.
+
+## Verdict
+
+**Branch A confirmed: device creds = `AWS_S3_MULTIPART_ACTIONS` (no
+`s3:PutObjectRetention`, no `s3:DeleteObject`); the kopia repo is created
+*non-lock-aware*; we rely on the bucket's default GOVERNANCE 30-day
+retention + versioning + lifecycle.** Ops can finalize the device managed
+policy as exactly `AWS_S3_MULTIPART_ACTIONS`.
+
+## Findings (per question)
+
+### 1. PutObjectRetention vs bucket-default retention (the branch decision)
+
+kopia needs `s3:PutObjectRetention` **only when it manages retention
+itself** — i.e. the repo is created with `--retention-mode` and locks are
+renewed via full-maintenance `--extend-object-locks`. That's the
+kopia-documented "ransomware" path, and it's confirmed that even with
+`--extend-object-locks` kopia still requires `PutObjectRetention` on the
+primary bucket (so it can't be isolated away).
+
+We deliberately do **not** use that mode. Instead we create a *plain*
+kopia repo (no `--retention-mode`) against a bucket whose **default object
+lock retention** is GOVERNANCE 30d. S3 applies the default retention to
+every `PutObject` **server-side**, which requires only `s3:PutObject` — not
+`s3:PutObjectRetention`. So the device key needs neither delete nor
+retention permission. ✔ matches the plan's H3.
+
+- **Consequence (already accepted):** without `--extend-object-locks`, a
+  live blob's lock is fixed at 30d from its last write and never renewed.
+  Irrelevant under the device-compromise threat (the device can't delete);
+  it only matters against an AWS-level attacker, which is out of scope.
+  Re-enabling renewal later = lock-aware mode + `PutObjectRetention` on the
+  **maintenance** role (never the device).
+- **Caveat:** this is *not* the kopia-documented happy path; it rests on S3
+  default-retention semantics (solid) rather than a kopia doc page. Live
+  test item (a) confirms kopia writes + maintains happily this way.
+
+### 2. Maintenance deletes on a versioned bucket (H2)
+
+Non-lock-aware kopia issues real `DeleteObject`; on a versioned bucket that
+writes a **delete marker** (succeeds, reclaims nothing) — it does **not**
+error. Reclamation is via the S3 lifecycle `noncurrentVersionExpiration`
+rule, as the plan says. The maintenance role needs `s3:DeleteObject` (it
+has it). (Note: kopia *also* has a "hidden marker" soft-delete it uses with
+restricted/lock-aware keys — not our path; our maintenance role deletes for
+real and lets lifecycle reclaim.) ✔ matches the plan's H2; the earlier
+"throws errors on locked deletes" framing was wrong.
+
+### 3. Temporary credentials / `credential_process` (`AWS_SESSION_TOKEN`)
+
+`kopia repository create/connect s3` supports `--session-token` (and the
+`AWS_SESSION_TOKEN` env). So the short-lived STS creds (which include a
+session token) work, and the `credential_process`-style refresh is viable.
+✔ unblocks the bestool credential path.
+
+### 4. Source host = server-id
+
+`--override-hostname` and `--override-username` exist, set at **`kopia
+repository connect`** time (connection-level, *not* per-snapshot — the
+per-snapshot `--hostname`/`--username` were removed in 0.6.0). bestool
+reconnects per run (it re-derives the connection from Canopy every run), so
+it passes `--override-hostname=<server-id>` (`--override-username=canopy`)
+on connect → source `canopy@<server-id>:<path>`. The **type** goes in the
+path and a `canopy-type=<type>` snapshot tag (`kopia snapshot create
+--tags`). ✔ matches the plan's per-`(server, type)` source model.
+
+### 5. Point-in-time recovery (H1)
+
+`kopia repository connect … --point-in-time=<ts>` exists and is the
+documented recovery path for a versioned+locked bucket (recover to before
+a poisoning/deletion). ✔ the H1 recovery runbook is real.
+
+- **Caveat:** GitHub issue #4346 reports `--point-in-time` failing with
+  "repository not initialized" on some S3-*compatible* endpoints, and
+  #3492 covers a recovery edge case (missing files after deleted objects).
+  Real AWS S3 is kopia's primary supported target, but **PIT recovery must
+  be live-tested on real AWS S3** before we depend on it operationally —
+  it's our break-glass path. Live test item (b).
+
+### 6. CloudWatch `BucketSizeBytes` dimension (lower-stakes, may trail)
+
+`BucketSizeBytes` carries a `StorageType` dimension, and **all object
+versions (current + noncurrent) count** toward it per storage class. So the
+S3-metrics task sums `BucketSizeBytes` across the relevant `StorageType`s —
+`StandardStorage` plus the intelligent-tiering classes (`.storageconfig`
+puts pack blobs in `INTELLIGENT_TIERING`). Confirm the exact emitted
+dimensions against a real bucket. Lower-stakes; `bucket_bytes` is
+best-effort anyway.
+
+## What this unblocks
+
+- **ops** (action-set): the device role = `AWS_S3_MULTIPART_ACTIONS`, no
+  `PutObjectRetention`. The repo is created non-lock-aware; the bucket
+  keeps its default GOVERNANCE 30d retention + the lifecycle rules.
+- **bestool** (kopia wiring): connect with `--session-token` +
+  `--override-hostname=<server-id>`; `kopia snapshot create --tags
+  canopy-device=… canopy-run=… canopy-type=…`; do **not** pass
+  `--retention-mode`.
+
+## Remaining live confirmations (run when a throwaway bucket + creds exist)
+
+These don't change the branch; they de-risk the two assumptions that rest
+on semantics/known-issues rather than a kopia doc. Script below.
+
+(a) Plain kopia repo create + snapshot + maintenance against a versioned,
+    default-GOVERNANCE-retention bucket, using a **device key without
+    PutObjectRetention/Delete** and a **maintenance key with delete** —
+    confirm no `AccessDenied` for retention and that maintenance succeeds.
+(b) `--point-in-time` reconnect works on real AWS S3.
+(c) The `BucketSizeBytes` `StorageType` dimensions emitted.
+
+```bash
+#!/usr/bin/env bash
+# Operator-run live confirmation. Needs: aws cli with creds, kopia.
+# Creates a throwaway bucket — review + delete after.
+set -euo pipefail
+B="bes-kopia-spike-$(date +%s)"; R="ap-southeast-2"
+KP="spike-pass-$(openssl rand -hex 8)"
+
+# 1. Versioned bucket + object lock + 30d GOVERNANCE default retention
+aws s3api create-bucket --bucket "$B" --region "$R" \
+  --create-bucket-configuration LocationConstraint="$R" \
+  --object-lock-enabled-for-bucket
+aws s3api put-object-lock-configuration --bucket "$B" \
+  --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=GOVERNANCE,Days=30}}'
+
+# 2. DEVICE creds: NO delete, NO PutObjectRetention (AWS_S3_MULTIPART_ACTIONS).
+#    Use a scoped IAM user/role with: s3:GetObject,PutObject,
+#    AbortMultipartUpload,ListBucketMultipartUploads,ListMultipartUploadParts,
+#    ListBucket,GetBucketLocation on the bucket. Export its creds, then:
+kopia repository create s3 --bucket "$B" --region "$R" --password "$KP" \
+  --override-hostname server-test --override-username canopy
+#    ^ EXPECT: success. FAIL = AccessDenied mentioning PutObjectRetention
+#      → fall back to granting PutObjectRetention (safe; lengthen-only).
+echo hello > /tmp/spike.txt
+kopia snapshot create /tmp/spike.txt --tags canopy-type:tamanu-postgres
+aws s3api list-object-versions --bucket "$B" --query 'Versions[0].ObjectLockMode' # EXPECT: GOVERNANCE (default applied on PUT)
+
+# 3. MAINTENANCE creds: full S3 incl. delete. Re-connect with those, then:
+kopia maintenance run --full --safety none   # EXPECT: success; deletes become markers
+aws s3api list-object-versions --bucket "$B" --query 'DeleteMarkers' # EXPECT: markers present, no errors
+
+# 4. PIT (item b): note a timestamp, mutate, then:
+kopia repository connect s3 --bucket "$B" --region "$R" --password "$KP" \
+  --point-in-time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"   # EXPECT: connects (watch for issue #4346)
+
+# 5. CloudWatch dimensions (item c): after metrics populate (~a day),
+aws cloudwatch list-metrics --namespace AWS/S3 --metric-name BucketSizeBytes \
+  --dimensions Name=BucketName,Value="$B"
+
+# cleanup: object-locked objects can't be deleted for 30d; the throwaway
+# bucket will linger until the lock lapses (expected). Tag it for teardown.
+```

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -164,8 +164,7 @@ CREATE TABLE server_group_backup_config (
     bucket            TEXT NOT NULL,           -- this group's own bucket (one bucket per group)
     prefix            TEXT NOT NULL DEFAULT '', -- usually empty: the repo lives at the bucket root
     target_role_arn   TEXT NOT NULL,           -- per-bucket role Canopy assumes (encodes the account; may be cross-account)
-    region            TEXT,                    -- NULL → deployment default
-    endpoint          TEXT,                    -- NULL → AWS; set for non-AWS S3
+    region            TEXT,                    -- NULL → deployment default (AWS region)
     expected_interval INTERVAL,                -- NULL → manual-only (no schedule, no staleness); set → scheduled cadence + staleness
     retention         JSONB NOT NULL,          -- kopia keep-* policy; Canopy asserts it into the repo
     repo_password_ref TEXT NOT NULL,           -- reference to the secret, NOT the secret
@@ -188,7 +187,7 @@ handling — Canopy just assumes the configured ARN. The group → bucket →
 role relationship is 1:1; what varies N:M (servers spanning accounts,
 groups sharing an account) lives outside this row. See "IAM model".
 
-`region`/`endpoint` are what `GET /backup-target` serves to devices.
+`region` (an AWS region) is what `GET /backup-target` serves to devices.
 `expected_interval` is the group's **declared backup cadence** and the
 single source for it: it both paces the devices (see "Backup cadence")
 and drives staleness detection — so schedule and alert can't drift apart.
@@ -380,7 +379,6 @@ GET /backup-target
     "bucket": "...",
     "prefix": "",             -- normally empty (repo at bucket root); non-empty only for a sub-path
     "region": "...",
-    "endpoint": "...",        -- optional; for non-AWS S3
     "repo_password": "..."    -- the kopia repo passphrase (read from the k8s Secret)
   }
   Response 412: device not bound to a live server (DeviceHasNoServer)
@@ -397,7 +395,7 @@ the stage-1 accepted-risk note and the blind-relay stub both cover.)
 This is the piece that keeps the bucket out of device provisioning. The
 `credential_process` output format (above) is **fixed by the AWS SDK** and
 carries only the four credential fields — it cannot carry the bucket,
-prefix, region, or endpoint. Yet the device must know all of those to
+prefix, or region. Yet the device must know all of those to
 address S3 at all. So rather than baking them into each device's kopia
 config at provision time (which would make "rotating bucket / changing
 prefix" a per-device reconfiguration, not the server-side-only change this
@@ -431,10 +429,10 @@ completed", and it is the input to staleness detection below. A device
 that fails to even reach this endpoint shows up as staleness (no recent
 success), so a crashed run is not silent.
 
-(`region`/`endpoint` are per-group columns on `server_group_backup_config`
-— each group's bucket can live in its own region, or behind a non-AWS S3
-endpoint. They're read from config, not snapshotted; the issuance audit
-log snapshots only `bucket`/`prefix` — see `backup_credential_issuances`.)
+(`region` is a per-group column on `server_group_backup_config` — each
+group's bucket can live in its own AWS region. It's read from config, not
+snapshotted; the issuance audit log snapshots only `bucket`/`prefix` — see
+`backup_credential_issuances`.)
 
 `purpose` is a real capability gate, not just audit metadata:
 
@@ -790,7 +788,7 @@ holds no hardcoded bucket:
 bestool canopy backup [--purpose backup|restore]
 ```
 
-- `GET /backup-target` to learn `{bucket, prefix, region, endpoint}`
+- `GET /backup-target` to learn `{bucket, prefix, region}`
   **on every run** — never cached to persistent device config.
 - Reconciles the kopia repository connection against that target (so a
   changed bucket/prefix is picked up here), with
@@ -1204,11 +1202,10 @@ to point at. We should learn that from Canopy checking itself, not from
 devices starting to fail.
 
 **It runs per server-group, not fleet-wide.** Each group has its own
-bucket with its own `region`/`endpoint` and its own Object Lock config,
-so bucket-level access can differ per group — and with a non-AWS-S3
-`endpoint`, the cred pathway differs too (it isn't reached via AWS STS at
-all). So a failure is normally *scoped to one group*; it's only fleet-wide
-when the genuinely shared piece breaks. The preflight reflects that split:
+bucket (its own account, region, role, and Object Lock config), so
+bucket-level access can differ per group. A failure is therefore normally
+*scoped to one group*; it's only fleet-wide when the genuinely shared
+piece breaks. The preflight reflects that split:
 
 Shared, checked once:
 - **Identity resolves** — `sts:GetCallerIdentity` confirms the pod's IRSA
@@ -1286,7 +1283,7 @@ Surface it loudly; don't take Canopy down over it.
   inserted. Devices in the group start succeeding on their next run; if
   the row lands before the bucket, the preflight alerts and issuance
   fails cleanly rather than corrupting anything.
-- **Changing region or endpoint** — update the
+- **Changing region** — update the
   `server_group_backup_config` row. Each device picks it up on its next
   scheduled `bestool canopy backup` (every-run target fetch); no per-host
   command, no coordinated cutover. Staleness detection flags any host

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -840,10 +840,15 @@ rides the existing ~1-minute device↔canopy healthcheck** rather than a
 separate device-side timer. On each tick Canopy answers "back up now /
 nothing to do," and the device launches `bestool canopy backup` as its
 own process when told. This drops responsiveness from a coarse local timer
-to ~1 minute essentially for free (the tick already happens), and a
-held-open bestool connection makes it cheaper still — near-instant if we
-want push. The device holds no schedule of its own; the existing tick *is*
-the trigger.
+to ~1 minute essentially for free (the ~1-minute device report cadence is
+long-established — it predates this plan and already underpins
+`reachability` and the rest of canopy's health tracking — so it's a given,
+not an assumption to validate), and a held-open bestool connection makes
+it cheaper still — near-instant if we want push. The device holds no
+schedule of its own; the existing tick *is* the trigger. (What *is*
+unspecified is the command-channel transport — today's status-POST
+*response* carries no command — which is the deferred item below, not the
+cadence.)
 
 Canopy computes "back up now?" as **"the schedule is due OR an operator
 requested a one-off":**

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -486,21 +486,22 @@ enable versioning + Object Lock with the default ≥30-day retention.
 Getting this wrong isn't fixable in place; it means recreating the
 bucket.
 
-Who provisions it is a decision (flagged in open questions), and it
-trades off against privilege:
+**IaC provisions the buckets.** A Terraform module (or equivalent)
+creates each group's bucket — with versioning + Object Lock + default
+retention — when a group is onboarded, following the naming convention
+the IAM patterns key off. Canopy only ever *uses* the bucket; it is never
+granted `CreateBucket` or bucket-config powers, keeping those out of the
+public-server's blast radius. Canopy's role is to *verify*, not create:
+the per-group preflight checks the bucket exists, is reachable, and has
+the expected Object Lock — so a missing or misconfigured bucket (e.g. IaC
+not yet applied for a new group, or the lock dropped) surfaces as an
+alert naming that group, rather than as silent backup failure.
 
-- **Out-of-band (IaC / admin step):** a Terraform module or admin tool
-  creates the bucket with lock when a group is onboarded; Canopy only
-  *uses* it (and the preflight verifies it). Keeps `CreateBucket` and
-  bucket-config powers out of the public-server's blast radius.
-- **Canopy-driven:** Canopy creates the bucket on group-config setup.
-  More "behind the scenes" but hands the control plane bucket-creation
-  authority, a meaningful privilege increase.
-
-Recommend out-of-band provisioning with preflight verification for the
-first cut: bucket creation is rare (once per group) and heavyweight, and
-the preflight already checks the lock is correct — so we get the
-"managed" feel without granting `CreateBucket` to the request path.
+This means group onboarding is a two-step dance — IaC applies the bucket,
+then the `server_group_backup_config` row is inserted — and the ordering
+matters: insert the row before the bucket exists and the group's devices
+get clean preflight/issuance failures (not corruption), which the alert
+makes obvious. Worth noting for the onboarding runbook.
 
 ## `bestool` changes
 
@@ -871,9 +872,11 @@ Surface it loudly; don't take Canopy down over it.
   its Object-Lock'd objects persist independently — they can't be deleted
   until their locks expire (~30 days), so bucket teardown is a deliberate,
   delayed step, not a side effect of removing the config row.
-- **Onboarding a group** — provision its bucket (with Object Lock, see
-  "Per-group buckets"), then insert the `server_group_backup_config` row.
-  Devices in the group start succeeding on their next run.
+- **Onboarding a group** — IaC provisions its bucket (with Object Lock,
+  see "Per-group buckets"), then the `server_group_backup_config` row is
+  inserted. Devices in the group start succeeding on their next run; if
+  the row lands before the bucket, the preflight alerts and issuance
+  fails cleanly rather than corrupting anything.
 - **Changing region or endpoint** — update the
   `server_group_backup_config` row. Each device picks it up on its next
   scheduled `bestool canopy backup` (every-run target fetch); no per-host
@@ -901,11 +904,10 @@ Surface it loudly; don't take Canopy down over it.
 
 None blocking, but flag-and-decide-during-implementation:
 
-- **Bucket provisioning ownership.** Out-of-band (IaC / admin) vs.
-  Canopy-driven `CreateBucket` (see "Per-group buckets"). Recommended
-  out-of-band for the first cut to keep `CreateBucket` out of the request
-  path; decide, and settle the bucket naming convention the IAM patterns
-  key off. Whichever, Object Lock must be enabled at creation.
+- **Bucket naming convention.** IaC provisions the buckets (decided —
+  see "Per-group buckets"); settle the exact name template (e.g.
+  `canopy-backup-<root-id>`) so the IaC module, the IAM role patterns,
+  and Canopy's `bucket` value all agree on it.
 - **Per-device session naming for CloudTrail.** Suggested
   `device-<uuid>`; check max length and allowed chars on
   `RoleSessionName`.

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -910,6 +910,28 @@ went, and a job scans those reports in the database.
    group recovery call.) Distinct from the `backup-monitoring` Pulumi stack
    (AWS Backup service), so this detection is genuinely new.
 
+   **`is_monitored` is absolute — by design, no backup exception.** Per-
+   server staleness events are always *recorded* (so they show on the
+   server's detail page / status indicator) but open an incident → Slack
+   *only* for monitored servers — exactly the existing gate. We don't
+   override it: some prods are intentionally intermittently-alive, and
+   per-server backup checks on them would be noise. An unmonitored server
+   in a backup-configured group thus has visible-but-non-paging backup
+   staleness. **But group-level checks must still page** (next).
+
+**Group-level checks alert regardless of `is_monitored`.** Whether Canopy
+can mint creds for a group, whether its bucket/Object-Lock is intact
+(preflight), whether maintenance is running, and whether the repo is
+corrupt (poisoning detection) are *group / control-plane* concerns, not
+any one server's — so they must **not** pass through the per-server
+`is_monitored` gate. **Mechanism wrinkle to settle:** the incident model
+is *server-keyed* (membership gates on a server's `is_monitored`), and
+there's no obvious "group-level issue with no server". So group-level
+alerts need a server-independent path — e.g. a group-scoped incident, or
+raising against the group rather than a member. Flagged for
+implementation; do not route these through a per-server `NewEvent`, which
+would inherit the monitored gate.
+
 The limit of signal 1 is that it's the *device's word*: it scans the
 Canopy database for what devices reported, not for what's actually in the
 bucket. A device that crashes before reporting looks (safely) stale; a

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -168,6 +168,7 @@ CREATE TABLE server_group_backup_config (
     expected_interval INTERVAL,                -- NULL → manual-only (no schedule, no staleness); set → scheduled cadence + staleness
     retention         JSONB NOT NULL,          -- kopia keep-* policy; Canopy asserts it into the repo
     repo_password_ref TEXT NOT NULL,           -- reference to the secret, NOT the secret
+    status            TEXT NOT NULL,           -- 'provisioning' | 'escrow_pending' | 'ready'; backups dormant until 'ready'
     created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -1190,6 +1191,51 @@ exact home (private-server, a dedicated worker, or a CronJob that itself
 fans out per-group Jobs) is an implementation detail to settle then;
 what's fixed is that it's Canopy's responsibility, not a client's.
 
+## Operator workflows & repo provisioning (private-server UI)
+
+Onboarding a group is a real workflow with operator UI shipping **in this
+plan** (private-server React, `TailscaleAdmin`-gated, fitting the existing
+`private-web` SPA/admin pattern), each screen with Playwright e2e coverage
+per AGENTS.md — *not* deferred to SQL bootstrap.
+
+**Repo creation.** "Canopy owns repo creation" is concrete: a one-shot
+Canopy-spawned **init Job** (kopia image) runs `kopia repository create`
++ asserts the initial retention policy, using the **maintenance role's**
+IRSA (creating the format blob needs more than the no-delete device set).
+It is triggered from the onboarding UI, not implicitly on first backup.
+
+**Lifecycle state** (`server_group_backup_config.status`):
+`provisioning` (init Job running) → `escrow_pending` (repo created,
+awaiting escrow ack) → `ready`. Backups stay **dormant (412/409)** until
+`ready`, so "authorized" = config set + repo created + escrow
+acknowledged.
+
+Screens:
+- **Onboarding / config** — set `bucket` / `target_role_arn` / `region` /
+  `expected_interval` / `retention`, and kick off repo creation.
+- **Escrow** — after creation, reveal the generated passphrase **once**
+  with a "saved to Bitwarden" acknowledgment that flips `escrow_pending →
+  ready` (from-birth repos only; imports skip — operator already has it).
+- **One-off "backup now"** — an operator button that enqueues a pending
+  request (see below); the device picks it up on its next ~1-minute tick.
+- **Stats panel** — read-only view of `backup_repo_stats` + recent
+  `backup_runs` per group.
+
+**One-off request state** (so the pending flag has a home):
+
+```sql
+CREATE TABLE backup_requests (
+    server_id    UUID NOT NULL REFERENCES servers(id),
+    purpose      TEXT NOT NULL,            -- "backup" | "restore"
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    requested_by TEXT,                     -- operator identity
+    PRIMARY KEY (server_id, purpose)
+);
+```
+
+A row makes Canopy answer "back up now" on the server's next tick
+(bypassing the cadence debounce); cleared when the run is reported.
+
 ## Upstream access preflight
 
 The device-staleness signals above watch the *devices*. This watches
@@ -1397,10 +1443,12 @@ as new `jobs`-crate bins; the `ServerRank::Production`→`"prod"` mapping;
 **Still open (genuine choices, not gaps):**
 - The **transport** for the cadence signal (how it rides today's
   ~1-minute healthcheck — tailnet poll / device poll / held-open).
-- Whether to expose an **operator "backup now"** action and stats in
-  `private-server` now or bootstrap via SQL first.
 - Tunable cadence defaults (heartbeat/inspection/maintenance/preflight) —
   chosen above, adjustable later.
+
+(The operator UI — onboarding, repo creation, escrow, one-off backup,
+stats — is **decided: ships in-plan**; see "Operator workflows & repo
+provisioning".)
 
 ## Out of scope (do not silently fold in)
 
@@ -1436,8 +1484,7 @@ as new `jobs`-crate bins; the `ServerRank::Production`→`"prod"` mapping;
   + `abortIncompleteMultipartUpload` — are now **in scope**, since they're
   load-bearing for GC on a versioned bucket; see "Interaction with
   versioning + the 30-day Object Lock".)
-- Operator UI in `private-server` / React for editing
-  `server_group_backup_config` (will want it eventually; not in the
-  first cut — bootstrap via SQL). This now includes the maintenance
-  schedule and the repo-password reference, still bootstrapped via SQL /
-  secret tooling for the first cut.
+- (No longer deferred: the operator UI for onboarding, repo creation,
+  escrow, one-off backup, and the stats panel **ships in this plan** — see
+  "Operator workflows & repo provisioning". What's still out is *bulk* /
+  fleet-wide config editing beyond the per-group onboarding screen.)

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -749,6 +749,55 @@ exact home (private-server, a dedicated worker, or a CronJob that itself
 fans out per-group Jobs) is an implementation detail to settle then;
 what's fixed is that it's Canopy's responsibility, not a client's.
 
+## Upstream access preflight
+
+The device-staleness signals above watch the *devices*. This watches
+**Canopy's own upstream access**, which is a different and higher-stakes
+failure class: if the trust on `canopy-backup-issuer` is edited, the pod's
+IRSA annotation is dropped, a role is deleted, or the bucket's Object Lock
+is removed, the failure is *fleet-wide and instantaneous* — every
+issuance 502s and every maintenance job fails at once. We should learn
+that from Canopy checking itself, not from devices starting to fail.
+
+A periodic preflight (control-plane health machinery, same alerting path
+but flagged at control-plane / fleet-wide severity, distinct from
+per-device staleness):
+
+- **Identity resolves** — `sts:GetCallerIdentity` confirms the pod's IRSA
+  web-identity is mounted and valid.
+- **Issuance chain works** — a dry-run `AssumeRole` on
+  `canopy-backup-issuer` with a harmless session policy, confirming the
+  trust policy + role still admit Canopy. Optionally use the returned
+  creds for a **read-only no-op** against the bucket (e.g. `HeadBucket` /
+  a scoped `ListBucket` on a probe prefix) so the check proves the creds
+  *work*, not merely that `AssumeRole` returned.
+- **Object Lock is in place** — verify the backups bucket still has the
+  expected (≥30-day) Object Lock configuration. The whole "a compromised
+  server can't destroy backups" guarantee rests on this; if someone
+  removes or weakens the lock, the protection silently erodes with no
+  other symptom, so it must be actively checked.
+- **Maintenance path** — either a cheap preflight maintenance Job
+  (connect to a repo + no-op and exit) on its own IRSA, or lean on
+  `backup_maintenance_runs` failures. The former is proactive; the latter
+  only catches it when maintenance next runs. Flagged below.
+
+Prefer **behavioural** checks (try to assume; try a harmless S3 op) over
+IAM/policy *introspection*: behavioural checks test the real path and
+need no extra `iam:Get*` permissions, except the Object Lock check, which
+does need `s3:GetBucketObjectLockConfiguration` — an acceptable read to
+add given how load-bearing the lock is. Consistent with the session-
+policy reasoning earlier: we care that the effect is right, not that a
+described config *looks* right.
+
+Reactively, the live paths are signals too: `/backup-credentials` already
+502s on STS failure and maintenance failures land in
+`backup_maintenance_runs` — track their rates so a regression surfaces
+between preflights, not only at the next scheduled probe.
+
+This should **alert, not gate readiness**: a failing upstream check
+pulling the pod out of rotation would only make a fleet-wide problem
+worse. Surface it loudly; don't take Canopy down over it.
+
 ## Operational story (what we gain, day-one)
 
 - **"Did device X back up today?"** — `backup_runs` gives the real
@@ -780,6 +829,10 @@ what's fixed is that it's Canopy's responsibility, not a client's.
   from a stuck client owner is no longer a failure mode, and
   `backup_maintenance_runs` + staleness alerting catch a stuck *Canopy*
   maintenance instead.
+- **A broken control plane is caught at the source** — the upstream
+  preflight alerts if Canopy loses its issuer access, or the bucket's
+  Object Lock is removed, *before* a single device fails, instead of the
+  fleet discovering it the hard way.
 
 ## Open questions
 
@@ -818,6 +871,12 @@ None blocking, but flag-and-decide-during-implementation:
   latest-snapshot inventory is stored (extend `backup_maintenance_runs`,
   or a dedicated table) and the inspection cadence if it's a job
   separate from maintenance.
+- **Preflight depth and cadence.** How often the upstream preflight runs,
+  and whether it does the deeper checks (S3 read no-op against a probe
+  prefix; `GetBucketObjectLockConfiguration`) or just `GetCallerIdentity`
+  + dry-run `AssumeRole`. Deeper = more confidence, slightly more IAM
+  surface. Also: proactive maintenance preflight Job vs. relying on
+  `backup_maintenance_runs` failures.
 - **Repo password storage.** Canopy owns the per-group kopia password;
   where does the secret actually live (k8s secret vs. Secrets Manager
   vs. ...) and how is it served to devices and injected into Jobs?

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -38,10 +38,11 @@ directly (no proxy through Canopy).
   of every backup to Canopy uptime, and a much larger protocol surface.
 - Cross-group restore. The endpoint signature can stay minimal because
   this is genuinely out of scope, not "deferred."
-- Cost dashboards and byte-level reconciliation against S3
-  inventory / CloudWatch. (Missed-backup alerting *is* in scope now —
-  see staleness detection — and maintenance/expiry execution is owned by
-  Canopy; what's deferred is cost/usage analytics.)
+- Cost *dashboards* and byte-level reconciliation against S3 inventory.
+  (A *basic* cached size/stats readout per group — `backup_repo_stats`,
+  including the CloudWatch `BucketSizeBytes` billing basis — *is* in scope
+  for display; missed-backup alerting and maintenance/expiry execution are
+  owned by Canopy. What's deferred is rich cost/usage *analytics*.)
 - Tuning the kopia *retention policy* values (keep N daily / M weekly).
   Canopy now *owns, declares, and enforces* the policy (see "Retention
   policy ownership") — the mechanism is in scope — but the actual values
@@ -158,7 +159,7 @@ CREATE TABLE server_group_backup_config (
     target_role_arn   TEXT NOT NULL,           -- per-bucket role Canopy assumes (encodes the account; may be cross-account)
     region            TEXT,                    -- NULL → deployment default
     endpoint          TEXT,                    -- NULL → AWS; set for non-AWS S3
-    expected_interval INTERVAL,                -- declared cadence: paces devices AND drives staleness; NULL → neither
+    expected_interval INTERVAL,                -- NULL → manual-only (no schedule, no staleness); set → scheduled cadence + staleness
     retention         JSONB NOT NULL,          -- kopia keep-* policy; Canopy asserts it into the repo
     repo_password_ref TEXT NOT NULL,           -- reference to the secret, NOT the secret
     created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -183,20 +184,24 @@ groups sharing an account) lives outside this row. See "IAM model".
 `region`/`endpoint` are what `GET /backup-target` serves to devices.
 `expected_interval` is the group's **declared backup cadence** and the
 single source for it: it both paces the devices (see "Backup cadence")
-and drives staleness detection. Set it to `1 day` and devices aim to
-back up daily *and* Canopy alerts when one hasn't. Because it's one
-value, the schedule and the alert can't drift apart.
+and drives staleness detection — so schedule and alert can't drift apart.
+It has three states: **NULL** → manual-only (backups *possible* via
+operator one-off, but no schedule and no staleness alerting); **set** →
+scheduled cadence + staleness. (A *missing config row entirely* is the
+separate "not set up → `409`" case.)
 
 `retention` holds the kopia keep-policy (e.g. `{"keep_daily": 7,
-"keep_weekly": 4, ...}`); Canopy asserts it into the repo at creation and
-each maintenance run — see "Retention policy ownership". The values start
-at a default; the schedule is owned here, not left to drift inside the
-repo.
+"keep_weekly": 4, "keep_monthly": 6, "keep_latest": 1}`); Canopy asserts
+it into the repo at creation and each maintenance run — see "Retention
+policy ownership". The org **minimum** (`keep_daily 7, keep_weekly 4,
+keep_monthly 6`) is enforced as a floor in code — a per-group override may
+*raise* the counts but never drop below it; `keep_latest 1` is the default
+but is *not* floor-enforced.
 
-`repo_password_ref` points at the group's kopia repository password
-(held in a k8s secret / Secrets Manager, not stored here in plaintext —
-see "Repository password ownership"). It's the secret *reference*; the
-column never holds the password itself.
+`repo_password_ref` names the group's kopia repository password, held as a
+**k8s Secret** (the column is the Secret name, never the password). The
+password is Canopy-generated for from-birth repos or operator-supplied for
+imported ones — see "Repository password ownership".
 
 A row is keyed by the root server id (the parentless server that heads
 the group). Devices without a configured root row → `409 Conflict` from
@@ -220,8 +225,9 @@ CREATE TABLE backup_credential_issuances (
     issued_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
     expires_at          TIMESTAMPTZ NOT NULL,
     purpose             TEXT NOT NULL,       -- "backup" | "restore"
-    sts_assumed_role    TEXT NOT NULL,
-    sts_request_id      TEXT,                -- from AssumeRole response, for cross-ref with CloudTrail
+    sts_assumed_role    TEXT NOT NULL,       -- the per-bucket target_role_arn that was assumed
+    sts_request_id      TEXT,                -- from AssumeRole response, best-effort; pointer to the AssumeRole event
+    access_key_id       TEXT,                -- the issued temp AccessKeyId; joins this row to downstream CloudTrail S3 activity
     bucket              TEXT NOT NULL,       -- snapshot of config at issuance time
     prefix              TEXT NOT NULL
 );
@@ -233,7 +239,11 @@ CREATE INDEX ON backup_credential_issuances (root_server_id, issued_at DESC);
 This is the audit log of credential *issuance*. It answers "was a device
 handed creds" but not "did the backup succeed" — see `backup_runs` for
 that. We snapshot bucket/prefix at issuance time so the log stays correct
-even if the group config is later changed.
+even if the group config is later changed. `access_key_id` is the durable
+join key: any CloudTrail S3 event made with these creds carries the same
+`AccessKeyId`, so months later you can map an S3 action back to this row
+(device, purpose, bucket, time). `sts_request_id` is the best-effort
+pointer to the `AssumeRole` event itself.
 
 ### New table: `backup_runs`
 
@@ -280,6 +290,44 @@ Written by the Canopy maintenance Jobs (see "Canopy-owned maintenance").
 A group whose maintenance silently stops is a slow-motion failure (repo
 bloat, retention not enforced), so this feeds the same staleness
 alerting as `backup_runs`.
+
+### New table: `backup_repo_snapshots`
+
+```sql
+CREATE TABLE backup_repo_snapshots (
+    root_server_id     UUID NOT NULL REFERENCES servers(id),
+    source             TEXT NOT NULL,            -- kopia source: canopy@<server-id>:<path>
+    server_id          UUID REFERENCES servers(id),  -- parsed from source
+    latest_snapshot_at TIMESTAMPTZ,
+    observed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (root_server_id, source)
+);
+```
+
+The ground-truth inventory written by the read-only inspection Job
+(signal 2): the latest snapshot actually present in the repo, per source.
+`source` encodes the **server id** (the backup subject); the device that
+took it lives in the snapshot's tags, not here.
+
+### New table: `backup_repo_stats`
+
+```sql
+CREATE TABLE backup_repo_stats (
+    root_server_id   UUID PRIMARY KEY REFERENCES servers(id),
+    snapshot_count   INTEGER,
+    source_count     INTEGER,
+    logical_bytes    BIGINT,                  -- kopia: pre-dedup size across snapshots
+    physical_bytes   BIGINT,                  -- kopia: deduplicated + compressed repo size
+    bucket_bytes     BIGINT,                  -- S3 actual stored bytes (the billing basis; from CloudWatch)
+    observed_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Cached repo/bucket stats for operator display, refreshed by the
+inspection cycle. `bucket_bytes` (CloudWatch `BucketSizeBytes`) is the
+real billing basis and runs *ahead* of `physical_bytes` — versioning plus
+the 30-day Object Lock keep expired-but-not-yet-deletable data around, so
+the gap between the two is itself the visible cost of the lock.
 
 ## Endpoint shape
 
@@ -646,31 +694,44 @@ property: a server-side config change propagates to the whole fleet
 automatically on each host's next run. There is no operator command to
 run per host and nothing to "forget to re-run".
 
-### Backup cadence
+### Backup cadence and triggering
 
-Who decides *when* `bestool canopy backup` runs is a real question,
-because Canopy is **pull-based** — it has no inbound path to devices (the
-push/proxy direction is explicitly rejected), so it physically cannot
-trigger a backup. A local trigger must exist. The design choice is only
-whether the cadence is hardcoded per host (drifts from Canopy's
-`expected_interval`, and changing the fleet cadence means touching every
-host) or owned by Canopy like everything else.
+**Canopy is authoritative for *when* a device backs up, and the signal
+rides the existing ~1-minute device↔canopy healthcheck** rather than a
+separate device-side timer. On each tick Canopy answers "back up now /
+nothing to do," and the device launches `bestool canopy backup` as its
+own process when told. This drops responsiveness from a coarse local timer
+to ~1 minute essentially for free (the tick already happens), and a
+held-open bestool connection makes it cheaper still — near-instant if we
+want push. The device holds no schedule of its own; the existing tick *is*
+the trigger.
 
-We own it in Canopy:
+Canopy computes "back up now?" as **"the schedule is due OR an operator
+requested a one-off":**
 
-- A local systemd timer fires `bestool canopy backup` as a *heartbeat* —
-  frequent enough (say hourly) that it never gates the real cadence, and
-  needing no per-host tuning.
-- Each tick, bestool already fetches the target/creds; it also reads the
-  group's `expected_interval` and backs up only if the last successful
-  run is older than that. So the *effective* schedule is Canopy's
-  declared cadence; the local timer is just "wake up and ask".
-- Staleness alerting reads the same `expected_interval`, so the cadence
-  the fleet targets and the cadence Canopy polices are one number and
-  cannot diverge.
+- **Scheduled** (`expected_interval` set): due when the last successful
+  `backup_run` is older than `expected_interval`. One value drives both
+  this and staleness, so they can't drift.
+- **Manual-only** (`expected_interval` NULL): never due on a schedule, no
+  staleness alerting — but an operator one-off still fires (see below).
+- **Operator one-off** — a first-class capability: an operator (via Canopy)
+  requests a best-effort-immediate backup; Canopy sets a pending-backup
+  flag for that device/group and emits "back up now" on the next tick
+  (within a minute, or instantly over a held connection), **bypassing the
+  cadence debounce**. Works for *both* manual-only and scheduled groups
+  (out-of-band "back up now"). Cleared when the run is reported.
 
-Changing a group's cadence is then the same single-row update as any
-other config — no per-host action.
+This gives **provision-then-authorize**: the device image ships with the
+backup wiring unconditionally and simply gets "nothing to do" (a benign,
+non-failure state — `bestool` treats it as dormant, not an error) until an
+operator authorizes/configures the group; backups then begin on the next
+tick with no per-host action.
+
+Changing a group's cadence is a single-row update — no per-host action.
+The transport specifics (how the signal rides today's minute-cadence
+healthcheck — tailnet poll, device poll, or a held-open connection) are an
+implementation detail for the repo-alignment pass; the *model* (Canopy
+authoritative, minute-cadence, schedule-or-manual) is fixed here.
 
 bestool work is in a separate repo; this plan covers the Canopy side
 and the bestool side will be a sibling change there.
@@ -694,33 +755,34 @@ went, and a job scans those reports in the database.
 
 1. bestool reports each run via `POST /backup-report`, written to
    `backup_runs`.
-2. A periodic Canopy job (alongside the existing health/alerting
-   machinery — the same path that surfaces and recovers other device
-   health signals) scans the **devices expected to be backing up** —
-   i.e. every `Server`-role device whose group root has a
-   `server_group_backup_config` with a non-NULL `expected_interval` —
-   and, joining each against its most recent `backup_runs` row,
-   classifies it:
-   - **Stale**: a device that previously reported successful backups but
-     has no `outcome = 'success'` row newer than `expected_interval`
-     (times a small grace factor) → alert.
-   - **Never backed up**: a device in the scanned set that has been
-     present longer than `expected_interval` and has *no* successful
-     `backup_runs` row → alert. (Catches a host that was never wired up,
-     which a "last success" check alone would miss.)
-   - **Recovered**: a previously-stale device reporting success again
+2. A periodic Canopy job (a tokio loop in the `jobs` crate, like
+   `reachability`) scans the **servers expected to be backed up** — those
+   in a group whose `server_group_backup_config` has a non-NULL
+   `expected_interval` — joins each against its most recent `backup_runs`
+   row, and classifies it. (Detection is **server-centric**: the subject
+   is the server being protected; the device is the actor recorded in
+   `backup_runs`/snapshot tags. A manual-only or unconfigured group is
+   simply not in the scanned set, so unauthorized devices never alert.)
+   - **Stale**: previously reported success but no `outcome = 'success'`
+     newer than `expected_interval × 2` → alert. (`×2` = the anti-flap
+     factor from the decisions; not per-group configurable yet. Given the
+     ~1-min trigger retries quickly, two missed intervals signals genuine
+     breakage, not a blip.)
+   - **Never backed up**: present longer than `expected_interval × 2` with
+     *no* successful `backup_runs` row → alert. "Present since" is
+     `max(device_server_associations.first_seen, server_group_backup_config.created_at)`
+     — the later of "device joined the server" and "group was authorized"
+     — so neither a freshly-added device nor a freshly-authorized group
+     false-alarms.
+   - **Recovered**: a previously-stale server reporting success again
      clears the alert.
-
-   The scanned set — "which devices ought to back up" — is the part to
-   pin down in implementation: the natural definition is `Server`-role
-   devices associated with a configured group, but it leans on the same
-   `devices.server_id` / "device present" questions flagged below.
-3. Alerts route through the existing operator notification path
-   (Slack/email via `PRIVATE_URL`). Note this is Canopy's own app-level
-   alerting — distinct from the `backup-monitoring` Pulumi stack, which
-   watches the **AWS Backup service** (EBS/RDS) via EventBridge→SNS and
-   does not cover kopia-to-S3 backups. This detection is genuinely new;
-   the only thing shared is the precedent of alerting to Slack.
+3. Alerts route through Canopy's existing incident machinery: raise
+   `Incident::open_for(...)` (and `Incident::resolve(...)` on recovery),
+   which enqueues to `slack_outbox`, drained to Slack by the
+   `slacker_outbox` job. Same path the reachability healthcheck already
+   uses — distinct from the `backup-monitoring` Pulumi stack, which
+   watches the **AWS Backup service** (EBS/RDS) and does not cover
+   kopia-to-S3 backups. This detection is genuinely new.
 
 The limit of signal 1 is that it's the *device's word*: it scans the
 Canopy database for what devices reported, not for what's actually in the
@@ -731,18 +793,24 @@ as healthy. Reports are timely but not authoritative.
 
 ### Signal 2 — repository inspection (authoritative, periodic)
 
-Now that maintenance jobs already connect to each group's repository with
-the password, Canopy can read the **ground truth**: the snapshots that
-actually exist. A check — piggybacked on the maintenance job, or a
-dedicated read-only job on the same footing — lists the repo's snapshots
-and records, per source, the latest snapshot time. That's what *actually
-landed in the bucket*, independent of whether any device reported, was
-honest, or is even reachable.
+Canopy reads the **ground truth** — the snapshots that actually exist — via
+a **dedicated, read-only inspection Job**, decoupled from maintenance at
+both the job and schedule level. It connects to each group's repo with
+**read-only (restore-level) creds** (never write/delete — smaller blast
+radius than the maintenance Job), runs `kopia snapshot list`, and writes
+`backup_repo_snapshots` (latest snapshot per source) plus `backup_repo_stats`
+(snapshot/source counts, logical & physical repo size, and the S3
+`bucket_bytes` from CloudWatch — the billing basis). It runs on its **own
+cadence** (defaulting to roughly `expected_interval`, tunable), so signal-2
+freshness isn't gated by the slow maintenance interval.
 
-- For this to attribute snapshots to devices, the kopia **source must
-  encode the device** (e.g. fix the snapshot host to the device id) so
-  Canopy can map `user@host:path` back to a device. The backup setup must
-  pin this deterministically — flagged below.
+- Attribution: the kopia **source encodes the server** — `bestool` overrides
+  the kopia hostname to the **server id** (`canopy@<server-id>:<path>`), so
+  the source is the backup subject and survives device replacement
+  (continuous history, no fragmented chain). The *device + run* that
+  produced a snapshot live in its **tags** (`canopy-device=<uuid>`,
+  `canopy-run=<run-uuid>`, the run-uuid minted client-side and echoed in
+  `backup_runs`), closing the loop snapshot → run → issuance → CloudTrail.
 - Reconciliation against signal 1 is where the value is:
   - report says success **but** no recent snapshot in the repo → the
     report is wrong or the upload didn't persist → **alert** (the case
@@ -750,15 +818,13 @@ honest, or is even reachable.
   - recent snapshot **but** no report → backups are fine, the reporting
     path is broken → lower-severity notice.
   - neither → genuinely stale (agrees with signal 1).
-- It is *not* a replacement for signal 1's timeliness: it only sees the
-  repo as often as the job runs (maintenance cadence), so an hourly-miss
-  won't surface until the next inspection. Reports stay the day-to-day
-  signal; repo inspection is the periodic trust anchor.
+- It is *not* a replacement for signal 1's timeliness; reports stay the
+  day-to-day signal, repo inspection is the periodic trust anchor.
 - Trust property: signal 2 depends only on the bucket (Object-Lock
   protected), not on any device, so it's the signal a compromised server
   cannot fake into showing a healthy backup.
 
-Both signals feed the same alerting path.
+Both signals feed the same `Incident` alerting path.
 
 This is the half of "did device X back up today" that the audit log
 alone can't give: `backup_credential_issuances` says creds were handed
@@ -789,12 +855,42 @@ here, for two reasons:
   permission templates above), so a compromised server cannot delete
   backups.
 
-So Canopy owns maintenance. Concretely, a scheduled control-plane task
-spawns a **Kubernetes Job per group** that runs `kopia maintenance run`
-(quick on a short cadence, full less often) against that group's bucket,
-then exits. Spawning a Job rather than running kopia in-process keeps the
-heavy, long-running work off the Canopy pod and lets it use the kopia
-image directly.
+So Canopy owns maintenance. Concretely, a scheduler loop in the `jobs`
+crate (like `reachability`) spawns a **Kubernetes Job per group** that
+runs the maintenance cycle against that group's bucket, then exits.
+Spawning a Job rather than running kopia in-process keeps the heavy,
+long-running work off the Canopy pod and lets it use the kopia image
+directly.
+
+The maintenance cycle is **three steps**, not just "run maintenance":
+1. **assert** the group's retention policy into the repo (so the declared
+   policy, not a drifted in-repo one, governs);
+2. **`kopia snapshot expire`** — apply that policy, dropping snapshots
+   beyond `keep-daily/weekly/monthly`. This step is *required* and easy to
+   miss: because device creds have no delete, **clients can't self-expire
+   at snapshot time**, so without Canopy running expire the retention
+   policy never actually fires and the repo grows unbounded;
+3. **`kopia maintenance run`** (quick or full) — index compaction + content
+   GC of the now-unreferenced blobs.
+
+Cadence: **quick daily, full weekly** (deployment-wide defaults, per-group
+override later). Full more often is largely wasted — the 30-day Object Lock
+means GC can't reclaim younger blobs anyway (the ~30-day reclamation lag),
+and expired manifests are themselves locked, so expire/GC *mark* but
+physical deletion lags. Client-side maintenance *and* expiry stay disabled
+(clients lack delete), with the repo's maintenance owner set to the Canopy
+identity.
+
+**Scheduling is hash-jittered** so the fleet doesn't stampede: each group's
+slot within its cadence window is `hash(group) mod window`, stable per
+group, spreading Job-creation / STS / S3 / compute load evenly (applies to
+inspection and per-group preflight too).
+
+Spawned Jobs carry the org's three **billing tags** as pod labels —
+`billing.product` / `billing.stage` / `billing.deployment` — set from the
+group (its `billing.*` tags if present, else `product=tamanu`, `stage=` the
+highest server rank in the group, `deployment=` the group name) so AWS
+split cost allocation attributes the compute to the right deployment.
 
 ### Credentials for the maintenance Job
 
@@ -868,19 +964,38 @@ it: Canopy owns the per-group repository password, because Canopy is the
 one party that must always be able to connect (it runs maintenance) and
 is already the source of truth for backup config.
 
-- Canopy generates the password when a group's backup config is first
-  set up, and serves it to devices (alongside the target) so bestool can
-  `kopia repository connect`, and injects it into maintenance Jobs.
-- This is *not* a new exposure on the device side: any client writing to
-  an encrypted kopia repo inherently holds the password — that's
-  intrinsic to direct-to-S3 backup, not something maintenance adds.
-- Storage of the password on the Canopy side is sensitive. Plaintext in
-  the DB is the easy option but probably wrong; a k8s secret or AWS
-  Secrets Manager reference held by `server_group_backup_config` is more
-  appropriate. **Open question — decide during implementation.**
+Ownership splits cleanly: **IaC owns the bucket** (container), **Canopy
+owns the repo** — including its encryption key, since key + retention +
+maintenance are all the repo's lifecycle.
+
+- **Storage: a k8s Secret** in Canopy's namespace (canopy is k8s-native;
+  the password is a cluster-side encryption key, not an AWS resource, so
+  it needn't live in the deployment account). `repo_password_ref` is the
+  Secret name. Canopy reads it via the k8s API on demand (service-account
+  RBAC: `get` secrets — handles dynamically-added groups without a pod
+  restart). Maintenance/inspection Jobs **mount it via `secretKeyRef`**
+  (never through env/logs).
+- **Provenance, two modes:** *from-birth* — Canopy generates the password
+  when it sets up a new repo; *import* — for adopting a pre-existing kopia
+  repo, the operator supplies the existing passphrase (or points
+  `repo_password_ref` at an already-created Secret). (Importing an
+  existing repo also brings a pre-existing bucket whose lock/account may
+  not match the from-birth assumptions — broader than the passphrase, and
+  related to the migration concern.)
+- **DR escrow (from-birth only):** the backups survive a Canopy
+  catastrophe (object-locked in the deployment account) but are *useless
+  without the passphrase*, which would die with Canopy's Secrets/DB. So at
+  generation, surface it **once** in the Tailscale-gated admin UI —
+  "copy this into Bitwarden now" — ideally gated on operator
+  acknowledgment before the repo is marked ready. The k8s Secret is the
+  operational copy; Bitwarden is the break-glass copy. (Imported repos
+  skip this; the operator already has the passphrase.)
+- Serving to devices is *not* a new exposure: any client writing to an
+  encrypted kopia repo inherently holds the password (intrinsic to
+  direct-to-S3 backup). Canopy serves it over mTLS on `/backup-target`.
 - The repo's maintenance *owner* is set to the Canopy maintenance
-  identity, and client-side maintenance is disabled, so clients never
-  attempt the maintenance they no longer have delete rights for.
+  identity, and client-side maintenance/expiry is disabled, so clients
+  never attempt operations they lack delete rights for.
 
 ### Audit
 
@@ -924,28 +1039,32 @@ Shared, checked once:
   web-identity is mounted and valid. This is the only genuinely shared
   piece; everything else is per-bucket and therefore per-group.
 
-Per configured group:
-- **Role trust + creds work** — assume *that group's* `target_role_arn`
-  (cross-account), confirming the per-bucket role still exists and its
-  trust still admits Canopy, then do a **read-only no-op** with the
-  returned creds against *that group's* bucket/endpoint (e.g. `HeadBucket`
-  / a scoped `ListBucket`), so the check proves the group's creds actually
-  work, not merely that `AssumeRole` returned. This catches a single
-  group's role/bucket/endpoint being wrong while others are fine.
+Per configured group (deep checks — shallow "did AssumeRole return" isn't
+enough):
+- **Both purposes issue valid creds** — assume *that group's*
+  `target_role_arn` (cross-account) **both ways**: plain (the `backup`
+  path) *and* with the read-only restore session policy (the `restore`
+  path), each followed by a **read-only no-op** against the bucket. This
+  is the issuance path itself, so it proves we can mint *working* creds
+  for *every* purpose — catching a broken restore session policy (the
+  `GetBucketLocation` class of bug) proactively, not at restore time,
+  while plain backup issuance looks fine.
 - **Object Lock is in place** — verify *that group's* bucket still has the
   expected (≥30-day) Object Lock configuration. The whole "a compromised
   server can't destroy backups" guarantee rests on this; if someone
   removes or weakens the lock, the protection silently erodes with no
   other symptom, so it must be actively checked — per bucket, since the
   config is per bucket.
-- **Maintenance path** — that group's maintenance Job already exercises
-  its own pathway; either add a cheap preflight Job (connect + no-op and
-  exit) on its own IRSA, or lean on `backup_maintenance_runs` failures for
-  that group. The former is proactive; the latter only catches it when
-  maintenance next runs. Flagged below.
+- **Maintenance path** — no separate maintenance preflight Job needed: the
+  read-only inspection Job already connects to each group's repo on its
+  cadence (proving reachability + password), and maintenance-specific
+  failures surface via `backup_maintenance_runs`.
 
-Alerts name the affected group(s) and fire at control-plane severity
-(distinct from per-device staleness); a check that fails for *every*
+**Cadence (hash-jittered per group, like maintenance):** the shared
+`GetCallerIdentity` rides the ~1-minute loop (free); the per-group deep
+checks run hourly (cheap at fleet scale, and a broken bucket/lock isn't a
+sub-hour emergency). Alerts name the affected group(s) at control-plane
+severity (distinct from per-device staleness); a check failing for *every*
 group points at the shared IRSA identity rather than any one bucket.
 
 Prefer **behavioural** checks (try to assume; try a harmless S3 op) over
@@ -967,10 +1086,17 @@ Surface it loudly; don't take Canopy down over it.
 
 ## Operational story (what we gain, day-one)
 
-- **"Did device X back up today?"** — `backup_runs` gives the real
-  answer (a successful run landed), and `backup_credential_issuances`
-  the cheaper "creds were issued" proxy. Byte-level reconciliation
-  against S3 inventory / CloudWatch still comes later.
+- **"Did device X back up today?"** — three corroborating answers:
+  `backup_runs` (what the device *reported*), `backup_credential_issuances`
+  (the cheaper "creds were issued" proxy), and `backup_repo_snapshots`
+  (what *actually landed* in the repo). Disagreement is itself a signal.
+- **"How big / how much is this costing?"** — `backup_repo_stats` caches
+  repo size (logical & physical) and the S3 `bucket_bytes` billing basis
+  per group for display, refreshed by the inspection cycle.
+- **One-off / manual backups** — an operator can trigger a best-effort
+  immediate backup for any group (scheduled or manual-only) via Canopy;
+  it fires on the next ~1-minute tick. Useful before risky changes, and
+  the only backup path for manual-only groups.
 - **Decommissioning a device** — revoke its mTLS cert (existing
   mechanism); it can no longer call the endpoint, so it can no longer
   get fresh creds. Already-issued creds expire within an hour.
@@ -1007,75 +1133,82 @@ Surface it loudly; don't take Canopy down over it.
   names the affected group rather than waiting for the fleet to discover
   it the hard way.
 
-## Open questions
+## Decisions (resolved in review)
 
-None blocking, but flag-and-decide-during-implementation:
+The original open questions were worked through one by one; outcomes
+(detail in the body sections):
 
-- **Cross-account assume hardening.** The IAM model is decided (per-bucket
-  roles, assumed cross-account — see "IAM model"); remaining details:
-  whether to use an `ExternalId` on the trust (cheap confused-deputy
-  hygiene even first-party), and confirming the `backups` stack changes
-  (set role trust to Canopy's central principal + the maintenance Job
-  principal; add the reduced device-backup action set; export the role ARN
-  for the config row).
-- **Per-device session naming for CloudTrail.** Suggested
-  `device-<uuid>`; check max length and allowed chars on
-  `RoleSessionName`.
-- **`sts_request_id` storage.** AWS returns it; check the Rust SDK
-  surface for retrieving it cleanly.
-- **`devices.server_id` invariant.** Implementation needs to confirm
-  every `Server`-role device has a server association; if not, the
-  endpoint returns 409 and we file a separate issue for the
-  data-consistency gap.
-- **Staleness "device present" definition.** The "never backed up" check
-  needs a notion of how long a device has existed in a configured group
-  (first-seen / association timestamp) to avoid alerting on a host added
-  minutes ago. Pick the existing timestamp to key off when implementing.
-- **Grace factor for staleness.** `expected_interval × N` before
-  alerting — pick N (and whether it's configurable per group) during
-  implementation; start simple.
-- **Default retention values.** The keep-* schedule for the `retention`
-  field's default — a product decision, not invented here. Note the
-  effective floor is 30 days regardless (Object Lock), so anything
-  shorter is meaningless; the default should be ≥ that.
-- **Heartbeat interval and last-success source.** The local timer's
-  fixed interval (must be ≤ the smallest `expected_interval` in use),
-  and whether bestool debounces against locally-recorded last-success or
-  asks Canopy (which already has `backup_runs`). Asking Canopy is
-  drift-proof but adds a round-trip; local state is cheaper but can lie
-  after a host rebuild. Decide during implementation.
-- **kopia source → device mapping.** Repository inspection (signal 2)
-  needs to attribute each snapshot source back to a device, so the
-  snapshot source must encode the device deterministically (e.g. host =
-  device id). Pin this in the backup setup; settle where the per-source
-  latest-snapshot inventory is stored (extend `backup_maintenance_runs`,
-  or a dedicated table) and the inspection cadence if it's a job
-  separate from maintenance.
-- **Preflight depth, cadence, and per-group cost.** How often the
-  upstream preflight runs, and whether it does the deeper per-group checks
-  (S3 read no-op against a probe prefix; `GetBucketObjectLockConfiguration`)
-  or just the shared `GetCallerIdentity` + dry-run `AssumeRole`. Deeper =
-  more confidence, slightly more IAM surface. The per-group bucket checks
-  scale with group count, so settle a cadence that stays cheap at fleet
-  scale (and whether shared vs. per-group checks run on different
-  cadences). Also: proactive maintenance preflight Job vs. relying on
-  `backup_maintenance_runs` failures.
-- **Repo password storage.** Canopy owns the per-group kopia password;
-  where does the secret actually live (k8s secret vs. Secrets Manager
-  vs. ...) and how is it served to devices and injected into Jobs?
-  `repo_password_ref` is a reference, not the secret — settle the
-  backing store during implementation.
-- **Maintenance cadence.** Quick vs. full intervals — start with
-  deployment-wide defaults; per-group override is a later column if
-  needed. Decide the scheduler home (CronJob fanning out per-group Jobs,
-  a private-server task, or a dedicated worker).
-- **Maintenance Job IRSA wiring.** Scoping is settled by the per-bucket
-  model (the Job assumes the group's per-bucket full-access role — broad
-  on its own bucket, so no session-policy downscope and no 1-hour cap, yet
-  still confined to one group). What's left is the mechanics: registering
-  the cluster's OIDC provider in each deployment account so the Job's
-  service account can assume that account's maintenance role directly
-  (cross-account web-identity, not chained).
+1. **Cross-account hardening** — **no `ExternalId`** (first-party within
+   one Org; the per-bucket role trust already names Canopy's principal).
+   The `backups`-stack changes (IRSA trust, reduced action set, export role
+   ARN) are implementation tasks, not open.
+2. **Session naming + correlation** — `RoleSessionName` =
+   **`canopy-<purpose>-<uuid>`** (the `canopy-` prefix makes provenance
+   unambiguous in CloudTrail; purpose + device inline). Maintenance/
+   inspection sessions: `canopy-maint-<group>`; per-bucket roles get a
+   `canopy-` name too. **Also store the issued `AccessKeyId`** on
+   `backup_credential_issuances` — the durable join from a CloudTrail S3
+   event back to the issuance (purpose/device/bucket/time).
+3. **`sts_request_id`** — **keep** (nullable, best-effort via the SDK
+   `RequestId` trait); belt-and-suspenders with `access_key_id`.
+4. **Device→server/group resolution** — the **`409` policy is locked**
+   (no server binding / no group / no config → `409`; real gaps filed
+   separately), which gives the **provision-then-authorize** property. The
+   lookup *mechanics* are deferred (see below).
+5. **Staleness "present since"** —
+   `max(device_server_associations.first_seen, server_group_backup_config.created_at)`.
+6. **Grace factor** — **`×2`**, not per-group configurable yet.
+7. **Default retention** — `keep-daily 7, keep-weekly 4, keep-monthly 6`
+   (org minimum, **floor-enforced in code**), `keep-latest 1` default (not
+   floored), `keep-annual 0`.
+8. **Cadence / trigger** — **Canopy-authoritative**, signal on the
+   ~1-minute healthcheck; three `expected_interval` states; **operator
+   one-off backup** is a first-class capability; `409` = dormant. Transport
+   deferred.
+9. **Inspection + source mapping** — **dedicated read-only inspection Job
+   on its own schedule** (decoupled from maintenance); kopia source host =
+   **server id**; snapshot **tags** carry device + a client-minted run-uuid
+   (echoed in `backup_runs`); writes `backup_repo_snapshots` +
+   `backup_repo_stats`.
+10. **Preflight** — **deep** checks (S3 no-op + `GetBucketObjectLockConfiguration`),
+    **both purposes** (backup plain + restore with session policy);
+    shared-identity ~every minute, per-group hourly, hash-jittered.
+11. **Repo password** — **k8s Secret** in Canopy's namespace; Canopy
+    generates for from-birth / operator supplies for import; read via k8s
+    API, mounted into Jobs via `secretKeyRef`, served to devices over mTLS;
+    **one-off Bitwarden escrow** for from-birth repos.
+12. **Maintenance** — scheduler loops in the **`jobs` crate**; cycle =
+    **assert-retention → `kopia snapshot expire` → `kopia maintenance run`**;
+    quick-daily / full-weekly; **hash-jittered** per-group scheduling;
+    spawned Jobs carry the three `billing.*` tags.
+13. **Maintenance Job IRSA** — **direct cross-account web-identity** (not
+    chained, so no 1-hour cap); OIDC-provider-per-account wiring is ops/IaC.
+
+New capabilities captured along the way: operator one-off backup (8),
+repo-import onboarding mode + Bitwarden escrow (11), repo/bucket stats for
+display (9 + the cost non-goal), `billing.*` tags on Jobs (12),
+hash-jittered scheduling (12).
+
+## Deferred to the "review against current state of the repo" pass
+
+These need reconciling against the real schema/code, not re-deciding:
+
+- **Rekey `root_server_id` → `group_id`** (the real `server_groups` table)
+  across the config + audit + new tables, and **fix device→server
+  resolution** (`servers.device_id`, not `device.server_id`; there is no
+  `Server::root_id`/parent hierarchy). The "parentless server heads the
+  group" framing and handler-flow steps 2–3 are historical and must be
+  rewritten.
+- Confirm the **`Incident` API** shape and the **`jobs`-crate scheduler**
+  conventions against the actual code.
+- The **server-rank → billing `stage`** mapping (uses canopy's rank concept).
+- The **transport** for the cadence signal (how it rides today's
+  ~1-minute healthcheck — tailnet poll / device poll / held-open).
+- Whether to expose an **operator "backup now"** action and stats in
+  `private-server` now or bootstrap via SQL first.
+
+(Tunable defaults — heartbeat/inspection/maintenance/preflight cadences —
+are chosen as defaults above and adjustable later; not blocking.)
 
 ## Out of scope (do not silently fold in)
 

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -154,6 +154,50 @@ Reasons not to put it in `private-server`:
   credential/region provider, a client on `AppState`, and a `FromRef`
   impl. (Don't pin crate versions without checking the registry.)
 
+## Backup types
+
+Backups aren't all "snapshot this path". A Postgres backup, for instance,
+is a *procedure* — quiesce/checkpoint Postgres into a consistent state,
+take a btrfs snapshot, kopia-snapshot the snapshot mount, clean up. That
+"how" is host-specific and belongs **client-side**, in bestool. So the
+system is organised around **backup types**:
+
+- **bestool registers the types it can do.** A type is a named, client-side
+  procedure that ends in a (type-tagged) kopia snapshot into the group's
+  repo. `tamanu-postgres` is the first (it's also what PGRO restores);
+  more will follow. bestool *advertises* its server's capabilities to
+  Canopy (`server_backup_capabilities`); the procedure itself is opaque to
+  Canopy.
+- **Canopy is type-*aware* for scheduling + audit, type-*agnostic* for
+  execution.** It records which types exist, decides *when* each runs
+  (cadence / one-off), issues creds, and tracks outcomes per type — but it
+  never knows the "how". This keeps Canopy generic and the mechanics on the
+  host that owns them.
+- **Well-known types come up enabled; others need approval.** A type name
+  has canopy-wide defaults (`backup_type_defaults`: schedule, retention,
+  `auto_enable`). `auto_enable` seeds the `enabled` flag **when bestool
+  registers the capability**: a `tamanu-postgres` capability is created
+  enabled (and runs at its default schedule/retention), an unknown type is
+  created disabled awaiting operator approval. After that, `enabled` is
+  operator-controlled per server — an operator can turn a type off for a
+  server and it stays off regardless of the default.
+- **Schedule and retention are per-`(group, type)`** (`server_group_backup_schedule`),
+  overriding the per-type defaults (effective = override ?? default; org
+  retention floor still applies). Different types in a group can keep
+  different rhythms and keep-policies. Canopy asserts each type's retention
+  as a kopia **per-source/path policy**, and `kopia snapshot expire` honours
+  it per source.
+- **The repo is shared; the type is a dimension.** One bucket/repo per
+  group holds all types from all the group's servers; a snapshot's source
+  is `canopy@<server-id>` with a `canopy-type=<type>` tag (and the type in
+  the path), so `(server, type)` is one source. Scheduling, the "back up
+  now" trigger, staleness, signal-2 inventory, and PGRO's signal-3 are all
+  per-`(server, type)`; `type` is a column on runs / issuances / requests /
+  repo-snapshots.
+
+So a backup is keyed `(server, type)`, not just `(server)`. The schema and
+sections below thread that through; PGRO consumes a *specific* type.
+
 ## Database changes
 
 ### New table: `server_group_backup_config`
@@ -165,14 +209,17 @@ CREATE TABLE server_group_backup_config (
     prefix            TEXT NOT NULL DEFAULT '', -- usually empty: the repo lives at the bucket root
     target_role_arn   TEXT NOT NULL,           -- per-bucket role Canopy assumes (encodes the account; may be cross-account)
     region            TEXT,                    -- NULL → deployment default (AWS region)
-    expected_interval INTERVAL,                -- NULL → manual-only (no schedule, no staleness); set → scheduled cadence + staleness
-    retention         JSONB NOT NULL,          -- kopia keep-* policy; Canopy asserts it into the repo
     repo_password_ref TEXT NOT NULL,           -- reference to the secret, NOT the secret
     status            TEXT NOT NULL,           -- 'provisioning' | 'escrow_pending' | 'ready'; backups dormant until 'ready'
     created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 ```
+
+This row holds the **repo-level** facts for the group (one repo/bucket per
+group, shared by all backup *types*). **Schedule and retention are no
+longer here** — they're per-`(group, type)` (see "Backup types"), because
+different types in a group want different rhythms and keep-policies.
 
 `bucket` is the group's **own** bucket — one bucket per group, not a
 shared bucket with per-group prefixes. Isolation is therefore at the
@@ -189,21 +236,9 @@ role relationship is 1:1; what varies N:M (servers spanning accounts,
 groups sharing an account) lives outside this row. See "IAM model".
 
 `region` (an AWS region) is what `GET /backup-target` serves to devices.
-`expected_interval` is the group's **declared backup cadence** and the
-single source for it: it both paces the devices (see "Backup cadence")
-and drives staleness detection — so schedule and alert can't drift apart.
-It has three states: **NULL** → manual-only (backups *possible* via
-operator one-off, but no schedule and no staleness alerting); **set** →
-scheduled cadence + staleness. (A *missing config row entirely* is the
-separate "not set up → `409`" case.)
-
-`retention` holds the kopia keep-policy (e.g. `{"keep_daily": 7,
-"keep_weekly": 4, "keep_monthly": 6, "keep_latest": 1}`); Canopy asserts
-it into the repo at creation and each maintenance run — see "Retention
-policy ownership". The org **minimum** (`keep_daily 7, keep_weekly 4,
-keep_monthly 6`) is enforced as a floor in code — a per-group override may
-*raise* the counts but never drop below it; `keep_latest 1` is the default
-but is *not* floor-enforced.
+Schedule (`expected_interval`) and `retention` live per-`(group, type)` in
+`server_group_backup_schedule` with per-type canopy-wide defaults — see
+"Backup types" and "Retention policy ownership".
 
 `repo_password_ref` names the group's kopia repository password, held as a
 **k8s Secret** (the column is the Secret name, never the password). The
@@ -219,9 +254,62 @@ already one `server_group`, so a shared bucket maps to that single group —
 the 1:1 group→bucket invariant holds; see "Per-group buckets".)
 
 Keeping this in a separate table rather than columns on `server_groups`
-because more backup-related fields are likely to land here (retention,
-encryption-key id, monitoring thresholds) and they all naturally
-co-locate, and most groups won't have backup config.
+because more backup-related fields are likely to land here (encryption-key
+id, monitoring thresholds) and they all naturally co-locate, and most
+groups won't have backup config.
+
+### New tables: backup types (registry, defaults, per-(group,type) config)
+
+See "Backup types" for the concept. Three tables carry the type dimension:
+
+```sql
+-- What each server ADVERTISES it can back up (bestool registers these),
+-- and whether it's enabled for that server. `enabled` is SEEDED at
+-- registration from the type's auto_enable default; thereafter it's
+-- operator-controlled state (an operator can turn a type off for a server,
+-- and that sticks regardless of the auto_enable default).
+CREATE TABLE server_backup_capabilities (
+    server_id     UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
+    type          TEXT NOT NULL,            -- e.g. "tamanu-postgres"
+    enabled       BOOLEAN NOT NULL,         -- seeded = backup_type_defaults.auto_enable at registration
+    registered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (server_id, type)
+);
+
+-- Canopy-wide defaults per well-known type. auto_enable only sets the
+-- INITIAL enabled value on a capability at registration; it is not a
+-- perpetual override.
+CREATE TABLE backup_type_defaults (
+    type              TEXT PRIMARY KEY,      -- "tamanu-postgres", ...
+    default_interval  INTERVAL,              -- default schedule (NULL → manual-only)
+    default_retention JSONB NOT NULL,        -- default kopia keep-policy (>= org floor)
+    auto_enable       BOOLEAN NOT NULL DEFAULT false
+);
+
+-- Per-(group,type) schedule/retention OVERRIDES (optional). Effective
+-- value = this row ?? backup_type_defaults; org retention floor still
+-- applies. Absent row → the type defaults apply.
+CREATE TABLE server_group_backup_schedule (
+    group_id          UUID NOT NULL REFERENCES server_groups(id) ON DELETE CASCADE,
+    type              TEXT NOT NULL,
+    expected_interval INTERVAL,              -- NULL → inherit type default; both NULL → manual-only
+    retention         JSONB,                 -- NULL → inherit type default
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (group_id, type)
+);
+```
+
+**Enablement is per-`(server, type)`** on the capability row: when bestool
+registers a capability, Canopy seeds `enabled` from the type's
+`auto_enable` (so `tamanu-postgres` comes up enabled, an unknown type comes
+up disabled awaiting approval), and an operator can flip it per server
+afterwards — that operator choice is durable and not re-overridden by the
+default. A `(server, type)` **runs** when its capability is `enabled`; its
+**schedule/retention** come from `server_group_backup_schedule(group, type)`
+?? the type default (org retention floor always applies). Scheduling,
+staleness, and the "back up now" trigger are per-`(server, type)`; runs and
+snapshots carry the `type`.
 
 ### New table: `backup_credential_issuances`
 
@@ -230,6 +318,7 @@ CREATE TABLE backup_credential_issuances (
     id                  BIGSERIAL PRIMARY KEY,
     device_id           UUID NOT NULL REFERENCES devices(id),
     group_id            UUID NOT NULL REFERENCES server_groups(id),
+    type                TEXT NOT NULL,       -- the backup type these creds were issued for
     issued_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
     expires_at          TIMESTAMPTZ NOT NULL,
     purpose             TEXT NOT NULL,       -- "backup" | "restore"
@@ -260,6 +349,8 @@ CREATE TABLE backup_runs (
     id              UUID PRIMARY KEY,         -- the run-uuid, minted by bestool at run start
     device_id       UUID NOT NULL REFERENCES devices(id),
     group_id        UUID NOT NULL REFERENCES server_groups(id),
+    server_id       UUID REFERENCES servers(id),  -- the server backed up (staleness is per server+type)
+    type            TEXT NOT NULL,            -- the backup type that ran
     purpose         TEXT NOT NULL,            -- "backup" | "restore"
     outcome         TEXT NOT NULL,            -- "success" | "failure"
     error           TEXT,                     -- populated on failure
@@ -316,6 +407,7 @@ CREATE TABLE backup_repo_snapshots (
     group_id           UUID NOT NULL REFERENCES server_groups(id),
     source             TEXT NOT NULL,            -- kopia source: canopy@<server-id>:<path>
     server_id          UUID REFERENCES servers(id),  -- parsed from source
+    type               TEXT,                     -- backup type, from the canopy-type tag
     latest_snapshot_at TIMESTAMPTZ,
     observed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (group_id, source)
@@ -324,8 +416,10 @@ CREATE TABLE backup_repo_snapshots (
 
 The ground-truth inventory written by the read-only inspection Job
 (signal 2): the latest snapshot actually present in the repo, per source.
-`source` encodes the **server id** (the backup subject); the device that
-took it lives in the snapshot's tags, not here.
+`source` encodes the **server id** (the backup subject) and the **type**
+(path/`canopy-type` tag), so a `(server, type)` is one source; the device
+that took it lives in the tags, not here. Staleness keys on
+`(server, type)`.
 
 ### New table: `backup_repo_stats`
 
@@ -359,15 +453,30 @@ inspection creds avoids CloudWatch creep on the read-only inspector.
 
 ## Endpoint shape
 
-Three endpoints, all `ServerDevice`-authenticated and all resolving the
-device → root → `server_group_backup_config` the same way:
+Four `ServerDevice`-authenticated endpoints; all device→server→group
+resolution is identical (§ Handler flow).
+
+### `POST /backup-capabilities` — register what this server can back up
+
+```
+POST /backup-capabilities
+  Authorization: mTLS via ServerDevice
+  Body: { "types": ["tamanu-postgres", ...] }   -- the types bestool can run on this server
+  Response 204
+```
+
+bestool calls this to advertise its server's backup types. Canopy upserts
+`server_backup_capabilities` for the resolved server, seeding `enabled`
+from each type's `backup_type_defaults.auto_enable` for newly-registered
+types (existing rows keep their operator-set `enabled`). See "Backup
+types".
 
 ### `POST /backup-credentials` — short-lived creds
 
 ```
 POST /backup-credentials
   Authorization: mTLS via ServerDevice
-  Body: { "purpose": "backup" | "restore" }   -- default "backup"
+  Body: { "type": "tamanu-postgres", "purpose": "backup" | "restore" }   -- purpose default "backup"
   Response 200: {
     "Version": 1,
     "AccessKeyId": "...",
@@ -425,6 +534,7 @@ POST /backup-report
   Authorization: mTLS via ServerDevice
   Body: {
     "run_id":         "...",   -- the run-uuid bestool minted at run start (becomes backup_runs.id)
+    "type":           "...",   -- the backup type that ran
     "purpose": "backup" | "restore",
     "outcome": "success" | "failure",
     "error":          "...",   -- optional, on failure
@@ -868,20 +978,23 @@ unspecified is the command-channel transport — today's status-POST
 *response* carries no command — which is the deferred item below, not the
 cadence.)
 
-Canopy computes "back up now?" as **"the schedule is due OR an operator
-requested a one-off":**
+Canopy computes "back up now?" **per `(server, type)`** — the signal names
+*which type* to run — as **"that type's schedule is due OR an operator
+requested a one-off":** (the effective schedule for a `(group, type)` is
+its `server_group_backup_schedule` override ?? the type default — see
+"Backup types".)
 
-- **Scheduled** (`expected_interval` set): due when the last successful
-  `backup_run` is older than `expected_interval`. One value drives both
-  this and staleness, so they can't drift.
-- **Manual-only** (`expected_interval` NULL): never due on a schedule, no
+- **Scheduled** (effective interval set): due when the last successful
+  `backup_run` *for that type* is older than the interval. One value drives
+  both this and staleness, so they can't drift.
+- **Manual-only** (effective interval NULL): never due on a schedule, no
   staleness alerting — but an operator one-off still fires (see below).
 - **Operator one-off** — a first-class capability: an operator (via Canopy)
-  requests a best-effort-immediate backup; Canopy sets a pending-backup
-  flag for that device/group and emits "back up now" on the next tick
-  (within a minute, or instantly over a held connection), **bypassing the
-  cadence debounce**. Works for *both* manual-only and scheduled groups
-  (out-of-band "back up now"). Cleared when the run is reported.
+  requests a best-effort-immediate backup of a specific `(server, type)`;
+  Canopy writes a `backup_requests` row and emits "back up now" for that
+  type on the next tick (within a minute, or instantly over a held
+  connection), **bypassing the cadence debounce**. Works for both
+  manual-only and scheduled types. Cleared when the run is reported.
 
 This gives **provision-then-authorize**: the device image ships with the
 backup wiring unconditionally and simply gets "nothing to do" (a benign,
@@ -918,13 +1031,14 @@ went, and a job scans those reports in the database.
 1. bestool reports each run via `POST /backup-report`, written to
    `backup_runs`.
 2. A periodic Canopy job (a tokio loop in the `jobs` crate, like
-   `reachability`) scans the **servers expected to be backed up** — those
-   in a group whose `server_group_backup_config` has a non-NULL
-   `expected_interval` — joins each against its most recent `backup_runs`
-   row, and classifies it. (Detection is **server-centric**: the subject
-   is the server being protected; the device is the actor recorded in
-   `backup_runs`/snapshot tags. A manual-only or unconfigured group is
-   simply not in the scanned set, so unauthorized devices never alert.)
+   `reachability`) scans the **`(server, type)` pairs expected to be
+   backed up** — each enabled capability whose effective schedule (per
+   "Backup types") is non-NULL — joins each against its most recent
+   `backup_runs` row *for that type*, and classifies it. (Detection is
+   **server-centric per type**: the subject is the server's backup *of that
+   type*; the device is the actor recorded in `backup_runs`/snapshot tags.
+   A disabled, manual-only, or unconfigured `(server, type)` is simply not
+   in the scanned set.)
    - **Stale**: previously reported success but no `purpose = 'backup'`
      row with `outcome = 'success'` newer than `expected_interval × 2` →
      alert. (Filter on `purpose='backup'` — a recent successful *restore*
@@ -1192,21 +1306,25 @@ minimum retention is 30 days** no matter what the policy says, since
 nothing can be deleted sooner.
 
 Because Canopy already owns repo creation, the password, and maintenance,
-it also owns the retention policy:
+it also owns the retention policy — now **per `(group, type)`** (see
+"Backup types"):
 
-- The intended values live declaratively on `server_group_backup_config`
-  (a `retention` field), not only inside the repo.
-- Canopy sets the kopia policy from that field at repo creation, and
-  **re-asserts it at the start of each maintenance run**, so the
-  declared policy is the source of truth and an in-repo policy that has
-  drifted (or been tampered with by a writer) is corrected rather than
-  silently honoured.
-- This keeps retention answerable from Canopy ("what's group X's policy?"
-  is a DB read) instead of requiring a repo connect to inspect.
+- Retention is declarative in Canopy: the **effective** policy for a
+  `(group, type)` = its `server_group_backup_schedule.retention` override
+  ?? the type's `backup_type_defaults.default_retention`, with the org
+  floor (`keep_daily 7, keep_weekly 4, keep_monthly 6`) enforced in code.
+- Canopy asserts each type's effective policy as a kopia **per-source/path
+  policy** (the type's source), at repo creation and **re-asserted at each
+  maintenance run** — so the declared policy is the source of truth and a
+  drifted/tampered in-repo policy is corrected, and `kopia snapshot expire`
+  applies the right keep-policy per type. Retention stays answerable from a
+  DB read, no repo connect needed.
 
-The *values themselves* are a product decision and remain deferred (see
-non-goals); what's fixed here is that Canopy declares and enforces them,
-with a sane default applied until tuned.
+The default *values per type* are a product call (e.g. `tamanu-postgres` →
+the org-floor schedule); what's fixed is that Canopy declares and enforces
+them per type. The 30-day Object Lock is still an immutability floor
+distinct from the keep-policy (effective minimum retention is 30 days
+regardless).
 
 ### Repository password ownership
 
@@ -1305,15 +1423,17 @@ Screens:
 ```sql
 CREATE TABLE backup_requests (
     server_id    UUID NOT NULL REFERENCES servers(id),
+    type         TEXT NOT NULL,            -- which backup type to run now
     purpose      TEXT NOT NULL,            -- "backup" | "restore"
     requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     requested_by TEXT,                     -- operator identity
-    PRIMARY KEY (server_id, purpose)
+    PRIMARY KEY (server_id, type, purpose)
 );
 ```
 
-A row makes Canopy answer "back up now" on the server's next tick
-(bypassing the cadence debounce); cleared when the run is reported.
+A row makes Canopy answer "back up now" for that `(server, type)` on the
+server's next tick (bypassing the cadence debounce); cleared when the run
+is reported.
 
 ## Upstream access preflight
 
@@ -1397,15 +1517,17 @@ kill. Bringing it in eliminates those static keys and makes Canopy the
 single control plane for *all* backup access. It's a **bidirectional,
 first-party relationship**:
 
-- **Creds out (Canopy → PGRO).** PGRO is a **restore-only** consumer, so it
-  gets short-lived read-only creds + target + repo password from Canopy —
-  reusing the `restore` session policy, the per-bucket role, and the
-  password ownership (canopy-mediated; option (a)). But PGRO is *not* a
-  fleet device and *not* in the group it reads — it's trusted first-party
-  infra, so this needs an **external-restore grant**: an operator-authorized,
-  audited "consumer C may read group X, read-only". That's a deliberate,
-  controlled cousin of the cross-group restore that's banned *for devices*
-  (a different trust class, not a loophole in that rule).
+- **Creds out (Canopy → PGRO).** PGRO is a **restore-only** consumer of a
+  **specific backup type** (`tamanu-postgres` — the same type bestool
+  produces). It gets short-lived read-only creds + target + repo password
+  from Canopy — reusing the `restore` session policy, the per-bucket role,
+  and the password ownership (canopy-mediated; option (a)). But PGRO is
+  *not* a fleet device and *not* in the group it reads — it's trusted
+  first-party infra, so this needs an **external-restore grant**: an
+  operator-authorized, audited "consumer C may read group X's *type T*,
+  read-only". That's a deliberate, controlled cousin of the cross-group
+  restore that's banned *for devices* (a different trust class, not a
+  loophole in that rule).
 - **Reports in (PGRO → Canopy) = Signal 3, restore-verification.** PGRO
   actually restoring a backup *proves it is restorable* — the strongest
   backup-health signal there is, beyond signal 2's "a snapshot exists". PGRO
@@ -1564,6 +1686,15 @@ New capabilities captured along the way: operator one-off backup (8),
 repo-import onboarding mode + Bitwarden escrow (11), repo/bucket stats for
 display (9 + the cost non-goal), `billing.*` tags on Jobs (12),
 hash-jittered scheduling (12).
+
+Added after the spec pass: **backup types** — bestool registers the types
+its server can back up (the "how" is client-side; `tamanu-postgres` first);
+Canopy is type-aware for scheduling/audit, type-agnostic for execution.
+Schedule + retention are per-`(group, type)` over per-type canopy-wide
+defaults; `auto_enable` seeds a capability's `enabled` at registration
+(operator-toggleable per server thereafter); `type` threads through runs /
+issuances / requests / repo-snapshots and the repo `canopy-type` tag; PGRO
+consumes a specific type. See "Backup types".
 
 ## Repo-alignment outcomes (applied) + remaining prerequisites
 

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -48,11 +48,12 @@ directly (no proxy through Canopy).
   policy ownership") — the mechanism is in scope — but the actual values
   start at a sane default and per-group tuning is later.
 - WORM immutability is a **required property of every group's bucket**
-  (30-day S3 Object Lock), not a follow-up. Existing buckets already have
-  it; new per-group buckets must enable it at creation (it can't be
-  retrofitted — see "Per-group buckets"). The plan also has to be
-  compatible with it (object-lock-aware kopia repos; GC reclaims on a
-  ~30-day lag).
+  (versioning + 30-day S3 Object Lock), not a follow-up. Existing buckets
+  already have it; new per-group buckets must enable it at creation (it
+  can't be retrofitted — see "Per-group buckets"). The plan has to be
+  compatible with it: reclamation is via **S3 lifecycle** on the versioned
+  bucket (in scope — see "Interaction with versioning + the 30-day Object
+  Lock"), not kopia deletes directly.
 - Picking the backup tool. Kopia is the assumed consumer because it
   fits the AWS SDK `credential_process` hook cleanly, but rclone works
   through the same mechanism if it turns out to be preferred.
@@ -692,6 +693,13 @@ retrofitted. The stack does this (`objectLockEnabled: true` +
 `objectLockConfiguration`), so a group's bucket is correct by
 construction; getting it wrong would mean recreating the bucket.
 
+The bucket also needs **lifecycle rules** — `noncurrentVersionExpiration`
+~35 days (≥ the 30-day lock) + a 7-day `abortIncompleteMultipartUpload` —
+since on a versioned bucket they're what actually reclaims space (see
+"Interaction with versioning + the 30-day Object Lock"). The
+`tamanu/on-linux` stack already has these (`kopia.ts`); the standalone
+`backups` stack does **not** and must gain them as part of this work.
+
 **IaC (Pulumi) provisions the buckets.** Onboarding a group means standing
 up its `backups` stack (bucket + lock + roles) and then inserting the
 `server_group_backup_config` row. Canopy only ever *uses* the bucket; it
@@ -1018,22 +1026,40 @@ would re-introduce the 1-hour cap). It's broad *on its own bucket*, not
 across a pattern — so a maintenance bug or compromise is still confined to
 that one group, the same structural isolation the device path gets.
 
-### Interaction with the 30-day Object Lock
+### Interaction with versioning + the 30-day Object Lock
 
-The buckets have a 30-day S3 Object Lock, which constrains maintenance:
-kopia GC cannot actually delete a pack blob until its lock expires, so
-storage from expired snapshots is reclaimed on a ~30-day lag, not
-immediately. This is expected and is the price of ransomware-proof
-backups — it must not be read as maintenance failing. Two implications
-for implementation:
+Object Lock requires **versioning**, so every bucket here is versioned —
+which changes how deletion actually works, and the plan must account for
+it:
 
-- The kopia repository must be created **object-lock-aware** (kopia
-  supports this explicitly: it tracks retention and avoids trying to
-  delete still-locked blobs). A repo created oblivious to the lock will
-  throw errors when maintenance attempts deletes that S3 refuses.
-- Budget for the lag: at any time the bucket holds up to ~30 days of
-  not-yet-collectable garbage on top of live data. Fine, but worth
-  noting for capacity/cost.
+- On a versioned bucket, kopia's `DeleteObject` is **never refused**; it
+  writes a *delete marker* and the prior version becomes *noncurrent*. So
+  maintenance doesn't "throw errors on locked deletes" (an earlier draft
+  said that) — it appears to succeed while **reclaiming nothing**.
+- Physical reclamation therefore happens via **S3 lifecycle**, not kopia's
+  delete: a `noncurrentVersionExpiration` rule expires noncurrent versions
+  (and delete markers), gated by the Object Lock (a version still under
+  retention is not expired until its lock lapses). This is also how kopia's
+  *own* GC reclaims space (kopia "delete" → marker → lifecycle), so the
+  lifecycle rule is **load-bearing for normal operation**, not optional.
+
+**So the lifecycle rules are in scope** for the per-group buckets (see
+"Per-group buckets"): `noncurrentVersionExpiration` ~35 days (≥ the 30-day
+lock, matching the existing `tamanu/on-linux` stack) + a 7-day
+`abortIncompleteMultipartUpload`. The standalone `backups` stack has no
+lifecycle rules today — they must be added.
+
+Consequences:
+- Reclamation lags ~35 days (a version becomes deletable only after both
+  the ~35-day rule *and* its lock have elapsed) — budget for up to ~35
+  days of not-yet-collectable garbage on top of live data.
+- That ~35-day window is also the **recovery deadline** for
+  overwrite-poisoning (see "Recovery from poisoning"): the good noncurrent
+  versions survive exactly until lifecycle reclaims them.
+- We do **not** rely on kopia client-side lock-awareness (extending
+  per-object locks) — that only matters against an AWS-level attacker,
+  which is out of scope; see "AWS setup" for why devices need no
+  `PutObjectRetention`.
 
 ### Retention policy ownership
 
@@ -1351,10 +1377,13 @@ as new `jobs`-crate bins; the `ServerRank::Production`→`"prod"` mapping;
   group is on a shared bucket today). The design is one-bucket-per-group;
   moving legacy data across is a separate operational task.
 - bestool subcommand implementation (separate repo).
-- **Tuning** retention policy values, encryption-at-rest beyond default
-  SSE-S3, S3 lifecycle rules. (Retention *execution* is in scope — Canopy
-  maintenance runs it — but the kopia retention values start at a default
-  and per-group tuning is later.)
+- **Tuning** retention policy values and encryption-at-rest beyond default
+  SSE-S3. (Retention *execution* is in scope — Canopy maintenance runs it —
+  but the kopia retention values start at a default and per-group tuning is
+  later. Note: the *reclamation* lifecycle rules — `noncurrentVersionExpiration`
+  + `abortIncompleteMultipartUpload` — are now **in scope**, since they're
+  load-bearing for GC on a versioned bucket; see "Interaction with
+  versioning + the 30-day Object Lock".)
 - Operator UI in `private-server` / React for editing
   `server_group_backup_config` (will want it eventually; not in the
   first cut — bootstrap via SQL). This now includes the maintenance

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -453,19 +453,22 @@ destructive action outright, and avoids accidental client-side expiry),
 but the guarantee "a compromised server cannot destroy recent backups"
 rests on Object Lock, not on IAM alone.
 
-**Caveat — the lock is `GOVERNANCE`, not `COMPLIANCE`** (per the `backups`
-Pulumi stack: `mode: 'GOVERNANCE', days: 30`). Governance retention can be
-overridden by a principal holding `s3:BypassGovernanceRetention`, and the
-existing full-access role grants `s3:*`, which includes it. So today the
-guarantee holds against *device* creds (no delete at all) but **not**
-against the maintenance / full-access role, which could bypass the lock
-and delete recent objects. To make the guarantee hold against every
-principal we control, either explicitly *deny* `s3:BypassGovernanceRetention`
-on the maintenance role (its GC only ever deletes objects whose lock has
-already expired, so it never legitimately needs bypass) or move the
-buckets to `COMPLIANCE` mode (no principal, not even root, can delete
-early). Flagged in open questions. See "Canopy-owned maintenance" for how
-the lock interacts with kopia GC.
+**The threat boundary is a compromised device, and that's what this
+defends.** The lock is `GOVERNANCE`, not `COMPLIANCE` (per the `backups`
+Pulumi stack: `mode: 'GOVERNANCE', days: 30`) — and we're keeping it that
+way. A device cred has neither `DeleteObject` nor
+`s3:BypassGovernanceRetention` (the reduced action set grants only
+Get/Put/multipart), so a compromised server physically cannot destroy
+backups, full stop. That is the guarantee.
+
+What GOVERNANCE deliberately leaves open is *AWS-level* compromise: a
+principal holding `s3:BypassGovernanceRetention` — e.g. the full-access /
+maintenance role's AWS credentials — can override the lock. Protecting
+against that (COMPLIANCE mode, or denying bypass on the maintenance role)
+is **explicitly out of scope** for now: defending the AWS account itself
+is a separate problem from defending the fleet of devices. So the
+guarantee is precisely "no device can destroy backups", not "nobody can".
+See "Canopy-owned maintenance" for how the lock interacts with kopia GC.
 
 ## AWS setup (provisioned by the Pulumi `backups` stack)
 
@@ -494,9 +497,10 @@ short-lived creds for them instead. The IaC changes are therefore:
   `PutObjectRetention`). The full set stays on the maintenance role only.
 - **Maintenance role** = the existing full-access role (or a sibling),
   assumed by the maintenance Job's own IRSA (not chained — see
-  "Canopy-owned maintenance"). Only this identity can delete, and per the
-  GOVERNANCE caveat above it should additionally *deny*
-  `s3:BypassGovernanceRetention`.
+  "Canopy-owned maintenance"). Only this identity can delete. It keeps
+  `s3:*` (incl. the ability to bypass GOVERNANCE) — that's the accepted
+  AWS-level trust boundary, see the threat-boundary note above; the
+  protection target here is device compromise, not this first-party role.
 
 IAM-model choice (now informed by the repo): the existing stack already
 makes **per-bucket roles**, so the natural fit is per-bucket roles that
@@ -949,12 +953,6 @@ None blocking, but flag-and-decide-during-implementation:
   with session-policy narrowing. Decide and update the `backups` stack
   accordingly (add the IRSA trust + the reduced device action set either
   way). See "AWS setup".
-- **GOVERNANCE vs COMPLIANCE / bypass denial.** The lock is GOVERNANCE, so
-  the full-access role can bypass it. Either deny
-  `s3:BypassGovernanceRetention` on the maintenance role or switch buckets
-  to COMPLIANCE, to make "can't destroy recent backups" hold against every
-  principal we control (see the caveat under session policies). A change to
-  the `backups` stack.
 - **Per-device session naming for CloudTrail.** Suggested
   `device-<uuid>`; check max length and allowed chars on
   `RoleSessionName`.
@@ -1015,6 +1013,12 @@ None blocking, but flag-and-decide-during-implementation:
 
 - Cross-group restore mechanism (explicitly disallowed by product
   decision).
+- **AWS-level compromise protection.** The threat boundary is a
+  compromised *device*; defending against a compromised AWS principal that
+  holds `s3:BypassGovernanceRetention` (e.g. the maintenance role's creds)
+  is a separate problem. We stay on GOVERNANCE Object Lock and accept that
+  the first-party maintenance role can bypass it. (COMPLIANCE mode /
+  bypass-denial remain available later if the threat model widens.)
 - Data-plane proxy / Canopy-served S3/WebDAV (explicitly rejected).
 - **Device-local S3 proxy** (kopia → `localhost`, a bestool daemon
   re-signs and forwards to the real bucket). Considered as an

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -37,8 +37,9 @@ directly (no proxy through Canopy).
   see staleness detection — and maintenance/expiry execution is owned by
   Canopy; what's deferred is cost/usage analytics.)
 - Tuning the kopia *retention policy* values (keep N daily / M weekly).
-  Canopy now *executes* retention via maintenance, but the policy values
-  themselves start at a sane default; per-group tuning is later.
+  Canopy now *owns, declares, and enforces* the policy (see "Retention
+  policy ownership") — the mechanism is in scope — but the actual values
+  start at a sane default and per-group tuning is later.
 - WORM immutability is **already in place** (30-day S3 Object Lock on the
   buckets) — not a follow-up. This plan just has to be compatible with it
   (object-lock-aware kopia repos; GC reclaims on a ~30-day lag).
@@ -145,6 +146,7 @@ CREATE TABLE server_group_backup_config (
     region            TEXT,                    -- NULL → deployment default
     endpoint          TEXT,                    -- NULL → AWS; set for non-AWS S3
     expected_interval INTERVAL,                -- NULL → no staleness alerting
+    retention         JSONB NOT NULL,          -- kopia keep-* policy; Canopy asserts it into the repo
     repo_password_ref TEXT NOT NULL,           -- reference to the secret, NOT the secret
     created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -155,6 +157,12 @@ CREATE TABLE server_group_backup_config (
 `expected_interval` drives staleness detection (below): if a group is
 expected to back up daily, set it to `1 day` and Canopy alerts when a
 device in the group has no recent successful run.
+
+`retention` holds the kopia keep-policy (e.g. `{"keep_daily": 7,
+"keep_weekly": 4, ...}`); Canopy asserts it into the repo at creation and
+each maintenance run — see "Retention policy ownership". The values start
+at a default; the schedule is owned here, not left to drift inside the
+repo.
 
 `repo_password_ref` points at the group's kopia repository password
 (held in a k8s secret / Secrets Manager, not stored here in plaintext —
@@ -590,6 +598,33 @@ for implementation:
   not-yet-collectable garbage on top of live data. Fine, but worth
   noting for capacity/cost.
 
+### Retention policy ownership
+
+"How long backups are kept" is a kopia **policy** (`keep-latest`,
+`keep-daily`, `keep-weekly`, …) stored *in the repository* and applied at
+snapshot + maintenance time. It is distinct from the 30-day Object Lock:
+the lock is an immutability floor on physical deletion; the kopia policy
+is the logical keep/expire schedule. Note the floor means the **effective
+minimum retention is 30 days** no matter what the policy says, since
+nothing can be deleted sooner.
+
+Because Canopy already owns repo creation, the password, and maintenance,
+it also owns the retention policy:
+
+- The intended values live declaratively on `server_group_backup_config`
+  (a `retention` field), not only inside the repo.
+- Canopy sets the kopia policy from that field at repo creation, and
+  **re-asserts it at the start of each maintenance run**, so the
+  declared policy is the source of truth and an in-repo policy that has
+  drifted (or been tampered with by a writer) is corrected rather than
+  silently honoured.
+- This keeps retention answerable from Canopy ("what's group X's policy?"
+  is a DB read) instead of requiring a repo connect to inspect.
+
+The *values themselves* are a product decision and remain deferred (see
+non-goals); what's fixed here is that Canopy declares and enforces them,
+with a sane default applied until tuned.
+
 ### Repository password ownership
 
 This is the new dependency maintenance forces into the open: kopia
@@ -685,6 +720,10 @@ None blocking, but flag-and-decide-during-implementation:
 - **Grace factor for staleness.** `expected_interval × N` before
   alerting — pick N (and whether it's configurable per group) during
   implementation; start simple.
+- **Default retention values.** The keep-* schedule for the `retention`
+  field's default — a product decision, not invented here. Note the
+  effective floor is 30 days regardless (Object Lock), so anything
+  shorter is meaningless; the default should be ≥ that.
 - **Repo password storage.** Canopy owns the per-group kopia password;
   where does the secret actually live (k8s secret vs. Secrets Manager
   vs. ...) and how is it served to devices and injected into Jobs?

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -200,6 +200,14 @@ sections below thread that through; PGRO consumes a *specific* type.
 
 ## Database changes
 
+> RESOLVED (impl) — **FK semantics are uniform plain `REFERENCES`, NO
+> `ON DELETE` clause anywhere.** The `ON DELETE CASCADE` shown in the DDL
+> blocks below was **not** shipped: `server_groups`/`servers`/`devices` are
+> *archived* (`deleted_at` soft-delete), never hard-deleted, so the
+> cascade-vs-preserve distinction is moot. Read every `ON DELETE CASCADE` /
+> "no-CASCADE on purpose" note in this section as superseded by the uniform
+> archival rule (see also the "Decommissioning a group" note further down).
+
 ### New table: `server_group_backup_config`
 
 ```sql
@@ -1185,13 +1193,21 @@ here, for two reasons:
   permission templates above), so a compromised server cannot delete
   backups.
 
-So Canopy owns maintenance. Concretely, a scheduler loop (a new
-`crates/jobs/src/bin/<name>.rs` following the existing `reachability` /
-`pingtask` `spawn()` + `loop { sleep(60); pool.get; … }` template, with its
-own single-replica Deployment in `ops/pulumi/tamanu/meta/src/jobs.ts`)
-**spawns a Kubernetes Job per group** that runs the maintenance cycle
-against that group's bucket, then exits. Spawning a Job keeps the heavy,
+So Canopy owns maintenance. Concretely, a scheduler loop (following the
+existing `pingtask`/`monitor` `spawn()` + `loop { sleep(60); pool.get; … }`
+template) **spawns a Kubernetes Job per group** that runs the maintenance
+cycle against that group's bucket, then exits. Spawning a Job keeps the heavy,
 long-running work off the loop pod and lets it use the kopia image.
+RESOLVED (impl): the maintenance/inspection/preflight/s3-metrics loops ship as
+**one bin `crates/jobs/src/bin/backups.rs`** (four modules under
+`crates/jobs/src/backup/`, run via `tokio::try_join!`) with a **single**
+`backups` Deployment — not one bin/Deployment each. The DB-only staleness +
+reconcile sweep instead folded into the renamed **`monitor`** bin (formerly
+`reachability`, which now also runs tailnet key-expiry). The **kopia Job image
+now exists in-repo** at `images/kopia-job/` (Dockerfile + entrypoint +
+`CONTRACT.md`), to be moved to `third-party-builds` and built/published by ops;
+config is passed as ENV vars and results return via the pod termination message
+(see the maintenance/inspection spec §5).
 
 **Greenfield infra (net-new to canopy):** the loop pattern matches
 `reachability`, but everything about *spawning k8s Jobs* is new — canopy
@@ -1590,13 +1606,13 @@ detection/reconciliation against `backup_repo_snapshots` / `backup_runs`.
   row; devices in that group start getting `409`. The group's bucket and
   its Object-Lock'd objects persist independently — they can't be deleted
   until their locks expire (~30 days), so bucket teardown is a deliberate,
-  delayed step, not a side effect of removing the config row. Note: the
-  config row cascades on `server_groups` delete, but the **audit tables
-  (`backup_credential_issuances`/`backup_runs`/`backup_maintenance_runs`)
-  reference `server_groups(id)` without CASCADE on purpose** — so deleting
-  a `server_groups` row that has any audit history fails until it's dealt
-  with. That's intentional audit preservation; the runbook decides
-  (archive vs detach) rather than silently cascading the trail away.
+  delayed step, not a side effect of removing the config row.
+  RESOLVED (impl): the earlier "config row cascades / audit tables don't"
+  split was **not** shipped — *all* backup FKs are plain `REFERENCES` (no
+  cascade), and `server_groups` are archived (`deleted_at`), never
+  hard-deleted, so the trail is preserved by the archival model rather than by
+  any per-table cascade choice. Decommissioning deletes the config row to stop
+  issuance; the group is archived, not `DELETE`d.
 - **Onboarding a group** — IaC provisions its bucket (with Object Lock,
   see "Per-group buckets"), then the `server_group_backup_config` row is
   inserted. Devices in the group start succeeding on their next run; if

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -157,6 +157,11 @@ even if the group config is later changed.
 
 ## Endpoint shape
 
+Two endpoints, both `ServerDevice`-authenticated and both resolving the
+device → root → `server_group_backup_config` the same way:
+
+### `POST /backup-credentials` — short-lived creds
+
 ```
 POST /backup-credentials
   Authorization: mTLS via ServerDevice
@@ -171,6 +176,42 @@ POST /backup-credentials
   Response 409: no backup config for this device's group
   Response 502: STS call failed
 ```
+
+### `GET /backup-target` — where to back up to
+
+```
+GET /backup-target
+  Authorization: mTLS via ServerDevice
+  Response 200: {
+    "storage": "s3",
+    "bucket": "...",
+    "prefix": "groups/<root-id>/",
+    "region": "...",
+    "endpoint": "..."         -- optional; for non-AWS S3
+  }
+  Response 409: no backup config for this device's group
+```
+
+This is the piece that keeps the bucket out of device provisioning. The
+`credential_process` output format (above) is **fixed by the AWS SDK** and
+carries only the four credential fields — it cannot carry the bucket,
+prefix, region, or endpoint. Yet the device must know all of those to
+address S3 at all. So rather than baking them into each device's kopia
+config at provision time (which would make "rotating bucket / changing
+prefix" a per-device reconfiguration, not the server-side-only change this
+plan promises), bestool fetches them from Canopy at runtime via this
+endpoint and reconstructs the kopia repository connection from the result.
+
+The only thing a device is ever provisioned with is its Canopy URL, its
+mTLS identity, and "run bestool" — never a bucket name. Canopy is the sole
+owner of backup-target config; changing it is a single-row update with no
+device-side coordination.
+
+(`region`/`endpoint` can be added as columns to `server_group_backup_config`
+when implementing, or derived from a single deployment-wide default if the
+backups bucket always lives in one region. Decide during implementation;
+the audit-log snapshot should capture whatever the device was actually
+told.)
 
 `purpose` is a real capability gate, not just audit metadata:
 
@@ -269,21 +310,36 @@ rejected by S3, not just by kopia.
 
 ## `bestool` changes
 
-A new subcommand:
+A new subcommand for the credential refresh, plumbed as kopia's
+`credential_process`:
 
 ```
 bestool backup-credentials [--purpose backup|restore]   # default: backup
 ```
 
 - Reads the device's mTLS identity from its existing location.
-- POSTs to the Canopy endpoint with the optional purpose.
+- POSTs to `/backup-credentials` with the optional purpose.
 - Writes the response JSON to stdout verbatim.
 - Exits 0 on success, non-zero on any failure (the AWS SDK treats any
   non-zero exit as "creds unavailable").
 
-The device's kopia config (set up once during provisioning) points at
-S3 with `credential_process = bestool backup-credentials`. From then on
-kopia just works.
+And a driver subcommand that owns the kopia invocation so the device
+holds no hardcoded bucket:
+
+```
+bestool backup [--purpose backup|restore]
+```
+
+- `GET /backup-target` to learn `{bucket, prefix, region, endpoint}`.
+- Connects/creates the kopia repository against that target, with
+  `credential_process = bestool backup-credentials` for the creds.
+- Runs the backup (or restore).
+
+The device is provisioned only with its Canopy URL and mTLS identity.
+The bucket, prefix and region are never written to the device's
+persistent config — bestool re-derives the repository connection from
+Canopy on each run, so a server-side config change takes effect on the
+next backup with zero device reconfiguration.
 
 bestool work is in a separate repo; this plan covers the Canopy side
 and the bestool side will be a sibling change there.

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -18,6 +18,12 @@ directly (no proxy through Canopy).
 - Cross-*group* restore is explicitly **not** supported.
 - Every credential issuance is recorded so we can answer "did device X
   back up today, and when."
+- No device can delete backups: `DeleteObject` is never granted to a
+  device cred, so a compromised server cannot wipe its group's backups.
+- Canopy owns repository maintenance (compaction, GC, retention/expiry),
+  running it as Kubernetes Jobs off the client servers — both to keep
+  that heavy, slow work off the servers and so that delete rights live
+  only in the control plane.
 
 ## Non-goals (for this plan)
 
@@ -26,9 +32,16 @@ directly (no proxy through Canopy).
   of every backup to Canopy uptime, and a much larger protocol surface.
 - Cross-group restore. The endpoint signature can stay minimal because
   this is genuinely out of scope, not "deferred."
-- Retention policy enforcement, cost dashboards, alerting on missed
-  backups. The audit log this plan introduces is the foundation for
-  those, but the features themselves come later.
+- Cost dashboards and byte-level reconciliation against S3
+  inventory / CloudWatch. (Missed-backup alerting *is* in scope now —
+  see staleness detection — and maintenance/expiry execution is owned by
+  Canopy; what's deferred is cost/usage analytics.)
+- Tuning the kopia *retention policy* values (keep N daily / M weekly).
+  Canopy now *executes* retention via maintenance, but the policy values
+  themselves start at a sane default; per-group tuning is later.
+- WORM immutability (S3 Object Lock / versioning). Dropping `DeleteObject`
+  from device creds is the first step; full protection against a
+  malicious server overwriting objects is a follow-up.
 - Picking the backup tool. Kopia is the assumed consumer because it
   fits the AWS SDK `credential_process` hook cleanly, but rclone works
   through the same mechanism if it turns out to be preferred.
@@ -54,6 +67,21 @@ directly (no proxy through Canopy).
 ┌──────────┐
 │    S3    │
 └──────────┘
+
+Maintenance path (Canopy-owned, no device involvement):
+
+┌──────────┐  spawns k8s Job per group   ┌──────────────────┐
+│ Canopy   │ ──────────────────────────► │ maintenance Job  │
+│          │                             │ (kopia image,    │
+└──────────┘                             │  own IRSA → full │
+                                         │  S3 incl delete) │
+                                         └──────────────────┘
+                                                  │
+                                                  │ kopia maintenance
+                                                  ▼
+                                            ┌──────────┐
+                                            │    S3    │
+                                            └──────────┘
 ```
 
 Two STS calls per issuance:
@@ -117,6 +145,7 @@ CREATE TABLE server_group_backup_config (
     region            TEXT,                    -- NULL → deployment default
     endpoint          TEXT,                    -- NULL → AWS; set for non-AWS S3
     expected_interval INTERVAL,                -- NULL → no staleness alerting
+    repo_password_ref TEXT NOT NULL,           -- reference to the secret, NOT the secret
     created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -126,6 +155,11 @@ CREATE TABLE server_group_backup_config (
 `expected_interval` drives staleness detection (below): if a group is
 expected to back up daily, set it to `1 day` and Canopy alerts when a
 device in the group has no recent successful run.
+
+`repo_password_ref` points at the group's kopia repository password
+(held in a k8s secret / Secrets Manager, not stored here in plaintext —
+see "Repository password ownership"). It's the secret *reference*; the
+column never holds the password itself.
 
 A row is keyed by the root server id (the parentless server that heads
 the group). Devices without a configured root row → `409 Conflict` from
@@ -187,6 +221,28 @@ Written by `POST /backup-report`. This is the "a backup actually
 completed" signal that staleness detection reads. Issuance alone is not
 enough: a device can get creds and then crash before uploading anything,
 and that must not read as a healthy backup.
+
+### New table: `backup_maintenance_runs`
+
+```sql
+CREATE TABLE backup_maintenance_runs (
+    id              BIGSERIAL PRIMARY KEY,
+    root_server_id  UUID NOT NULL REFERENCES servers(id),
+    kind            TEXT NOT NULL,            -- "quick" | "full"
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at     TIMESTAMPTZ,
+    outcome         TEXT,                     -- "success" | "failure"; NULL while running
+    error           TEXT,
+    bytes_reclaimed BIGINT                    -- if kopia surfaces it
+);
+
+CREATE INDEX ON backup_maintenance_runs (root_server_id, started_at DESC);
+```
+
+Written by the Canopy maintenance Jobs (see "Canopy-owned maintenance").
+A group whose maintenance silently stops is a slow-motion failure (repo
+bloat, retention not enforced), so this feeds the same staleness
+alerting as `backup_runs`.
 
 ## Endpoint shape
 
@@ -269,12 +325,18 @@ told.)
 
 `purpose` is a real capability gate, not just audit metadata:
 
-- `"backup"` (default): read + write + delete + multipart, scoped to
-  the group's prefix. Kopia needs delete for snapshot expiry.
+- `"backup"` (default): read + write + multipart, **no `DeleteObject`**,
+  scoped to the group's prefix. Snapshot expiry and blob GC are *not*
+  done by the device — Canopy owns maintenance (see "Canopy-owned
+  maintenance" below), so the device never needs delete. A compromised
+  server therefore cannot delete backups.
 - `"restore"`: read-only (Get + ListBucket), scoped to the group's
   prefix. A device with these creds physically cannot mutate the
   bucket, so an accidental `kopia repository create` or similar can't
   damage backups.
+
+No device purpose grants `DeleteObject`. The only identity that can
+delete from the bucket is the Canopy maintenance role.
 
 The choice is the caller's; both purposes are available to every
 `Server`-role device within the group. There's no privilege gradient
@@ -296,7 +358,7 @@ Handler flow:
 
 ### Session policy templates
 
-**`purpose = "backup"`** — read + write + delete:
+**`purpose = "backup"`** — read + write, no delete:
 
 ```json
 {
@@ -305,7 +367,7 @@ Handler flow:
     {
       "Effect": "Allow",
       "Action": [
-        "s3:GetObject", "s3:PutObject", "s3:DeleteObject",
+        "s3:GetObject", "s3:PutObject",
         "s3:AbortMultipartUpload", "s3:ListBucketMultipartUploads",
         "s3:ListMultipartUploadParts"
       ],
@@ -352,12 +414,36 @@ listing. The restore variant omits all mutation actions — even an
 explicit attempt to `kopia repository create` over the prefix is
 rejected by S3, not just by kopia.
 
+`AbortMultipartUpload` is retained on the backup purpose: it can only
+discard a device's *own in-flight* multipart upload, never a committed
+object, so it doesn't weaken the "can't delete backups" property — it
+just lets a failed upload clean up its own parts instead of leaving
+billable orphans.
+
+What dropping `DeleteObject` does **not** give you is full immutability:
+the backup purpose still has `PutObject`, so a compromised server could
+overwrite or corrupt existing repo objects (kopia content blobs are
+content-addressed, but index/pack/manifest blobs are still
+over-writable). Defeating a *malicious* (not merely accidental) server
+needs S3 Object Lock / versioning (WORM) so even overwrites are
+governed. That's a worthwhile follow-up but out of scope here; removing
+delete is the high-value, low-cost first step (it kills the most
+destructive action — wholesale deletion — outright).
+
 ## AWS setup (out-of-band of this plan, but documented here for completeness)
 
 - `canopy-backup-issuer` role with trust policy allowing the Canopy pod's
   IRSA role to assume it.
 - Role policy grants broad `s3:*` on the backups bucket (broad because
-  the session policy is what actually constrains each call).
+  the session policy is what actually constrains each call). Note: the
+  *device* session policies never grant delete, so even though the role
+  could, the creds handed to devices can't.
+- `canopy-backup-maintenance` role (or service account) for the
+  maintenance Jobs, with full S3 incl. `DeleteObject` on the backups
+  bucket. This is the only identity in the system that can delete backup
+  objects. It is first-party (Canopy-controlled), never handed to a
+  device. See "Canopy-owned maintenance" for why it gets its own IRSA
+  identity rather than chained creds.
 - The backups bucket is created separately. Single bucket to start;
   the `bucket` column in `server_group_backup_config` means moving to
   one-bucket-per-group later is a data migration, not a code change.
@@ -446,6 +532,90 @@ window lapses and Canopy alerts. The propagation itself is automatic
 (every-run target fetch); detection is the backstop for when automatic
 propagation doesn't take.
 
+## Canopy-owned maintenance
+
+A kopia repository needs periodic maintenance: index compaction, blob
+garbage collection, and snapshot retention/expiry. In the default kopia
+deployment, one client "owns" the repo and runs this. We don't want that
+here, for two reasons:
+
+- **Load.** Full maintenance walks the whole repo and rewrites packs —
+  it takes a while and is I/O heavy. Putting it on a client server steals
+  resources from the thing that server actually exists to do.
+- **Least privilege.** Maintenance is the *only* operation that needs
+  `DeleteObject`. If a client ran it, every client would need delete, and
+  a compromised server could wipe the group's backups. By moving
+  maintenance to Canopy, no device cred ever needs delete (see the
+  session policies above), so a compromised server cannot delete backups.
+
+So Canopy owns maintenance. Concretely, a scheduled control-plane task
+spawns a **Kubernetes Job per group** that runs `kopia maintenance run`
+(quick on a short cadence, full less often) against that group's prefix,
+then exits. Spawning a Job rather than running kopia in-process keeps the
+heavy, long-running work off the Canopy pod and lets it use the kopia
+image directly.
+
+### Credentials for the maintenance Job
+
+The Job assumes `canopy-backup-maintenance` (full S3 incl. delete on the
+bucket). Crucially it gets this via **its own IRSA service account**, not
+chained creds minted by Canopy. The reason is the 1-hour cap on chained
+AssumeRole sessions noted up top: device backups tolerate it because
+`credential_process` refreshes on demand, but a full-maintenance run can
+exceed an hour, and we don't want it dying mid-rewrite. A direct IRSA
+identity on the Job refreshes transparently with no cap.
+
+Maintenance is first-party Canopy-controlled code, so granting it broad
+bucket access (rather than per-group prefix narrowing via a session
+policy, which would re-introduce the 1-hour cap) is an acceptable
+trade-off. Per-prefix narrowing is what protects against *untrusted*
+device creds; it's not load-bearing for our own maintenance job. (If we
+later want per-group blast-radius limits on maintenance too, one role per
+group is the escape hatch — flagged, not built.)
+
+### Repository password ownership
+
+This is the new dependency maintenance forces into the open: kopia
+repositories are encrypted, and **connecting to one — to back up, to
+restore, or to maintain — requires the repository password.** Today
+nothing in the plan says where that password lives. Maintenance settles
+it: Canopy owns the per-group repository password, because Canopy is the
+one party that must always be able to connect (it runs maintenance) and
+is already the source of truth for backup config.
+
+- Canopy generates the password when a group's backup config is first
+  set up, and serves it to devices (alongside the target) so bestool can
+  `kopia repository connect`, and injects it into maintenance Jobs.
+- This is *not* a new exposure on the device side: any client writing to
+  an encrypted kopia repo inherently holds the password — that's
+  intrinsic to direct-to-S3 backup, not something maintenance adds.
+- Storage of the password on the Canopy side is sensitive. Plaintext in
+  the DB is the easy option but probably wrong; a k8s secret or AWS
+  Secrets Manager reference held by `server_group_backup_config` is more
+  appropriate. **Open question — decide during implementation.**
+- The repo's maintenance *owner* is set to the Canopy maintenance
+  identity, and client-side maintenance is disabled, so clients never
+  attempt the maintenance they no longer have delete rights for.
+
+### Audit
+
+Maintenance runs are logged like device runs — a `backup_maintenance_runs`
+table (root_server_id, kind quick|full, started/finished, outcome, error,
+bytes reclaimed if available). Same value as `backup_runs`: "is
+maintenance actually happening for this group, and did it succeed." A
+group whose maintenance has silently stopped is a slow-motion problem
+(repo bloat, retention not enforced), so it feeds the same staleness
+alerting.
+
+### Where it lives
+
+The device-facing endpoints are on `public-server` (mTLS). Maintenance
+scheduling is internal control-plane work, not device-facing, and needs
+Kubernetes API access (a service account with RBAC to create Jobs). The
+exact home (private-server, a dedicated worker, or a CronJob that itself
+fans out per-group Jobs) is an implementation detail to settle then;
+what's fixed is that it's Canopy's responsibility, not a client's.
+
 ## Operational story (what we gain, day-one)
 
 - **"Did device X back up today?"** — `backup_runs` gives the real
@@ -468,6 +638,14 @@ propagation doesn't take.
   the *config* change propagate automatically, but the operator still
   owns the migration/cutover decision. (Listed under out-of-scope as
   per-group bucket migration.)
+- **A compromised server can't delete backups** — no device cred grants
+  `DeleteObject`; only the Canopy maintenance role can. (It can still
+  *overwrite* until WORM lands — see non-goals.)
+- **Maintenance just happens** — clients don't run it and don't have the
+  rights to; Canopy spawns the Jobs. Repo bloat / unenforced retention
+  from a stuck client owner is no longer a failure mode, and
+  `backup_maintenance_runs` + staleness alerting catch a stuck *Canopy*
+  maintenance instead.
 
 ## Open questions
 
@@ -489,6 +667,19 @@ None blocking, but flag-and-decide-during-implementation:
 - **Grace factor for staleness.** `expected_interval × N` before
   alerting — pick N (and whether it's configurable per group) during
   implementation; start simple.
+- **Repo password storage.** Canopy owns the per-group kopia password;
+  where does the secret actually live (k8s secret vs. Secrets Manager
+  vs. ...) and how is it served to devices and injected into Jobs?
+  `repo_password_ref` is a reference, not the secret — settle the
+  backing store during implementation.
+- **Maintenance cadence.** Quick vs. full intervals — start with
+  deployment-wide defaults; per-group override is a later column if
+  needed. Decide the scheduler home (CronJob fanning out per-group Jobs,
+  a private-server task, or a dedicated worker).
+- **Maintenance Job scoping.** Broad-bucket IRSA (simple, no 1-hour cap)
+  vs. one role per group (tighter blast radius, but per-group narrowing
+  via session policy re-introduces the cap). Recommended: broad for the
+  first cut since maintenance is first-party.
 
 ## Out of scope (do not silently fold in)
 
@@ -508,8 +699,14 @@ None blocking, but flag-and-decide-during-implementation:
 - Per-group bucket migration (the schema supports it; the operational
   work is separate).
 - bestool subcommand implementation (separate repo).
-- Backup retention, encryption-at-rest beyond default SSE-S3, lifecycle
-  policies (separate concerns).
+- **Tuning** retention policy values, encryption-at-rest beyond default
+  SSE-S3, S3 lifecycle rules. (Retention *execution* is in scope — Canopy
+  maintenance runs it — but the kopia retention values start at a default
+  and per-group tuning is later.)
+- WORM immutability via S3 Object Lock / versioning. Dropping device
+  delete is the first step; governing overwrites is a follow-up.
 - Operator UI in `private-server` / React for editing
   `server_group_backup_config` (will want it eventually; not in the
-  first cut — bootstrap via SQL).
+  first cut — bootstrap via SQL). This now includes the maintenance
+  schedule and the repo-password reference, still bootstrapped via SQL /
+  secret tooling for the first cut.

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -257,7 +257,7 @@ pointer to the `AssumeRole` event itself.
 
 ```sql
 CREATE TABLE backup_runs (
-    id              BIGSERIAL PRIMARY KEY,
+    id              UUID PRIMARY KEY,         -- the run-uuid, minted by bestool at run start
     device_id       UUID NOT NULL REFERENCES devices(id),
     group_id        UUID NOT NULL REFERENCES server_groups(id),
     purpose         TEXT NOT NULL,            -- "backup" | "restore"
@@ -276,6 +276,16 @@ Written by `POST /backup-report`. This is the "a backup actually
 completed" signal that staleness detection reads. Issuance alone is not
 enough: a device can get creds and then crash before uploading anything,
 and that must not read as a healthy backup.
+
+`id` is **not** a serial — it's the **run-uuid bestool mints at run
+start**, so the device can stamp it into the snapshot's tags (`canopy-run`)
+*before* the row exists, and supplies it in `POST /backup-report`. That's
+what makes the `snapshot → run → issuance` join real. A client-supplied
+PK is safe: `device_id`/`group_id` come from the authenticated
+`ServerDevice` context (not the client's claim), so attribution can't be
+forged, and a duplicate `id` just fails *its own* insert (PK violation) —
+it can't overwrite another row. Only `backup_runs` needs this; the other
+audit tables stay Canopy-generated `BIGSERIAL`.
 
 ### New table: `backup_maintenance_runs`
 
@@ -405,6 +415,7 @@ device-side coordination.
 POST /backup-report
   Authorization: mTLS via ServerDevice
   Body: {
+    "run_id":         "...",   -- the run-uuid bestool minted at run start (becomes backup_runs.id)
     "purpose": "backup" | "restore",
     "outcome": "success" | "failure",
     "error":          "...",   -- optional, on failure
@@ -925,8 +936,9 @@ freshness isn't gated by the slow maintenance interval.
   the source is the backup subject and survives device replacement
   (continuous history, no fragmented chain). The *device + run* that
   produced a snapshot live in its **tags** (`canopy-device=<uuid>`,
-  `canopy-run=<run-uuid>`, the run-uuid minted client-side and echoed in
-  `backup_runs`), closing the loop snapshot → run → issuance → CloudTrail.
+  `canopy-run=<run-uuid>`, where the run-uuid is **`backup_runs.id`** —
+  minted by bestool at run start, stamped on the snapshot, then reported),
+  closing the loop snapshot → run → issuance → CloudTrail.
 - Reconciliation against signal 1 is where the value is:
   - report says success **but** no recent snapshot in the repo → the
     report is wrong or the upload didn't persist → **alert** (the case

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -538,7 +538,13 @@ when one goes quiet. That detection catches a stale config, a dead
 timer, a crashed run, or a network outage — all the ways a backup can
 fail, not just config drift.
 
-Mechanism:
+There are two independent ways for Canopy to know, and we use both:
+
+### Signal 1 — device reports (timely, self-reported)
+
+This is the cheap, immediate signal: bestool tells Canopy how each run
+went, and a job scans those reports in the database.
+
 1. bestool reports each run via `POST /backup-report`, written to
    `backup_runs`.
 2. A periodic Canopy job (alongside the existing health/alerting
@@ -565,10 +571,49 @@ Mechanism:
 3. Alerts route through the existing operator notification path
    (Slack/email via `PRIVATE_URL`).
 
+The limit of signal 1 is that it's the *device's word*: it scans the
+Canopy database for what devices reported, not for what's actually in the
+bucket. A device that crashes before reporting looks (safely) stale; a
+compromised or buggy device could report success it didn't achieve; a
+snapshot that the device believes it wrote but that never persisted reads
+as healthy. Reports are timely but not authoritative.
+
+### Signal 2 — repository inspection (authoritative, periodic)
+
+Now that maintenance jobs already connect to each group's repository with
+the password, Canopy can read the **ground truth**: the snapshots that
+actually exist. A check — piggybacked on the maintenance job, or a
+dedicated read-only job on the same footing — lists the repo's snapshots
+and records, per source, the latest snapshot time. That's what *actually
+landed in the bucket*, independent of whether any device reported, was
+honest, or is even reachable.
+
+- For this to attribute snapshots to devices, the kopia **source must
+  encode the device** (e.g. fix the snapshot host to the device id) so
+  Canopy can map `user@host:path` back to a device. The backup setup must
+  pin this deterministically — flagged below.
+- Reconciliation against signal 1 is where the value is:
+  - report says success **but** no recent snapshot in the repo → the
+    report is wrong or the upload didn't persist → **alert** (the case
+    signal 1 alone cannot catch).
+  - recent snapshot **but** no report → backups are fine, the reporting
+    path is broken → lower-severity notice.
+  - neither → genuinely stale (agrees with signal 1).
+- It is *not* a replacement for signal 1's timeliness: it only sees the
+  repo as often as the job runs (maintenance cadence), so an hourly-miss
+  won't surface until the next inspection. Reports stay the day-to-day
+  signal; repo inspection is the periodic trust anchor.
+- Trust property: signal 2 depends only on the bucket (Object-Lock
+  protected), not on any device, so it's the signal a compromised server
+  cannot fake into showing a healthy backup.
+
+Both signals feed the same alerting path.
+
 This is the half of "did device X back up today" that the audit log
 alone can't give: `backup_credential_issuances` says creds were handed
-out; `backup_runs` + this job says whether the backup landed and shouts
-when it didn't.
+out; `backup_runs` says what the device *reported*; repository inspection
+says what *actually landed* — and the three together shout when they
+disagree.
 
 A bucket change therefore can't silently break the fleet: if a host
 fails to pick up the new target or fails to upload, its next expected
@@ -766,6 +811,13 @@ None blocking, but flag-and-decide-during-implementation:
   asks Canopy (which already has `backup_runs`). Asking Canopy is
   drift-proof but adds a round-trip; local state is cheaper but can lie
   after a host rebuild. Decide during implementation.
+- **kopia source → device mapping.** Repository inspection (signal 2)
+  needs to attribute each snapshot source back to a device, so the
+  snapshot source must encode the device deterministically (e.g. host =
+  device id). Pin this in the backup setup; settle where the per-source
+  latest-snapshot inventory is stored (extend `backup_maintenance_runs`,
+  or a dedicated table) and the inspection cadence if it's a job
+  separate from maintenance.
 - **Repo password storage.** Canopy owns the per-group kopia password;
   where does the secret actually live (k8s secret vs. Secrets Manager
   vs. ...) and how is it served to devices and injected into Jobs?

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -458,11 +458,12 @@ interacts with kopia GC.
 
 ## `bestool` changes
 
-A new subcommand for the credential refresh, plumbed as kopia's
-`credential_process`:
+These hang off bestool's existing `canopy` subcommand, since they're all
+Canopy-mediated. A subcommand for the credential refresh, plumbed as
+kopia's `credential_process`:
 
 ```
-bestool backup-credentials [--purpose backup|restore]   # default: backup
+bestool canopy backup-credentials [--purpose backup|restore]   # default: backup
 ```
 
 - Reads the device's mTLS identity from its existing location.
@@ -475,14 +476,14 @@ And a driver subcommand that owns the kopia invocation so the device
 holds no hardcoded bucket:
 
 ```
-bestool backup [--purpose backup|restore]
+bestool canopy backup [--purpose backup|restore]
 ```
 
 - `GET /backup-target` to learn `{bucket, prefix, region, endpoint}`
   **on every run** — never cached to persistent device config.
 - Reconciles the kopia repository connection against that target (so a
   changed bucket/prefix is picked up here), with
-  `credential_process = bestool backup-credentials` for the creds.
+  `credential_process = bestool canopy backup-credentials` for the creds.
 - Runs the backup (or restore).
 - Reports the run outcome back to Canopy (see "Backup reporting" below),
   so the control plane learns "backup completed", not just "creds
@@ -492,7 +493,7 @@ The device is provisioned only with its Canopy URL and mTLS identity.
 The bucket, prefix and region are never written to the device's
 persistent config — bestool re-derives the repository connection from
 Canopy on *every* run. This is the crux of the "no per-host action"
-property: `bestool backup` is the scheduled job (systemd timer / cron)
+property: `bestool canopy backup` is the scheduled job (systemd timer / cron)
 that already runs on each host on its backup cadence, so a server-side
 config change propagates to the whole fleet automatically on each host's
 next scheduled backup. There is no operator command to run per host and
@@ -681,7 +682,7 @@ what's fixed is that it's Canopy's responsibility, not a client's.
   row; devices in that group start getting `409`.
 - **Changing prefix, region, or endpoint** — update the
   `server_group_backup_config` row. Each device picks it up on its next
-  scheduled `bestool backup` (every-run target fetch); no per-host
+  scheduled `bestool canopy backup` (every-run target fetch); no per-host
   command, no coordinated cutover. Staleness detection flags any host
   that fails to roll over.
 - **Rotating the *bucket*** — note this is not a free config flip: a

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -39,9 +39,9 @@ directly (no proxy through Canopy).
 - Tuning the kopia *retention policy* values (keep N daily / M weekly).
   Canopy now *executes* retention via maintenance, but the policy values
   themselves start at a sane default; per-group tuning is later.
-- WORM immutability (S3 Object Lock / versioning). Dropping `DeleteObject`
-  from device creds is the first step; full protection against a
-  malicious server overwriting objects is a follow-up.
+- WORM immutability is **already in place** (30-day S3 Object Lock on the
+  buckets) — not a follow-up. This plan just has to be compatible with it
+  (object-lock-aware kopia repos; GC reclaims on a ~30-day lag).
 - Picking the backup tool. Kopia is the assumed consumer because it
   fits the AWS SDK `credential_process` hook cleanly, but rclone works
   through the same mechanism if it turns out to be preferred.
@@ -420,15 +420,15 @@ object, so it doesn't weaken the "can't delete backups" property — it
 just lets a failed upload clean up its own parts instead of leaving
 billable orphans.
 
-What dropping `DeleteObject` does **not** give you is full immutability:
-the backup purpose still has `PutObject`, so a compromised server could
-overwrite or corrupt existing repo objects (kopia content blobs are
-content-addressed, but index/pack/manifest blobs are still
-over-writable). Defeating a *malicious* (not merely accidental) server
-needs S3 Object Lock / versioning (WORM) so even overwrites are
-governed. That's a worthwhile follow-up but out of scope here; removing
-delete is the high-value, low-cost first step (it kills the most
-destructive action — wholesale deletion — outright).
+Dropping `DeleteObject` is defence-in-depth on top of the real backstop:
+**the buckets already have a 30-day S3 Object Lock.** So even a cred that
+*could* delete or overwrite can't destroy a backup object younger than 30
+days — a locked version is retained regardless. The no-delete device
+policy still earns its place (it removes the most destructive action
+outright, and avoids accidental client-side expiry), but the guarantee
+"a compromised server cannot destroy recent backups" rests on Object
+Lock, not on IAM alone. See "Canopy-owned maintenance" for how the lock
+interacts with kopia GC.
 
 ## AWS setup (out-of-band of this plan, but documented here for completeness)
 
@@ -573,6 +573,23 @@ device creds; it's not load-bearing for our own maintenance job. (If we
 later want per-group blast-radius limits on maintenance too, one role per
 group is the escape hatch — flagged, not built.)
 
+### Interaction with the 30-day Object Lock
+
+The buckets have a 30-day S3 Object Lock, which constrains maintenance:
+kopia GC cannot actually delete a pack blob until its lock expires, so
+storage from expired snapshots is reclaimed on a ~30-day lag, not
+immediately. This is expected and is the price of ransomware-proof
+backups — it must not be read as maintenance failing. Two implications
+for implementation:
+
+- The kopia repository must be created **object-lock-aware** (kopia
+  supports this explicitly: it tracks retention and avoids trying to
+  delete still-locked blobs). A repo created oblivious to the lock will
+  throw errors when maintenance attempts deletes that S3 refuses.
+- Budget for the lag: at any time the bucket holds up to ~30 days of
+  not-yet-collectable garbage on top of live data. Fine, but worth
+  noting for capacity/cost.
+
 ### Repository password ownership
 
 This is the new dependency maintenance forces into the open: kopia
@@ -638,9 +655,10 @@ what's fixed is that it's Canopy's responsibility, not a client's.
   the *config* change propagate automatically, but the operator still
   owns the migration/cutover decision. (Listed under out-of-scope as
   per-group bucket migration.)
-- **A compromised server can't delete backups** — no device cred grants
-  `DeleteObject`; only the Canopy maintenance role can. (It can still
-  *overwrite* until WORM lands — see non-goals.)
+- **A compromised server can't destroy recent backups** — no device cred
+  grants `DeleteObject`, and the 30-day Object Lock means even a delete-
+  or overwrite-capable cred can't damage backup objects younger than 30
+  days. IAM removes the action; Object Lock is the hard backstop.
 - **Maintenance just happens** — clients don't run it and don't have the
   rights to; Canopy spawns the Jobs. Repo bloat / unenforced retention
   from a stuck client owner is no longer a failure mode, and
@@ -703,8 +721,8 @@ None blocking, but flag-and-decide-during-implementation:
   SSE-S3, S3 lifecycle rules. (Retention *execution* is in scope — Canopy
   maintenance runs it — but the kopia retention values start at a default
   and per-group tuning is later.)
-- WORM immutability via S3 Object Lock / versioning. Dropping device
-  delete is the first step; governing overwrites is a follow-up.
+- Standing up Object Lock — the buckets already have a 30-day lock; this
+  plan consumes it (object-lock-aware repos), it doesn't create it.
 - Operator UI in `private-server` / React for editing
   `server_group_backup_config` (will want it eventually; not in the
   first cut — bootstrap via SQL). This now includes the maintenance

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -355,7 +355,8 @@ POST /backup-credentials
     "SessionToken": "...",
     "Expiration": "..."
   }
-  Response 409: no backup config for this device's group
+  Response 412: device not bound to a live server (DeviceHasNoServer)
+  Response 409: server ungrouped, or no backup config for the group
   Response 502: STS call failed
 ```
 
@@ -371,7 +372,8 @@ GET /backup-target
     "region": "...",
     "endpoint": "..."         -- optional; for non-AWS S3
   }
-  Response 409: no backup config for this device's group
+  Response 412: device not bound to a live server (DeviceHasNoServer)
+  Response 409: server ungrouped, or no backup config for the group
 ```
 
 This is the piece that keeps the bucket out of device provisioning. The
@@ -450,8 +452,12 @@ Handler flow:
    `Device` (`device.0.0`) — server/group resolution is the handler's job
    (same as `statuses.rs`).
 2. Resolve the device's server via `Server::live_by_device_id` (devices
-   have no `server_id`; servers reference devices). No live server →
-   `409` (the `DeviceHasNoServer` case, as in `events.rs`).
+   have no `server_id`; servers reference devices — and the
+   `servers_device_id_unique` partial unique index guarantees at most one
+   server per device, so this is a single server, not a set). No live
+   server → **`412`** via the existing `AppError::DeviceHasNoServer`
+   (which maps to `PRECONDITION_FAILED`, `commons-errors/src/lib.rs:193`;
+   used by `events.rs`).
 3. Read that server's `group_id: Option<Uuid>`; `None` (ungrouped) →
    `409`.
 4. Read `server_group_backup_config` for that `group_id`; `409` if absent.
@@ -1301,10 +1307,13 @@ The original open questions were worked through one by one; outcomes
    event back to the issuance (purpose/device/bucket/time).
 3. **`sts_request_id`** — **keep** (nullable, best-effort via the SDK
    `RequestId` trait); belt-and-suspenders with `access_key_id`.
-4. **Device→server/group resolution** — the **`409` policy is locked**
-   (no server binding / no group / no config → `409`; real gaps filed
-   separately), which gives the **provision-then-authorize** property. The
-   lookup *mechanics* are deferred (see below).
+4. **Device→server/group resolution** — dormant-when-unconfigured is
+   locked: **no live server → `412`** (`DeviceHasNoServer`, the existing
+   code maps it to `PRECONDITION_FAILED`), **ungrouped or no config →
+   `409`**. (Corrected from "single 409" — `DeviceHasNoServer` is 412 in
+   the codebase.) Gives the **provision-then-authorize** property; bestool
+   treats *both* 412 and 409 as benign "dormant, nothing to do". Lookup
+   mechanics resolved in the repo-alignment commit.
 5. **Staleness "present since"** —
    `max(device_server_associations.first_seen, server_group_backup_config.created_at)`.
 6. **Grace factor** — **`×2`**, not per-group configurable yet.

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -509,6 +509,15 @@ group's Pulumi stack); the **restore** set is the read-only **session
 policy** Canopy passes when assuming that same role for `purpose=restore`
 (it ANDs down to read-only).
 
+Normativity (to avoid drift): for the **backup role policy**, the existing
+**`AWS_S3_MULTIPART_ACTIONS` constant is the source of truth** (it includes
+`GetObjectAttributes`/`GetObjectTorrent` etc. that the illustrative JSON
+below omits, and is composed as `[...AWS_S3_DELETE_ACTIONS,
+'s3:PutObjectRetention']` minus those — see `constants/external.ts`); the
+JSON below is illustrative. The **restore session-policy JSON is
+normative** — Canopy authors it at assume-time, and it's where the
+`GetBucketLocation`/`s3:prefix` split actually matters.
+
 **`purpose = "backup"`** — read + write, no delete (the role policy):
 
 ```json
@@ -580,11 +589,15 @@ sub-path case. The restore variant omits all mutation actions — even an
 explicit attempt to `kopia repository create` is rejected by S3, not just
 by kopia.
 
-`AbortMultipartUpload` is retained on the backup purpose: it can only
-discard a device's *own in-flight* multipart upload, never a committed
-object, so it doesn't weaken the "can't delete backups" property — it
-just lets a failed upload clean up its own parts instead of leaving
-billable orphans.
+`AbortMultipartUpload` is retained on the backup purpose so a failed
+upload can clean up its own parts instead of leaving billable orphans. To
+be precise (it's resource-scoped to `<bucket>/<prefix>*`, *not*
+upload-owner-scoped, and `ListBucketMultipartUploads` makes sibling upload
+IDs discoverable): a compromised device could abort *any* in-flight
+multipart upload in the group's bucket. That's only a same-group
+backup-disruption DoS — no committed object is at risk — so it doesn't
+weaken the "can't delete backups" property, but it isn't "own uploads
+only".
 
 Dropping `DeleteObject` is defence-in-depth on top of the real backstop:
 **every group's bucket has versioning + a 30-day S3 Object Lock** (both
@@ -717,6 +730,11 @@ short-lived creds for them instead. The IaC changes are therefore:
   `s3:*` (incl. the ability to bypass GOVERNANCE) — that's the accepted
   AWS-level trust boundary, see the threat-boundary note above; the
   protection target here is device compromise, not this first-party role.
+- **Add `s3:GetBucketObjectLockConfiguration`** to the per-bucket role
+  Canopy assumes — the per-group preflight reads it to confirm the lock is
+  still in place, and no existing action set (`AWS_S3_MULTIPART_ACTIONS`
+  etc.) includes it, so it would otherwise surface as a day-one preflight
+  `AccessDenied`. (Read-only; harmless on the device set.)
 
 ### IAM model: per-bucket roles, assumed cross-account
 
@@ -907,11 +925,12 @@ went, and a job scans those reports in the database.
    is the server being protected; the device is the actor recorded in
    `backup_runs`/snapshot tags. A manual-only or unconfigured group is
    simply not in the scanned set, so unauthorized devices never alert.)
-   - **Stale**: previously reported success but no `outcome = 'success'`
-     newer than `expected_interval × 2` → alert. (`×2` = the anti-flap
-     factor from the decisions; not per-group configurable yet. Given the
-     ~1-min trigger retries quickly, two missed intervals signals genuine
-     breakage, not a blip.)
+   - **Stale**: previously reported success but no `purpose = 'backup'`
+     row with `outcome = 'success'` newer than `expected_interval × 2` →
+     alert. (Filter on `purpose='backup'` — a recent successful *restore*
+     must not reset backup staleness. `×2` = the anti-flap factor; not
+     per-group configurable yet. Given the ~1-min trigger retries quickly,
+     two missed intervals signals genuine breakage, not a blip.)
    - **Never backed up**: present longer than `expected_interval × 2` with
      *no* successful `backup_runs` row → alert. "Present since" is
      `max(server-present, group-authorized)` where *group-authorized* is
@@ -928,7 +947,8 @@ went, and a job scans those reports in the database.
    `Incident::open_for`). Construct a `NewEvent { source: "canopy", ref:
    "backup-staleness", severity, message, active }` and call
    `NewEvent::save(conn, server_id, device_id)` (mirroring reachability's
-   `source="canopy"`/`ref="reachability"`). Downstream,
+   `source="canopy"`/`ref="reachability"`; for a server-centric alert pass
+   the server's latest-associated `device_id`). Downstream,
    `re_evaluate_incident_membership → find_or_open_incident →
    enqueue_slack_open → SlackOutbox::enqueue` opens the incident and queues
    Slack automatically — but only for a **monitored** server in a group and
@@ -983,7 +1003,11 @@ size). The S3 `bucket_bytes` billing figure is filled by a **separate
 S3-metrics task** with its own CloudWatch permissions — *not* on these
 read-only creds (see `backup_repo_stats`). It runs on its **own cadence**
 (defaulting to roughly `expected_interval`, tunable), so signal-2 freshness
-isn't gated by the slow maintenance interval.
+isn't gated by the slow maintenance interval — with a **floor (e.g.
+weekly) for manual-only groups** whose `expected_interval` is NULL but
+still hold backups worth inspecting. (Its read-only creds are chained from
+the scheduler's IRSA, so the 1-hour cap applies — fine for a `snapshot
+list` / verify pass.)
 
 - Attribution: the kopia **source encodes the server** — `bestool` overrides
   the kopia hostname to the **server id** (`canopy@<server-id>:<path>`), so
@@ -1378,7 +1402,13 @@ Surface it loudly; don't take Canopy down over it.
   row; devices in that group start getting `409`. The group's bucket and
   its Object-Lock'd objects persist independently — they can't be deleted
   until their locks expire (~30 days), so bucket teardown is a deliberate,
-  delayed step, not a side effect of removing the config row.
+  delayed step, not a side effect of removing the config row. Note: the
+  config row cascades on `server_groups` delete, but the **audit tables
+  (`backup_credential_issuances`/`backup_runs`/`backup_maintenance_runs`)
+  reference `server_groups(id)` without CASCADE on purpose** — so deleting
+  a `server_groups` row that has any audit history fails until it's dealt
+  with. That's intentional audit preservation; the runbook decides
+  (archive vs detach) rather than silently cascading the trail away.
 - **Onboarding a group** — IaC provisions its bucket (with Object Lock,
   see "Per-group buckets"), then the `server_group_backup_config` row is
   inserted. Devices in the group start succeeding on their next run; if

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -753,33 +753,50 @@ what's fixed is that it's Canopy's responsibility, not a client's.
 
 The device-staleness signals above watch the *devices*. This watches
 **Canopy's own upstream access**, which is a different and higher-stakes
-failure class: if the trust on `canopy-backup-issuer` is edited, the pod's
-IRSA annotation is dropped, a role is deleted, or the bucket's Object Lock
-is removed, the failure is *fleet-wide and instantaneous* — every
-issuance 502s and every maintenance job fails at once. We should learn
+failure class: if the trust on the issuer role is edited, the pod's IRSA
+annotation is dropped, a role is deleted, or a bucket's Object Lock is
+removed, devices can't get creds and maintenance Jobs fail — and the
+backups stop without any per-device fault to point at. We should learn
 that from Canopy checking itself, not from devices starting to fail.
 
-A periodic preflight (control-plane health machinery, same alerting path
-but flagged at control-plane / fleet-wide severity, distinct from
-per-device staleness):
+**It runs per server-group, not fleet-wide.** Each group carries its own
+`bucket`/`prefix`/`region`/`endpoint` (the schema already allows divergent
+buckets, and one-bucket-per-group is a planned data migration), so the
+bucket-level access and the Object Lock config can differ per group —
+and once buckets diverge, even the cred pathway can (e.g. a non-AWS-S3
+`endpoint` isn't reached via AWS STS at all). So a failure is normally
+*scoped to one group*; it's only fleet-wide when the genuinely shared
+piece breaks. The preflight reflects that split:
 
+Shared, checked once:
 - **Identity resolves** — `sts:GetCallerIdentity` confirms the pod's IRSA
   web-identity is mounted and valid.
-- **Issuance chain works** — a dry-run `AssumeRole` on
-  `canopy-backup-issuer` with a harmless session policy, confirming the
-  trust policy + role still admit Canopy. Optionally use the returned
-  creds for a **read-only no-op** against the bucket (e.g. `HeadBucket` /
-  a scoped `ListBucket` on a probe prefix) so the check proves the creds
-  *work*, not merely that `AssumeRole` returned.
-- **Object Lock is in place** — verify the backups bucket still has the
+- **Issuer role admits Canopy** — a dry-run `AssumeRole` on the issuer
+  role with a harmless session policy, confirming trust + role still
+  exist. (When per-bucket roles arrive, this becomes per-pathway.)
+
+Per configured group:
+- **Group creds work** — mint creds scoped to *that group's* bucket/prefix
+  and do a **read-only no-op** against *that group's* bucket/endpoint
+  (e.g. `HeadBucket` / a scoped `ListBucket` on a probe prefix), so the
+  check proves the group's creds actually work, not merely that
+  `AssumeRole` returned. This is the check that catches a single group's
+  bucket/endpoint/policy being wrong while others are fine.
+- **Object Lock is in place** — verify *that group's* bucket still has the
   expected (≥30-day) Object Lock configuration. The whole "a compromised
   server can't destroy backups" guarantee rests on this; if someone
   removes or weakens the lock, the protection silently erodes with no
-  other symptom, so it must be actively checked.
-- **Maintenance path** — either a cheap preflight maintenance Job
-  (connect to a repo + no-op and exit) on its own IRSA, or lean on
-  `backup_maintenance_runs` failures. The former is proactive; the latter
-  only catches it when maintenance next runs. Flagged below.
+  other symptom, so it must be actively checked — per bucket, since the
+  config is per bucket.
+- **Maintenance path** — that group's maintenance Job already exercises
+  its own pathway; either add a cheap preflight Job (connect + no-op and
+  exit) on its own IRSA, or lean on `backup_maintenance_runs` failures for
+  that group. The former is proactive; the latter only catches it when
+  maintenance next runs. Flagged below.
+
+Alerts name the affected group(s) and fire at control-plane severity
+(distinct from per-device staleness); a check that fails for *every*
+group points at the shared identity/issuer rather than any one bucket.
 
 Prefer **behavioural** checks (try to assume; try a harmless S3 op) over
 IAM/policy *introspection*: behavioural checks test the real path and
@@ -791,12 +808,12 @@ described config *looks* right.
 
 Reactively, the live paths are signals too: `/backup-credentials` already
 502s on STS failure and maintenance failures land in
-`backup_maintenance_runs` — track their rates so a regression surfaces
-between preflights, not only at the next scheduled probe.
+`backup_maintenance_runs` — track their rates (per group) so a regression
+surfaces between preflights, not only at the next scheduled probe.
 
 This should **alert, not gate readiness**: a failing upstream check
-pulling the pod out of rotation would only make a fleet-wide problem
-worse. Surface it loudly; don't take Canopy down over it.
+pulling the pod out of rotation would only make the problem worse.
+Surface it loudly; don't take Canopy down over it.
 
 ## Operational story (what we gain, day-one)
 
@@ -829,10 +846,11 @@ worse. Surface it loudly; don't take Canopy down over it.
   from a stuck client owner is no longer a failure mode, and
   `backup_maintenance_runs` + staleness alerting catch a stuck *Canopy*
   maintenance instead.
-- **A broken control plane is caught at the source** — the upstream
-  preflight alerts if Canopy loses its issuer access, or the bucket's
-  Object Lock is removed, *before* a single device fails, instead of the
-  fleet discovering it the hard way.
+- **A broken control plane is caught at the source** — the per-group
+  upstream preflight alerts if Canopy loses a group's bucket access, or a
+  bucket's Object Lock is removed, *before* a single device fails, and
+  names the affected group rather than waiting for the fleet to discover
+  it the hard way.
 
 ## Open questions
 
@@ -871,11 +889,14 @@ None blocking, but flag-and-decide-during-implementation:
   latest-snapshot inventory is stored (extend `backup_maintenance_runs`,
   or a dedicated table) and the inspection cadence if it's a job
   separate from maintenance.
-- **Preflight depth and cadence.** How often the upstream preflight runs,
-  and whether it does the deeper checks (S3 read no-op against a probe
-  prefix; `GetBucketObjectLockConfiguration`) or just `GetCallerIdentity`
-  + dry-run `AssumeRole`. Deeper = more confidence, slightly more IAM
-  surface. Also: proactive maintenance preflight Job vs. relying on
+- **Preflight depth, cadence, and per-group cost.** How often the
+  upstream preflight runs, and whether it does the deeper per-group checks
+  (S3 read no-op against a probe prefix; `GetBucketObjectLockConfiguration`)
+  or just the shared `GetCallerIdentity` + dry-run `AssumeRole`. Deeper =
+  more confidence, slightly more IAM surface. The per-group bucket checks
+  scale with group count, so settle a cadence that stays cheap at fleet
+  scale (and whether shared vs. per-group checks run on different
+  cadences). Also: proactive maintenance preflight Job vs. relying on
   `backup_maintenance_runs` failures.
 - **Repo password storage.** Canopy owns the per-group kopia password;
   where does the secret actually live (k8s secret vs. Secrets Manager

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -640,6 +640,22 @@ is a separate problem from defending the fleet of devices. So the
 guarantee is precisely "no device can destroy backups", not "nobody can".
 See "Canopy-owned maintenance" for how the lock interacts with kopia GC.
 
+**Accepted stage-1 risk — the issuer's blast radius.** `public-server`
+(internet-facing) holds, fleet-wide: STS-assume on every group's
+per-bucket role (read + **write**, i.e. the poisoning vector) and — since
+it serves the repo password on `/backup-target` — Secret-read for every
+group's repo password (which decrypts everything). So a `public-server`
+RCE yields fleet-wide backup read + poison in one hop. For stage 1 we
+**accept** this (same trust as canopy's other internet surface), relying
+on poisoning detection + recovery to bound the damage. The hardening that
+removes it (a blind-relay issuer) is captured separately in
+[`backup-credentials-blind-relay.md`](./backup-credentials-blind-relay.md).
+Two requirements that hold regardless: **the maintenance role's trust must
+never include the `public-server` principal** (delete/bypass stays
+Job-only, so a `public-server` compromise can't reach the *delete*
+capability), and the issuer rights must not extend beyond per-bucket
+assume.
+
 ## AWS setup (provisioned by the Pulumi `backups` stack)
 
 This already mostly exists. The `backups` stack in `ops/pulumi/backups`

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -111,13 +111,21 @@ Reasons not to put it in `private-server`:
 
 ```sql
 CREATE TABLE server_group_backup_config (
-    root_server_id  UUID PRIMARY KEY REFERENCES servers(id) ON DELETE CASCADE,
-    bucket          TEXT NOT NULL,
-    prefix          TEXT NOT NULL,           -- e.g. "groups/<root-id>/"
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    root_server_id    UUID PRIMARY KEY REFERENCES servers(id) ON DELETE CASCADE,
+    bucket            TEXT NOT NULL,
+    prefix            TEXT NOT NULL,           -- e.g. "groups/<root-id>/"
+    region            TEXT,                    -- NULL → deployment default
+    endpoint          TEXT,                    -- NULL → AWS; set for non-AWS S3
+    expected_interval INTERVAL,                -- NULL → no staleness alerting
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 ```
+
+`region`/`endpoint` are what `GET /backup-target` serves to devices.
+`expected_interval` drives staleness detection (below): if a group is
+expected to back up daily, set it to `1 day` and Canopy alerts when a
+device in the group has no recent successful run.
 
 A row is keyed by the root server id (the parentless server that heads
 the group). Devices without a configured root row → `409 Conflict` from
@@ -151,13 +159,38 @@ CREATE INDEX ON backup_credential_issuances (device_id, issued_at DESC);
 CREATE INDEX ON backup_credential_issuances (root_server_id, issued_at DESC);
 ```
 
-This is the audit log that "did device X back up today" queries against.
-We snapshot bucket/prefix at issuance time so the log stays correct
+This is the audit log of credential *issuance*. It answers "was a device
+handed creds" but not "did the backup succeed" — see `backup_runs` for
+that. We snapshot bucket/prefix at issuance time so the log stays correct
 even if the group config is later changed.
+
+### New table: `backup_runs`
+
+```sql
+CREATE TABLE backup_runs (
+    id              BIGSERIAL PRIMARY KEY,
+    device_id       UUID NOT NULL REFERENCES devices(id),
+    root_server_id  UUID NOT NULL REFERENCES servers(id),
+    purpose         TEXT NOT NULL,            -- "backup" | "restore"
+    outcome         TEXT NOT NULL,            -- "success" | "failure"
+    error           TEXT,                     -- populated on failure
+    bytes_uploaded  BIGINT,
+    snapshot_id     TEXT,                     -- kopia snapshot/manifest id
+    reported_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ON backup_runs (root_server_id, reported_at DESC);
+CREATE INDEX ON backup_runs (device_id, reported_at DESC);
+```
+
+Written by `POST /backup-report`. This is the "a backup actually
+completed" signal that staleness detection reads. Issuance alone is not
+enough: a device can get creds and then crash before uploading anything,
+and that must not read as a healthy backup.
 
 ## Endpoint shape
 
-Two endpoints, both `ServerDevice`-authenticated and both resolving the
+Three endpoints, all `ServerDevice`-authenticated and all resolving the
 device → root → `server_group_backup_config` the same way:
 
 ### `POST /backup-credentials` — short-lived creds
@@ -206,6 +239,27 @@ The only thing a device is ever provisioned with is its Canopy URL, its
 mTLS identity, and "run bestool" — never a bucket name. Canopy is the sole
 owner of backup-target config; changing it is a single-row update with no
 device-side coordination.
+
+### `POST /backup-report` — outcome of a run
+
+```
+POST /backup-report
+  Authorization: mTLS via ServerDevice
+  Body: {
+    "purpose": "backup" | "restore",
+    "outcome": "success" | "failure",
+    "error":          "...",   -- optional, on failure
+    "bytes_uploaded": 12345,   -- optional
+    "snapshot_id":    "..."    -- optional, kopia snapshot/manifest id
+  }
+  Response 204
+```
+
+bestool calls this after the kopia run finishes. It is what turns the
+control plane's signal from "creds were issued" into "a backup actually
+completed", and it is the input to staleness detection below. A device
+that fails to even reach this endpoint shows up as staleness (no recent
+success), so a crashed run is not silent.
 
 (`region`/`endpoint` can be added as columns to `server_group_backup_config`
 when implementing, or derived from a single deployment-wide default if the
@@ -330,35 +384,90 @@ holds no hardcoded bucket:
 bestool backup [--purpose backup|restore]
 ```
 
-- `GET /backup-target` to learn `{bucket, prefix, region, endpoint}`.
-- Connects/creates the kopia repository against that target, with
+- `GET /backup-target` to learn `{bucket, prefix, region, endpoint}`
+  **on every run** — never cached to persistent device config.
+- Reconciles the kopia repository connection against that target (so a
+  changed bucket/prefix is picked up here), with
   `credential_process = bestool backup-credentials` for the creds.
 - Runs the backup (or restore).
+- Reports the run outcome back to Canopy (see "Backup reporting" below),
+  so the control plane learns "backup completed", not just "creds
+  issued".
 
 The device is provisioned only with its Canopy URL and mTLS identity.
 The bucket, prefix and region are never written to the device's
 persistent config — bestool re-derives the repository connection from
-Canopy on each run, so a server-side config change takes effect on the
-next backup with zero device reconfiguration.
+Canopy on *every* run. This is the crux of the "no per-host action"
+property: `bestool backup` is the scheduled job (systemd timer / cron)
+that already runs on each host on its backup cadence, so a server-side
+config change propagates to the whole fleet automatically on each host's
+next scheduled backup. There is no operator command to run per host and
+nothing to "forget to re-run".
 
 bestool work is in a separate repo; this plan covers the Canopy side
 and the bestool side will be a sibling change there.
 
+## Backup reporting and staleness detection
+
+The thing that actually protects against *silently* broken backups is
+not the credential or target delivery mechanism — a backup that simply
+doesn't run is silent regardless of how config reaches the device. The
+protection is Canopy *knowing* each device's backup state and alerting
+when one goes quiet. That detection catches a stale config, a dead
+timer, a crashed run, or a network outage — all the ways a backup can
+fail, not just config drift.
+
+Mechanism:
+1. bestool reports each run via `POST /backup-report`, written to
+   `backup_runs`.
+2. A periodic Canopy job (alongside the existing health/alerting
+   machinery — the same path that surfaces and recovers other device
+   health signals) scans, per group with a non-NULL `expected_interval`:
+   - **Stale**: a device that previously reported successful backups but
+     has no `outcome = 'success'` row newer than `expected_interval`
+     (times a small grace factor) → alert.
+   - **Never backed up**: a device in a configured group that has been
+     present longer than `expected_interval` and has *no* successful
+     `backup_runs` row → alert. (Catches a host that was never wired up,
+     which a "last success" check alone would miss.)
+   - **Recovered**: a previously-stale device reporting success again
+     clears the alert.
+3. Alerts route through the existing operator notification path
+   (Slack/email via `PRIVATE_URL`).
+
+This is the half of "did device X back up today" that the audit log
+alone can't give: `backup_credential_issuances` says creds were handed
+out; `backup_runs` + this job says whether the backup landed and shouts
+when it didn't.
+
+A bucket change therefore can't silently break the fleet: if a host
+fails to pick up the new target or fails to upload, its next expected
+window lapses and Canopy alerts. The propagation itself is automatic
+(every-run target fetch); detection is the backstop for when automatic
+propagation doesn't take.
+
 ## Operational story (what we gain, day-one)
 
-- **"Did device X back up today?"** — query
-  `backup_credential_issuances` for the device, with a recent
-  `issued_at`. Not a perfect proxy (creds issued ≠ bytes uploaded) but
-  it's the cheap version. Real "bytes uploaded" comes from S3
-  inventory / CloudWatch later.
+- **"Did device X back up today?"** — `backup_runs` gives the real
+  answer (a successful run landed), and `backup_credential_issuances`
+  the cheaper "creds were issued" proxy. Byte-level reconciliation
+  against S3 inventory / CloudWatch still comes later.
 - **Decommissioning a device** — revoke its mTLS cert (existing
   mechanism); it can no longer call the endpoint, so it can no longer
   get fresh creds. Already-issued creds expire within an hour.
 - **Decommissioning a group** — delete its `server_group_backup_config`
   row; devices in that group start getting `409`.
-- **Rotating bucket / changing prefix** — update the
-  `server_group_backup_config` row. Existing creds keep working until
-  expiry, then refresh with the new config. No coordinated cutover.
+- **Changing prefix, region, or endpoint** — update the
+  `server_group_backup_config` row. Each device picks it up on its next
+  scheduled `bestool backup` (every-run target fetch); no per-host
+  command, no coordinated cutover. Staleness detection flags any host
+  that fails to roll over.
+- **Rotating the *bucket*** — note this is not a free config flip: a
+  kopia repository lives *in* its bucket, so a new bucket is either a
+  repo data migration or a deliberate start-fresh. The mechanism makes
+  the *config* change propagate automatically, but the operator still
+  owns the migration/cutover decision. (Listed under out-of-scope as
+  per-group bucket migration.)
 
 ## Open questions
 
@@ -373,12 +482,29 @@ None blocking, but flag-and-decide-during-implementation:
   every `Server`-role device has a server association; if not, the
   endpoint returns 409 and we file a separate issue for the
   data-consistency gap.
+- **Staleness "device present" definition.** The "never backed up" check
+  needs a notion of how long a device has existed in a configured group
+  (first-seen / association timestamp) to avoid alerting on a host added
+  minutes ago. Pick the existing timestamp to key off when implementing.
+- **Grace factor for staleness.** `expected_interval × N` before
+  alerting — pick N (and whether it's configurable per group) during
+  implementation; start simple.
 
 ## Out of scope (do not silently fold in)
 
 - Cross-group restore mechanism (explicitly disallowed by product
   decision).
 - Data-plane proxy / Canopy-served S3/WebDAV (explicitly rejected).
+- **Device-local S3 proxy** (kopia → `localhost`, a bestool daemon
+  re-signs and forwards to the real bucket). Considered as an
+  alternative to the every-run target fetch: it maximises decoupling
+  (kopia never knows the bucket) and could be a future interposition
+  point, but it relocates rather than removes the large S3 protocol
+  surface this plan avoids (SigV4 re-signing, streaming multipart, a
+  supervised long-lived daemon), and — crucially — it does **not** solve
+  silent breakage either (a dead proxy is just as silent). Detection
+  does that. Rejected for the first cut; revisit only if we want the
+  interposition point for its own sake.
 - Per-group bucket migration (the schema supports it; the operational
   work is separate).
 - bestool subcommand implementation (separate repo).

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -543,16 +543,25 @@ Mechanism:
    `backup_runs`.
 2. A periodic Canopy job (alongside the existing health/alerting
    machinery — the same path that surfaces and recovers other device
-   health signals) scans, per group with a non-NULL `expected_interval`:
+   health signals) scans the **devices expected to be backing up** —
+   i.e. every `Server`-role device whose group root has a
+   `server_group_backup_config` with a non-NULL `expected_interval` —
+   and, joining each against its most recent `backup_runs` row,
+   classifies it:
    - **Stale**: a device that previously reported successful backups but
      has no `outcome = 'success'` row newer than `expected_interval`
      (times a small grace factor) → alert.
-   - **Never backed up**: a device in a configured group that has been
+   - **Never backed up**: a device in the scanned set that has been
      present longer than `expected_interval` and has *no* successful
      `backup_runs` row → alert. (Catches a host that was never wired up,
      which a "last success" check alone would miss.)
    - **Recovered**: a previously-stale device reporting success again
      clears the alert.
+
+   The scanned set — "which devices ought to back up" — is the part to
+   pin down in implementation: the natural definition is `Server`-role
+   devices associated with a configured group, but it leans on the same
+   `devices.server_id` / "device present" questions flagged below.
 3. Alerts route through the existing operator notification path
    (Slack/email via `PRIVATE_URL`).
 

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -13,10 +13,14 @@ directly (no proxy through Canopy).
   its own backups bucket, and a device only ever gets access to its own
   group's bucket. (Stronger than prefix-sharing inside one bucket — a
   scoping bug can't even name another group's bucket.)
-- Within-group cross-device restore: every device in a group can
-  request read-only creds for the group's scope (`purpose=restore`), so
-  restoring onto a freshly-rebuilt sibling is trivial and the restoring
-  device can't accidentally damage the source backups.
+- Within-group cross-device **and cross-account** restore: every device
+  in a group can request read-only creds for the group's scope
+  (`purpose=restore`), so restoring onto a freshly-rebuilt sibling is
+  trivial and the restoring device can't accidentally damage the source
+  backups. This explicitly includes the spanning-account case — e.g. a
+  pre-prod server (in a different account) restoring from the group's
+  prod-account backups — because membership, not the device's account,
+  decides the target.
 - Cross-*group* restore is explicitly **not** supported.
 - Every credential issuance is recorded so we can answer "did device X
   back up today, and when."
@@ -148,6 +152,7 @@ CREATE TABLE server_group_backup_config (
     root_server_id    UUID PRIMARY KEY REFERENCES servers(id) ON DELETE CASCADE,
     bucket            TEXT NOT NULL,           -- this group's own bucket (one bucket per group)
     prefix            TEXT NOT NULL DEFAULT '', -- usually empty: the repo lives at the bucket root
+    target_role_arn   TEXT NOT NULL,           -- per-bucket role Canopy assumes (encodes the account; may be cross-account)
     region            TEXT,                    -- NULL → deployment default
     endpoint          TEXT,                    -- NULL → AWS; set for non-AWS S3
     expected_interval INTERVAL,                -- declared cadence: paces devices AND drives staleness; NULL → neither
@@ -164,6 +169,13 @@ bucket boundary, and `prefix` is usually empty (the kopia repo sits at
 the bucket root); it stays in the schema only for the rare case of
 parking a repo under a sub-path. See "Per-group buckets" for naming and
 provisioning.
+
+`target_role_arn` is the per-bucket role Canopy assumes to mint creds for
+this group; because the ARN names the account, a bucket in a different
+account (or a shared account hosting several groups) needs no special
+handling — Canopy just assumes the configured ARN. The group → bucket →
+role relationship is 1:1; what varies N:M (servers spanning accounts,
+groups sharing an account) lives outside this row. See "IAM model".
 
 `region`/`endpoint` are what `GET /backup-target` serves to devices.
 `expected_interval` is the group's **declared backup cadence** and the
@@ -364,6 +376,16 @@ The choice is the caller's; both purposes are available to every
 ("only some devices can restore") — that was considered and rejected
 because cross-device restore within a group is meant to be cheap.
 
+This is what makes **pre-prod restoring from prod backups** work without
+a special path. The requesting device's own account is irrelevant: Canopy
+resolves device → group → the group's single target (the prod-account
+bucket/role) and assumes that role. The creds it returns are *prod-account
+creds for the prod bucket*, so from S3's point of view the pre-prod device
+is making ordinary same-account read calls — the only cross-account hop is
+Canopy's `AssumeRole`, which it already does. A pre-prod server in another
+account just asks for `purpose=restore` and reads the group's backups;
+nothing about the spanning-account topology leaks into the device.
+
 Handler flow:
 1. `ServerDevice` extractor authenticates the caller (existing).
 2. Look up the device's server via `device.server_id` (assumed to
@@ -502,18 +524,35 @@ short-lived creds for them instead. The IaC changes are therefore:
   AWS-level trust boundary, see the threat-boundary note above; the
   protection target here is device compromise, not this first-party role.
 
-IAM-model choice (now informed by the repo): the existing stack already
-makes **per-bucket roles**, so the natural fit is per-bucket roles that
-trust Canopy's IRSA — Canopy assumes the specific group's role and the
-scoping is *structural* (the role's policy only names its own bucket), so
-no session policy is needed for correctness. The alternative is a single
-central issuer role over a bucket *pattern* with a per-call session policy
-narrowing to the one bucket (what the session-policy templates below
-describe). Per-bucket roles align with the existing per-stack structure
-and give stronger isolation; the session-policy approach means fewer
-roles. **Decide during implementation** — flagged in open questions. The
-permission *sets* in the templates below apply either way (they're either
-the role policy or the session policy).
+### IAM model: per-bucket roles, assumed cross-account
+
+**Decided: one role per bucket (= per group), assumed by Canopy
+cross-account.** The topology forces this and the existing stack already
+fits it:
+
+- Most deployments have their **own AWS account**, so the bucket and its
+  role live in the *deployment's* account while Canopy's pod (IRSA) lives
+  in the central account. Issuing creds is a **cross-account `AssumeRole`**:
+  the deployment-account role trusts Canopy's central principal, Canopy
+  assumes it across the boundary. The group's config stores the **role
+  ARN** (which encodes the account), so same-account, cross-account, and
+  shared-account are one code path.
+- A single central role over a bucket *pattern* (the discarded
+  alternative) can't reach buckets in other accounts without each bucket's
+  policy also granting it — i.e. per-account IaC regardless — so it buys
+  nothing here.
+- Granularity must be the **bucket, not the account**: small deployments
+  now share an account (multiple groups co-tenant), so an account-scoped
+  role would let co-tenant groups reach each other's buckets. A per-bucket
+  role keeps them isolated *structurally* — the role's policy names only
+  its own bucket, so a Canopy bug degrades to "wrong/again no creds",
+  never "another group's bucket".
+
+Scoping is therefore structural; no session policy is needed for
+correctness. The one place a session policy still earns its keep is the
+read-only **restore** downscope on the same per-bucket role (it can only
+narrow). The permission *sets* in the templates below are the role's own
+policy (backup role) plus that restore session policy.
 
 ### Per-group buckets
 
@@ -946,13 +985,13 @@ Surface it loudly; don't take Canopy down over it.
 
 None blocking, but flag-and-decide-during-implementation:
 
-- **IAM model: per-bucket roles vs. central pattern + session policy.**
-  The existing `backups` stack makes per-bucket roles, favouring per-bucket
-  roles that trust Canopy's IRSA (structural scoping, no session policy);
-  the alternative is one central role over a `bes-kopia-backups-*` pattern
-  with session-policy narrowing. Decide and update the `backups` stack
-  accordingly (add the IRSA trust + the reduced device action set either
-  way). See "AWS setup".
+- **Cross-account assume hardening.** The IAM model is decided (per-bucket
+  roles, assumed cross-account — see "IAM model"); remaining details:
+  whether to use an `ExternalId` on the trust (cheap confused-deputy
+  hygiene even first-party), and confirming the `backups` stack changes
+  (set role trust to Canopy's central principal + the maintenance Job
+  principal; add the reduced device-backup action set; export the role ARN
+  for the config row).
 - **Per-device session naming for CloudTrail.** Suggested
   `device-<uuid>`; check max length and allowed chars on
   `RoleSessionName`.

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -144,8 +144,14 @@ fits cleanly into `public-server`.
 Reasons not to put it in `private-server`:
 - `private-server` is for operator/admin access via Tailscale; devices
   reach Canopy through the internet-facing `public-server` with mTLS.
-- `public-server` already has the right state (DB, AWS clients if we
-  add one), the right auth extractors, and the right deployment shape.
+- `public-server` already has the right state (DB via `State<Db>`), the
+  right auth extractors (`ServerDevice`), and the right deployment shape.
+  **But the AWS client is greenfield:** there is *no* AWS SDK anywhere in
+  the workspace today (only the `aws-lc-rs` crypto backend — not the SDK),
+  and `AppState` has no AWS field. This feature introduces canopy's first
+  AWS SDK usage — net-new `aws-config` + `aws-sdk-{sts,s3,…}` deps, a
+  credential/region provider, a client on `AppState`, and a `FromRef`
+  impl. (Don't pin crate versions without checking the registry.)
 
 ## Database changes
 
@@ -153,7 +159,7 @@ Reasons not to put it in `private-server`:
 
 ```sql
 CREATE TABLE server_group_backup_config (
-    root_server_id    UUID PRIMARY KEY REFERENCES servers(id) ON DELETE CASCADE,
+    group_id          UUID PRIMARY KEY REFERENCES server_groups(id) ON DELETE CASCADE,
     bucket            TEXT NOT NULL,           -- this group's own bucket (one bucket per group)
     prefix            TEXT NOT NULL DEFAULT '', -- usually empty: the repo lives at the bucket root
     target_role_arn   TEXT NOT NULL,           -- per-bucket role Canopy assumes (encodes the account; may be cross-account)
@@ -203,17 +209,18 @@ but is *not* floor-enforced.
 password is Canopy-generated for from-birth repos or operator-supplied for
 imported ones — see "Repository password ownership".
 
-A row is keyed by the root server id (the parentless server that heads
-the group). Devices without a configured root row → `409 Conflict` from
-the credential endpoint with an instructive message.
+A row is keyed by **`group_id`** → `server_groups(id)` (the real grouping;
+`server_groups` is a flat first-class table, and servers carry a nullable
+`group_id` — there is no server hierarchy or "root server"). A device
+whose server has no group, or whose group has no config row, gets
+`409 Conflict` from the credential endpoint. (prod + its clones are
+already one `server_group`, so a shared bucket maps to that single group —
+the 1:1 group→bucket invariant holds; see "Per-group buckets".)
 
-Keeping this in a separate table rather than columns on `servers`
-because:
-- The columns are meaningful only on roots — adding them to `servers`
-  pollutes every row with mostly-NULL fields.
-- More backup-related fields are likely to land here (retention,
-  encryption-key id, monitoring thresholds) and they all naturally
-  co-locate.
+Keeping this in a separate table rather than columns on `server_groups`
+because more backup-related fields are likely to land here (retention,
+encryption-key id, monitoring thresholds) and they all naturally
+co-locate, and most groups won't have backup config.
 
 ### New table: `backup_credential_issuances`
 
@@ -221,7 +228,7 @@ because:
 CREATE TABLE backup_credential_issuances (
     id                  BIGSERIAL PRIMARY KEY,
     device_id           UUID NOT NULL REFERENCES devices(id),
-    root_server_id      UUID NOT NULL REFERENCES servers(id),
+    group_id            UUID NOT NULL REFERENCES server_groups(id),
     issued_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
     expires_at          TIMESTAMPTZ NOT NULL,
     purpose             TEXT NOT NULL,       -- "backup" | "restore"
@@ -233,7 +240,7 @@ CREATE TABLE backup_credential_issuances (
 );
 
 CREATE INDEX ON backup_credential_issuances (device_id, issued_at DESC);
-CREATE INDEX ON backup_credential_issuances (root_server_id, issued_at DESC);
+CREATE INDEX ON backup_credential_issuances (group_id, issued_at DESC);
 ```
 
 This is the audit log of credential *issuance*. It answers "was a device
@@ -251,7 +258,7 @@ pointer to the `AssumeRole` event itself.
 CREATE TABLE backup_runs (
     id              BIGSERIAL PRIMARY KEY,
     device_id       UUID NOT NULL REFERENCES devices(id),
-    root_server_id  UUID NOT NULL REFERENCES servers(id),
+    group_id        UUID NOT NULL REFERENCES server_groups(id),
     purpose         TEXT NOT NULL,            -- "backup" | "restore"
     outcome         TEXT NOT NULL,            -- "success" | "failure"
     error           TEXT,                     -- populated on failure
@@ -260,7 +267,7 @@ CREATE TABLE backup_runs (
     reported_at     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX ON backup_runs (root_server_id, reported_at DESC);
+CREATE INDEX ON backup_runs (group_id, reported_at DESC);
 CREATE INDEX ON backup_runs (device_id, reported_at DESC);
 ```
 
@@ -274,7 +281,7 @@ and that must not read as a healthy backup.
 ```sql
 CREATE TABLE backup_maintenance_runs (
     id              BIGSERIAL PRIMARY KEY,
-    root_server_id  UUID NOT NULL REFERENCES servers(id),
+    group_id        UUID NOT NULL REFERENCES server_groups(id),
     kind            TEXT NOT NULL,            -- "quick" | "full"
     started_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     finished_at     TIMESTAMPTZ,
@@ -283,7 +290,7 @@ CREATE TABLE backup_maintenance_runs (
     bytes_reclaimed BIGINT                    -- if kopia surfaces it
 );
 
-CREATE INDEX ON backup_maintenance_runs (root_server_id, started_at DESC);
+CREATE INDEX ON backup_maintenance_runs (group_id, started_at DESC);
 ```
 
 Written by the Canopy maintenance Jobs (see "Canopy-owned maintenance").
@@ -295,12 +302,12 @@ alerting as `backup_runs`.
 
 ```sql
 CREATE TABLE backup_repo_snapshots (
-    root_server_id     UUID NOT NULL REFERENCES servers(id),
+    group_id           UUID NOT NULL REFERENCES server_groups(id),
     source             TEXT NOT NULL,            -- kopia source: canopy@<server-id>:<path>
     server_id          UUID REFERENCES servers(id),  -- parsed from source
     latest_snapshot_at TIMESTAMPTZ,
     observed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
-    PRIMARY KEY (root_server_id, source)
+    PRIMARY KEY (group_id, source)
 );
 ```
 
@@ -313,7 +320,7 @@ took it lives in the snapshot's tags, not here.
 
 ```sql
 CREATE TABLE backup_repo_stats (
-    root_server_id   UUID PRIMARY KEY REFERENCES servers(id),
+    group_id         UUID PRIMARY KEY REFERENCES server_groups(id),
     snapshot_count   INTEGER,
     source_count     INTEGER,
     logical_bytes    BIGINT,                  -- kopia: pre-dedup size across snapshots
@@ -438,20 +445,25 @@ account just asks for `purpose=restore` and reads the group's backups;
 nothing about the spanning-account topology leaks into the device.
 
 Handler flow:
-1. `ServerDevice` extractor authenticates the caller (existing).
-2. Look up the device's server via `device.server_id` (assumed to
-   exist — verify when implementing; if a device isn't yet associated
-   with a server, return `409`).
-3. `Server::root_id` walks up to the group root.
-4. Read `server_group_backup_config` for that root; `409` if absent. This
-   yields the group's `target_role_arn` (the per-bucket role to assume).
+1. `ServerDevice` extractor authenticates the caller. It yields only a
+   `Device` (`device.0.0`) — server/group resolution is the handler's job
+   (same as `statuses.rs`).
+2. Resolve the device's server via `Server::live_by_device_id` (devices
+   have no `server_id`; servers reference devices). No live server →
+   `409` (the `DeviceHasNoServer` case, as in `events.rs`).
+3. Read that server's `group_id: Option<Uuid>`; `None` (ungrouped) →
+   `409`.
+4. Read `server_group_backup_config` for that `group_id`; `409` if absent.
+   This yields the group's `target_role_arn` (the per-bucket role to
+   assume).
 5. Only for `purpose=restore`: build the read-only session policy
    (template below). The `backup` purpose needs none — the per-bucket
    role's own policy is already correctly scoped.
 6. Cross-account `sts:AssumeRole` on the group's `target_role_arn` (with
-   the restore session policy if applicable), session name like
-   `device-<device-id>`.
-7. Insert into `backup_credential_issuances` (recording the assumed role).
+   the restore session policy if applicable), session name
+   `canopy-<purpose>-<device-id>`.
+7. Insert into `backup_credential_issuances` (recording the assumed role
+   and the issued `access_key_id`).
 8. Return the `credential_process` JSON.
 
 ### Permission templates
@@ -585,11 +597,15 @@ short-lived creds for them instead. The IaC changes are therefore:
 - **Trust Canopy's IRSA**, not (only) EC2: the roles Canopy assumes from
   need `Principal` set to the Canopy pod's IRSA role.
 - **A reduced device-backup action set.** `AWS_S3_BACKUP_ACTIONS` today is
-  `[...multipart, s3:DeleteObject, s3:PutObjectRetention]` — it includes
-  delete because, in the EC2 model, the server ran maintenance. Under this
-  plan the device must *not* delete, so device-backup creds use a new
-  reduced constant (multipart + Get/Put, **no** `DeleteObject`, **no**
-  `PutObjectRetention`). The full set stays on the maintenance role only.
+  `[...AWS_S3_MULTIPART_ACTIONS, s3:DeleteObject, s3:PutObjectRetention]` —
+  it includes delete because, in the EC2 model, the server ran maintenance.
+  Under this plan the device must *not* delete, so device-backup creds use
+  the existing **`AWS_S3_MULTIPART_ACTIONS`** constant directly (already
+  Get/Put + multipart + ListBucket/GetBucketLocation, **no** `DeleteObject`,
+  **no** `PutObjectRetention`) rather than a new list. The full set stays on
+  the maintenance role only. When adding IRSA trust to these roles, preserve
+  the stack's existing optional IAM-Users path and the `.storageconfig`
+  object so they aren't clobbered.
 - **Maintenance role** = the existing full-access role (or a sibling),
   assumed by the maintenance Job's own IRSA (not chained — see
   "Canopy-owned maintenance"). Only this identity can delete. It keeps
@@ -652,6 +668,17 @@ failure.
 The ordering matters: insert the row before the stack is applied and the
 group's devices get clean preflight/issuance failures (not corruption),
 which the alert makes obvious. Worth noting for the onboarding runbook.
+
+**Clones don't break the 1:1 invariant.** The `ops/pulumi` `cloneOf`
+mechanism (in `tamanu/on-linux`) lets a clone stack *re-export* its
+parent's bucket/role instead of provisioning its own — but a prod
+deployment and its clones are **already one `server_group`** in canopy.
+So that shared bucket maps to the *single* group's one config row; it's
+the same within-group, cross-account picture as "pre-prod restores from
+prod backups", not N groups → 1 bucket. The 1:1 *group*→bucket invariant
+holds. (The standalone `backups` stack is strictly 1:1 per stack; the
+`bucketName` config override only renames the bucket, it doesn't share
+one.)
 
 ## `bestool` changes
 
@@ -770,19 +797,32 @@ went, and a job scans those reports in the database.
      breakage, not a blip.)
    - **Never backed up**: present longer than `expected_interval × 2` with
      *no* successful `backup_runs` row → alert. "Present since" is
-     `max(device_server_associations.first_seen, server_group_backup_config.created_at)`
-     — the later of "device joined the server" and "group was authorized"
-     — so neither a freshly-added device nor a freshly-authorized group
-     false-alarms.
+     `max(server-present, group-authorized)` where *group-authorized* is
+     `server_group_backup_config.created_at` and *server-present* is taken
+     from `device_server_associations` — but note `first_seen` there is per
+     `(device_id, server_id)` **pair**, so for a server-centric anchor use
+     `MIN(first_seen)` over that server's rows (earliest any device saw it)
+     rather than treating it as a per-server scalar. This way neither a
+     freshly-present server nor a freshly-authorized group false-alarms.
    - **Recovered**: a previously-stale server reporting success again
      clears the alert.
-3. Alerts route through Canopy's existing incident machinery: raise
-   `Incident::open_for(...)` (and `Incident::resolve(...)` on recovery),
-   which enqueues to `slack_outbox`, drained to Slack by the
-   `slacker_outbox` job. Same path the reachability healthcheck already
-   uses — distinct from the `backup-monitoring` Pulumi stack, which
-   watches the **AWS Backup service** (EBS/RDS) and does not cover
-   kopia-to-S3 backups. This detection is genuinely new.
+3. Alerts go through the existing **issues/events** model, exactly as
+   `reachability` does — *not* a direct "open incident" call (there is no
+   `Incident::open_for`). Construct a `NewEvent { source: "canopy", ref:
+   "backup-staleness", severity, message, active }` and call
+   `NewEvent::save(conn, server_id, device_id)` (mirroring reachability's
+   `source="canopy"`/`ref="reachability"`). Downstream,
+   `re_evaluate_incident_membership → find_or_open_incident →
+   enqueue_slack_open → SlackOutbox::enqueue` opens the incident and queues
+   Slack automatically — but only for a **monitored** server in a group and
+   only when the issue severity satisfies `opens_incident()` (≥ `Error`),
+   so staleness events must be raised at `Error`+. **Recovery** is the same
+   `(source, ref)` event with `active: false` (lower severity), which lets
+   the issue leave the incident and auto-close. The `slacker_outbox` binary
+   drains the queue to Slack. (`Incident::resolve(incident_id, by, reason)`
+   exists but is the operator-driven, UUID-keyed human resolution — not a
+   group recovery call.) Distinct from the `backup-monitoring` Pulumi stack
+   (AWS Backup service), so this detection is genuinely new.
 
 The limit of signal 1 is that it's the *device's word*: it scans the
 Canopy database for what devices reported, not for what's actually in the
@@ -855,12 +895,24 @@ here, for two reasons:
   permission templates above), so a compromised server cannot delete
   backups.
 
-So Canopy owns maintenance. Concretely, a scheduler loop in the `jobs`
-crate (like `reachability`) spawns a **Kubernetes Job per group** that
-runs the maintenance cycle against that group's bucket, then exits.
-Spawning a Job rather than running kopia in-process keeps the heavy,
-long-running work off the Canopy pod and lets it use the kopia image
-directly.
+So Canopy owns maintenance. Concretely, a scheduler loop (a new
+`crates/jobs/src/bin/<name>.rs` following the existing `reachability` /
+`pingtask` `spawn()` + `loop { sleep(60); pool.get; … }` template, with its
+own single-replica Deployment in `ops/pulumi/tamanu/meta/src/jobs.ts`)
+**spawns a Kubernetes Job per group** that runs the maintenance cycle
+against that group's bucket, then exits. Spawning a Job keeps the heavy,
+long-running work off the loop pod and lets it use the kopia image.
+
+**Greenfield infra (net-new to canopy):** the loop pattern matches
+`reachability`, but everything about *spawning k8s Jobs* is new — canopy
+has **no Kubernetes API client** (no `kube`/`k8s-openapi` in the workspace)
+and its pods today carry **no ServiceAccount / IRSA** (the shared
+`spec.ts` injects only env/affinity/tolerations/resources). So this needs:
+a `kube` client dependency, a ServiceAccount plumbed through `spec.ts`
+with RBAC to create Jobs and `get` Secrets, and IRSA wiring (the
+`common/eksServiceAccount.ts` helper exists but isn't used by canopy yet).
+Don't read "like reachability" as "already have the machinery" — that loop
+only does a DB sweep.
 
 The maintenance cycle is **three steps**, not just "run maintenance":
 1. **assert** the group's retention policy into the repo (so the declared
@@ -888,9 +940,17 @@ inspection and per-group preflight too).
 
 Spawned Jobs carry the org's three **billing tags** as pod labels —
 `billing.product` / `billing.stage` / `billing.deployment` — set from the
-group (its `billing.*` tags if present, else `product=tamanu`, `stage=` the
-highest server rank in the group, `deployment=` the group name) so AWS
-split cost allocation attributes the compute to the right deployment.
+group (its `billing.*` tags if present, else `product=tamanu`,
+`deployment=` the group name, and `stage=` derived from the group's
+highest member rank via the existing `ServerGroup::highest_member_ranks`
+/ `rank_priority`). One gotcha to encode: the `ServerRank` Display strings
+(`production`/`clone`/`demo`/`test`/`dev`) **don't all match the stage
+values ops already emits** — ops's `typeGuess` yields `prod` (not
+`production`). So map explicitly (`Production → "prod"`, `Demo → "demo"`,
+…) to match existing CUR tags, and pick a fallback (`prod`, or omit
+`billing.stage`) for groups whose members are all unranked — which
+`highest_member_ranks` omits. So AWS split cost allocation attributes the
+compute to the right deployment.
 
 ### Credentials for the maintenance Job
 
@@ -1000,7 +1060,7 @@ maintenance are all the repo's lifecycle.
 ### Audit
 
 Maintenance runs are logged like device runs — a `backup_maintenance_runs`
-table (root_server_id, kind quick|full, started/finished, outcome, error,
+table (group_id, kind quick|full, started/finished, outcome, error,
 bytes reclaimed if available). Same value as `backup_runs`: "is
 maintenance actually happening for this group, and did it succeed." A
 group whose maintenance has silently stopped is a slow-motion problem
@@ -1189,26 +1249,34 @@ repo-import onboarding mode + Bitwarden escrow (11), repo/bucket stats for
 display (9 + the cost non-goal), `billing.*` tags on Jobs (12),
 hash-jittered scheduling (12).
 
-## Deferred to the "review against current state of the repo" pass
+## Repo-alignment outcomes (applied) + remaining prerequisites
 
-These need reconciling against the real schema/code, not re-deciding:
+A repo-alignment review reconciled the plan against the real `canopy` +
+`ops/pulumi` source. **Applied throughout:** rekeyed everything to
+`group_id` → `server_groups` (flat table; no `root_server_id`/hierarchy);
+device→server via `Server::live_by_device_id` (not `device.server_id`);
+alerting via `NewEvent::save(source="canopy", ref="backup-staleness")` at
+severity ≥ `Error` (not the non-existent `Incident::open_for`); schedulers
+as new `jobs`-crate bins; the `ServerRank::Production`→`"prod"` mapping;
+`first_seen` is per device-server pair (`MIN` over the server); reuse
+`AWS_S3_MULTIPART_ACTIONS` for the device set.
 
-- **Rekey `root_server_id` → `group_id`** (the real `server_groups` table)
-  across the config + audit + new tables, and **fix device→server
-  resolution** (`servers.device_id`, not `device.server_id`; there is no
-  `Server::root_id`/parent hierarchy). The "parentless server heads the
-  group" framing and handler-flow steps 2–3 are historical and must be
-  rewritten.
-- Confirm the **`Incident` API** shape and the **`jobs`-crate scheduler**
-  conventions against the actual code.
-- The **server-rank → billing `stage`** mapping (uses canopy's rank concept).
+**Net-new infrastructure this requires (none exists in canopy today):**
+- The **AWS SDK** — `aws-config` + `aws-sdk-{sts,s3,secretsmanager?}`, a
+  provider, and an `AppState` client (first AWS SDK usage in the workspace).
+- A **Kubernetes API client** (`kube`/`k8s-openapi`) for spawning Jobs.
+- A **ServiceAccount + IRSA** on canopy's pods (plumb through `spec.ts`;
+  the `common/eksServiceAccount.ts` helper exists but is unused), plus RBAC
+  to create Jobs and `get` Secrets, and the OIDC-provider-per-account
+  wiring for cross-account Job web-identity.
+
+**Still open (genuine choices, not gaps):**
 - The **transport** for the cadence signal (how it rides today's
   ~1-minute healthcheck — tailnet poll / device poll / held-open).
 - Whether to expose an **operator "backup now"** action and stats in
   `private-server` now or bootstrap via SQL first.
-
-(Tunable defaults — heartbeat/inspection/maintenance/preflight cadences —
-are chosen as defaults above and adjustable later; not blocking.)
+- Tunable cadence defaults (heartbeat/inspection/maintenance/preflight) —
+  chosen above, adjustable later.
 
 ## Out of scope (do not silently fold in)
 

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -1,0 +1,333 @@
+# Backup credentials
+
+Issue short-lived S3 credentials to devices on demand, so backups can run
+without each server holding its own long-lived bucket credentials. Canopy
+becomes the control plane; the actual backup bytes flow device → S3
+directly (no proxy through Canopy).
+
+## Goal
+
+- One credential to manage per device — the existing mTLS identity.
+- No long-lived AWS access keys on servers or in operator hands.
+- Per-group isolation: a device only ever gets access to its own
+  server-group's backup scope.
+- Within-group cross-device restore: every device in a group can
+  request read-only creds for the group's scope (`purpose=restore`), so
+  restoring onto a freshly-rebuilt sibling is trivial and the restoring
+  device can't accidentally damage the source backups.
+- Cross-*group* restore is explicitly **not** supported.
+- Every credential issuance is recorded so we can answer "did device X
+  back up today, and when."
+
+## Non-goals (for this plan)
+
+- Serving S3/WebDAV/kopia-repository traffic through Canopy. Considered
+  and rejected: bandwidth on the Canopy data path, availability coupling
+  of every backup to Canopy uptime, and a much larger protocol surface.
+- Cross-group restore. The endpoint signature can stay minimal because
+  this is genuinely out of scope, not "deferred."
+- Retention policy enforcement, cost dashboards, alerting on missed
+  backups. The audit log this plan introduces is the foundation for
+  those, but the features themselves come later.
+- Picking the backup tool. Kopia is the assumed consumer because it
+  fits the AWS SDK `credential_process` hook cleanly, but rclone works
+  through the same mechanism if it turns out to be preferred.
+
+## Architecture overview
+
+```
+┌──────────┐  AssumeRoleWithWebIdentity (IRSA)   ┌─────────┐
+│ Canopy   │ ──────────────────────────────────► │   STS   │
+│  pod     │ ◄────────────────────────────────── │         │
+└──────────┘   irsa-session creds                 └─────────┘
+     │
+     │  POST /backup-credentials  (mTLS, ServerDevice)
+     ▼
+┌──────────┐  AssumeRole + session policy        ┌─────────┐
+│  device  │                                     │   STS   │
+│ (kopia + │ ◄────── creds_process JSON ──────── │         │
+│ bestool) │                                     └─────────┘
+└──────────┘
+     │
+     │  S3 API directly (boto/AWS SDK using temp creds)
+     ▼
+┌──────────┐
+│    S3    │
+└──────────┘
+```
+
+Two STS calls per issuance:
+1. The pod's IRSA session is implicit — kubernetes injects it.
+2. From that session, Canopy calls `AssumeRole` on a dedicated
+   `canopy-backup-issuer` role, passing a session policy that narrows
+   S3 access to the requesting device's group prefix.
+
+The resulting temp creds go back to the device verbatim.
+
+## AWS quirks worth knowing up front
+
+- **Chained AssumeRole sessions are capped at 1 hour**, regardless of
+  the target role's `MaxSessionDuration`. Since IRSA gives the pod a
+  session, all our issuances are chained. This is fine in practice
+  because `credential_process` refreshes on demand, but it means Canopy
+  must be reachable for the lifetime of a backup, not just at the
+  start. If a device can reach S3, it can almost certainly reach
+  Canopy, so this is a note rather than a constraint.
+- **`credential_process` output format** is fixed by the AWS SDK:
+  ```json
+  {
+    "Version": 1,
+    "AccessKeyId": "...",
+    "SecretAccessKey": "...",
+    "SessionToken": "...",
+    "Expiration": "2026-05-21T13:00:00Z"
+  }
+  ```
+  `bestool` produces exactly this on stdout and exits.
+- **Session policies are ANDed with the role policy.** The role's
+  policy grants broad S3 access to the backups bucket; the per-call
+  session policy narrows that to the specific prefix. A bug in the
+  session policy can only ever *over*-restrict, never expand — good
+  failure mode.
+
+## Where it lives in the repo
+
+A new endpoint on `public-server` alongside `artifacts.rs` and
+`bestool.rs`, mounted at `/backup-credentials` (or similar). Uses the
+existing `ServerDevice` extractor so the auth path is identical to other
+device endpoints. No new binary needed — the original "probably a
+separate binary" framing was for the proxy approach; control-plane only
+fits cleanly into `public-server`.
+
+Reasons not to put it in `private-server`:
+- `private-server` is for operator/admin access via Tailscale; devices
+  reach Canopy through the internet-facing `public-server` with mTLS.
+- `public-server` already has the right state (DB, AWS clients if we
+  add one), the right auth extractors, and the right deployment shape.
+
+## Database changes
+
+### New table: `server_group_backup_config`
+
+```sql
+CREATE TABLE server_group_backup_config (
+    root_server_id  UUID PRIMARY KEY REFERENCES servers(id) ON DELETE CASCADE,
+    bucket          TEXT NOT NULL,
+    prefix          TEXT NOT NULL,           -- e.g. "groups/<root-id>/"
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+A row is keyed by the root server id (the parentless server that heads
+the group). Devices without a configured root row → `409 Conflict` from
+the credential endpoint with an instructive message.
+
+Keeping this in a separate table rather than columns on `servers`
+because:
+- The columns are meaningful only on roots — adding them to `servers`
+  pollutes every row with mostly-NULL fields.
+- More backup-related fields are likely to land here (retention,
+  encryption-key id, monitoring thresholds) and they all naturally
+  co-locate.
+
+### New table: `backup_credential_issuances`
+
+```sql
+CREATE TABLE backup_credential_issuances (
+    id                  BIGSERIAL PRIMARY KEY,
+    device_id           UUID NOT NULL REFERENCES devices(id),
+    root_server_id      UUID NOT NULL REFERENCES servers(id),
+    issued_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at          TIMESTAMPTZ NOT NULL,
+    purpose             TEXT NOT NULL,       -- "backup" | "restore"
+    sts_assumed_role    TEXT NOT NULL,
+    sts_request_id      TEXT,                -- from AssumeRole response, for cross-ref with CloudTrail
+    bucket              TEXT NOT NULL,       -- snapshot of config at issuance time
+    prefix              TEXT NOT NULL
+);
+
+CREATE INDEX ON backup_credential_issuances (device_id, issued_at DESC);
+CREATE INDEX ON backup_credential_issuances (root_server_id, issued_at DESC);
+```
+
+This is the audit log that "did device X back up today" queries against.
+We snapshot bucket/prefix at issuance time so the log stays correct
+even if the group config is later changed.
+
+## Endpoint shape
+
+```
+POST /backup-credentials
+  Authorization: mTLS via ServerDevice
+  Body: { "purpose": "backup" | "restore" }   -- default "backup"
+  Response 200: {
+    "Version": 1,
+    "AccessKeyId": "...",
+    "SecretAccessKey": "...",
+    "SessionToken": "...",
+    "Expiration": "..."
+  }
+  Response 409: no backup config for this device's group
+  Response 502: STS call failed
+```
+
+`purpose` is a real capability gate, not just audit metadata:
+
+- `"backup"` (default): read + write + delete + multipart, scoped to
+  the group's prefix. Kopia needs delete for snapshot expiry.
+- `"restore"`: read-only (Get + ListBucket), scoped to the group's
+  prefix. A device with these creds physically cannot mutate the
+  bucket, so an accidental `kopia repository create` or similar can't
+  damage backups.
+
+The choice is the caller's; both purposes are available to every
+`Server`-role device within the group. There's no privilege gradient
+("only some devices can restore") — that was considered and rejected
+because cross-device restore within a group is meant to be cheap.
+
+Handler flow:
+1. `ServerDevice` extractor authenticates the caller (existing).
+2. Look up the device's server via `device.server_id` (assumed to
+   exist — verify when implementing; if a device isn't yet associated
+   with a server, return `409`).
+3. `Server::root_id` walks up to the group root.
+4. Read `server_group_backup_config` for that root; `409` if absent.
+5. Build the session policy (template below).
+6. Call `sts:AssumeRole` on `canopy-backup-issuer` with the session
+   policy and a session name like `device-<device-id>`.
+7. Insert into `backup_credential_issuances`.
+8. Return the `credential_process` JSON.
+
+### Session policy templates
+
+**`purpose = "backup"`** — read + write + delete:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject", "s3:PutObject", "s3:DeleteObject",
+        "s3:AbortMultipartUpload", "s3:ListBucketMultipartUploads",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Resource": "arn:aws:s3:::<bucket>/<prefix>*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+      "Resource": "arn:aws:s3:::<bucket>",
+      "Condition": {
+        "StringLike": { "s3:prefix": ["<prefix>*"] }
+      }
+    }
+  ]
+}
+```
+
+**`purpose = "restore"`** — read-only:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::<bucket>/<prefix>*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+      "Resource": "arn:aws:s3:::<bucket>",
+      "Condition": {
+        "StringLike": { "s3:prefix": ["<prefix>*"] }
+      }
+    }
+  ]
+}
+```
+
+The `s3:ListBucket` condition prefix is what kopia needs to enumerate
+its own snapshots; without it the device sees the entire bucket
+listing. The restore variant omits all mutation actions — even an
+explicit attempt to `kopia repository create` over the prefix is
+rejected by S3, not just by kopia.
+
+## AWS setup (out-of-band of this plan, but documented here for completeness)
+
+- `canopy-backup-issuer` role with trust policy allowing the Canopy pod's
+  IRSA role to assume it.
+- Role policy grants broad `s3:*` on the backups bucket (broad because
+  the session policy is what actually constrains each call).
+- The backups bucket is created separately. Single bucket to start;
+  the `bucket` column in `server_group_backup_config` means moving to
+  one-bucket-per-group later is a data migration, not a code change.
+
+## `bestool` changes
+
+A new subcommand:
+
+```
+bestool backup-credentials [--purpose backup|restore]   # default: backup
+```
+
+- Reads the device's mTLS identity from its existing location.
+- POSTs to the Canopy endpoint with the optional purpose.
+- Writes the response JSON to stdout verbatim.
+- Exits 0 on success, non-zero on any failure (the AWS SDK treats any
+  non-zero exit as "creds unavailable").
+
+The device's kopia config (set up once during provisioning) points at
+S3 with `credential_process = bestool backup-credentials`. From then on
+kopia just works.
+
+bestool work is in a separate repo; this plan covers the Canopy side
+and the bestool side will be a sibling change there.
+
+## Operational story (what we gain, day-one)
+
+- **"Did device X back up today?"** — query
+  `backup_credential_issuances` for the device, with a recent
+  `issued_at`. Not a perfect proxy (creds issued ≠ bytes uploaded) but
+  it's the cheap version. Real "bytes uploaded" comes from S3
+  inventory / CloudWatch later.
+- **Decommissioning a device** — revoke its mTLS cert (existing
+  mechanism); it can no longer call the endpoint, so it can no longer
+  get fresh creds. Already-issued creds expire within an hour.
+- **Decommissioning a group** — delete its `server_group_backup_config`
+  row; devices in that group start getting `409`.
+- **Rotating bucket / changing prefix** — update the
+  `server_group_backup_config` row. Existing creds keep working until
+  expiry, then refresh with the new config. No coordinated cutover.
+
+## Open questions
+
+None blocking, but flag-and-decide-during-implementation:
+
+- **Per-device session naming for CloudTrail.** Suggested
+  `device-<uuid>`; check max length and allowed chars on
+  `RoleSessionName`.
+- **`sts_request_id` storage.** AWS returns it; check the Rust SDK
+  surface for retrieving it cleanly.
+- **`devices.server_id` invariant.** Implementation needs to confirm
+  every `Server`-role device has a server association; if not, the
+  endpoint returns 409 and we file a separate issue for the
+  data-consistency gap.
+
+## Out of scope (do not silently fold in)
+
+- Cross-group restore mechanism (explicitly disallowed by product
+  decision).
+- Data-plane proxy / Canopy-served S3/WebDAV (explicitly rejected).
+- Per-group bucket migration (the schema supports it; the operational
+  work is separate).
+- bestool subcommand implementation (separate repo).
+- Backup retention, encryption-at-rest beyond default SSE-S3, lifecycle
+  policies (separate concerns).
+- Operator UI in `private-server` / React for editing
+  `server_group_backup_config` (will want it eventually; not in the
+  first cut — bootstrap via SQL).

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -1382,6 +1382,72 @@ This should **alert, not gate readiness**: a failing upstream check
 pulling the pod out of rotation would only make the problem worse.
 Surface it loudly; don't take Canopy down over it.
 
+## External restore consumers + restore-verification (PGRO)
+
+*(Stage: later / additive — depends on the per-bucket roles, repo-password
+ownership, and the issues/events alerting all being in place. Captured here
+so the relationship is designed-for, not bolted on.)*
+
+**PGRO** (`PostgreSQL Restore Operator` — a separate repo, a Rust k8s
+operator) watches a kopia repo and restores Postgres *physical* backups
+into working replicas (data/analytics + DR-testing). Today it authenticates
+with **static long-lived AWS keys + the repo password in a hand-set k8s
+Secret** — the exact long-lived-creds pattern this whole system exists to
+kill. Bringing it in eliminates those static keys and makes Canopy the
+single control plane for *all* backup access. It's a **bidirectional,
+first-party relationship**:
+
+- **Creds out (Canopy → PGRO).** PGRO is a **restore-only** consumer, so it
+  gets short-lived read-only creds + target + repo password from Canopy —
+  reusing the `restore` session policy, the per-bucket role, and the
+  password ownership (canopy-mediated; option (a)). But PGRO is *not* a
+  fleet device and *not* in the group it reads — it's trusted first-party
+  infra, so this needs an **external-restore grant**: an operator-authorized,
+  audited "consumer C may read group X, read-only". That's a deliberate,
+  controlled cousin of the cross-group restore that's banned *for devices*
+  (a different trust class, not a loophole in that rule).
+- **Reports in (PGRO → Canopy) = Signal 3, restore-verification.** PGRO
+  actually restoring a backup *proves it is restorable* — the strongest
+  backup-health signal there is, beyond signal 2's "a snapshot exists". PGRO
+  reports per-replica outcomes (which snapshot, success/failure, replica
+  health) back to Canopy; a failed or stale restorability check is a
+  high-severity **group-level** alert (the server-independent incident path,
+  like poisoning detection). This closes the lifecycle loop end-to-end —
+  *backed up (1) → persisted (2) → restorable (3)* — cross-referenced by
+  snapshot id.
+
+Having **both directions** is why this is canopy-mediated rather than PGRO
+assuming a role directly: one bidirectional first-party relationship (creds
+out, reports in) over a single channel, not two disjoint mechanisms.
+
+**First-party auth path — PGRO runs in a *different* k8s cluster from
+Canopy (so there's no shared cluster / Secret to lean on). Design later;
+two options to weigh:**
+- **Tailscale** — both are on the tailnet, so PGRO can reach Canopy's
+  private API over Tailscale, reusing existing Tailscale identity/gating.
+  Available today, least new machinery.
+- **OIDC trust** — Canopy as an **OIDC relying party**, federating PGRO's
+  cluster OIDC (and others). More general and more extensible: the *same*
+  mechanism would let **GitHub Actions** and other internal automation
+  authenticate to Canopy — a first-party automation auth surface beyond
+  PGRO. Likely the better long-term direction; not designed here.
+
+Either way, the one channel carries both directions.
+
+**New state:** a `backup_restore_checks` record (per group: snapshot
+restored, outcome, replica health, `observed_at`) feeding signal-3
+detection/reconciliation against `backup_repo_snapshots` / `backup_runs`.
+
+**Cross-repo work (additive, later stage):**
+- `pgro`: drop the static `kopia-credentials` Secret; fetch + refresh
+  restore creds from Canopy; the `PostgresPhysicalReplica` CRD references a
+  canopy *group*; report per-replica restore outcomes back.
+- `canopy`: the first-party (non-device) auth surface (Tailscale or OIDC);
+  the external-restore grant + audit; a restore-report endpoint +
+  `backup_restore_checks`; signal-3 detection/alerting.
+- `ops`: the auth plumbing (OIDC trust config or Tailscale exposure) and
+  PGRO's read-only access path.
+
 ## Operational story (what we gain, day-one)
 
 - **"Did device X back up today?"** — three corroborating answers:

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -341,11 +341,21 @@ CREATE TABLE backup_repo_stats (
 );
 ```
 
-Cached repo/bucket stats for operator display, refreshed by the
-inspection cycle. `bucket_bytes` (CloudWatch `BucketSizeBytes`) is the
-real billing basis and runs *ahead* of `physical_bytes` — versioning plus
-the 30-day Object Lock keep expired-but-not-yet-deletable data around, so
-the gap between the two is itself the visible cost of the lock.
+Cached repo/bucket stats for operator display, written by **two distinct
+tasks**: the read-only kopia **inspection Job** fills the repo-derived
+fields (`snapshot_count`, `source_count`, `logical_bytes`,
+`physical_bytes`), while a **separate S3-metrics task** fills
+`bucket_bytes` from CloudWatch `BucketSizeBytes` (it's the real billing
+basis and runs *ahead* of `physical_bytes` — versioning + the lock keep
+expired-but-not-yet-deletable data around, so the gap is the visible cost
+of the lock). `bucket_bytes` is **best-effort / nullable** — it may lag or
+be absent independently of the kopia stats. The two are split because they
+need different permissions: kopia inspection uses read-only S3 creds, but
+the CloudWatch read needs `cloudwatch:GetMetricStatistics` (and the metric
+lives in the *deployment* account, so it's a cross-account read) — granted
+via a **dedicated least-privilege IRSA role** for the S3-metrics task or
+folded into a canopy-wide IRSA (implementation choice). Keeping it off the
+inspection creds avoids CloudWatch creep on the read-only inspector.
 
 ## Endpoint shape
 
@@ -962,11 +972,13 @@ a **dedicated, read-only inspection Job**, decoupled from maintenance at
 both the job and schedule level. It connects to each group's repo with
 **read-only (restore-level) creds** (never write/delete — smaller blast
 radius than the maintenance Job), runs `kopia snapshot list`, and writes
-`backup_repo_snapshots` (latest snapshot per source) plus `backup_repo_stats`
-(snapshot/source counts, logical & physical repo size, and the S3
-`bucket_bytes` from CloudWatch — the billing basis). It runs on its **own
-cadence** (defaulting to roughly `expected_interval`, tunable), so signal-2
-freshness isn't gated by the slow maintenance interval.
+`backup_repo_snapshots` (latest snapshot per source) plus the repo-derived
+fields of `backup_repo_stats` (snapshot/source counts, logical & physical
+size). The S3 `bucket_bytes` billing figure is filled by a **separate
+S3-metrics task** with its own CloudWatch permissions — *not* on these
+read-only creds (see `backup_repo_stats`). It runs on its **own cadence**
+(defaulting to roughly `expected_interval`, tunable), so signal-2 freshness
+isn't gated by the slow maintenance interval.
 
 - Attribution: the kopia **source encodes the server** — `bestool` overrides
   the kopia hostname to the **server id** (`canopy@<server-id>:<path>`), so

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -446,62 +446,96 @@ billable orphans.
 
 Dropping `DeleteObject` is defence-in-depth on top of the real backstop:
 **every group's bucket has a 30-day S3 Object Lock** (a required property,
-set at creation — see "Per-group buckets"). So even a cred that *could*
-delete or overwrite can't destroy a backup object younger than 30 days —
-a locked version is retained regardless. The no-delete device
-policy still earns its place (it removes the most destructive action
-outright, and avoids accidental client-side expiry), but the guarantee
-"a compromised server cannot destroy recent backups" rests on Object
-Lock, not on IAM alone. See "Canopy-owned maintenance" for how the lock
-interacts with kopia GC.
+set at creation — see "Per-group buckets"). So a cred without delete
+can't destroy a backup object regardless — a locked version is retained.
+The no-delete device policy still earns its place (it removes the most
+destructive action outright, and avoids accidental client-side expiry),
+but the guarantee "a compromised server cannot destroy recent backups"
+rests on Object Lock, not on IAM alone.
 
-## AWS setup (out-of-band of this plan, but documented here for completeness)
+**Caveat — the lock is `GOVERNANCE`, not `COMPLIANCE`** (per the `backups`
+Pulumi stack: `mode: 'GOVERNANCE', days: 30`). Governance retention can be
+overridden by a principal holding `s3:BypassGovernanceRetention`, and the
+existing full-access role grants `s3:*`, which includes it. So today the
+guarantee holds against *device* creds (no delete at all) but **not**
+against the maintenance / full-access role, which could bypass the lock
+and delete recent objects. To make the guarantee hold against every
+principal we control, either explicitly *deny* `s3:BypassGovernanceRetention`
+on the maintenance role (its GC only ever deletes objects whose lock has
+already expired, so it never legitimately needs bypass) or move the
+buckets to `COMPLIANCE` mode (no principal, not even root, can delete
+early). Flagged in open questions. See "Canopy-owned maintenance" for how
+the lock interacts with kopia GC.
 
-Because there's one bucket per group, the roles grant against a **bucket
-naming convention** rather than a single named bucket, and the per-call
-session policy still narrows to the one bucket the call is for.
+## AWS setup (provisioned by the Pulumi `backups` stack)
 
-- `canopy-backup-issuer` role with trust policy allowing the Canopy pod's
-  IRSA role to assume it.
-- Role policy grants broad `s3:*` on the bucket pattern (e.g.
-  `arn:aws:s3:::canopy-backup-*`) — broad because the session policy is
-  what actually constrains each call to the one group's bucket. Note: the
-  *device* session policies never grant delete, so even though the role
-  could, the creds handed to devices can't.
-- `canopy-backup-maintenance` role (or service account) for the
-  maintenance Jobs, with full S3 incl. `DeleteObject` on the same bucket
-  pattern. This is the only identity in the system that can delete backup
-  objects. It is first-party (Canopy-controlled), never handed to a
-  device. See "Canopy-owned maintenance" for why it gets its own IRSA
-  identity rather than chained creds.
+This already mostly exists. The `backups` stack in `ops/pulumi/backups`
+creates, per Pulumi stack, exactly the one-bucket-per-repo shape this plan
+wants: an S3 bucket with `objectLockEnabled`, versioning, a 30-day
+GOVERNANCE Object Lock, a `DenyInsecureTransport` bucket policy, plus two
+IAM roles — a full-access role (`s3:*`) and a kopia role
+(`AWS_S3_BACKUP_ACTIONS`). What it does *not* yet have is the
+Canopy-mediated path; today those roles are assumed by **EC2** instance
+profiles (`Principal: { Service: ec2.amazonaws.com }`), i.e. the
+AWS-resident model where a server assumes its role directly.
+
+The canopy fleet is the reason the Canopy path exists: those servers are
+remote, authenticated by mTLS, and generally *not* EC2 instances in our
+account, so they can't assume an AWS role directly — Canopy issues
+short-lived creds for them instead. The IaC changes are therefore:
+
+- **Trust Canopy's IRSA**, not (only) EC2: the roles Canopy assumes from
+  need `Principal` set to the Canopy pod's IRSA role.
+- **A reduced device-backup action set.** `AWS_S3_BACKUP_ACTIONS` today is
+  `[...multipart, s3:DeleteObject, s3:PutObjectRetention]` — it includes
+  delete because, in the EC2 model, the server ran maintenance. Under this
+  plan the device must *not* delete, so device-backup creds use a new
+  reduced constant (multipart + Get/Put, **no** `DeleteObject`, **no**
+  `PutObjectRetention`). The full set stays on the maintenance role only.
+- **Maintenance role** = the existing full-access role (or a sibling),
+  assumed by the maintenance Job's own IRSA (not chained — see
+  "Canopy-owned maintenance"). Only this identity can delete, and per the
+  GOVERNANCE caveat above it should additionally *deny*
+  `s3:BypassGovernanceRetention`.
+
+IAM-model choice (now informed by the repo): the existing stack already
+makes **per-bucket roles**, so the natural fit is per-bucket roles that
+trust Canopy's IRSA — Canopy assumes the specific group's role and the
+scoping is *structural* (the role's policy only names its own bucket), so
+no session policy is needed for correctness. The alternative is a single
+central issuer role over a bucket *pattern* with a per-call session policy
+narrowing to the one bucket (what the session-policy templates below
+describe). Per-bucket roles align with the existing per-stack structure
+and give stronger isolation; the session-policy approach means fewer
+roles. **Decide during implementation** — flagged in open questions. The
+permission *sets* in the templates below apply either way (they're either
+the role policy or the session policy).
 
 ### Per-group buckets
 
-Each group gets its own bucket, named by convention (e.g.
-`canopy-backup-<root-id>`) so the role patterns above cover it without
-per-bucket IAM edits. The hard constraint: **S3 Object Lock must be
-enabled at bucket creation** — it cannot be retrofitted onto an existing
-bucket. So provisioning a group's bucket must, atomically at creation,
-enable versioning + Object Lock with the default ≥30-day retention.
-Getting this wrong isn't fixable in place; it means recreating the
-bucket.
+One Pulumi `backups` stack per group → one bucket per group, named by the
+stack's convention (`bes-kopia-backups-<stack>`; README: begin with
+`bes-`, contain `kopia-backups`). The role IAM keys off that convention.
+The hard constraint, already satisfied by the stack but worth stating:
+**S3 Object Lock must be enabled at bucket creation** — it cannot be
+retrofitted. The stack does this (`objectLockEnabled: true` +
+`objectLockConfiguration`), so a group's bucket is correct by
+construction; getting it wrong would mean recreating the bucket.
 
-**IaC provisions the buckets.** A Terraform module (or equivalent)
-creates each group's bucket — with versioning + Object Lock + default
-retention — when a group is onboarded, following the naming convention
-the IAM patterns key off. Canopy only ever *uses* the bucket; it is never
-granted `CreateBucket` or bucket-config powers, keeping those out of the
-public-server's blast radius. Canopy's role is to *verify*, not create:
-the per-group preflight checks the bucket exists, is reachable, and has
-the expected Object Lock — so a missing or misconfigured bucket (e.g. IaC
-not yet applied for a new group, or the lock dropped) surfaces as an
-alert naming that group, rather than as silent backup failure.
+**IaC (Pulumi) provisions the buckets.** Onboarding a group means standing
+up its `backups` stack (bucket + lock + roles) and then inserting the
+`server_group_backup_config` row. Canopy only ever *uses* the bucket; it
+is never granted `CreateBucket` or bucket-config powers, keeping those out
+of the public-server's blast radius. Canopy's role is to *verify*, not
+create: the per-group preflight checks the bucket exists, is reachable,
+and has the expected Object Lock — so a missing or misconfigured bucket
+(e.g. the stack not yet applied for a new group, or the lock weakened)
+surfaces as an alert naming that group, rather than as silent backup
+failure.
 
-This means group onboarding is a two-step dance — IaC applies the bucket,
-then the `server_group_backup_config` row is inserted — and the ordering
-matters: insert the row before the bucket exists and the group's devices
-get clean preflight/issuance failures (not corruption), which the alert
-makes obvious. Worth noting for the onboarding runbook.
+The ordering matters: insert the row before the stack is applied and the
+group's devices get clean preflight/issuance failures (not corruption),
+which the alert makes obvious. Worth noting for the onboarding runbook.
 
 ## `bestool` changes
 
@@ -614,7 +648,11 @@ went, and a job scans those reports in the database.
    devices associated with a configured group, but it leans on the same
    `devices.server_id` / "device present" questions flagged below.
 3. Alerts route through the existing operator notification path
-   (Slack/email via `PRIVATE_URL`).
+   (Slack/email via `PRIVATE_URL`). Note this is Canopy's own app-level
+   alerting — distinct from the `backup-monitoring` Pulumi stack, which
+   watches the **AWS Backup service** (EBS/RDS) via EventBridge→SNS and
+   does not cover kopia-to-S3 backups. This detection is genuinely new;
+   the only thing shared is the precedent of alerting to Slack.
 
 The limit of signal 1 is that it's the *device's word*: it scans the
 Canopy database for what devices reported, not for what's actually in the
@@ -904,10 +942,19 @@ Surface it loudly; don't take Canopy down over it.
 
 None blocking, but flag-and-decide-during-implementation:
 
-- **Bucket naming convention.** IaC provisions the buckets (decided —
-  see "Per-group buckets"); settle the exact name template (e.g.
-  `canopy-backup-<root-id>`) so the IaC module, the IAM role patterns,
-  and Canopy's `bucket` value all agree on it.
+- **IAM model: per-bucket roles vs. central pattern + session policy.**
+  The existing `backups` stack makes per-bucket roles, favouring per-bucket
+  roles that trust Canopy's IRSA (structural scoping, no session policy);
+  the alternative is one central role over a `bes-kopia-backups-*` pattern
+  with session-policy narrowing. Decide and update the `backups` stack
+  accordingly (add the IRSA trust + the reduced device action set either
+  way). See "AWS setup".
+- **GOVERNANCE vs COMPLIANCE / bypass denial.** The lock is GOVERNANCE, so
+  the full-access role can bypass it. Either deny
+  `s3:BypassGovernanceRetention` on the maintenance role or switch buckets
+  to COMPLIANCE, to make "can't destroy recent backups" hold against every
+  principal we control (see the caveat under session policies). A change to
+  the `backups` stack.
 - **Per-device session naming for CloudTrail.** Suggested
   `device-<uuid>`; check max length and allowed chars on
   `RoleSessionName`.

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -66,8 +66,8 @@ directly (no proxy through Canopy).
      │
      │  POST /backup-credentials  (mTLS, ServerDevice)
      ▼
-┌──────────┐  AssumeRole + session policy        ┌─────────┐
-│  device  │                                     │   STS   │
+┌──────────┐  AssumeRole (group's per-bucket      ┌─────────┐
+│  device  │   role, cross-account)              │   STS   │
 │ (kopia + │ ◄────── creds_process JSON ──────── │         │
 │ bestool) │                                     └─────────┘
 └──────────┘
@@ -96,9 +96,11 @@ Maintenance path (Canopy-owned, no device involvement):
 
 Two STS calls per issuance:
 1. The pod's IRSA session is implicit — kubernetes injects it.
-2. From that session, Canopy calls `AssumeRole` on a dedicated
-   `canopy-backup-issuer` role, passing a session policy that narrows
-   S3 access to the requesting device's group bucket.
+2. From that session, Canopy performs a cross-account `AssumeRole` on the
+   group's configured per-bucket role (`target_role_arn`), whose own
+   policy structurally scopes to that one group's bucket. No session
+   policy is involved for the backup purpose; a session policy is added
+   only to downscope a `restore` to read-only. See "IAM model".
 
 The resulting temp creds go back to the device verbatim.
 
@@ -122,11 +124,12 @@ The resulting temp creds go back to the device verbatim.
   }
   ```
   `bestool` produces exactly this on stdout and exits.
-- **Session policies are ANDed with the role policy.** The role's
-  policy grants broad S3 access across the bucket pattern; the per-call
-  session policy narrows that to the one group's bucket. A bug in the
-  session policy can only ever *over*-restrict, never expand — good
-  failure mode.
+- **Scoping is structural, via the per-bucket role.** Each group's role
+  policy names only that group's bucket, so the bucket scoping doesn't
+  depend on a session policy at all. Session policies enter only for the
+  `restore` downscope (read-only), where the AND semantics mean a bug can
+  only ever *over*-restrict, never expand — good failure mode. See "IAM
+  model".
 
 ## Where it lives in the repo
 
@@ -308,7 +311,7 @@ GET /backup-target
   Response 200: {
     "storage": "s3",
     "bucket": "...",
-    "prefix": "groups/<root-id>/",
+    "prefix": "",             -- normally empty (repo at bucket root); non-empty only for a sub-path
     "region": "...",
     "endpoint": "..."         -- optional; for non-AWS S3
   }
@@ -353,20 +356,20 @@ success), so a crashed run is not silent.
 
 (`region`/`endpoint` are per-group columns on `server_group_backup_config`
 — each group's bucket can live in its own region, or behind a non-AWS S3
-endpoint. The audit-log snapshot should capture whatever the device was
-actually told.)
+endpoint. They're read from config, not snapshotted; the issuance audit
+log snapshots only `bucket`/`prefix` — see `backup_credential_issuances`.)
 
 `purpose` is a real capability gate, not just audit metadata:
 
 - `"backup"` (default): read + write + multipart, **no `DeleteObject`**,
-  scoped to the group's prefix. Snapshot expiry and blob GC are *not*
-  done by the device — Canopy owns maintenance (see "Canopy-owned
-  maintenance" below), so the device never needs delete. A compromised
-  server therefore cannot delete backups.
+  scoped to the group's bucket (prefix normally empty). Snapshot expiry
+  and blob GC are *not* done by the device — Canopy owns maintenance (see
+  "Canopy-owned maintenance" below), so the device never needs delete. A
+  compromised server therefore cannot delete backups.
 - `"restore"`: read-only (Get + ListBucket), scoped to the group's
-  prefix. A device with these creds physically cannot mutate the
-  bucket, so an accidental `kopia repository create` or similar can't
-  damage backups.
+  bucket (prefix normally empty). A device with these creds physically
+  cannot mutate the bucket, so an accidental `kopia repository create` or
+  similar can't damage backups.
 
 No device purpose grants `DeleteObject`. The only identity that can
 delete from the bucket is the Canopy maintenance role.
@@ -392,16 +395,26 @@ Handler flow:
    exist — verify when implementing; if a device isn't yet associated
    with a server, return `409`).
 3. `Server::root_id` walks up to the group root.
-4. Read `server_group_backup_config` for that root; `409` if absent.
-5. Build the session policy (template below).
-6. Call `sts:AssumeRole` on `canopy-backup-issuer` with the session
-   policy and a session name like `device-<device-id>`.
-7. Insert into `backup_credential_issuances`.
+4. Read `server_group_backup_config` for that root; `409` if absent. This
+   yields the group's `target_role_arn` (the per-bucket role to assume).
+5. Only for `purpose=restore`: build the read-only session policy
+   (template below). The `backup` purpose needs none — the per-bucket
+   role's own policy is already correctly scoped.
+6. Cross-account `sts:AssumeRole` on the group's `target_role_arn` (with
+   the restore session policy if applicable), session name like
+   `device-<device-id>`.
+7. Insert into `backup_credential_issuances` (recording the assumed role).
 8. Return the `credential_process` JSON.
 
-### Session policy templates
+### Permission templates
 
-**`purpose = "backup"`** — read + write, no delete:
+These are the permission *sets*. Under the decided IAM model, the
+**backup** set is the per-bucket role's own policy (authored in the
+group's Pulumi stack); the **restore** set is the read-only **session
+policy** Canopy passes when assuming that same role for `purpose=restore`
+(it ANDs down to read-only).
+
+**`purpose = "backup"`** — read + write, no delete (the role policy):
 
 ```json
 {
@@ -418,7 +431,12 @@ Handler flow:
     },
     {
       "Effect": "Allow",
-      "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+      "Action": ["s3:GetBucketLocation"],
+      "Resource": "arn:aws:s3:::<bucket>"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
       "Resource": "arn:aws:s3:::<bucket>",
       "Condition": {
         "StringLike": { "s3:prefix": ["<prefix>*"] }
@@ -428,7 +446,7 @@ Handler flow:
 }
 ```
 
-**`purpose = "restore"`** — read-only:
+**`purpose = "restore"`** — read-only (the session policy):
 
 ```json
 {
@@ -441,7 +459,12 @@ Handler flow:
     },
     {
       "Effect": "Allow",
-      "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+      "Action": ["s3:GetBucketLocation"],
+      "Resource": "arn:aws:s3:::<bucket>"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
       "Resource": "arn:aws:s3:::<bucket>",
       "Condition": {
         "StringLike": { "s3:prefix": ["<prefix>*"] }
@@ -451,14 +474,16 @@ Handler flow:
 }
 ```
 
-With one bucket per group, `<prefix>` is normally empty, so these
-resolve to the whole bucket (`<bucket>/*`) and an unconditioned
-`ListBucket` — which is correct, since the group owns the bucket
-outright. The `s3:prefix` condition only does work in the rare
-sub-path case; it's kept in the template so a non-empty prefix still
-scopes listings. The restore variant omits all mutation actions — even
-an explicit attempt to `kopia repository create` is rejected by S3, not
-just by kopia.
+`s3:GetBucketLocation` is a bucket-level op with no prefix notion — the
+`s3:prefix` context key isn't populated for it, so it must be its own
+**unconditioned** statement; folding it under the `s3:prefix` condition
+(as an earlier draft did) would silently deny it. With one bucket per
+group, `<prefix>` is normally empty, so the `ListBucket` condition
+matches everything and the device lists the whole bucket — correct, since
+the group owns it outright; the condition only does work in the rare
+sub-path case. The restore variant omits all mutation actions — even an
+explicit attempt to `kopia repository create` is rejected by S3, not just
+by kopia.
 
 `AbortMultipartUpload` is retained on the backup purpose: it can only
 discard a device's *own in-flight* multipart upload, never a committed
@@ -761,11 +786,12 @@ here, for two reasons:
   `DeleteObject`. If a client ran it, every client would need delete, and
   a compromised server could wipe the group's backups. By moving
   maintenance to Canopy, no device cred ever needs delete (see the
-  session policies above), so a compromised server cannot delete backups.
+  permission templates above), so a compromised server cannot delete
+  backups.
 
 So Canopy owns maintenance. Concretely, a scheduled control-plane task
 spawns a **Kubernetes Job per group** that runs `kopia maintenance run`
-(quick on a short cadence, full less often) against that group's prefix,
+(quick on a short cadence, full less often) against that group's bucket,
 then exits. Spawning a Job rather than running kopia in-process keeps the
 heavy, long-running work off the Canopy pod and lets it use the kopia
 image directly.
@@ -780,13 +806,13 @@ AssumeRole sessions noted up top: device backups tolerate it because
 exceed an hour, and we don't want it dying mid-rewrite. A direct IRSA
 identity on the Job refreshes transparently with no cap.
 
-Maintenance is first-party Canopy-controlled code, so granting it access
-to the whole bucket pattern (rather than narrowing to the one group's
-bucket via a session policy, which would re-introduce the 1-hour cap) is
-an acceptable trade-off. Per-bucket narrowing is what protects against
-*untrusted* device creds; it's not load-bearing for our own maintenance
-job. (If we later want per-group blast-radius limits on maintenance too,
-one role per bucket is the escape hatch — flagged, not built.)
+Like the device path, maintenance uses the **per-bucket** role — the
+group's full-access role (`s3:*` on that one bucket, incl. delete),
+assumed directly by the Job's IRSA. Because the role is already scoped to
+the single bucket, it needs no session-policy downscope (which is what
+would re-introduce the 1-hour cap). It's broad *on its own bucket*, not
+across a pattern — so a maintenance bug or compromise is still confined to
+that one group, the same structural isolation the device path gets.
 
 ### Interaction with the 30-day Object Lock
 
@@ -879,11 +905,12 @@ what's fixed is that it's Canopy's responsibility, not a client's.
 
 The device-staleness signals above watch the *devices*. This watches
 **Canopy's own upstream access**, which is a different and higher-stakes
-failure class: if the trust on the issuer role is edited, the pod's IRSA
-annotation is dropped, a role is deleted, or a bucket's Object Lock is
-removed, devices can't get creds and maintenance Jobs fail — and the
-backups stop without any per-device fault to point at. We should learn
-that from Canopy checking itself, not from devices starting to fail.
+failure class: if the pod's IRSA annotation is dropped (shared), or a
+group's per-bucket role trust is edited / the role deleted / that group's
+bucket Object Lock removed (per-group), devices can't get creds and
+maintenance Jobs fail — and the backups stop without any per-device fault
+to point at. We should learn that from Canopy checking itself, not from
+devices starting to fail.
 
 **It runs per server-group, not fleet-wide.** Each group has its own
 bucket with its own `region`/`endpoint` and its own Object Lock config,
@@ -894,18 +921,17 @@ when the genuinely shared piece breaks. The preflight reflects that split:
 
 Shared, checked once:
 - **Identity resolves** — `sts:GetCallerIdentity` confirms the pod's IRSA
-  web-identity is mounted and valid.
-- **Issuer role admits Canopy** — a dry-run `AssumeRole` on the issuer
-  role with a harmless session policy, confirming trust + role still
-  exist. (When per-bucket roles arrive, this becomes per-pathway.)
+  web-identity is mounted and valid. This is the only genuinely shared
+  piece; everything else is per-bucket and therefore per-group.
 
 Per configured group:
-- **Group creds work** — mint creds scoped to *that group's* bucket/prefix
-  and do a **read-only no-op** against *that group's* bucket/endpoint
-  (e.g. `HeadBucket` / a scoped `ListBucket` on a probe prefix), so the
-  check proves the group's creds actually work, not merely that
-  `AssumeRole` returned. This is the check that catches a single group's
-  bucket/endpoint/policy being wrong while others are fine.
+- **Role trust + creds work** — assume *that group's* `target_role_arn`
+  (cross-account), confirming the per-bucket role still exists and its
+  trust still admits Canopy, then do a **read-only no-op** with the
+  returned creds against *that group's* bucket/endpoint (e.g. `HeadBucket`
+  / a scoped `ListBucket`), so the check proves the group's creds actually
+  work, not merely that `AssumeRole` returned. This catches a single
+  group's role/bucket/endpoint being wrong while others are fine.
 - **Object Lock is in place** — verify *that group's* bucket still has the
   expected (≥30-day) Object Lock configuration. The whole "a compromised
   server can't destroy backups" guarantee rests on this; if someone
@@ -920,7 +946,7 @@ Per configured group:
 
 Alerts name the affected group(s) and fire at control-plane severity
 (distinct from per-device staleness); a check that fails for *every*
-group points at the shared identity/issuer rather than any one bucket.
+group points at the shared IRSA identity rather than any one bucket.
 
 Prefer **behavioural** checks (try to assume; try a harmless S3 op) over
 IAM/policy *introspection*: behavioural checks test the real path and
@@ -1043,10 +1069,13 @@ None blocking, but flag-and-decide-during-implementation:
   deployment-wide defaults; per-group override is a later column if
   needed. Decide the scheduler home (CronJob fanning out per-group Jobs,
   a private-server task, or a dedicated worker).
-- **Maintenance Job scoping.** Broad-bucket IRSA (simple, no 1-hour cap)
-  vs. one role per group (tighter blast radius, but per-group narrowing
-  via session policy re-introduces the cap). Recommended: broad for the
-  first cut since maintenance is first-party.
+- **Maintenance Job IRSA wiring.** Scoping is settled by the per-bucket
+  model (the Job assumes the group's per-bucket full-access role — broad
+  on its own bucket, so no session-policy downscope and no 1-hour cap, yet
+  still confined to one group). What's left is the mechanics: registering
+  the cluster's OIDC provider in each deployment account so the Job's
+  service account can assume that account's maintenance role directly
+  (cross-account web-identity, not chained).
 
 ## Out of scope (do not silently fold in)
 

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -370,11 +370,19 @@ GET /backup-target
     "bucket": "...",
     "prefix": "",             -- normally empty (repo at bucket root); non-empty only for a sub-path
     "region": "...",
-    "endpoint": "..."         -- optional; for non-AWS S3
+    "endpoint": "...",        -- optional; for non-AWS S3
+    "repo_password": "..."    -- the kopia repo passphrase (read from the k8s Secret)
   }
   Response 412: device not bound to a live server (DeviceHasNoServer)
   Response 409: server ungrouped, or no backup config for the group
 ```
+
+(`repo_password` is here because bestool needs it to `kopia repository
+connect`. **Consequence:** `public-server` — the *internet-facing* pod —
+must itself read the group's k8s Secret, so the net-new k8s machinery
+isn't only on the jobs side: `public-server` needs a kube client +
+ServiceAccount with Secret-read RBAC. This widens its blast radius, which
+the stage-1 accepted-risk note and the blind-relay stub both cover.)
 
 This is the piece that keeps the bucket out of device provisioning. The
 `credential_process` output format (above) is **fixed by the AWS SDK** and
@@ -1361,13 +1369,18 @@ as new `jobs`-crate bins; the `ServerRank::Production`→`"prod"` mapping;
 `AWS_S3_MULTIPART_ACTIONS` for the device set.
 
 **Net-new infrastructure this requires (none exists in canopy today):**
-- The **AWS SDK** — `aws-config` + `aws-sdk-{sts,s3,secretsmanager?}`, a
-  provider, and an `AppState` client (first AWS SDK usage in the workspace).
-- A **Kubernetes API client** (`kube`/`k8s-openapi`) for spawning Jobs.
-- A **ServiceAccount + IRSA** on canopy's pods (plumb through `spec.ts`;
-  the `common/eksServiceAccount.ts` helper exists but is unused), plus RBAC
-  to create Jobs and `get` Secrets, and the OIDC-provider-per-account
-  wiring for cross-account Job web-identity.
+- The **AWS SDK** — `aws-config` + `aws-sdk-{sts,s3,…}`, a provider, and an
+  `AppState` client (first AWS SDK usage in the workspace).
+- A **Kubernetes API client** (`kube`/`k8s-openapi`) — for spawning Jobs
+  (jobs side) **and** for `public-server` to read the repo-password Secret
+  it serves on `/backup-target`.
+- A **ServiceAccount + IRSA** on canopy's pods — **including
+  `public-server`**, which today carries none (the shared `spec.ts`
+  injects no ServiceAccount). RBAC: the jobs side needs create-Jobs +
+  `get` Secrets; `public-server` needs `get` Secrets for repo passwords.
+  Plus IRSA wiring (the `common/eksServiceAccount.ts` helper exists but is
+  unused) and the OIDC-provider-per-account wiring for cross-account Job
+  web-identity.
 
 **Still open (genuine choices, not gaps):**
 - The **transport** for the cadence signal (how it rides today's

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -9,8 +9,10 @@ directly (no proxy through Canopy).
 
 - One credential to manage per device — the existing mTLS identity.
 - No long-lived AWS access keys on servers or in operator hands.
-- Per-group isolation: a device only ever gets access to its own
-  server-group's backup scope.
+- Per-group isolation at the **bucket** boundary: each server-group has
+  its own backups bucket, and a device only ever gets access to its own
+  group's bucket. (Stronger than prefix-sharing inside one bucket — a
+  scoping bug can't even name another group's bucket.)
 - Within-group cross-device restore: every device in a group can
   request read-only creds for the group's scope (`purpose=restore`), so
   restoring onto a freshly-rebuilt sibling is trivial and the restoring
@@ -40,9 +42,12 @@ directly (no proxy through Canopy).
   Canopy now *owns, declares, and enforces* the policy (see "Retention
   policy ownership") — the mechanism is in scope — but the actual values
   start at a sane default and per-group tuning is later.
-- WORM immutability is **already in place** (30-day S3 Object Lock on the
-  buckets) — not a follow-up. This plan just has to be compatible with it
-  (object-lock-aware kopia repos; GC reclaims on a ~30-day lag).
+- WORM immutability is a **required property of every group's bucket**
+  (30-day S3 Object Lock), not a follow-up. Existing buckets already have
+  it; new per-group buckets must enable it at creation (it can't be
+  retrofitted — see "Per-group buckets"). The plan also has to be
+  compatible with it (object-lock-aware kopia repos; GC reclaims on a
+  ~30-day lag).
 - Picking the backup tool. Kopia is the assumed consumer because it
   fits the AWS SDK `credential_process` hook cleanly, but rclone works
   through the same mechanism if it turns out to be preferred.
@@ -89,7 +94,7 @@ Two STS calls per issuance:
 1. The pod's IRSA session is implicit — kubernetes injects it.
 2. From that session, Canopy calls `AssumeRole` on a dedicated
    `canopy-backup-issuer` role, passing a session policy that narrows
-   S3 access to the requesting device's group prefix.
+   S3 access to the requesting device's group bucket.
 
 The resulting temp creds go back to the device verbatim.
 
@@ -114,8 +119,8 @@ The resulting temp creds go back to the device verbatim.
   ```
   `bestool` produces exactly this on stdout and exits.
 - **Session policies are ANDed with the role policy.** The role's
-  policy grants broad S3 access to the backups bucket; the per-call
-  session policy narrows that to the specific prefix. A bug in the
+  policy grants broad S3 access across the bucket pattern; the per-call
+  session policy narrows that to the one group's bucket. A bug in the
   session policy can only ever *over*-restrict, never expand — good
   failure mode.
 
@@ -141,8 +146,8 @@ Reasons not to put it in `private-server`:
 ```sql
 CREATE TABLE server_group_backup_config (
     root_server_id    UUID PRIMARY KEY REFERENCES servers(id) ON DELETE CASCADE,
-    bucket            TEXT NOT NULL,
-    prefix            TEXT NOT NULL,           -- e.g. "groups/<root-id>/"
+    bucket            TEXT NOT NULL,           -- this group's own bucket (one bucket per group)
+    prefix            TEXT NOT NULL DEFAULT '', -- usually empty: the repo lives at the bucket root
     region            TEXT,                    -- NULL → deployment default
     endpoint          TEXT,                    -- NULL → AWS; set for non-AWS S3
     expected_interval INTERVAL,                -- declared cadence: paces devices AND drives staleness; NULL → neither
@@ -152,6 +157,13 @@ CREATE TABLE server_group_backup_config (
     updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 ```
+
+`bucket` is the group's **own** bucket — one bucket per group, not a
+shared bucket with per-group prefixes. Isolation is therefore at the
+bucket boundary, and `prefix` is usually empty (the kopia repo sits at
+the bucket root); it stays in the schema only for the rare case of
+parking a repo under a sub-path. See "Per-group buckets" for naming and
+provisioning.
 
 `region`/`endpoint` are what `GET /backup-target` serves to devices.
 `expected_interval` is the group's **declared backup cadence** and the
@@ -327,11 +339,10 @@ completed", and it is the input to staleness detection below. A device
 that fails to even reach this endpoint shows up as staleness (no recent
 success), so a crashed run is not silent.
 
-(`region`/`endpoint` can be added as columns to `server_group_backup_config`
-when implementing, or derived from a single deployment-wide default if the
-backups bucket always lives in one region. Decide during implementation;
-the audit-log snapshot should capture whatever the device was actually
-told.)
+(`region`/`endpoint` are per-group columns on `server_group_backup_config`
+— each group's bucket can live in its own region, or behind a non-AWS S3
+endpoint. The audit-log snapshot should capture whatever the device was
+actually told.)
 
 `purpose` is a real capability gate, not just audit metadata:
 
@@ -418,11 +429,14 @@ Handler flow:
 }
 ```
 
-The `s3:ListBucket` condition prefix is what kopia needs to enumerate
-its own snapshots; without it the device sees the entire bucket
-listing. The restore variant omits all mutation actions — even an
-explicit attempt to `kopia repository create` over the prefix is
-rejected by S3, not just by kopia.
+With one bucket per group, `<prefix>` is normally empty, so these
+resolve to the whole bucket (`<bucket>/*`) and an unconditioned
+`ListBucket` — which is correct, since the group owns the bucket
+outright. The `s3:prefix` condition only does work in the rare
+sub-path case; it's kept in the template so a non-empty prefix still
+scopes listings. The restore variant omits all mutation actions — even
+an explicit attempt to `kopia repository create` is rejected by S3, not
+just by kopia.
 
 `AbortMultipartUpload` is retained on the backup purpose: it can only
 discard a device's *own in-flight* multipart upload, never a committed
@@ -431,9 +445,10 @@ just lets a failed upload clean up its own parts instead of leaving
 billable orphans.
 
 Dropping `DeleteObject` is defence-in-depth on top of the real backstop:
-**the buckets already have a 30-day S3 Object Lock.** So even a cred that
-*could* delete or overwrite can't destroy a backup object younger than 30
-days — a locked version is retained regardless. The no-delete device
+**every group's bucket has a 30-day S3 Object Lock** (a required property,
+set at creation — see "Per-group buckets"). So even a cred that *could*
+delete or overwrite can't destroy a backup object younger than 30 days —
+a locked version is retained regardless. The no-delete device
 policy still earns its place (it removes the most destructive action
 outright, and avoids accidental client-side expiry), but the guarantee
 "a compromised server cannot destroy recent backups" rests on Object
@@ -442,21 +457,50 @@ interacts with kopia GC.
 
 ## AWS setup (out-of-band of this plan, but documented here for completeness)
 
+Because there's one bucket per group, the roles grant against a **bucket
+naming convention** rather than a single named bucket, and the per-call
+session policy still narrows to the one bucket the call is for.
+
 - `canopy-backup-issuer` role with trust policy allowing the Canopy pod's
   IRSA role to assume it.
-- Role policy grants broad `s3:*` on the backups bucket (broad because
-  the session policy is what actually constrains each call). Note: the
+- Role policy grants broad `s3:*` on the bucket pattern (e.g.
+  `arn:aws:s3:::canopy-backup-*`) — broad because the session policy is
+  what actually constrains each call to the one group's bucket. Note: the
   *device* session policies never grant delete, so even though the role
   could, the creds handed to devices can't.
 - `canopy-backup-maintenance` role (or service account) for the
-  maintenance Jobs, with full S3 incl. `DeleteObject` on the backups
-  bucket. This is the only identity in the system that can delete backup
+  maintenance Jobs, with full S3 incl. `DeleteObject` on the same bucket
+  pattern. This is the only identity in the system that can delete backup
   objects. It is first-party (Canopy-controlled), never handed to a
   device. See "Canopy-owned maintenance" for why it gets its own IRSA
   identity rather than chained creds.
-- The backups bucket is created separately. Single bucket to start;
-  the `bucket` column in `server_group_backup_config` means moving to
-  one-bucket-per-group later is a data migration, not a code change.
+
+### Per-group buckets
+
+Each group gets its own bucket, named by convention (e.g.
+`canopy-backup-<root-id>`) so the role patterns above cover it without
+per-bucket IAM edits. The hard constraint: **S3 Object Lock must be
+enabled at bucket creation** — it cannot be retrofitted onto an existing
+bucket. So provisioning a group's bucket must, atomically at creation,
+enable versioning + Object Lock with the default ≥30-day retention.
+Getting this wrong isn't fixable in place; it means recreating the
+bucket.
+
+Who provisions it is a decision (flagged in open questions), and it
+trades off against privilege:
+
+- **Out-of-band (IaC / admin step):** a Terraform module or admin tool
+  creates the bucket with lock when a group is onboarded; Canopy only
+  *uses* it (and the preflight verifies it). Keeps `CreateBucket` and
+  bucket-config powers out of the public-server's blast radius.
+- **Canopy-driven:** Canopy creates the bucket on group-config setup.
+  More "behind the scenes" but hands the control plane bucket-creation
+  authority, a meaningful privilege increase.
+
+Recommend out-of-band provisioning with preflight verification for the
+first cut: bucket creation is rare (once per group) and heavyweight, and
+the preflight already checks the lock is correct — so we get the
+"managed" feel without granting `CreateBucket` to the request path.
 
 ## `bestool` changes
 
@@ -654,13 +698,13 @@ AssumeRole sessions noted up top: device backups tolerate it because
 exceed an hour, and we don't want it dying mid-rewrite. A direct IRSA
 identity on the Job refreshes transparently with no cap.
 
-Maintenance is first-party Canopy-controlled code, so granting it broad
-bucket access (rather than per-group prefix narrowing via a session
-policy, which would re-introduce the 1-hour cap) is an acceptable
-trade-off. Per-prefix narrowing is what protects against *untrusted*
-device creds; it's not load-bearing for our own maintenance job. (If we
-later want per-group blast-radius limits on maintenance too, one role per
-group is the escape hatch — flagged, not built.)
+Maintenance is first-party Canopy-controlled code, so granting it access
+to the whole bucket pattern (rather than narrowing to the one group's
+bucket via a session policy, which would re-introduce the 1-hour cap) is
+an acceptable trade-off. Per-bucket narrowing is what protects against
+*untrusted* device creds; it's not load-bearing for our own maintenance
+job. (If we later want per-group blast-radius limits on maintenance too,
+one role per bucket is the escape hatch — flagged, not built.)
 
 ### Interaction with the 30-day Object Lock
 
@@ -759,14 +803,12 @@ removed, devices can't get creds and maintenance Jobs fail — and the
 backups stop without any per-device fault to point at. We should learn
 that from Canopy checking itself, not from devices starting to fail.
 
-**It runs per server-group, not fleet-wide.** Each group carries its own
-`bucket`/`prefix`/`region`/`endpoint` (the schema already allows divergent
-buckets, and one-bucket-per-group is a planned data migration), so the
-bucket-level access and the Object Lock config can differ per group —
-and once buckets diverge, even the cred pathway can (e.g. a non-AWS-S3
-`endpoint` isn't reached via AWS STS at all). So a failure is normally
-*scoped to one group*; it's only fleet-wide when the genuinely shared
-piece breaks. The preflight reflects that split:
+**It runs per server-group, not fleet-wide.** Each group has its own
+bucket with its own `region`/`endpoint` and its own Object Lock config,
+so bucket-level access can differ per group — and with a non-AWS-S3
+`endpoint`, the cred pathway differs too (it isn't reached via AWS STS at
+all). So a failure is normally *scoped to one group*; it's only fleet-wide
+when the genuinely shared piece breaks. The preflight reflects that split:
 
 Shared, checked once:
 - **Identity resolves** — `sts:GetCallerIdentity` confirms the pod's IRSA
@@ -825,18 +867,21 @@ Surface it loudly; don't take Canopy down over it.
   mechanism); it can no longer call the endpoint, so it can no longer
   get fresh creds. Already-issued creds expire within an hour.
 - **Decommissioning a group** — delete its `server_group_backup_config`
-  row; devices in that group start getting `409`.
-- **Changing prefix, region, or endpoint** — update the
+  row; devices in that group start getting `409`. The group's bucket and
+  its Object-Lock'd objects persist independently — they can't be deleted
+  until their locks expire (~30 days), so bucket teardown is a deliberate,
+  delayed step, not a side effect of removing the config row.
+- **Onboarding a group** — provision its bucket (with Object Lock, see
+  "Per-group buckets"), then insert the `server_group_backup_config` row.
+  Devices in the group start succeeding on their next run.
+- **Changing region or endpoint** — update the
   `server_group_backup_config` row. Each device picks it up on its next
   scheduled `bestool canopy backup` (every-run target fetch); no per-host
   command, no coordinated cutover. Staleness detection flags any host
-  that fails to roll over.
-- **Rotating the *bucket*** — note this is not a free config flip: a
-  kopia repository lives *in* its bucket, so a new bucket is either a
-  repo data migration or a deliberate start-fresh. The mechanism makes
-  the *config* change propagate automatically, but the operator still
-  owns the migration/cutover decision. (Listed under out-of-scope as
-  per-group bucket migration.)
+  that fails to roll over. (This means pointing at a *different* bucket;
+  since a kopia repo lives in its bucket, that's a repo migration or a
+  start-fresh the operator owns — not a free flip — even though the config
+  change itself propagates automatically.)
 - **A compromised server can't destroy recent backups** — no device cred
   grants `DeleteObject`, and the 30-day Object Lock means even a delete-
   or overwrite-capable cred can't damage backup objects younger than 30
@@ -856,6 +901,11 @@ Surface it loudly; don't take Canopy down over it.
 
 None blocking, but flag-and-decide-during-implementation:
 
+- **Bucket provisioning ownership.** Out-of-band (IaC / admin) vs.
+  Canopy-driven `CreateBucket` (see "Per-group buckets"). Recommended
+  out-of-band for the first cut to keep `CreateBucket` out of the request
+  path; decide, and settle the bucket naming convention the IAM patterns
+  key off. Whichever, Object Lock must be enabled at creation.
 - **Per-device session naming for CloudTrail.** Suggested
   `device-<uuid>`; check max length and allowed chars on
   `RoleSessionName`.
@@ -927,15 +977,14 @@ None blocking, but flag-and-decide-during-implementation:
   silent breakage either (a dead proxy is just as silent). Detection
   does that. Rejected for the first cut; revisit only if we want the
   interposition point for its own sake.
-- Per-group bucket migration (the schema supports it; the operational
-  work is separate).
+- Migrating *existing* shared-bucket data into per-group buckets (if any
+  group is on a shared bucket today). The design is one-bucket-per-group;
+  moving legacy data across is a separate operational task.
 - bestool subcommand implementation (separate repo).
 - **Tuning** retention policy values, encryption-at-rest beyond default
   SSE-S3, S3 lifecycle rules. (Retention *execution* is in scope — Canopy
   maintenance runs it — but the kopia retention values start at a default
   and per-group tuning is later.)
-- Standing up Object Lock — the buckets already have a 30-day lock; this
-  plan consumes it (object-lock-aware repos), it doesn't create it.
 - Operator UI in `private-server` / React for editing
   `server_group_backup_config` (will want it eventually; not in the
   first cut — bootstrap via SQL). This now includes the maintenance

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -552,21 +552,59 @@ just lets a failed upload clean up its own parts instead of leaving
 billable orphans.
 
 Dropping `DeleteObject` is defence-in-depth on top of the real backstop:
-**every group's bucket has a 30-day S3 Object Lock** (a required property,
-set at creation — see "Per-group buckets"). So a cred without delete
-can't destroy a backup object regardless — a locked version is retained.
-The no-delete device policy still earns its place (it removes the most
-destructive action outright, and avoids accidental client-side expiry),
-but the guarantee "a compromised server cannot destroy recent backups"
-rests on Object Lock, not on IAM alone.
+**every group's bucket has versioning + a 30-day S3 Object Lock** (both
+required, set at creation — see "Per-group buckets"). A device cred has
+neither `DeleteObject` nor `s3:BypassGovernanceRetention`, so it cannot
+*delete* anything. But it *does* keep `PutObject` on existing keys, so the
+one residual attack is **overwrite-poisoning**: a compromised device
+overwrites live blobs, burying the good versions as *noncurrent*. This is
+survivable, not destruction:
 
-**The threat boundary is a compromised device, and that's what this
-defends.** The lock is `GOVERNANCE`, not `COMPLIANCE` (per the `backups`
-Pulumi stack: `mode: 'GOVERNANCE', days: 30`) — and we're keeping it that
-way. A device cred has neither `DeleteObject` nor
-`s3:BypassGovernanceRetention` (the reduced action set grants only
-Get/Put/multipart), so a compromised server physically cannot destroy
-backups, full stop. That is the guarantee.
+- Versioning preserves the good (noncurrent) versions; the Object Lock
+  keeps them undeletable, and lifecycle can't reclaim them until the
+  lock/lifecycle window elapses (see "Interaction with the 30-day Object
+  Lock").
+- kopia content blobs are **content-addressed and hash-verified**, so
+  poisoning surfaces as *detectable corruption* (signal 2 catches it —
+  see below), not silently-served bad data.
+- Recovery is a version-level rollback driven by the maintenance role
+  (see "Recovery from poisoning"), within the window.
+
+So the precise guarantee: **a compromised device cannot delete backups,
+and cannot *permanently* destroy them** — overwrite-poisoning is a
+bounded, detectable DoS recoverable by version rollback within the
+lock/lifecycle window. (Not "full stop": the current restore would be
+broken until recovery.)
+
+**The threat boundary is a compromised device.** The lock is `GOVERNANCE`,
+not `COMPLIANCE` (per the `backups` Pulumi stack: `mode: 'GOVERNANCE',
+days: 30`) — and we're keeping it that way; AWS-level compromise stays out
+of scope (see non-goals).
+
+### Recovery from poisoning
+
+If signal 2 reports corruption / unreadability for a group's repo (the
+overwrite-poisoning case above), recovery is a **version-level rollback,
+driven by the maintenance role** — which already has `s3:*`, hence
+`GetObjectVersion` / `ListBucketVersions`, in the deployment account. The
+device `restore` creds stay read-only-*current* (no version access);
+recovery is a deliberate operator action, not a device capability.
+
+Runbook (to be written out at implementation):
+1. Stop issuing to the group (so the attacker can't keep overwriting).
+2. Identify the poisoning time from `backup_runs` / `backup_repo_snapshots`
+   / version timestamps.
+3. `kopia repository connect … --point-in-time <before-poisoning>` and
+   restore/roll the repo back past the bad versions (kopia supports PIT
+   reconnect against a versioned, object-locked bucket).
+4. Re-verify, then resume issuance.
+
+The deadline is the **lock/lifecycle window** (~30–35 days from the
+overwrite — see "Interaction with the 30-day Object Lock"); after that
+lifecycle reclaims the good noncurrent versions. Detection latency
+(signal 2, ~daily) is far inside that window, so the window is ample —
+but the runbook and the deadline must be known before an incident, not
+discovered during one.
 
 What GOVERNANCE deliberately leaves open is *AWS-level* compromise: a
 principal holding `s3:BypassGovernanceRetention` — e.g. the full-access /
@@ -863,6 +901,16 @@ freshness isn't gated by the slow maintenance interval.
 - Trust property: signal 2 depends only on the bucket (Object-Lock
   protected), not on any device, so it's the signal a compromised server
   cannot fake into showing a healthy backup.
+- **Poisoning / corruption detection → critical incident.** Inspection
+  also *verifies* the repo (kopia detects content-blob hash mismatches /
+  unreadable index — the overwrite-poisoning signature, see "Recovery from
+  poisoning"). On detected corruption, raise a **`Critical`-severity**
+  event so it opens an incident for immediate investigation (Critical
+  satisfies `opens_incident()`), pointing at the recovery runbook. This is
+  a **group-level** alert — it fires independent of any server's
+  `is_monitored` (see the group-level-checks note under detection), since
+  a corrupt repo endangers the whole group's backups regardless of which
+  servers are monitored.
 
 Both signals feed the same `Incident` alerting path.
 

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -645,6 +645,22 @@ short-lived creds for them instead. The IaC changes are therefore:
   the maintenance role only. When adding IRSA trust to these roles, preserve
   the stack's existing optional IAM-Users path and the `.storageconfig`
   object so they aren't clobbered.
+
+  *Why dropping `PutObjectRetention` is safe (H3):* the lock is applied by
+  the bucket's **default retention** (the stack's `objectLockConfiguration`
+  GOVERNANCE 30d auto-locks every PUT), so the device needs no permission to
+  set retention itself — and we deliberately do **not** run the repo
+  client-lock-aware (kopia setting/extending per-object locks). Client lock
+  *extension* only buys protection against an AWS-level (delete-capable)
+  attacker, which is out of scope; under device-compromise, versioning +
+  default-retention + lifecycle + the recovery path already cover it.
+  **Verify before finalizing:** confirm kopia's S3 backend writes/maintains
+  fine against a default-retention bucket without client-side
+  `PutObjectRetention` (it deletes by key → markers, doesn't set per-object
+  retention). Fallback if kopia insists: re-grant `PutObjectRetention` to
+  devices — safe, because in GOVERNANCE-without-bypass it can only *lengthen*
+  a lock, never shorten it (minor cost-DoS vector, recoverable via the
+  maintenance role's bypass).
 - **Maintenance role** = the existing full-access role (or a sibling),
   assumed by the maintenance Job's own IRSA (not chained — see
   "Canopy-owned maintenance"). Only this identity can delete. It keeps
@@ -1360,8 +1376,10 @@ as new `jobs`-crate bins; the `ServerRank::Production`→`"prod"` mapping;
   compromised *device*; defending against a compromised AWS principal that
   holds `s3:BypassGovernanceRetention` (e.g. the maintenance role's creds)
   is a separate problem. We stay on GOVERNANCE Object Lock and accept that
-  the first-party maintenance role can bypass it. (COMPLIANCE mode /
-  bypass-denial remain available later if the threat model widens.)
+  the first-party maintenance role can bypass it. (COMPLIANCE mode,
+  bypass-denial, and kopia client-side **lock extension** — which keeps
+  live blobs' locks fresh against a delete-capable attacker — all remain
+  available later if the threat model widens.)
 - Data-plane proxy / Canopy-served S3/WebDAV (explicitly rejected).
 - **Device-local S3 proxy** (kopia → `localhost`, a bestool daemon
   re-signs and forwards to the real bucket). Considered as an

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -1291,10 +1291,13 @@ Surface it loudly; don't take Canopy down over it.
   since a kopia repo lives in its bucket, that's a repo migration or a
   start-fresh the operator owns — not a free flip — even though the config
   change itself propagates automatically.)
-- **A compromised server can't destroy recent backups** — no device cred
-  grants `DeleteObject`, and the 30-day Object Lock means even a delete-
-  or overwrite-capable cred can't damage backup objects younger than 30
-  days. IAM removes the action; Object Lock is the hard backstop.
+- **A compromised server can't *destroy* backups** — no device cred grants
+  `DeleteObject`, so deletion is impossible; and overwrite-poisoning is
+  survivable (versioning + Object Lock preserve the good versions;
+  signal-2 detects the corruption; version-rollback recovers within the
+  lock/lifecycle window). The current restore is broken until recovery —
+  so it's a detectable, recoverable DoS, not data loss. (See "Recovery
+  from poisoning".)
 - **Maintenance just happens** — clients don't run it and don't have the
   rights to; Canopy spawns the Jobs. Repo bloat / unenforced retention
   from a stuck client owner is no longer a failure mode, and

--- a/docs/plans/backup-credentials.md
+++ b/docs/plans/backup-credentials.md
@@ -145,7 +145,7 @@ CREATE TABLE server_group_backup_config (
     prefix            TEXT NOT NULL,           -- e.g. "groups/<root-id>/"
     region            TEXT,                    -- NULL → deployment default
     endpoint          TEXT,                    -- NULL → AWS; set for non-AWS S3
-    expected_interval INTERVAL,                -- NULL → no staleness alerting
+    expected_interval INTERVAL,                -- declared cadence: paces devices AND drives staleness; NULL → neither
     retention         JSONB NOT NULL,          -- kopia keep-* policy; Canopy asserts it into the repo
     repo_password_ref TEXT NOT NULL,           -- reference to the secret, NOT the secret
     created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -154,9 +154,11 @@ CREATE TABLE server_group_backup_config (
 ```
 
 `region`/`endpoint` are what `GET /backup-target` serves to devices.
-`expected_interval` drives staleness detection (below): if a group is
-expected to back up daily, set it to `1 day` and Canopy alerts when a
-device in the group has no recent successful run.
+`expected_interval` is the group's **declared backup cadence** and the
+single source for it: it both paces the devices (see "Backup cadence")
+and drives staleness detection. Set it to `1 day` and devices aim to
+back up daily *and* Canopy alerts when one hasn't. Because it's one
+value, the schedule and the alert can't drift apart.
 
 `retention` holds the kopia keep-policy (e.g. `{"keep_daily": 7,
 "keep_weekly": 4, ...}`); Canopy asserts it into the repo at creation and
@@ -493,11 +495,35 @@ The device is provisioned only with its Canopy URL and mTLS identity.
 The bucket, prefix and region are never written to the device's
 persistent config — bestool re-derives the repository connection from
 Canopy on *every* run. This is the crux of the "no per-host action"
-property: `bestool canopy backup` is the scheduled job (systemd timer / cron)
-that already runs on each host on its backup cadence, so a server-side
-config change propagates to the whole fleet automatically on each host's
-next scheduled backup. There is no operator command to run per host and
-nothing to "forget to re-run".
+property: a server-side config change propagates to the whole fleet
+automatically on each host's next run. There is no operator command to
+run per host and nothing to "forget to re-run".
+
+### Backup cadence
+
+Who decides *when* `bestool canopy backup` runs is a real question,
+because Canopy is **pull-based** — it has no inbound path to devices (the
+push/proxy direction is explicitly rejected), so it physically cannot
+trigger a backup. A local trigger must exist. The design choice is only
+whether the cadence is hardcoded per host (drifts from Canopy's
+`expected_interval`, and changing the fleet cadence means touching every
+host) or owned by Canopy like everything else.
+
+We own it in Canopy:
+
+- A local systemd timer fires `bestool canopy backup` as a *heartbeat* —
+  frequent enough (say hourly) that it never gates the real cadence, and
+  needing no per-host tuning.
+- Each tick, bestool already fetches the target/creds; it also reads the
+  group's `expected_interval` and backs up only if the last successful
+  run is older than that. So the *effective* schedule is Canopy's
+  declared cadence; the local timer is just "wake up and ask".
+- Staleness alerting reads the same `expected_interval`, so the cadence
+  the fleet targets and the cadence Canopy polices are one number and
+  cannot diverge.
+
+Changing a group's cadence is then the same single-row update as any
+other config — no per-host action.
 
 bestool work is in a separate repo; this plan covers the Canopy side
 and the bestool side will be a sibling change there.
@@ -725,6 +751,12 @@ None blocking, but flag-and-decide-during-implementation:
   field's default — a product decision, not invented here. Note the
   effective floor is 30 days regardless (Object Lock), so anything
   shorter is meaningless; the default should be ≥ that.
+- **Heartbeat interval and last-success source.** The local timer's
+  fixed interval (must be ≤ the smallest `expected_interval` in use),
+  and whether bestool debounces against locally-recorded last-success or
+  asks Canopy (which already has `backup_runs`). Asking Canopy is
+  drift-proof but adds a round-trip; local state is cheaper but can lie
+  after a host rebuild. Decide during implementation.
 - **Repo password storage.** Canopy owns the per-group kopia password;
   where does the secret actually live (k8s secret vs. Secrets Manager
   vs. ...) and how is it served to devices and injected into Jobs?

--- a/docs/plans/specs/canopy-database.md
+++ b/docs/plans/specs/canopy-database.md
@@ -1,0 +1,539 @@
+# Implementation spec: `canopy-database` (backup-credentials)
+
+Component: the **database crate** (`crates/database`) changes for the
+backup-credentials system. This is the foundational layer every other
+component (public-server endpoints, the `jobs`-crate schedulers, the
+private-server operator UI) builds on: it owns the migrations, the diesel
+models, and the `lib.rs` re-exports for all backup tables.
+
+Authoritative design: [`../backup-credentials.md`](../backup-credentials.md)
+(stage-2 stub: [`../backup-credentials-blind-relay.md`](../backup-credentials-blind-relay.md)).
+This spec does not re-litigate decided shape — it makes the DB layer concrete.
+
+---
+
+## Purpose
+
+Provide the persistent state for:
+
+- **`server_group_backup_config`** — per-group backup configuration + lifecycle
+  status (one row per configured group; `group_id` PK → `server_groups`).
+- **`backup_credential_issuances`** — audit log of every STS credential issuance.
+- **`backup_runs`** — what bestool reported per backup/restore run (client-minted UUID PK).
+- **`backup_maintenance_runs`** — Canopy-owned maintenance-Job outcomes.
+- **`backup_repo_snapshots`** — ground-truth inventory from the read-only inspection Job.
+- **`backup_repo_stats`** — cached repo + bucket size/stats for operator display.
+- **`backup_requests`** — pending operator one-off "backup now" flags.
+
+Plus the diesel model structs, insert/query helpers, and `lib.rs` module +
+re-exports. Where helpers fall on a component boundary (e.g. staleness scan
+queries used by the `jobs` crate, issuance recording used by public-server)
+this spec defines the **signatures and ownership**; the calling logic lives
+in those components' own specs.
+
+---
+
+## Conventions to follow (grounded in the repo)
+
+Read before implementing: `crates/database/src/{schema,servers,server_groups,devices,issues,statuses,pg_duration}.rs`
+and `migrations/2026-05-22-120000-0000_server_groups/{up,down}.sql`.
+
+- **Migrations are scaffolded with `just migration NAME`** (never hand-create
+  the directory — inconsistent naming; this is a flagged repeat mistake).
+  That runs `diesel migration generate`, producing
+  `migrations/<ts>_<name>/{up,down}.sql`. Then `just migrate` runs them and
+  `cargo fmt`s the regenerated `schema.rs`. The diesel CLI **regenerates
+  `crates/database/src/schema.rs`** from the live DB — do **not** hand-edit
+  `schema.rs`; let the migration drive it, then commit the diff.
+- One migration per logical change is the norm, but a cohesive feature can be
+  several sequential migrations (see the `2026-06-01-012906-000{0,1,2}` triple).
+  **Recommended: one migration `backup_credentials` creating all seven tables**
+  — they're a single feature landing together, with no data backfill needed
+  (all net-new tables), so splitting buys nothing. Keep `down.sql` a clean
+  `DROP TABLE ... ;` in reverse-dependency order.
+- **Timestamps**: columns are `TIMESTAMPTZ NOT NULL DEFAULT NOW()`. Models map
+  them with `#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as =
+  jiff_diesel::Timestamp)]` over a `jiff::Timestamp` field; nullable ones use
+  `jiff_diesel::NullableTimestamp` over `Option<Timestamp>`.
+- **`updated_at` auto-touch**: for tables with an `updated_at`, call
+  `SELECT diesel_manage_updated_at('<table>');` in `up.sql` (as
+  `server_groups` does). Only `server_group_backup_config` needs this here.
+- **INTERVAL columns** map to `crate::pg_duration::PgDuration` (wraps
+  `jiff::SignedDuration`; serde wire form is whole seconds as `i64`). For a
+  *nullable* interval (`expected_interval`), the field is
+  `Option<PgDuration>`; annotate the schema with `#[schema(value_type =
+  Option<i64>, format = "int64")]` for utoipa (see `ServerGroup::slack_open_delay`).
+- **Arbitrary JSONB** (`retention`) maps to `serde_json::Value` directly —
+  diesel handles `Jsonb -> serde_json::Value` natively (see `statuses.health`,
+  `statuses.extra`). The column is `JSONB NOT NULL`; in code we treat it as a
+  kopia keep-policy object. Do **not** invent a `TagMap`-style newtype unless a
+  validated shape is wanted — `serde_json::Value` matches existing JSONB columns.
+- **Models**: `#[derive(Debug, Clone, Serialize, Deserialize, Queryable,
+  Selectable, Insertable, utoipa::ToSchema)]`, `#[diesel(table_name =
+  crate::schema::<table>)]`, `#[diesel(check_for_backend(diesel::pg::Pg))]`.
+  A separate `New<Table>` `Insertable` struct is used where the insert shape
+  differs from the row (see `NewServerGroup`, `NewStatus`). Add
+  `#[diesel(belongs_to(...))]` + a `joinable!` entry where a join is wanted.
+- **Helper methods** are `impl` blocks with
+  `pub async fn (db: &mut AsyncPgConnection, ...) -> Result<...>` returning
+  `commons_errors::Result`, ending each query with `.map_err(AppError::from)`.
+  Use `use crate::schema::<table>::dsl;` inside each fn (the established style).
+- **`BIGSERIAL` PK** maps to `pub id: i64` in the model and is **omitted** from
+  the `New<Table>` insertable.
+- **Schema regen verification**: after the migration, `schema.rs` gains seven
+  `diesel::table!` blocks, plus `joinable!` and `allow_tables_to_appear_in_same_query!`
+  entries. Confirm `bigserial` surfaces as `Int8`, `JSONB` as `Jsonb`,
+  `INTERVAL` as `Interval`/`Nullable<Interval>`.
+
+---
+
+## Migration: `backup_credentials`
+
+`up.sql` creates the seven tables below. DDL is normative (it is what the
+diesel schema regen reads); the design doc's snippets are the source. Notes
+on the **decided FK semantics** are load-bearing and called out per table.
+
+### `server_group_backup_config`
+
+```sql
+CREATE TABLE server_group_backup_config (
+    group_id          UUID PRIMARY KEY REFERENCES server_groups(id) ON DELETE CASCADE,
+    bucket            TEXT NOT NULL,
+    prefix            TEXT NOT NULL DEFAULT '',
+    target_role_arn   TEXT NOT NULL,
+    region            TEXT,
+    expected_interval INTERVAL,
+    retention         JSONB NOT NULL CHECK (jsonb_typeof(retention) = 'object'),
+    repo_password_ref TEXT NOT NULL,
+    status            TEXT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+SELECT diesel_manage_updated_at('server_group_backup_config');
+```
+
+- **`ON DELETE CASCADE` is intentional** here (config is derived state, not
+  audit): deleting a `server_groups` row removes its config. This is the *only*
+  backup table that cascades — contrast the audit tables below.
+- `status` is a free-text column validated in code against
+  `{provisioning, escrow_pending, ready}`. Follow the codebase pattern of
+  storing enums as `TEXT` and validating at the API/model layer rather than a
+  PG enum or a diesel-orphan-rules dance (see `issues.resolved_reason`,
+  `servers.kind`). A `CHECK (status IN (...))` is acceptable and cheap; prefer
+  it for a closed three-value set.
+- The `jsonb_typeof = 'object'` CHECK mirrors the `tags` columns and guards
+  against a stray array/scalar landing in `retention`.
+
+### `backup_credential_issuances`
+
+```sql
+CREATE TABLE backup_credential_issuances (
+    id                  BIGSERIAL PRIMARY KEY,
+    device_id           UUID NOT NULL REFERENCES devices(id),
+    group_id            UUID NOT NULL REFERENCES server_groups(id),
+    issued_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at          TIMESTAMPTZ NOT NULL,
+    purpose             TEXT NOT NULL,
+    sts_assumed_role    TEXT NOT NULL,
+    sts_request_id      TEXT,
+    access_key_id       TEXT,
+    bucket              TEXT NOT NULL,
+    prefix              TEXT NOT NULL
+);
+CREATE INDEX ON backup_credential_issuances (device_id, issued_at DESC);
+CREATE INDEX ON backup_credential_issuances (group_id, issued_at DESC);
+```
+
+- **No CASCADE on `group_id`/`device_id` — deliberate audit preservation.**
+  Deleting a `server_groups` (or `devices`) row that has issuance history
+  **fails** the FK until the operator deals with it (archive/detach). This is
+  the decided "no-CASCADE audit-FK" rule (design §"Decommissioning a group").
+  Do not add `ON DELETE CASCADE`/`SET NULL`.
+- `bucket`/`prefix` are **snapshots at issuance time**, not FKs back to config.
+- `purpose` is `TEXT` validated in code (`backup`|`restore`).
+
+### `backup_runs`
+
+```sql
+CREATE TABLE backup_runs (
+    id              UUID PRIMARY KEY,
+    device_id       UUID NOT NULL REFERENCES devices(id),
+    group_id        UUID NOT NULL REFERENCES server_groups(id),
+    purpose         TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    error           TEXT,
+    bytes_uploaded  BIGINT,
+    snapshot_id     TEXT,
+    reported_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX ON backup_runs (group_id, reported_at DESC);
+CREATE INDEX ON backup_runs (device_id, reported_at DESC);
+```
+
+- **`id` is a client-supplied UUID** (the run-uuid bestool mints at run start),
+  **not** `gen_random_uuid()` and **not** `BIGSERIAL`. No `DEFAULT`. The
+  `New`-side insert provides it. A duplicate `id` fails its own insert (PK
+  violation) — that's the intended safety (design §`backup_runs`); the model
+  helper should surface that as a clean error, not panic.
+- `device_id`/`group_id` come from the authenticated `ServerDevice` context in
+  the caller, **never** from the client body — the model helper takes them as
+  parameters (see contract below), it does not read them from a deserialized
+  client struct.
+- No CASCADE on the FKs (audit table — same rule as issuances).
+- For the staleness scan, the hot query is "latest successful `purpose='backup'`
+  run per server/group"; the `(group_id, reported_at DESC)` index serves it.
+
+### `backup_maintenance_runs`
+
+```sql
+CREATE TABLE backup_maintenance_runs (
+    id              BIGSERIAL PRIMARY KEY,
+    group_id        UUID NOT NULL REFERENCES server_groups(id),
+    kind            TEXT NOT NULL,            -- "quick" | "full"
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at     TIMESTAMPTZ,
+    outcome         TEXT,                     -- NULL while running
+    error           TEXT,
+    bytes_reclaimed BIGINT
+);
+CREATE INDEX ON backup_maintenance_runs (group_id, started_at DESC);
+```
+
+- No CASCADE on `group_id` (audit table).
+- `outcome` NULL = still running; the model helper has a `start()` (insert,
+  returns the new `i64` id) and a `finish(id, outcome, error, bytes_reclaimed)`
+  update — the Job-side caller (jobs crate) owns the start/finish bracket.
+
+### `backup_repo_snapshots`
+
+```sql
+CREATE TABLE backup_repo_snapshots (
+    group_id           UUID NOT NULL REFERENCES server_groups(id),
+    source             TEXT NOT NULL,
+    server_id          UUID REFERENCES servers(id),
+    latest_snapshot_at TIMESTAMPTZ,
+    observed_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (group_id, source)
+);
+```
+
+- Composite PK `(group_id, source)`. The inspection Job **upserts** per source
+  (`ON CONFLICT (group_id, source) DO UPDATE`) — provide an `upsert` helper.
+- `server_id` is parsed from `source` by the caller and is **nullable** (a
+  source whose server-id no longer resolves still records). No CASCADE on
+  either FK — but note `server_id` referencing `servers(id)` without CASCADE
+  means a server delete with snapshot rows fails; that's consistent with the
+  audit-preservation stance (the inventory is evidence). Flag if the operator
+  workflow needs `SET NULL` here instead (open question below).
+
+### `backup_repo_stats`
+
+```sql
+CREATE TABLE backup_repo_stats (
+    group_id         UUID PRIMARY KEY REFERENCES server_groups(id),
+    snapshot_count   INTEGER,
+    source_count     INTEGER,
+    logical_bytes    BIGINT,
+    physical_bytes   BIGINT,
+    bucket_bytes     BIGINT,
+    observed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+- One row per group (PK = `group_id`). Filled by **two distinct writers**: the
+  inspection Job sets the repo-derived fields + `source_count`/`snapshot_count`;
+  the S3-metrics task sets `bucket_bytes` (best-effort/nullable, may lag).
+  Provide **two separate update helpers** so each writer touches only its
+  fields (don't clobber `bucket_bytes` from the inspection writer, or vice
+  versa) — both upsert on `group_id`.
+- This is a *cache*, not audit. CASCADE is defensible here (display-only,
+  rebuildable). **Decision needed** (open question): cascade vs no-cascade.
+  Lean **CASCADE** (it's not audit), but keep it separate from the
+  audit-table rule so the distinction is explicit.
+
+### `backup_requests`
+
+```sql
+CREATE TABLE backup_requests (
+    server_id    UUID NOT NULL REFERENCES servers(id),
+    purpose      TEXT NOT NULL,            -- "backup" | "restore"
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    requested_by TEXT,
+    PRIMARY KEY (server_id, purpose)
+);
+```
+
+- Keyed on `server_id` (per the design — one-off requests are server-scoped,
+  cleared when the run is reported). Composite PK `(server_id, purpose)` means
+  one pending request per (server, purpose); a second request is an upsert
+  (refresh `requested_at`/`requested_by`).
+- This is transient operator intent, not audit. CASCADE on `server_id` is
+  appropriate (a deleted server's pending flag is meaningless).
+
+`down.sql`: `DROP TABLE` all seven in any order (no inter-table FKs among
+them; all FKs point at pre-existing tables).
+
+---
+
+## Diesel models + `lib.rs`
+
+New module `crates/database/src/backups.rs` (single module for all seven
+tables — they're one cohesive feature, mirroring how `issues.rs` holds
+issues/events/incidents together). Register and re-export in `lib.rs`:
+
+```rust
+pub mod backups;
+pub use backups::{
+    ServerGroupBackupConfig, NewServerGroupBackupConfig,
+    BackupCredentialIssuance, NewBackupCredentialIssuance,
+    BackupRun, NewBackupRun,
+    BackupMaintenanceRun,
+    BackupRepoSnapshot,
+    BackupRepoStats,
+    BackupRequest, NewBackupRequest,
+    BackupPurpose, BackupConfigStatus, MaintenanceKind, RunOutcome,
+};
+```
+
+(Existing `lib.rs` re-exports `devices::*` and `bestool_snippets::*`; backups
+is the same pattern. The string-enum newtypes are optional — see below.)
+
+### String-typed enums
+
+`purpose`, `status`, `outcome`, `kind` are `TEXT` in the DB. Two options,
+consistent with existing code:
+
+- **Plain `String` fields**, validated at the API layer (matches
+  `issues.resolved_reason`, `servers.kind`). Simplest; lowest ceremony.
+- A small enum in `commons-types` with `Display`/`FromStr` and stored via
+  `deserialize_as = String, serialize_as = String` (matches how `Severity` and
+  `ServerKind` are handled). Preferred if the values are reused across
+  public-server, jobs, and private-web wire types — which they are
+  (`purpose` flows through three components).
+
+**Recommendation:** add `BackupPurpose { Backup, Restore }` and the run/maint
+outcome enums to `commons-types` (so public-server, jobs, and the generated
+`api-types.ts` share one definition), and keep `status` as a validated
+`String` for now (three-value, config-internal). Whichever is chosen, the
+model field types and the `CHECK` constraints must agree.
+
+### Model sketches (abbreviated; full set in `backups.rs`)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::server_group_backup_config)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ServerGroupBackupConfig {
+    pub group_id: Uuid,
+    pub bucket: String,
+    pub prefix: String,
+    pub target_role_arn: String,
+    pub region: Option<String>,
+    #[schema(value_type = Option<i64>, format = "int64")]
+    pub expected_interval: Option<PgDuration>,
+    pub retention: serde_json::Value,
+    pub repo_password_ref: String,
+    pub status: String,
+    #[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+    pub created_at: Timestamp,
+    #[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+    pub updated_at: Timestamp,
+}
+```
+
+`backup_runs` row maps `id: Uuid` (client-supplied, no default). Its
+`NewBackupRun` insertable **includes** `id` (unlike the BIGSERIAL tables which
+omit it). `bytes_uploaded`/`snapshot_id`/`error` are `Option<_>`.
+
+### Model helper methods (DB-layer surface this component owns)
+
+Defined here; their callers live in other components' specs. Signatures
+(`db: &mut AsyncPgConnection`, returning `commons_errors::Result`):
+
+- `ServerGroupBackupConfig::get(db, group_id) -> Result<Option<Self>>` — the
+  endpoint resolution path (absent → caller maps to 409).
+- `ServerGroupBackupConfig::upsert(db, NewServerGroupBackupConfig) -> Result<Self>`
+  and `set_status(db, group_id, status) -> Result<Self>` — operator UI / repo-init flow.
+- `ServerGroupBackupConfig::list_scheduled(db) -> Result<Vec<Self>>` — rows
+  with `expected_interval IS NOT NULL` (the staleness-scan set).
+- `BackupCredentialIssuance::record(db, NewBackupCredentialIssuance) -> Result<Self>`
+  — called by public-server step 7. Snapshots bucket/prefix; takes resolved
+  `device_id`/`group_id`/`access_key_id`/`sts_request_id`.
+- `BackupRun::record(db, NewBackupRun) -> Result<Self>` — called by
+  `POST /backup-report`. PK violation on duplicate `id` returns a clean
+  `Result::Err` (caller decides idempotency response).
+- `BackupRun::latest_success_for_server(db, server_id) -> Result<Option<Self>>`
+  and a bulk `latest_success_by_server(db, &[Uuid]) -> Result<HashMap<Uuid, Self>>`
+  filtered to `purpose='backup'`, `outcome='success'` — the staleness join.
+  (Server-centric: `backup_runs` rows carry `device_id`; the scan joins via the
+  server's associated devices, or filters by `group_id` then maps device→server
+  in the caller. Provide the query keyed the way the `jobs` scan needs — settle
+  with the jobs spec; the DB helper exposes both a per-group and per-device cut.)
+- `BackupMaintenanceRun::start(db, group_id, kind) -> Result<i64>` and
+  `finish(db, id, outcome, error, bytes_reclaimed) -> Result<()>`.
+- `BackupRepoSnapshot::upsert(db, group_id, source, server_id, latest_snapshot_at) -> Result<()>`
+  and `list_for_group(db, group_id) -> Result<Vec<Self>>`.
+- `BackupRepoStats::upsert_repo_fields(db, group_id, snapshot_count, source_count, logical, physical) -> Result<()>`
+  and `upsert_bucket_bytes(db, group_id, bucket_bytes) -> Result<()>` — the two
+  separate writers; both `ON CONFLICT (group_id) DO UPDATE` touching only their
+  own columns. `get(db, group_id) -> Result<Option<Self>>` for the stats panel.
+- `BackupRequest::enqueue(db, server_id, purpose, requested_by) -> Result<()>`
+  (upsert), `clear(db, server_id, purpose) -> Result<()>`,
+  `pending_for_server(db, server_id) -> Result<Vec<Self>>`.
+
+The "present since" anchor for never-backed-up detection
+(`max(MIN(device_server_associations.first_seen) over the server,
+server_group_backup_config.created_at)`) is a **jobs-crate query** that joins
+these tables; the DB crate exposes the building blocks (`list_scheduled`,
+`latest_success_*`, and existing `device_server_associations` access). Note
+`first_seen` is per `(device_id, server_id)` pair — use `MIN` over the server.
+
+---
+
+## Interfaces / contracts
+
+### Provided (to other components)
+
+- **Tables + schema** — the seven `diesel::table!` blocks in `schema.rs` and
+  the typed models in `backups.rs`, re-exported from `lib.rs`. Public-server,
+  the jobs crate, and private-server all `use database::{...}`.
+- **`ServerGroupBackupConfig` row** — the single source for `bucket`, `prefix`,
+  `region`, `target_role_arn`, `repo_password_ref`, `expected_interval`,
+  `retention`, `status`. Consumed by: `GET /backup-target` &
+  `POST /backup-credentials` (public-server); maintenance/inspection schedulers
+  & preflight (jobs); onboarding/stats UI (private-server).
+- **Audit-record helpers** — `BackupCredentialIssuance::record`,
+  `BackupRun::record`, `BackupMaintenanceRun::{start,finish}` — the write
+  surface for the issuance/report/maintenance flows.
+- **Scan helpers** — `list_scheduled`, `latest_success_*`,
+  `BackupRepoSnapshot::list_for_group` — inputs to staleness/reconciliation
+  detection (jobs crate, signals 1 & 2).
+- **`backup_requests` queue** — `enqueue`/`clear`/`pending_for_server` — the
+  operator one-off "backup now" home, read by the cadence-trigger path.
+- **Wire/utoipa shapes** — every model derives `utoipa::ToSchema`, so the
+  private-server handlers can use them in `#[utoipa::path]` and the regenerated
+  `openapi.json` → `api-types.ts` exposes them to private-web (run
+  `just gen-openapi` in the component that adds the handlers, not here).
+
+### Consumed (from existing code)
+
+- `server_groups(id)`, `servers(id)`, `devices(id)` — FK targets.
+- `crate::pg_duration::PgDuration` (INTERVAL ↔ `SignedDuration`).
+- `jiff_diesel::{Timestamp, NullableTimestamp}` (timestamp mapping).
+- `commons_errors::{AppError, Result}` (return type + `AppError::from`).
+- `device_server_associations` (`first_seen`, per device-server pair) — read by
+  the staleness "present since" query, joined alongside these tables.
+- `database::issues::NewEvent::save(conn, server_id, device_id)` — *not* called
+  by this crate, but the staleness/poisoning alerting (jobs) writes through it;
+  this crate must not duplicate alerting logic. (`source="canopy"`,
+  `ref="backup-staleness"` etc. live in the jobs component.)
+
+### Explicitly NOT in this component
+
+- No AWS SDK / STS / S3 calls (public-server + jobs).
+- No kube client / Secret reads (public-server + jobs).
+- No HTTP handlers, no scheduler loops, no alerting/`NewEvent` construction.
+- No utoipa `#[path]` annotations or `openapi.json` regen (that's whichever
+  crate adds the handlers).
+
+---
+
+## Data shapes
+
+- **`retention`** (JSONB): a kopia keep-policy object, e.g.
+  `{"keep_latest":1,"keep_daily":7,"keep_weekly":4,"keep_monthly":6,"keep_annual":0}`.
+  Stored as `serde_json::Value`; **floor enforcement** (`keep_daily≥7`,
+  `keep_weekly≥4`, `keep_monthly≥6`) is **code-level in the config write path
+  (private-server)**, not a DB constraint — the DB crate stores what it's given.
+  Document this so a reviewer doesn't expect a DB CHECK.
+- **`status`**: `provisioning` → `escrow_pending` → `ready`. Backups dormant
+  (412/409 from the endpoints) until `ready` — enforced by the *endpoint*, but
+  the column is the source of truth.
+- **`purpose`**: `backup` | `restore`.
+- **`outcome`**: `success` | `failure` (`backup_runs`); same plus NULL-while-
+  running for `backup_maintenance_runs`.
+- **`kind`**: `quick` | `full`.
+- **`source`** (`backup_repo_snapshots`): kopia source string
+  `canopy@<server-id>:<path>`; `server_id` parsed out by the caller.
+
+---
+
+## Testing approach (per AGENTS.md)
+
+DB-only tests via `commons_tests::db::TestDb::run(|mut conn, _url| async move { ... })`,
+`#[tokio::test(flavor = "multi_thread")]`, exercising **model functions
+directly** (not HTTP). Put them in `crates/database/tests/` with no `_test`
+suffix (e.g. `tests/backups.rs`), `use database::*;` for the models. Run with
+`just test-package database` or `just test-name <name>`.
+
+Cover:
+
+1. **Migration applies cleanly** — implicitly via every test (each spins a
+   fresh migrated DB) plus an explicit smoke test inserting one row per table.
+2. **`server_group_backup_config`** — insert/upsert round-trip incl. NULL
+   `region`/`expected_interval`, JSONB `retention` round-trips, `status`
+   transitions, `updated_at` auto-touch fires on update, `jsonb_typeof` CHECK
+   rejects a non-object retention.
+3. **Cascade vs no-cascade** — the load-bearing FK behaviour:
+   - Deleting a `server_groups` row **with** a config row but **no** audit rows
+     cascades the config away (success).
+   - Deleting a `server_groups` row that has `backup_credential_issuances` /
+     `backup_runs` / `backup_maintenance_runs` rows **fails** (FK violation) —
+     assert the error. This is the audit-preservation guarantee; test it
+     explicitly so a future "helpful" CASCADE can't silently slip in.
+4. **`backup_runs` client-supplied PK** — insert with a chosen UUID succeeds;
+   re-inserting the same UUID returns an error (PK violation surfaced as
+   `Result::Err`, not a panic); `device_id`/`group_id` are taken from
+   parameters (a test that the helper signature doesn't read them from a body).
+5. **Issuance audit** — `record` snapshots bucket/prefix; later changing the
+   config row does not mutate the issuance row. Indexes exercised by an
+   ordered `(device_id, issued_at DESC)` query returning newest-first.
+6. **Scan helpers** — `list_scheduled` returns only non-NULL-interval rows;
+   `latest_success_*` filters to `purpose='backup'` + `outcome='success'` and
+   ignores a newer `restore` success (the staleness-reset bug guard).
+7. **`backup_repo_stats` split writers** — `upsert_repo_fields` then
+   `upsert_bucket_bytes` accumulate without clobbering each other; either order.
+8. **`backup_repo_snapshots` upsert** — second observation of the same
+   `(group_id, source)` updates `latest_snapshot_at`/`observed_at` in place.
+9. **`backup_requests`** — enqueue is upsert on `(server_id, purpose)`; `clear`
+   removes; `pending_for_server` lists.
+
+No HTTP/e2e here (those belong to the public-server and private-server specs).
+Per repo memory: per-package tests while coding (`just test-package database`),
+no final full-suite run.
+
+---
+
+## Open questions / decisions to make
+
+1. **`backup_repo_stats` / `backup_requests` cascade.** Audit tables are
+   firmly no-cascade. Stats is a rebuildable cache and requests are transient
+   intent — both lean **CASCADE on group/server delete**. Confirm this is the
+   intended split (audit = preserve+block; cache/transient = cascade) and that
+   it's documented so the "no-CASCADE" rule isn't read as universal.
+2. **`backup_repo_snapshots.server_id` FK on a server delete.** As speced it's
+   `REFERENCES servers(id)` no-cascade, so deleting a server with snapshot rows
+   blocks. Is the inventory "evidence" (block, like audit) or derived display
+   (`SET NULL`/cascade)? The column is already nullable, so `ON DELETE SET NULL`
+   is a clean option — decide.
+3. **Enum representation.** `commons-types` enums (shared with public-server,
+   jobs, private-web wire types) vs plain validated `String`. Recommendation
+   above is enums for `purpose`/`outcome`/`kind`, `String` for `status` — needs
+   sign-off since it touches the generated `api-types.ts`.
+4. **Where `purpose`/`status` CHECK constraints live** — DB `CHECK (... IN ...)`
+   vs code-only validation. The codebase leans code-only for enum-ish text
+   (`servers.kind`), but the three-value `status` is a cheap CHECK win. Pick one
+   and apply consistently.
+5. **`backup_runs.id` collision response contract.** DB returns a PK-violation
+   error; the *endpoint* decides whether a duplicate report is a 409 or an
+   idempotent 204. That's a public-server decision, but the DB helper's
+   error-mapping (does `record` map unique-violation to a typed `AppError`
+   variant, or pass the raw diesel error?) should be settled here so the caller
+   can match on it. Lean: map to `AppError::Conflict` so the caller can branch.
+6. **`retention` validation surface.** Confirmed code-level (private-server
+   write path), not DB. Flagged only so no one expects a DB floor-CHECK.
+7. **Indexing for the staleness scan.** The provided indexes cover the
+   per-group/per-device "latest run" cuts. If the jobs scan ends up doing a
+   `DISTINCT ON (server)` over `backup_runs` joined through
+   `device_server_associations`, a covering index may be wanted — defer until
+   the jobs query is concrete, then add in a follow-up migration.

--- a/docs/plans/specs/canopy-database.md
+++ b/docs/plans/specs/canopy-database.md
@@ -537,3 +537,33 @@ no final full-suite run.
    `DISTINCT ON (server)` over `backup_runs` joined through
    `device_server_associations`, a covering index may be wanted — defer until
    the jobs query is concrete, then add in a follow-up migration.
+
+---
+
+## Backup types addendum (supersedes the relevant schema above)
+
+Added after this spec: backups are keyed `(server, type)`, not `(server)`.
+See the plan's "Backup types" section. Concrete deltas:
+
+- **`server_group_backup_config`** drops `expected_interval` and
+  `retention` — it's now repo-level only (`bucket`, `prefix`,
+  `target_role_arn`, `region`, `repo_password_ref`, `status`).
+- **New tables/models:**
+  - `server_backup_capabilities(server_id, type, enabled, registered_at)`
+    PK `(server_id, type)` — bestool-registered; `enabled` **seeded from**
+    `backup_type_defaults.auto_enable` at first registration, then
+    operator-toggleable per server.
+  - `backup_type_defaults(type PK, default_interval, default_retention
+    JSONB, auto_enable BOOL)` — canopy-wide per-type defaults.
+  - `server_group_backup_schedule(group_id, type, expected_interval,
+    retention)` PK `(group_id, type)` — schedule/retention overrides over
+    the type defaults; absent row → defaults.
+- **`type TEXT` column added to** `backup_credential_issuances`,
+  `backup_runs` (+ a `server_id` column for per-server-type staleness),
+  `backup_repo_snapshots`, and `backup_requests` (PK now
+  `(server_id, type, purpose)`). `backup_maintenance_runs` and
+  `backup_repo_stats` stay per-group (repo-level).
+- **New model surface:** capability upsert + per-server toggle; effective
+  schedule/retention resolution (`override ?? type-default`, with the org
+  retention floor enforced); "list active `(server, type)`" for the
+  scheduler/staleness.

--- a/docs/plans/specs/canopy-database.md
+++ b/docs/plans/specs/canopy-database.md
@@ -14,16 +14,25 @@ This spec does not re-litigate decided shape — it makes the DB layer concrete.
 
 ## Purpose
 
-Provide the persistent state for:
+Provide the persistent state for (**10 tables** as shipped — the "Backup
+types addendum" at the foot of this spec added `backup_type_defaults`,
+`server_backup_capabilities`, and `server_group_backup_schedule` to the
+original seven; they're folded into the list here):
 
-- **`server_group_backup_config`** — per-group backup configuration + lifecycle
-  status (one row per configured group; `group_id` PK → `server_groups`).
+- **`server_group_backup_config`** — per-group repo-level backup configuration +
+  lifecycle status (one row per configured group; `group_id` PK → `server_groups`).
+- **`backup_type_defaults`** — Canopy-wide per-type defaults (`default_interval`,
+  `default_retention`, `auto_enable`).
+- **`server_backup_capabilities`** — what each server advertises it can back up
+  (bestool-registered), with a per-server `enabled` toggle.
+- **`server_group_backup_schedule`** — per-`(group, type)` schedule/retention
+  overrides over the type defaults.
 - **`backup_credential_issuances`** — audit log of every STS credential issuance.
 - **`backup_runs`** — what bestool reported per backup/restore run (client-minted UUID PK).
-- **`backup_maintenance_runs`** — Canopy-owned maintenance-Job outcomes.
+- **`backup_maintenance_runs`** — Canopy-owned maintenance-Job outcomes (per-group).
 - **`backup_repo_snapshots`** — ground-truth inventory from the read-only inspection Job.
-- **`backup_repo_stats`** — cached repo + bucket size/stats for operator display.
-- **`backup_requests`** — pending operator one-off "backup now" flags.
+- **`backup_repo_stats`** — cached repo + bucket size/stats for operator display (per-group).
+- **`backup_requests`** — pending operator one-off "backup now" flags (per `(server, type, purpose)`).
 
 Plus the diesel model structs, insert/query helpers, and `lib.rs` module +
 re-exports. Where helpers fall on a component boundary (e.g. staleness scan
@@ -47,10 +56,14 @@ and `migrations/2026-05-22-120000-0000_server_groups/{up,down}.sql`.
   `schema.rs`; let the migration drive it, then commit the diff.
 - One migration per logical change is the norm, but a cohesive feature can be
   several sequential migrations (see the `2026-06-01-012906-000{0,1,2}` triple).
-  **Recommended: one migration `backup_credentials` creating all seven tables**
-  — they're a single feature landing together, with no data backfill needed
-  (all net-new tables), so splitting buys nothing. Keep `down.sql` a clean
-  `DROP TABLE ... ;` in reverse-dependency order.
+  RESOLVED (impl): the core landed as one migration
+  `2026-06-12-090526-0000_backup_credentials` creating all **10** tables (the
+  addendum tables included from the start), with a clean reverse-order
+  `DROP TABLE` `down.sql`. Two follow-up migrations layered on later:
+  `2026-06-15-064431-0000_backup_group_scoped_issues` and
+  `2026-06-16-001346-0000_backup_config_lifecycle_columns` (adds `mode`,
+  `last_init_error`, `escrow_acked_at`, `escrow_acked_by` to
+  `server_group_backup_config`).
 - **Timestamps**: columns are `TIMESTAMPTZ NOT NULL DEFAULT NOW()`. Models map
   them with `#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as =
   jiff_diesel::Timestamp)]` over a `jiff::Timestamp` field; nullable ones use
@@ -63,11 +76,17 @@ and `migrations/2026-05-22-120000-0000_server_groups/{up,down}.sql`.
   *nullable* interval (`expected_interval`), the field is
   `Option<PgDuration>`; annotate the schema with `#[schema(value_type =
   Option<i64>, format = "int64")]` for utoipa (see `ServerGroup::slack_open_delay`).
-- **Arbitrary JSONB** (`retention`) maps to `serde_json::Value` directly —
+- **JSONB `retention`** maps to `serde_json::Value` *at the storage layer* —
   diesel handles `Jsonb -> serde_json::Value` natively (see `statuses.health`,
-  `statuses.extra`). The column is `JSONB NOT NULL`; in code we treat it as a
-  kopia keep-policy object. Do **not** invent a `TagMap`-style newtype unless a
-  validated shape is wanted — `serde_json::Value` matches existing JSONB columns.
+  `statuses.extra`). The retention columns stay `JsonValue` in the model structs.
+  RESOLVED (impl): a validated shape **was** wanted after all — a typed
+  `RetentionPolicy` struct (`backups::RetentionPolicy`) sits *over* the raw
+  value with the kopia `keep_*` fields, `FLOOR_DAILY/WEEKLY/MONTHLY` constants,
+  `validate_floor()` (returns `AppError::BadRequest` listing the violated
+  fields), and `from_json`/`to_json`/`to_value` converters. The floor logic
+  lives in the DB crate and is called by the private-server write path; the
+  storage columns themselves remain `JsonValue` (so `RetentionPolicy` is a
+  helper, not a diesel column type).
 - **Models**: `#[derive(Debug, Clone, Serialize, Deserialize, Queryable,
   Selectable, Insertable, utoipa::ToSchema)]`, `#[diesel(table_name =
   crate::schema::<table>)]`, `#[diesel(check_for_backend(diesel::pg::Pg))]`.
@@ -80,7 +99,7 @@ and `migrations/2026-05-22-120000-0000_server_groups/{up,down}.sql`.
   Use `use crate::schema::<table>::dsl;` inside each fn (the established style).
 - **`BIGSERIAL` PK** maps to `pub id: i64` in the model and is **omitted** from
   the `New<Table>` insertable.
-- **Schema regen verification**: after the migration, `schema.rs` gains seven
+- **Schema regen verification**: after the migration, `schema.rs` gains the 10
   `diesel::table!` blocks, plus `joinable!` and `allow_tables_to_appear_in_same_query!`
   entries. Confirm `bigserial` surfaces as `Int8`, `JSONB` as `Jsonb`,
   `INTERVAL` as `Interval`/`Nullable<Interval>`.
@@ -89,40 +108,102 @@ and `migrations/2026-05-22-120000-0000_server_groups/{up,down}.sql`.
 
 ## Migration: `backup_credentials`
 
-`up.sql` creates the seven tables below. DDL is normative (it is what the
-diesel schema regen reads); the design doc's snippets are the source. Notes
-on the **decided FK semantics** are load-bearing and called out per table.
+`up.sql` creates the 10 tables below. DDL is normative (it is what the
+diesel schema regen reads); the design doc's snippets are the source.
+
+RESOLVED (impl) — **FK semantics are uniform: plain `REFERENCES` with NO
+`ON DELETE`/`ON UPDATE` clause everywhere.** `server_groups`, `servers`, and
+`devices` are *archived* (`deleted_at` soft-delete), never hard-deleted, so the
+cascade-vs-preserve distinction the original per-table notes agonised over is
+moot in practice. The per-table "CASCADE here / no-CASCADE there" prose below
+is **superseded** by this single rule; open questions 1 & 2 are resolved
+accordingly (see below). The original notes are kept inline for design history,
+struck through where they no longer hold.
+
+The addendum tables (`backup_type_defaults`, `server_backup_capabilities`,
+`server_group_backup_schedule`) and the type-keying deltas are folded into the
+DDL shown here; see the addendum at the foot for the design rationale.
 
 ### `server_group_backup_config`
 
+RESOLVED (impl) — `expected_interval` and `retention` moved off this table
+(repo-level only now; schedule/retention live per-`(group, type)` in
+`server_group_backup_schedule` per the addendum). Lifecycle columns (`mode`,
+`last_init_error`, `escrow_acked_at`, `escrow_acked_by`) were added by the
+`2026-06-16-...backup_config_lifecycle_columns` migration. As-shipped DDL:
+
 ```sql
 CREATE TABLE server_group_backup_config (
-    group_id          UUID PRIMARY KEY REFERENCES server_groups(id) ON DELETE CASCADE,
+    group_id          UUID PRIMARY KEY REFERENCES server_groups(id),
     bucket            TEXT NOT NULL,
     prefix            TEXT NOT NULL DEFAULT '',
     target_role_arn   TEXT NOT NULL,
     region            TEXT,
-    expected_interval INTERVAL,
-    retention         JSONB NOT NULL CHECK (jsonb_typeof(retention) = 'object'),
     repo_password_ref TEXT NOT NULL,
-    status            TEXT NOT NULL,
-    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    status            TEXT NOT NULL CHECK (status IN ('provisioning', 'escrow_pending', 'ready')),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- added by 2026-06-16-...backup_config_lifecycle_columns:
+    mode              TEXT NOT NULL DEFAULT 'from_birth' CHECK (mode IN ('from_birth', 'import')),
+    last_init_error   TEXT,
+    escrow_acked_at   TIMESTAMPTZ,
+    escrow_acked_by   TEXT
 );
 SELECT diesel_manage_updated_at('server_group_backup_config');
 ```
 
-- **`ON DELETE CASCADE` is intentional** here (config is derived state, not
-  audit): deleting a `server_groups` row removes its config. This is the *only*
-  backup table that cascades — contrast the audit tables below.
-- `status` is a free-text column validated in code against
-  `{provisioning, escrow_pending, ready}`. Follow the codebase pattern of
-  storing enums as `TEXT` and validating at the API/model layer rather than a
-  PG enum or a diesel-orphan-rules dance (see `issues.resolved_reason`,
-  `servers.kind`). A `CHECK (status IN (...))` is acceptable and cheap; prefer
-  it for a closed three-value set.
-- The `jsonb_typeof = 'object'` CHECK mirrors the `tags` columns and guards
-  against a stray array/scalar landing in `retention`.
+- ~~**`ON DELETE CASCADE` is intentional** here~~ — superseded: plain
+  `REFERENCES`, no cascade (archival model; groups are soft-deleted, not
+  hard-deleted).
+- `status` is a `TEXT` column with a `CHECK (status IN (...))` for the closed
+  three-value set `{provisioning, escrow_pending, ready}`, validated in code via
+  the `BackupConfigStatus` enum. The closed enums all carry a DB `CHECK`
+  in the shipped schema (status, mode, purpose, outcome, kind).
+- **Lifecycle columns:** `mode` is the 5th closed enum `BackupRepoMode`
+  (`from_birth` / `import`, with a DB CHECK); `last_init_error` is set by the
+  init Job on `kopia repository create` failure and cleared by the operator-UI
+  on retry; `escrow_acked_at`/`escrow_acked_by` stamp the Bitwarden-escrow ack
+  that flips `escrow_pending → ready`.
+
+### `backup_type_defaults`, `server_backup_capabilities`, `server_group_backup_schedule` (addendum tables)
+
+```sql
+CREATE TABLE backup_type_defaults (
+    type              TEXT PRIMARY KEY,
+    default_interval  INTERVAL,
+    default_retention JSONB NOT NULL CHECK (jsonb_typeof(default_retention) = 'object'),
+    auto_enable       BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE TABLE server_backup_capabilities (
+    server_id     UUID NOT NULL REFERENCES servers(id),
+    type          TEXT NOT NULL,
+    enabled       BOOLEAN NOT NULL,
+    registered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (server_id, type)
+);
+
+CREATE TABLE server_group_backup_schedule (
+    group_id          UUID NOT NULL REFERENCES server_groups(id),
+    type              TEXT NOT NULL,
+    expected_interval INTERVAL,
+    retention         JSONB CHECK (retention IS NULL OR jsonb_typeof(retention) = 'object'),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (group_id, type)
+);
+SELECT diesel_manage_updated_at('server_group_backup_schedule');
+```
+
+- `retention` now lives here (nullable, `jsonb_typeof='object'` CHECK when
+  present) and on `backup_type_defaults.default_retention` (NOT NULL, same
+  CHECK) — **superseding** the original `retention` column on
+  `server_group_backup_config`. Effective value for a `(group, type)` is the
+  schedule override `?? backup_type_defaults`, with the org retention floor
+  applied in code (`RetentionPolicy::validate_floor`).
+- `server_backup_capabilities.enabled` is **seeded** from
+  `backup_type_defaults.auto_enable` at first registration, then operator-
+  toggleable per server.
 
 ### `backup_credential_issuances`
 
@@ -131,9 +212,10 @@ CREATE TABLE backup_credential_issuances (
     id                  BIGSERIAL PRIMARY KEY,
     device_id           UUID NOT NULL REFERENCES devices(id),
     group_id            UUID NOT NULL REFERENCES server_groups(id),
-    issued_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    type                TEXT NOT NULL,
+    issued_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
     expires_at          TIMESTAMPTZ NOT NULL,
-    purpose             TEXT NOT NULL,
+    purpose             TEXT NOT NULL CHECK (purpose IN ('backup', 'restore')),
     sts_assumed_role    TEXT NOT NULL,
     sts_request_id      TEXT,
     access_key_id       TEXT,
@@ -144,13 +226,14 @@ CREATE INDEX ON backup_credential_issuances (device_id, issued_at DESC);
 CREATE INDEX ON backup_credential_issuances (group_id, issued_at DESC);
 ```
 
-- **No CASCADE on `group_id`/`device_id` — deliberate audit preservation.**
-  Deleting a `server_groups` (or `devices`) row that has issuance history
-  **fails** the FK until the operator deals with it (archive/detach). This is
-  the decided "no-CASCADE audit-FK" rule (design §"Decommissioning a group").
-  Do not add `ON DELETE CASCADE`/`SET NULL`.
+- ~~**No CASCADE on `group_id`/`device_id` — deliberate audit preservation**~~ —
+  superseded by the uniform no-cascade/archival rule (the FK is plain
+  `REFERENCES` regardless; the audit data is preserved because rows are
+  soft-deleted, not hard-deleted).
 - `bucket`/`prefix` are **snapshots at issuance time**, not FKs back to config.
-- `purpose` is `TEXT` validated in code (`backup`|`restore`).
+- `type TEXT` (addendum) — backups are keyed `(server, type)`.
+- `purpose` is `TEXT` with a DB `CHECK (purpose IN ('backup','restore'))`,
+  also validated in code via `BackupPurpose`.
 
 ### `backup_runs`
 
@@ -159,16 +242,23 @@ CREATE TABLE backup_runs (
     id              UUID PRIMARY KEY,
     device_id       UUID NOT NULL REFERENCES devices(id),
     group_id        UUID NOT NULL REFERENCES server_groups(id),
-    purpose         TEXT NOT NULL,
-    outcome         TEXT NOT NULL,
+    server_id       UUID REFERENCES servers(id),
+    type            TEXT NOT NULL,
+    purpose         TEXT NOT NULL CHECK (purpose IN ('backup', 'restore')),
+    outcome         TEXT NOT NULL CHECK (outcome IN ('success', 'failure')),
     error           TEXT,
     bytes_uploaded  BIGINT,
     snapshot_id     TEXT,
-    reported_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    reported_at     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX ON backup_runs (group_id, reported_at DESC);
 CREATE INDEX ON backup_runs (device_id, reported_at DESC);
+CREATE INDEX ON backup_runs (server_id, type, reported_at DESC);
 ```
+
+- `server_id` (nullable) + `type TEXT` were added by the addendum so staleness
+  is per-`(server, type)`. The third index `(server_id, type, reported_at DESC)`
+  serves that per-`(server, type)` "latest run" staleness scan.
 
 - **`id` is a client-supplied UUID** (the run-uuid bestool mints at run start),
   **not** `gen_random_uuid()` and **not** `BIGSERIAL`. No `DEFAULT`. The
@@ -179,9 +269,10 @@ CREATE INDEX ON backup_runs (device_id, reported_at DESC);
   the caller, **never** from the client body — the model helper takes them as
   parameters (see contract below), it does not read them from a deserialized
   client struct.
-- No CASCADE on the FKs (audit table — same rule as issuances).
+- Plain `REFERENCES` on the FKs (uniform no-cascade/archival rule).
 - For the staleness scan, the hot query is "latest successful `purpose='backup'`
-  run per server/group"; the `(group_id, reported_at DESC)` index serves it.
+  run per `(server, type)`"; the `(server_id, type, reported_at DESC)` index
+  serves it (the `(group_id, reported_at DESC)` index serves repo-level cuts).
 
 ### `backup_maintenance_runs`
 
@@ -199,7 +290,7 @@ CREATE TABLE backup_maintenance_runs (
 CREATE INDEX ON backup_maintenance_runs (group_id, started_at DESC);
 ```
 
-- No CASCADE on `group_id` (audit table).
+- Plain `REFERENCES` on `group_id` (uniform no-cascade/archival rule).
 - `outcome` NULL = still running; the model helper has a `start()` (insert,
   returns the new `i64` id) and a `finish(id, outcome, error, bytes_reclaimed)`
   update — the Job-side caller (jobs crate) owns the start/finish bracket.
@@ -211,20 +302,20 @@ CREATE TABLE backup_repo_snapshots (
     group_id           UUID NOT NULL REFERENCES server_groups(id),
     source             TEXT NOT NULL,
     server_id          UUID REFERENCES servers(id),
+    type               TEXT,
     latest_snapshot_at TIMESTAMPTZ,
-    observed_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    observed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (group_id, source)
 );
 ```
 
 - Composite PK `(group_id, source)`. The inspection Job **upserts** per source
   (`ON CONFLICT (group_id, source) DO UPDATE`) — provide an `upsert` helper.
-- `server_id` is parsed from `source` by the caller and is **nullable** (a
-  source whose server-id no longer resolves still records). No CASCADE on
-  either FK — but note `server_id` referencing `servers(id)` without CASCADE
-  means a server delete with snapshot rows fails; that's consistent with the
-  audit-preservation stance (the inventory is evidence). Flag if the operator
-  workflow needs `SET NULL` here instead (open question below).
+- `server_id` (and `type`, addendum) are parsed from `source` by the caller and
+  are **nullable** (a source whose server-id no longer resolves still records).
+  Plain `REFERENCES` on both FKs (uniform no-cascade/archival rule) — RESOLVED:
+  no `SET NULL`; servers are archived not deleted, so the "block on delete"
+  worry is moot.
 
 ### `backup_repo_stats`
 
@@ -246,57 +337,62 @@ CREATE TABLE backup_repo_stats (
   Provide **two separate update helpers** so each writer touches only its
   fields (don't clobber `bucket_bytes` from the inspection writer, or vice
   versa) — both upsert on `group_id`.
-- This is a *cache*, not audit. CASCADE is defensible here (display-only,
-  rebuildable). **Decision needed** (open question): cascade vs no-cascade.
-  Lean **CASCADE** (it's not audit), but keep it separate from the
-  audit-table rule so the distinction is explicit.
+- This is a *cache*, not audit. RESOLVED (impl): plain `REFERENCES`, no
+  cascade — the uniform archival rule applies here too (groups are
+  soft-deleted, so a "rebuildable cache should cascade" exception isn't needed).
 
 ### `backup_requests`
 
 ```sql
 CREATE TABLE backup_requests (
     server_id    UUID NOT NULL REFERENCES servers(id),
-    purpose      TEXT NOT NULL,            -- "backup" | "restore"
-    requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    type         TEXT NOT NULL,
+    purpose      TEXT NOT NULL CHECK (purpose IN ('backup', 'restore')),
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     requested_by TEXT,
-    PRIMARY KEY (server_id, purpose)
+    PRIMARY KEY (server_id, type, purpose)
 );
 ```
 
-- Keyed on `server_id` (per the design — one-off requests are server-scoped,
-  cleared when the run is reported). Composite PK `(server_id, purpose)` means
-  one pending request per (server, purpose); a second request is an upsert
-  (refresh `requested_at`/`requested_by`).
-- This is transient operator intent, not audit. CASCADE on `server_id` is
-  appropriate (a deleted server's pending flag is meaningless).
+- Keyed on `server_id` (one-off requests are server-scoped, cleared when the
+  run is reported). Composite PK is `(server_id, type, purpose)` (addendum
+  added `type`) — one pending request per `(server, type, purpose)`; a second
+  request is an upsert (refresh `requested_at`/`requested_by`).
+- This is transient operator intent, not audit. RESOLVED (impl): plain
+  `REFERENCES` on `server_id`, no cascade (uniform archival rule).
 
-`down.sql`: `DROP TABLE` all seven in any order (no inter-table FKs among
-them; all FKs point at pre-existing tables).
+`down.sql`: `DROP TABLE` all 10 in reverse-dependency order (no inter-table
+FKs among them; all FKs point at pre-existing tables).
 
 ---
 
 ## Diesel models + `lib.rs`
 
-New module `crates/database/src/backups.rs` (single module for all seven
+New module `crates/database/src/backups.rs` (single module for all 10
 tables — they're one cohesive feature, mirroring how `issues.rs` holds
-issues/events/incidents together). Register and re-export in `lib.rs`:
+issues/events/incidents together). RESOLVED (impl) — the as-shipped `lib.rs`
+re-export superset:
 
 ```rust
 pub mod backups;
 pub use backups::{
-    ServerGroupBackupConfig, NewServerGroupBackupConfig,
-    BackupCredentialIssuance, NewBackupCredentialIssuance,
-    BackupRun, NewBackupRun,
-    BackupMaintenanceRun,
-    BackupRepoSnapshot,
-    BackupRepoStats,
-    BackupRequest, NewBackupRequest,
-    BackupPurpose, BackupConfigStatus, MaintenanceKind, RunOutcome,
+    BackupCredentialIssuance, BackupMaintenanceRun, BackupRepoSnapshot, BackupRepoStats,
+    BackupRequest, BackupRun, BackupTypeDefault, NewBackupCredentialIssuance, NewBackupRun,
+    NewBackupTypeDefault, NewServerGroupBackupConfig, NewServerGroupBackupSchedule,
+    ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
 };
+// the enums are defined in commons-types and re-exported through database:
+pub use commons_types::backup::{
+    BackupConfigStatus, BackupPurpose, BackupRepoMode, BackupType, MaintenanceKind, RunOutcome,
+};
+// RetentionPolicy is reached as `database::backups::RetentionPolicy`
+// (it lives in the backups module; not in the flat re-export set).
 ```
 
 (Existing `lib.rs` re-exports `devices::*` and `bestool_snippets::*`; backups
-is the same pattern. The string-enum newtypes are optional — see below.)
+is the same pattern. The five closed enums — `BackupPurpose`, `RunOutcome`,
+`MaintenanceKind`, `BackupRepoMode`, `BackupConfigStatus` — live in
+`commons-types` plus the open `BackupType{Custom}`; see below.)
 
 ### String-typed enums
 
@@ -311,11 +407,18 @@ consistent with existing code:
   public-server, jobs, and private-web wire types — which they are
   (`purpose` flows through three components).
 
-**Recommendation:** add `BackupPurpose { Backup, Restore }` and the run/maint
-outcome enums to `commons-types` (so public-server, jobs, and the generated
-`api-types.ts` share one definition), and keep `status` as a validated
-`String` for now (three-value, config-internal). Whichever is chosen, the
-model field types and the `CHECK` constraints must agree.
+RESOLVED (impl): the enum option won across the board — **all** the closed
+enum-ish columns are typed `commons-types` enums (via a `text_enum!` macro that
+implements `Display`/`FromStr` + diesel `ToSql`/`FromSql` over `Text`), each
+backed by a DB `CHECK`. The five closed enums are `BackupPurpose
+{Backup, Restore}`, `RunOutcome {Success, Failure}`, `MaintenanceKind
+{Quick, Full}`, `BackupRepoMode {FromBirth, Import}`, and `BackupConfigStatus
+{Provisioning, EscrowPending, Ready}` (the original spec listed only the first
+four — `BackupRepoMode` is the 5th, added with the lifecycle columns).
+`status` did **not** stay a bare `String` — it's `BackupConfigStatus`.
+Separately, `backup type` is the **open** enum `BackupType` with a `Custom(String)`
+arm (no DB CHECK, any advertised name preserved verbatim). The model field
+types and the `CHECK` constraints agree.
 
 ### Model sketches (abbreviated; full set in `backups.rs`)
 
@@ -329,17 +432,24 @@ pub struct ServerGroupBackupConfig {
     pub prefix: String,
     pub target_role_arn: String,
     pub region: Option<String>,
-    #[schema(value_type = Option<i64>, format = "int64")]
-    pub expected_interval: Option<PgDuration>,
-    pub retention: serde_json::Value,
     pub repo_password_ref: String,
-    pub status: String,
+    pub status: BackupConfigStatus,
     #[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
     pub created_at: Timestamp,
     #[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
     pub updated_at: Timestamp,
+    // lifecycle columns (2026-06-16 migration):
+    #[schema(value_type = String)]
+    pub mode: BackupRepoMode,
+    pub last_init_error: Option<String>,
+    #[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+    pub escrow_acked_at: Option<Timestamp>,
+    pub escrow_acked_by: Option<String>,
 }
 ```
+
+(Note: `expected_interval`/`retention` are **not** on this struct — they moved
+to `server_group_backup_schedule` / `backup_type_defaults` per the addendum.)
 
 `backup_runs` row maps `id: Uuid` (client-supplied, no default). Its
 `NewBackupRun` insertable **includes** `id` (unlike the BIGSERIAL tables which
@@ -397,9 +507,11 @@ these tables; the DB crate exposes the building blocks (`list_scheduled`,
 - **Tables + schema** — the seven `diesel::table!` blocks in `schema.rs` and
   the typed models in `backups.rs`, re-exported from `lib.rs`. Public-server,
   the jobs crate, and private-server all `use database::{...}`.
-- **`ServerGroupBackupConfig` row** — the single source for `bucket`, `prefix`,
-  `region`, `target_role_arn`, `repo_password_ref`, `expected_interval`,
-  `retention`, `status`. Consumed by: `GET /backup-target` &
+- **`ServerGroupBackupConfig` row** — the single source for repo-level
+  `bucket`, `prefix`, `region`, `target_role_arn`, `repo_password_ref`,
+  `status`, `mode`, and the lifecycle fields. (Schedule/retention are now
+  per-`(group, type)` on `server_group_backup_schedule` / `backup_type_defaults`.)
+  Consumed by: `GET /backup-target` &
   `POST /backup-credentials` (public-server); maintenance/inspection schedulers
   & preflight (jobs); onboarding/stats UI (private-server).
 - **Audit-record helpers** — `BackupCredentialIssuance::record`,
@@ -440,12 +552,14 @@ these tables; the DB crate exposes the building blocks (`list_scheduled`,
 
 ## Data shapes
 
-- **`retention`** (JSONB): a kopia keep-policy object, e.g.
+- **`retention`** (JSONB, on `server_group_backup_schedule` /
+  `backup_type_defaults`): a kopia keep-policy object, e.g.
   `{"keep_latest":1,"keep_daily":7,"keep_weekly":4,"keep_monthly":6,"keep_annual":0}`.
-  Stored as `serde_json::Value`; **floor enforcement** (`keep_daily≥7`,
-  `keep_weekly≥4`, `keep_monthly≥6`) is **code-level in the config write path
-  (private-server)**, not a DB constraint — the DB crate stores what it's given.
-  Document this so a reviewer doesn't expect a DB CHECK.
+  Stored as `JsonValue`; the typed `RetentionPolicy` helper sits over it.
+  **Floor enforcement** (`keep_daily≥7`, `keep_weekly≥4`, `keep_monthly≥6`) is
+  `RetentionPolicy::validate_floor()` — a DB-crate function (returns
+  `AppError::BadRequest`) called by the private-server write path, **not** a DB
+  constraint (the only DB CHECK on these columns is `jsonb_typeof='object'`).
 - **`status`**: `provisioning` → `escrow_pending` → `ready`. Backups dormant
   (412/409 from the endpoints) until `ready` — enforced by the *endpoint*, but
   the column is the source of truth.
@@ -474,13 +588,13 @@ Cover:
    `region`/`expected_interval`, JSONB `retention` round-trips, `status`
    transitions, `updated_at` auto-touch fires on update, `jsonb_typeof` CHECK
    rejects a non-object retention.
-3. **Cascade vs no-cascade** — the load-bearing FK behaviour:
-   - Deleting a `server_groups` row **with** a config row but **no** audit rows
-     cascades the config away (success).
-   - Deleting a `server_groups` row that has `backup_credential_issuances` /
-     `backup_runs` / `backup_maintenance_runs` rows **fails** (FK violation) —
-     assert the error. This is the audit-preservation guarantee; test it
-     explicitly so a future "helpful" CASCADE can't silently slip in.
+3. **FK behaviour (archival model)** — RESOLVED (impl): there is **no** cascade
+   anywhere; groups/servers are archived (`deleted_at`), never hard-deleted, so
+   a config-delete does not cascade and a hard `DELETE` on a `server_groups` row
+   with any backup rows simply fails the FK (and is never done in practice). The
+   original "cascade the config / block on audit rows" split no longer applies —
+   the rule is uniform plain `REFERENCES`. (No dedicated cascade test is needed;
+   the archival path is what's exercised.)
 4. **`backup_runs` client-supplied PK** — insert with a chosen UUID succeeds;
    re-inserting the same UUID returns an error (PK violation surfaced as
    `Result::Err`, not a panic); `device_id`/`group_id` are taken from
@@ -506,32 +620,30 @@ no final full-suite run.
 
 ## Open questions / decisions to make
 
-1. **`backup_repo_stats` / `backup_requests` cascade.** Audit tables are
-   firmly no-cascade. Stats is a rebuildable cache and requests are transient
-   intent — both lean **CASCADE on group/server delete**. Confirm this is the
-   intended split (audit = preserve+block; cache/transient = cascade) and that
-   it's documented so the "no-CASCADE" rule isn't read as universal.
-2. **`backup_repo_snapshots.server_id` FK on a server delete.** As speced it's
-   `REFERENCES servers(id)` no-cascade, so deleting a server with snapshot rows
-   blocks. Is the inventory "evidence" (block, like audit) or derived display
-   (`SET NULL`/cascade)? The column is already nullable, so `ON DELETE SET NULL`
-   is a clean option — decide.
-3. **Enum representation.** `commons-types` enums (shared with public-server,
-   jobs, private-web wire types) vs plain validated `String`. Recommendation
-   above is enums for `purpose`/`outcome`/`kind`, `String` for `status` — needs
-   sign-off since it touches the generated `api-types.ts`.
-4. **Where `purpose`/`status` CHECK constraints live** — DB `CHECK (... IN ...)`
-   vs code-only validation. The codebase leans code-only for enum-ish text
-   (`servers.kind`), but the three-value `status` is a cheap CHECK win. Pick one
-   and apply consistently.
+1. **`backup_repo_stats` / `backup_requests` cascade.** RESOLVED (impl):
+   **no cascade** — there is *no* cache/transient-vs-audit split. Every backup
+   FK is plain `REFERENCES`, because groups/servers are archived (`deleted_at`),
+   not hard-deleted, so cascade-vs-preserve never fires.
+2. **`backup_repo_snapshots.server_id` FK on a server delete.** RESOLVED (impl):
+   plain `REFERENCES servers(id)`, no `SET NULL`/cascade — same archival rule.
+   The column is nullable only because a `source` server-id may not resolve at
+   observation time, not for delete semantics.
+3. **Enum representation.** RESOLVED (impl): `commons-types` enums for **all**
+   the closed sets (`purpose`, `outcome`, `kind`, `mode`/`BackupRepoMode`, and
+   `status`/`BackupConfigStatus` — `status` did not stay a plain `String`), each
+   with a matching DB `CHECK`; the open `BackupType{Custom}` for the type name.
+4. **Where `purpose`/`status` CHECK constraints live** — RESOLVED (impl): the
+   closed enums carry **both** a DB `CHECK (... IN ...)` *and* the typed
+   `commons-types` enum at the model layer.
 5. **`backup_runs.id` collision response contract.** DB returns a PK-violation
    error; the *endpoint* decides whether a duplicate report is a 409 or an
    idempotent 204. That's a public-server decision, but the DB helper's
    error-mapping (does `record` map unique-violation to a typed `AppError`
    variant, or pass the raw diesel error?) should be settled here so the caller
    can match on it. Lean: map to `AppError::Conflict` so the caller can branch.
-6. **`retention` validation surface.** Confirmed code-level (private-server
-   write path), not DB. Flagged only so no one expects a DB floor-CHECK.
+6. **`retention` validation surface.** RESOLVED (impl): code-level via the typed
+   `RetentionPolicy::validate_floor()` (DB crate), called by the private-server
+   write path; not a DB floor-CHECK (the only DB CHECK is `jsonb_typeof`).
 7. **Indexing for the staleness scan.** The provided indexes cover the
    per-group/per-device "latest run" cuts. If the jobs scan ends up doing a
    `DISTINCT ON (server)` over `backup_runs` joined through

--- a/docs/plans/specs/canopy-jobs-detection-preflight.md
+++ b/docs/plans/specs/canopy-jobs-detection-preflight.md
@@ -565,3 +565,19 @@ struct ScanRow {
 9. **Signal 3 (`backup_restore_checks` + PGRO ingest)** is explicitly
    later/additive — confirm it stays out of this component's first cut
    (only the group-level routing is built now, ready for it).
+
+---
+
+## Backup types addendum
+
+Per the plan's "Backup types": staleness is per-`(server, type)`.
+
+- The staleness scan iterates **enabled `(server, type)` capabilities whose
+  effective schedule is non-NULL**, comparing each to its most recent
+  `backup_runs` row **for that type** (`type = ?`, `purpose='backup'`,
+  `outcome='success'`). The `×2` grace and `max(MIN(first_seen),
+  schedule-created)` anchor are unchanged, just per-type.
+- Disabled / manual-only / unconfigured `(server, type)` are out of the
+  scanned set.
+- Group-level alerting (corruption, preflight) is unchanged — it's
+  per-group, not per-type.

--- a/docs/plans/specs/canopy-jobs-detection-preflight.md
+++ b/docs/plans/specs/canopy-jobs-detection-preflight.md
@@ -1,0 +1,567 @@
+# Spec: canopy-jobs-detection — staleness, reconciliation, alerting & upstream preflight
+
+Component of the **backup-credentials** system. Authoritative design:
+[`../backup-credentials.md`](../backup-credentials.md) (stage-2 stub:
+[`../backup-credentials-blind-relay.md`](../backup-credentials-blind-relay.md)).
+
+This spec covers the **detection / alerting / preflight** half of the
+Canopy control plane: the periodic jobs that decide whether each group's
+backups are healthy and raise issues/events when they are not. It does
+**not** cover credential issuance (`public-server` endpoints), the
+maintenance/inspection/init Jobs themselves, the operator UI, or the IaC —
+those are sibling components. It *consumes* the tables those components
+write (`backup_runs`, `backup_maintenance_runs`, `backup_repo_snapshots`,
+`server_group_backup_config`) and the AWS-client plumbing they introduce.
+
+## Purpose
+
+Three classes of periodic check, all running as loops in the `jobs` crate
+and all alerting through the existing issues/events/incidents model
+(`NewEvent::save`, `source="canopy"`):
+
+1. **Signal 1 — staleness scan** (DB-only, frequent): scan servers that are
+   *expected* to be backed up and alert when no recent successful backup is
+   on record. Server-centric. Also catches stuck maintenance.
+2. **Signal reconciliation (1 / 2 / 3)**: cross-check what devices
+   *reported* (signal 1, `backup_runs`) against what *actually landed*
+   (signal 2, `backup_repo_snapshots`) and — later — what PGRO proved
+   *restorable* (signal 3, `backup_restore_checks`). Disagreement is itself
+   an alert; repo corruption (poisoning) is a group-level critical.
+3. **Upstream preflight** (AWS-touching, hash-jittered): Canopy checking its
+   *own* access — `GetCallerIdentity` (shared, ~minute) plus per-group deep
+   checks (both purposes issue working creds + Object-Lock still in place),
+   hourly.
+
+The shared thread running through all three: a **group-level** failure
+(can't mint creds, lock removed, repo corrupt, restore broken) must page
+**regardless of any server's `is_monitored`**, whereas **per-server**
+staleness obeys the existing `is_monitored` gate. The incident model is
+server-keyed today, so the group-level path needs new plumbing (see
+[Group-level alerting](#group-level-alerting-server-independent)).
+
+## Where it lives
+
+New binaries in the **`jobs` crate**, following the
+`reachability`/`pingtask` template (`spawn() -> JoinHandle<()>`, a
+`loop { sleep(…); pool.get(); … }`, `#[tokio::main]` calling
+`spawn().await`):
+
+- `crates/jobs/src/bin/backup_staleness.rs` — signal-1 + reconciliation
+  scan (DB-only; no AWS). ~1–5 min cadence. Can ride the existing
+  `reachability` minute loop instead of a new pod if we prefer one fewer
+  Deployment — **decision below**.
+- `crates/jobs/src/bin/backup_preflight.rs` — upstream preflight (AWS SDK;
+  STS + S3). Shared `GetCallerIdentity` on a ~minute tick; per-group deep
+  checks hash-jittered hourly.
+
+The bulk of the logic lives in the **`database` crate** as model functions
+(like `Status::sweep_reachability`), so it's testable with
+`commons_tests::db::TestDb::run` without standing up a binary:
+
+- `crates/database/src/backup/staleness.rs` (or extend an existing
+  `backup` module the issuance component creates) — the scan + classify +
+  file-events logic.
+- `crates/database/src/backup/reconcile.rs` — signal 1↔2(↔3)
+  reconciliation.
+- The preflight's AWS calls live in the **binary** (the `database` crate
+  must not gain an AWS dependency); the preflight's *alerting* reuses the
+  same `NewEvent` helpers. The binary reads config rows via a `database`
+  model function and calls the AWS SDK directly.
+
+Per the workspace memory: `database` is the only crate allowed diesel; the
+preflight binary depends on the new AWS-SDK plumbing the issuance component
+adds (`aws-config` + `aws-sdk-sts` + `aws-sdk-s3`). The `jobs` crate gains
+those deps for `backup_preflight` only.
+
+## Refs and sources (issues/events keys)
+
+All events use `source = "canopy"` (the existing `CANOPY_SOURCE` constant
+in `statuses.rs`; promote it somewhere shared if both crates need it, or
+re-declare a `const BACKUP_*` set in the backup module). Refs (new
+constants — keep them all in one place, e.g. `database::backup::refs`):
+
+| ref | level | severity (active) | severity (recovery) | gate |
+|-----|-------|-------------------|---------------------|------|
+| `backup-staleness` | server | `Error` | `Info` (`active:false`) | `is_monitored` |
+| `backup-never` | server | `Error` | n/a (clears when first success lands) | `is_monitored` |
+| `backup-maintenance-stale` | group | `Error` | `Info` | none (group-level) |
+| `backup-reconcile-missing` | group | `Error` | `Info` | none (group-level) |
+| `backup-reconcile-report-gap` | server | `Warning` | `Info` | `is_monitored` |
+| `backup-corruption` | group | `Critical` | `Info` | none (group-level) |
+| `preflight-identity` | fleet/group | `Critical` | `Info` | none (group-level) |
+| `preflight-assume` | group | `Error` | `Info` | none (group-level) |
+| `preflight-object-lock` | group | `Critical` | `Info` | none (group-level) |
+| `restore-verification` (signal 3, later) | group | `Error` | `Info` | none (group-level) |
+
+Notes:
+- Staleness/never/report-gap are **per-server** → ordinary
+  `NewEvent::save(conn, server_id, Some(device_id))`. They inherit the
+  `is_monitored` incident gate by design (see plan: some prods are
+  intentionally intermittently-alive; per-server backup noise on them is
+  unwanted). They are still *recorded* (visible on the server page) even
+  when unmonitored — `NewEvent::save` records the issue/event unconditionally
+  and only skips the incident contribution.
+- Everything marked **group-level** must page even on unmonitored servers,
+  so it must **not** go through a per-server `NewEvent::save` (which would
+  re-inherit the gate). See [Group-level alerting](#group-level-alerting-server-independent).
+- `Error`+ is required for `opens_incident()` (`OPENS_INCIDENT = [Critical,
+  Error]`, `commons-types/src/issue.rs`). `Warning`/`Info` only join an
+  already-open incident for context; they never open one. So the
+  report-gap notice (`Warning`) is deliberately non-paging on its own.
+
+## Signal 1 — staleness scan
+
+Server-centric. The subject is the **server** being protected; the device
+is the actor recorded in `backup_runs`/snapshot tags.
+
+### Scanned set
+
+Servers in a group whose `server_group_backup_config` has:
+- `status = 'ready'` (dormant configs — `provisioning`/`escrow_pending` —
+  are not yet expected to back up), **and**
+- a non-NULL `expected_interval` (manual-only groups have no schedule, so
+  no staleness alerting — they're simply not in the set).
+
+A manual-only or unconfigured group is therefore never scanned, so
+unauthorized/un-set-up devices never alert. Implement as a single query
+joining `servers` → `server_group_backup_config` (on `servers.group_id`)
+filtered as above, returning `(server_id, group_id, expected_interval,
+config.created_at)`.
+
+### Per-server classification
+
+For each scanned server, find its most recent `backup_runs` row with
+`purpose = 'backup' AND outcome = 'success'` (the `(device_id, …)` /
+`(group_id, reported_at DESC)` indexes support this; a server-centric query
+joins runs to the server via `group_id` **and** the server identity — see
+the source-mapping note below). Let `grace = expected_interval * 2`.
+
+- **Stale** — a prior successful backup exists but none newer than
+  `now - grace` → file `backup-staleness` at `Error`, `active:true`.
+- **Never backed up** — *no* successful `purpose='backup'` row ever, **and**
+  the server has been expected long enough: `now - anchor > grace`, where
+
+  ```
+  anchor = max( MIN(first_seen over this server's device_server_associations rows),
+                server_group_backup_config.created_at )
+  ```
+
+  → file `backup-never` at `Error`, `active:true`. Below the grace from the
+  anchor: no alert yet (freshly-present server or freshly-authorized group
+  must not false-alarm).
+- **Recovered** — a previously-stale server reporting success again: file
+  `backup-staleness` `active:false` at `Info` (the issue leaves the
+  incident and auto-closes). Mirror the reachability sweep's
+  `(false, Some(issue)) if !issue.active => continue` short-circuit so we
+  don't re-file an already-closed recovery every tick.
+
+**Anchor details (do not get these wrong — they're explicit decisions):**
+- `first_seen` in `device_server_associations` is per `(device_id,
+  server_id)` **pair**, *not* a per-server scalar. Use
+  `MIN(first_seen)` over **all** of that server's association rows
+  (earliest any device saw it). Schema:
+  `device_server_associations (device_id, server_id, first_seen, last_seen)`.
+- `created_at` is `server_group_backup_config.created_at` (group-authorized
+  time). A server present long ago but whose group was authorized 5 minutes
+  ago must use the *later* of the two, so a just-authorized group doesn't
+  instantly fire `backup-never` on every member.
+- Filter runs on `purpose='backup'` **specifically** — a recent successful
+  *restore* must **not** reset backup staleness.
+
+### Mapping a `backup_run` to a server
+
+`backup_runs` carries `device_id` + `group_id` but **not** `server_id`
+directly. The protected server is identified via the kopia source
+(`canopy@<server-id>:<path>`, recorded in `backup_repo_snapshots.server_id`)
+and via the device→server association at report time. For signal 1, resolve
+the server from the run's `device_id` via `Server::live_by_device_id` (the
+`servers_device_id_unique` partial unique index guarantees at most one live
+server per device). Scan-side, it's cleaner to drive **from the server**:
+for each scanned server, find runs whose `device_id` is one of that
+server's associated devices and whose `group_id` matches. Encode this as a
+single classify query rather than per-server round-trips.
+
+### Maintenance staleness
+
+`backup_maintenance_runs` (group-level) feeds the same scan: a group whose
+last `outcome='success'` maintenance run (any `kind`) is older than a
+maintenance-cadence threshold (full-weekly default → e.g. `8 days`; make it
+a constant, not `expected_interval`-derived, since maintenance cadence is
+independent of backup cadence) → file `backup-maintenance-stale` at `Error`
+via the **group-level** path. Recovery: a fresh successful maintenance run
+clears it.
+
+## Signal reconciliation (1 / 2 / 3)
+
+Runs in the same `backup_staleness` loop (after signal-1 classify), reading
+`backup_repo_snapshots` (signal-2 ground truth) against `backup_runs`
+(signal-1 reports). Per scanned server (resolved to a kopia `source` =
+`canopy@<server-id>:<path>`, so the join key is `server_id`):
+
+- **report says success but no recent snapshot** (a `backup_runs` success
+  newer than `grace`, but `backup_repo_snapshots.latest_snapshot_at` for
+  that source is older than `grace`, or no snapshot row at all) → the report
+  is wrong or the upload didn't persist. **`backup-reconcile-missing`**,
+  `Error`, **group-level** (a device lying about success / data not landing
+  endangers the group's actual recoverability, so it pages regardless of
+  monitored). This is the case signal 1 alone cannot catch.
+- **recent snapshot but no report** (`latest_snapshot_at` fresh, but no
+  recent `backup_runs` success) → backups are fine, the *reporting path* is
+  broken. **`backup-reconcile-report-gap`**, `Warning`, **per-server**
+  (low-severity, non-paging — it's a telemetry gap, not a backup failure).
+- **neither** → genuinely stale; already covered by signal 1, emit nothing
+  extra here (avoid double-filing on the same `(server)`).
+
+Signal 2 is only as fresh as the inspection Job's last run; if
+`backup_repo_snapshots.observed_at` for a group is itself stale (older than
+the inspection floor), reconciliation can't conclude "missing" reliably —
+**skip the `reconcile-missing` verdict when signal-2 data is stale** and
+instead rely on the inspection Job's own failure to surface (it writes
+`backup_repo_snapshots`/stats; a Job that stops running is caught by the
+preflight/maintenance-staleness machinery, not here). Record this as a
+guard so a lagging inspector doesn't produce false "report lied" alerts.
+
+**Poisoning / corruption** is reported by the inspection Job (signal 2),
+not computed here: when inspection detects content-blob hash mismatch /
+unreadable index, it raises **`backup-corruption`** at `Critical`,
+group-level. This spec owns the *alerting shape* (the constant, severity,
+group-level routing, recovery-runbook pointer in the message body); the
+*detection* (running `kopia` verify) is the inspection-Job component. To
+avoid two components both knowing how to raise a group-level event, expose
+a single helper (below) that the inspection Job calls.
+
+**Signal 3 (restore-verification, later/additive):** PGRO reports
+per-replica restore outcomes into a future `backup_restore_checks` table; a
+failed/stale restorability check is **`restore-verification`** at `Error`,
+group-level. Same group-level helper. Stubbed here so the routing is
+designed-for, not bolted on; the table + ingest endpoint are out of scope
+for this component's first cut.
+
+## Group-level alerting (server-independent)
+
+**The core mechanism wrinkle.** The incident model
+(`crates/database/src/issues.rs`) is **server-keyed**: `Issue.server_id` is
+`NOT NULL`, `NewEvent::save(conn, server_id, device_id)` requires a server,
+and `re_evaluate_incident_membership` gates incident contribution on that
+server's `is_monitored`. Incidents themselves are **group-keyed**
+(`incidents.server_group_id`). There is no "group-level issue with no
+server" path today. Group-level backup checks must page regardless of
+`is_monitored`, so routing them through a per-server `NewEvent::save` is
+wrong (it would inherit the monitored gate and could be silenced by an
+unmonitored member).
+
+**Decision required — pick one (flagged in the plan as
+implementation-time):**
+
+- **Option A — representative monitored server.** Pick a deterministic
+  server in the group (e.g. the highest-rank live member, reusing
+  `ServerGroup::highest_member_ranks` ordering) and file against it, but
+  **bypass the monitored gate** for these refs. This needs a new code path
+  because `re_evaluate_incident_membership` hard-gates on `monitored`;
+  passing `monitored=true` unconditionally for group-level refs is the
+  smallest change but is a lie in the data. Fragile if the group has no
+  live members.
+- **Option B — group sentinel issue (recommended).** Add first-class
+  support for a group-scoped issue with no member server. Concretely: make
+  `issues.server_id` nullable **or** add an `issues.server_group_id`
+  nullable column, and teach `re_evaluate_incident_membership` /
+  `find_or_open_incident` to accept a group directly (the incident is
+  already group-keyed, so `find_or_open_incident(conn, group_id, …)` works
+  as-is — the only gap is producing an `Issue` that points at a group, not
+  a server, and skipping the `is_monitored` lookup for it). This is the
+  clean model and matches "group/control-plane concern, not any one
+  server's." It's a migration + a branch in the membership evaluator.
+
+This spec **recommends Option B** and treats it as the deliverable's
+central new piece of shared plumbing. Provide one helper that both this
+component and the inspection Job call:
+
+```rust
+// database::backup::alerts (new)
+pub async fn raise_group_event(
+    conn: &mut AsyncPgConnection,
+    group_id: Uuid,
+    r#ref: &str,
+    severity: Severity,
+    description: Option<&str>,
+    message: &str,
+    active: bool,
+) -> Result<()>;
+```
+
+Internally it find-or-creates a **group-scoped** issue keyed by
+`(server_group_id, source="canopy", ref)`, appends/coalesces an event (reuse
+`hash_event`), and runs the group-aware membership evaluation that ignores
+`is_monitored`. Recovery is the same `(source, ref)` with `active:false` at
+a lower severity, which lets the issue leave the incident and auto-close —
+identical lifecycle to the per-server path. **Do not** add an
+`Incident::open_for`; there is no such function — reuse
+`find_or_open_incident` → `enqueue_slack_open` → `SlackOutbox::enqueue`,
+which the existing evaluator already drives.
+
+The migration for Option B must be a separate `just migration` step
+(`just migration backup_group_scoped_issues`); never hand-create migration
+dirs. If `issues.server_id` becomes nullable, audit every existing query in
+`issues.rs` that assumes it non-null (the model is large — `list_for_server`,
+`list`, `reconcile_open_incidents`, `re_evaluate_incident_membership`'s
+`Server::get_by_id`). `reconcile_open_incidents` (run on reachability
+startup) must handle group-scoped issues (no server → resolve group
+directly, skip the `is_monitored` short-circuit). This is the
+refactor-thoroughly cost of Option B and must not be half-done.
+
+## Upstream preflight
+
+Watches **Canopy's own upstream access**, not the devices. Lives in
+`backup_preflight.rs`. Alert, **never gate readiness** (a failing check must
+not pull the pod out of rotation — that makes it worse).
+
+### Shared check (every ~minute, on the loop tick)
+
+- **`sts:GetCallerIdentity`** — confirms the pod's IRSA web-identity is
+  mounted and valid. Cheap; rides the minute loop. On failure → raise
+  **`preflight-identity`** at `Critical`, group-level (route it against a
+  fleet sentinel — Option B's group-scoped issue keyed to a "control-plane"
+  pseudo-group, **or** fan out one `preflight-identity` per configured group
+  since "every group's per-group check fails" is the same signal). The plan
+  says: a check failing for *every* group points at the shared IRSA
+  identity rather than any one bucket — so emitting per-group and letting
+  the operator see the fan-out is acceptable, but a single fleet-level alert
+  is cleaner. **Decision required** — see open questions.
+
+### Per-group deep checks (hourly, hash-jittered)
+
+For each `status='ready'` group with a config row, on its jittered slot
+(`hash(group_id) mod window`, stable per group — same scheme as maintenance
+and inspection; factor the jitter helper so all three share it):
+
+1. **Both purposes issue working creds.** Cross-account `sts:AssumeRole` on
+   the group's `target_role_arn`:
+   - **backup path**: plain assume (no session policy), then a **read-only
+     no-op** S3 call against the bucket (e.g. `HeadBucket` or
+     `GetBucketLocation` — a harmless op the backup role policy allows).
+   - **restore path**: assume **with the read-only restore session policy**
+     (the normative JSON from the plan — `GetObject` + unconditioned
+     `GetBucketLocation` + conditioned `ListBucket`), then the same
+     read-only no-op. This proves the restore session policy actually works
+     and catches the `GetBucketLocation`-folded-under-`s3:prefix` class of
+     bug **proactively**, while plain backup issuance still looks fine.
+
+   Any failure (assume or no-op) → **`preflight-assume`**, `Error`,
+   group-level. Message should distinguish which purpose/leg failed.
+2. **Object Lock still in place.** `s3:GetBucketObjectLockConfiguration` on
+   the group's bucket; assert it returns an enabled lock with `mode`
+   present and `days >= 30` (GOVERNANCE, the `backups` stack's `mode:
+   'GOVERNANCE', days: 30`). Missing/weakened lock → **`preflight-object-lock`**,
+   `Critical`, group-level (the whole "can't destroy backups" guarantee
+   rests on it, and there's no other symptom). This action is **not** in
+   `AWS_S3_MULTIPART_ACTIONS`; the issuance/IaC component must add it to the
+   per-bucket role Canopy assumes, or the check itself 403s on day one —
+   note that dependency, don't silently absorb it.
+
+Prefer **behavioural** checks (assume + harmless S3 op) over IAM/policy
+*introspection*: behavioural checks test the real path and need no extra
+`iam:Get*`. The Object-Lock read is the one allowed exception.
+
+The **maintenance path** needs no separate preflight: the read-only
+inspection Job already connects each group's repo on its cadence (proving
+reachability + password), and maintenance-specific failures surface via
+`backup_maintenance_runs` → `backup-maintenance-stale` (signal 1 above).
+
+### Reactive rate-tracking (light)
+
+The live paths are signals too: `/backup-credentials` 502s on STS failure
+and maintenance failures land in `backup_maintenance_runs`. Out of scope to
+build a metrics pipeline here, but note that a spike between hourly
+preflights should ideally surface — for the first cut, the hourly preflight
++ maintenance staleness cover it; richer rate-tracking is deferred.
+
+## Loop / scheduling shape
+
+Mirror `reachability`/`pingtask`:
+
+```rust
+pub fn spawn() -> JoinHandle<()> {
+    let pool = database::init();
+    task::spawn(async move {
+        loop {
+            sleep(Duration::from_secs(60)).await;
+            let Ok(mut db) = pool.get().await else { error!(…); continue; };
+            // signal-1 + reconcile scan (DB only)
+        }
+    })
+}
+```
+
+- **`backup_staleness`**: DB-only, 60 s tick. Runs signal-1 classify +
+  reconciliation each tick. Cheap (a couple of indexed queries + per-server
+  classify). **Decision:** stand up its own single-replica Deployment in
+  `ops/pulumi/tamanu/meta/src/jobs.ts`, *or* fold the scan into the existing
+  `reachability` loop (which already does a minute-cadence DB sweep + the
+  startup `reconcile_open_incidents`). Folding in avoids a new pod; a
+  separate binary keeps concerns isolated and is independently
+  schedulable. Recommend a **separate binary** for blast-radius and testing
+  clarity, matching the plan's "new `crates/jobs/src/bin/<name>.rs`"
+  framing.
+- **`backup_preflight`**: AWS-touching. 60 s tick for `GetCallerIdentity`;
+  per-group deep checks fire only when the tick lands in the group's
+  jittered hourly slot. Needs the AWS client + IRSA (greenfield — the
+  issuance/IaC component introduces the SDK deps, the ServiceAccount, and
+  the IRSA role; this binary reuses them). Its own single-replica
+  Deployment.
+
+Hash-jitter helper (shared with maintenance/inspection):
+`fn jitter_slot(group_id: Uuid, window: Duration) -> Duration` →
+`hash(group_id) mod window`, stable per group. Put it in `commons-servers`
+or a shared `backup` util so all schedulers agree.
+
+## Interfaces / contracts
+
+### Consumes (written by sibling components)
+
+- **`server_group_backup_config`** — `group_id`, `expected_interval`
+  (NULL / set states), `created_at`, `status` (`provisioning` /
+  `escrow_pending` / `ready`), `bucket`, `target_role_arn`, `region`. Read
+  via a new `database` model fn, e.g.
+  `BackupConfig::scannable(conn) -> Vec<ScanRow>` and
+  `BackupConfig::ready_groups(conn) -> Vec<…>`.
+- **`backup_runs`** — `device_id`, `group_id`, `purpose`, `outcome`,
+  `reported_at`. (Written by `POST /backup-report`, issuance component.)
+- **`backup_maintenance_runs`** — `group_id`, `kind`, `outcome`,
+  `started_at`/`finished_at`. (Written by maintenance Jobs.)
+- **`backup_repo_snapshots`** — `group_id`, `source`, `server_id`,
+  `latest_snapshot_at`, `observed_at`. (Written by inspection Job.)
+- **`device_server_associations`** — `(device_id, server_id, first_seen,
+  last_seen)`, for the `MIN(first_seen)` anchor.
+- **`servers`** / `Server::live_by_device_id`, `is_monitored`, `group_id`.
+- **AWS SDK plumbing** (`aws-config`, `aws-sdk-sts`, `aws-sdk-s3`), the
+  ServiceAccount + IRSA role, and `s3:GetBucketObjectLockConfiguration` on
+  the per-bucket roles — all introduced by the issuance/IaC components.
+
+### Provides (to other components / operators)
+
+- **`database::backup::alerts::raise_group_event(conn, group_id, ref,
+  severity, …)`** — the single group-level alerting entrypoint. The
+  **inspection Job** calls it for `backup-corruption`; **PGRO ingest**
+  (later) calls it for `restore-verification`. Owning this here means there
+  is exactly one place that knows how to open a group-level incident
+  without the `is_monitored` gate.
+- **Stable `(source, ref)` keys** (the table above) — operators silence /
+  snooze by these via the existing `silenced_refs` mechanism; the UI / Slack
+  reference them. Documenting them is part of the contract.
+- **Group-scoped issue support** (Option B migration) — a reusable
+  capability beyond backups (any future control-plane-level check can raise
+  a group issue).
+
+## Data shapes
+
+No new tables are owned by *this* component except the Option-B schema
+change to `issues` (nullable `server_id` or new nullable `server_group_id`)
+and — for signal 3, later — `backup_restore_checks` (out of scope for the
+first cut, noted for design-for). Everything else is reads.
+
+A small internal struct for the scan, e.g.:
+
+```rust
+struct ScanRow {
+    server_id: Uuid,
+    group_id: Uuid,
+    device_id: Option<Uuid>,        // latest-associated device, for NewEvent
+    expected_interval: SignedDuration,
+    config_created_at: Timestamp,
+    min_first_seen: Option<Timestamp>,
+    last_success_at: Option<Timestamp>,   // purpose='backup', outcome='success'
+    latest_snapshot_at: Option<Timestamp>,// from backup_repo_snapshots (reconcile)
+    snapshot_observed_at: Option<Timestamp>, // signal-2 freshness guard
+}
+```
+
+## Testing approach (per AGENTS.md)
+
+- **Database-level tests** (`commons_tests::db::TestDb::run`) are the
+  primary coverage, since the scan/classify/reconcile logic lives in the
+  `database` crate as model fns. Use direct model functions, not HTTP.
+  Always `use database::ModelName;`. Seed `server_group_backup_config`,
+  `servers`, `device_server_associations`, `backup_runs`,
+  `backup_maintenance_runs`, `backup_repo_snapshots` directly, then assert
+  on the issues/events rows produced.
+- Cases to cover (success **and** the boundary/negative cases):
+  - stale (success older than `×2`) fires `backup-staleness` `Error`;
+  - just-under-`×2` does **not** fire;
+  - never-backed-up past anchor fires `backup-never`; just-authorized group
+    (recent `config.created_at`) does **not**, even with an old
+    `first_seen`; freshly-present server (recent `MIN(first_seen)`) does
+    **not**, even with an old `config.created_at` — assert the `max(...)`
+    anchor explicitly with both orderings;
+  - a recent successful **restore** does **not** clear backup staleness
+    (purpose filter);
+  - recovery: stale → success files `active:false`, and re-running the scan
+    does not re-file (idempotence);
+  - manual-only (`expected_interval` NULL) and non-`ready` configs are
+    **not** scanned;
+  - maintenance staleness fires/clears on `backup_maintenance_runs`;
+  - reconcile: report-success-but-no-snapshot → `backup-reconcile-missing`
+    (group-level, **pages even when the server is unmonitored** — assert the
+    incident opens); snapshot-but-no-report → `report-gap` `Warning`
+    (does not open an incident on its own);
+  - reconcile **skips** the missing verdict when `snapshot_observed_at` is
+    stale;
+  - **group-level vs per-server gating**: a `backup-staleness` on an
+    unmonitored server records the issue but opens **no** incident; a
+    `backup-corruption` / `preflight-object-lock` on a group whose servers
+    are all unmonitored **does** open an incident (this is the headline
+    behaviour and must be tested directly against `incidents` rows).
+- **Reconciliation/incident interplay**: reuse the patterns in the existing
+  issues/events tests — assert `incidents` / `incident_issues` rows and the
+  `slack_outbox` enqueue (`KIND_INCIDENT_OPEN`) for the paging cases, and
+  that recovery enqueues the resolve.
+- **Preflight** AWS calls can't hit real STS/S3 in tests; structure the
+  binary so the AWS-touching functions take a trait/client object that can
+  be faked, and unit-test the **decision logic** (lock-config →
+  pass/fail, assume-result → which ref/severity) separately from the SDK
+  wiring. The alerting side (given a verdict, the right group event is
+  raised) is DB-testable via `raise_group_event`.
+- Use `#[tokio::test(flavor = "multi_thread")]`. Tests run on the ramdisk
+  Postgres via `just test` / `just test-package`. There's no rendered UI in
+  this component, so no Playwright here (the operator stats/onboarding UI is
+  a sibling component and owns its own e2e).
+
+## Open questions / decisions to make
+
+1. **Group-level routing (Option A vs B).** Recommend **B** (group-scoped
+   issue: nullable `issues.server_id` or new `server_group_id`). It's the
+   clean model and is reused by inspection (corruption) and PGRO (signal 3),
+   but it's a migration + a thorough sweep of `issues.rs`. Confirm before
+   building — this is the largest single decision and the rest of the
+   group-level alerting depends on it.
+2. **`preflight-identity` fan-out.** One fleet-level alert (needs a
+   control-plane sentinel target) vs one-per-group (reuses per-group
+   routing, operator sees the fan-out and infers "shared identity"). Lean
+   fleet-level if Option B gives us a non-group sentinel cheaply; otherwise
+   per-group.
+3. **Separate `backup_staleness` binary vs folding into `reachability`.**
+   Recommend separate binary (isolation, testability, matches plan
+   framing). Folding saves a Deployment. Confirm with the ops/Deployment
+   owner.
+4. **Maintenance-staleness threshold.** Independent of `expected_interval`
+   (maintenance cadence is full-weekly). Proposed constant ~`8 days`;
+   confirm and make it a named constant, not magic.
+5. **Reconcile severities.** `reconcile-missing` = `Error` group-level
+   (pages); `report-gap` = `Warning` per-server (non-paging). Confirm the
+   report-gap shouldn't be group-level — argument for per-server: a broken
+   *reporting* path is a single device's telemetry problem, not a
+   recoverability risk.
+6. **Signal-2 freshness floor for the reconcile guard.** What
+   `observed_at` age makes signal-2 "too stale to conclude missing"? Tie to
+   the inspection cadence floor (weekly for manual-only). Needs the
+   inspection component's cadence to be pinned first.
+7. **Anchor when a server has zero `device_server_associations` rows.**
+   `MIN(first_seen)` is NULL → fall back to `config.created_at` alone (the
+   `max` degenerates). Confirm that's the intended behaviour (a config'd
+   group with a server that no device has ever reported for: it's `never`
+   once `config.created_at` + grace elapses).
+8. **`CANOPY_SOURCE` sharing.** It currently lives in `statuses.rs`. Promote
+   to a shared location, or re-declare in the backup module? Minor, but pick
+   one to avoid drift.
+9. **Signal 3 (`backup_restore_checks` + PGRO ingest)** is explicitly
+   later/additive — confirm it stays out of this component's first cut
+   (only the group-level routing is built now, ready for it).

--- a/docs/plans/specs/canopy-jobs-maintenance-inspection.md
+++ b/docs/plans/specs/canopy-jobs-maintenance-inspection.md
@@ -1,0 +1,546 @@
+# Spec: canopy-jobs-maintenance-inspection
+
+**Component:** `canopy-jobs-maintenance` (repo: `canopy`)
+**Authoritative design:** [`../backup-credentials.md`](../backup-credentials.md) (and the blind-relay stub
+[`../backup-credentials-blind-relay.md`](../backup-credentials-blind-relay.md)).
+This spec implements the Canopy-owned **maintenance**, **read-only inspection**, **S3-metrics**, and
+**repo-creation init** paths — the scheduler loops in the `jobs` crate and the Kubernetes Jobs they spawn.
+
+This is the **first Kubernetes API client** and (jobs-side) the first IRSA usage anywhere in canopy. "Like
+reachability" describes only the `spawn()` + `loop { sleep(60); pool.get; … }` shape — the machinery to *spawn
+k8s Jobs* is entirely net-new.
+
+---
+
+## 1. Purpose
+
+Canopy owns kopia repository lifecycle for every backup-configured server-group: repo creation, retention
+enforcement, snapshot expiry, blob GC/compaction, ground-truth inventory, poisoning detection, and the bucket
+billing-size readout. Devices never run these (they have no `DeleteObject`); the control plane does, off the
+client servers, as Kubernetes Jobs running the kopia image.
+
+This component delivers four scheduler loops in `crates/jobs/src/bin/` plus the per-group k8s Jobs they spawn:
+
+1. **Maintenance scheduler** — per-group cycle `assert-retention → kopia snapshot expire → kopia maintenance
+   run`; quick-daily / full-weekly; hash-jittered per group; writes `backup_maintenance_runs`.
+2. **Inspection scheduler** — read-only `kopia snapshot list` + repo stats + repo verify (poisoning detection);
+   writes `backup_repo_snapshots` and the repo-derived fields of `backup_repo_stats`.
+3. **S3-metrics task** — CloudWatch `BucketSizeBytes` → `backup_repo_stats.bucket_bytes` (best-effort, separate
+   permissions, separate cadence).
+4. **Repo-creation init** — one-shot Job triggered by the onboarding UI: `kopia repository create` + assert
+   initial retention, using the maintenance role's IRSA.
+
+Out of scope here (other specs/components own them): the public-server device endpoints
+(`/backup-credentials`, `/backup-target`, `/backup-report`), the AWS-SDK client on `public-server`'s
+`AppState`, staleness detection over `backup_runs` (signal 1), the per-group upstream **preflight**, the
+operator UI, and all Pulumi `backups`-stack bucket/role changes. Where this component *depends on* those, it is
+called out in §6/§7. The **scheduler binaries themselves do the spawning**; the *job pod* image (kopia +
+entrypoint) is described as a contract in §5 but its non-canopy build lives in ops.
+
+---
+
+## 2. Where it lives & the loop template
+
+Four new binaries under `crates/jobs/src/bin/`, each following `reachability.rs` / `pingtask.rs`:
+
+```
+crates/jobs/src/bin/backup_maintenance.rs   # maintenance scheduler loop
+crates/jobs/src/bin/backup_inspection.rs    # read-only inspection scheduler loop
+crates/jobs/src/bin/backup_s3_metrics.rs    # CloudWatch BucketSizeBytes task
+```
+
+Repo-creation is **not** a scheduler loop — it's triggered on demand from the onboarding UI (private-server).
+The Job-spawning logic is shared with the maintenance scheduler, so it lives in a shared library module the
+private-server handler calls (see §3 "shared library"). It does not get its own bin.
+
+Each bin keeps the established structure verbatim:
+
+```rust
+pub fn spawn() -> JoinHandle<()> {
+    let pool = database::init();
+    task::spawn(async move {
+        // build the kube client + scheduler config ONCE at startup
+        // (like reachability builds the TailnetDirectory once)
+        loop {
+            sleep(Duration::from_secs(TICK)).await;
+            let Ok(mut db) = pool.get().await else { error!(...); continue; };
+            // … per-tick work …
+        }
+    })
+}
+
+#[derive(Debug, Parser)]
+struct Args { #[command(flatten)] logging: LoggingArgs }
+
+#[tokio::main]
+async fn main() -> miette::Result<()> { /* identical to reachability.rs main() */ }
+```
+
+Deviation from the DB-only sweeps: at startup each bin builds a **kube client** (and the maintenance/inspection
+bins an AWS config provider for the metrics task only — see below). If kube-client init fails the loop must log
+and **keep ticking** (so a transient API-server blip doesn't kill the pod), retrying client construction inside
+the loop — mirroring how `reachability` tolerates a `None` directory rather than panicking.
+
+Each scheduler runs as its **own single-replica `Recreate` Deployment** in `ops/pulumi/tamanu/meta/src/jobs.ts`
+(see §4). The spawned per-group work is a k8s **Job** (kopia image), not part of the loop pod.
+
+### Tick vs. cadence
+
+The loop ticks frequently (default 60s, matching reachability) but **per-group work is gated by hash-jittered
+cadence**, so a tick mostly finds nothing due. The loop's job each tick is: enumerate configured+`ready`
+groups, compute each group's due-ness for *this* binary's cadence, and spawn a Job only for those due. This
+keeps "is anything due" cheap (a DB read + arithmetic) and the heavy work in spawned Jobs.
+
+---
+
+## 3. Concrete changes (canopy)
+
+### 3.1 New crate dependencies (`crates/jobs/Cargo.toml`)
+
+Net-new; **do not pin versions without checking the registry** (per global rule). Needed:
+
+- `kube` (with `runtime`/`client` features as required) and `k8s-openapi` (pinned to a Kubernetes API
+  feature matching the cluster, e.g. `v1_30` — verify against the deployed control-plane version, do not
+  guess).
+- `aws-config` + `aws-sdk-cloudwatch` for the S3-metrics task, and `aws-sdk-sts` only if the metrics task
+  must assume a cross-account role itself (see §3.5). The maintenance/inspection **schedulers** do **not**
+  need the S3/STS SDK — the *Jobs* talk to S3 via their own IRSA; the scheduler only creates Jobs. Keep the
+  AWS deps off the maintenance/inspection bins if the metrics task is a separate bin (it is).
+- Likely `rand`/hashing already available via workspace; the hash-jitter uses a stable hash of the group UUID
+  (`Sha256` is already a dependency transitively via `database`; a stable non-crypto hash is fine — just must
+  be **stable across restarts**, so not `DefaultHasher` with a random seed).
+
+These deps are jobs-crate-local. (The AWS SDK also lands on `public-server` per the endpoints spec; the kube
+client also lands on `public-server` for Secret-read per `/backup-target` — both are *separate* additions owned
+by the endpoints component, not duplicated here.)
+
+### 3.2 New shared library module: `crates/jobs/src/lib.rs` + `backup/` submodules
+
+The jobs crate is currently bin-only (no `lib.rs`). Introduce a small library so the schedulers, the init-Job
+trigger (called from private-server), and tests share code without duplicating the kube/Job-template logic:
+
+```
+crates/jobs/src/lib.rs
+crates/jobs/src/backup/mod.rs
+crates/jobs/src/backup/jobspec.rs   # build the k8s Job manifest (image, args, labels, secretKeyRef, IRSA SA)
+crates/jobs/src/backup/schedule.rs  # hash-jitter + due-ness computation
+crates/jobs/src/backup/billing.rs   # ServerGroup -> billing.* pod labels
+crates/jobs/src/backup/spawn.rs     # create-Job-and-record helpers (kube client wrapper)
+```
+
+> If exposing `jobs` as a library for private-server to call introduces an awkward dependency direction
+> (private-server depending on the jobs crate), the alternative is to put the Job-template + spawn helpers in a
+> **commons** crate (e.g. `commons-servers`) that both `jobs` and `private-server` already depend on. **Decision
+> to make (§8):** library location. Default recommendation: `commons-servers::backup_jobs` so private-server's
+> "create repo" button and the jobs schedulers share one code path.
+
+`jobspec.rs` builds a `k8s_openapi::api::batch::v1::Job` with:
+
+- `metadata.namespace` = canopy's namespace (env, like the loop's own DATABASE_URL plumbing).
+- `metadata.generateName` = `canopy-backup-<kind>-<group-short>-` so each spawn is uniquely named and Job GC
+  can prune by label. `kind` ∈ `{maint-quick, maint-full, inspect, init}`.
+- `metadata.labels` and `spec.template.metadata.labels` carry the three **billing** pod labels plus a
+  `canopy-group=<uuid>` label and `canopy-backup-kind=<kind>` for selection/cleanup.
+- `spec.template.spec.serviceAccountName` = the IRSA service account appropriate to the kind:
+  - maintenance + init → the **maintenance** SA (assumes the per-bucket full-access role, incl. delete).
+  - inspection → the **read-only** SA (assumes the per-bucket role downscoped to read-only). The inspection
+    Job's creds are **chained** (read-only restore-level) so the 1-hour cap applies — fine for a list/verify
+    pass; maintenance/init use a **direct** web-identity (no chain, no cap — a full run can exceed an hour).
+    See design "Credentials for the maintenance Job".
+- `spec.template.spec.containers[0]`:
+  - `image` = the kopia job image (see §5; ops-provided; reference by the same `image()` mechanism `spec.ts`
+    uses, or a dedicated image ref — **decision §8**).
+  - `args` = the kopia driver entrypoint args (subcommand + flags: bucket, region, role ARN, snapshot/expire
+    flags, retention JSON, callback URL/run id — see §5 contract).
+  - `env`/`secretKeyRef`: the repo password is mounted via **`secretKeyRef`** from the group's
+    `repo_password_ref` Secret (never via plain env value, never logged). The bucket/region/role are env or
+    args (non-secret).
+  - resource requests/limits and the spot tolerations/affinity mirroring `spec.ts` defaults.
+- `spec.backoffLimit` small (e.g. 2) and `spec.ttlSecondsAfterFinished` set so finished Jobs self-prune
+  (avoids unbounded Job accumulation — the loop also reaps, see §3.6).
+- `restartPolicy: Never` (matches the migrator/chrome-versions Jobs).
+
+`billing.rs` computes labels from the group:
+
+- `billing.product` = group's `billing.product` tag if present else `"tamanu"`.
+- `billing.deployment` = group's `billing.deployment` tag if present else the group **name**.
+- `billing.stage` = group's `billing.stage` tag if present, else derived from
+  `ServerGroup::highest_member_ranks` → `rank_priority`, mapped **explicitly** to the CUR stage strings ops
+  already emits — **not** the `ServerRank` `Display` strings, which don't match:
+
+  | `ServerRank` | `Display` | billing stage |
+  |---|---|---|
+  | `Production` | `production` | `prod` |
+  | `Clone` | `clone` | `clone` |
+  | `Demo` | `demo` | `demo` |
+  | `Test` | `test` | `test` |
+  | `Dev` | `dev` | `dev` |
+
+  For a group whose members are all unranked (`highest_member_ranks` omits them), fall back to `prod` **or**
+  omit `billing.stage` — **decision §8**; recommend omit, since a wrong `prod` mis-attributes cost. (The
+  `Production → "prod"` mismatch is the load-bearing gotcha; the others happen to coincide but map them all
+  explicitly so a future `Display` rename can't silently break CUR tags.)
+
+`schedule.rs` provides hash-jittered due-ness:
+
+```rust
+/// Stable per-group slot within a cadence window. Stable across restarts:
+/// hashes the group UUID bytes, NOT a randomly-seeded hasher.
+pub fn slot_offset(group_id: Uuid, window: Duration) -> Duration;
+
+/// "Is this group due now for `kind`?" — combines the group's last
+/// run-of-this-kind (from backup_maintenance_runs / observed_at on the
+/// stats/snapshots tables) with the cadence + jitter slot.
+pub fn is_due(group_id: Uuid, kind: Kind, last: Option<Timestamp>, now: Timestamp) -> bool;
+```
+
+### 3.3 Database changes
+
+The **tables** are defined in the design doc and shared with sibling components; this component **reads** config
+and **writes** run/inventory/stats rows. Migrations are created with **`just migration NAME`** (never
+hand-authored — per project rule). To avoid two specs both trying to own the same migration, ownership is:
+
+- `server_group_backup_config`, `backup_credential_issuances`, `backup_runs`, `backup_requests` — owned by the
+  **endpoints/onboarding** components (this component only **reads** `server_group_backup_config`).
+- **This component owns the migrations for** `backup_maintenance_runs`, `backup_repo_snapshots`,
+  `backup_repo_stats` (DDL verbatim from the design doc §"Database changes"). If a single migration is
+  preferred for the whole feature, coordinate so this component contributes these three tables.
+
+New database-crate model modules (mirroring `chrome_releases.rs` shape: a `Queryable` struct + a `New*` insert
+struct + impl methods, re-exported from `lib.rs`):
+
+- `crates/database/src/backup_maintenance_runs.rs` — `MaintenanceRun` / `NewMaintenanceRun`.
+  - `NewMaintenanceRun::start(conn, group_id, kind) -> id` (insert with `outcome = NULL`, returns `BIGSERIAL`).
+  - `MaintenanceRun::finish(conn, id, outcome, error, bytes_reclaimed)`.
+  - `MaintenanceRun::latest_for_group(conn, group_id, kind) -> Option<MaintenanceRun>` (for due-ness +
+    staleness).
+- `crates/database/src/backup_repo_snapshots.rs` — `RepoSnapshot` / `NewRepoSnapshot`.
+  - `NewRepoSnapshot::upsert_many(conn, group_id, rows)` (PK `(group_id, source)`, `ON CONFLICT … DO UPDATE`
+    `latest_snapshot_at`/`observed_at`).
+  - parse `server_id` from the kopia `source` (`canopy@<server-id>:<path>`) at write time.
+- `crates/database/src/backup_repo_stats.rs` — `RepoStats`.
+  - `RepoStats::upsert_repo_fields(conn, group_id, snapshot_count, source_count, logical, physical)` — written
+    by inspection.
+  - `RepoStats::upsert_bucket_bytes(conn, group_id, bytes)` — written by the S3-metrics task; must **not**
+    clobber the repo fields (partial upsert), since the two tasks run on different cadences. `bucket_bytes` is
+    nullable/best-effort.
+
+Use PostgreSQL-native upserts (`ON CONFLICT`) per project DB conventions; keep the per-task partial-update
+separation so the two writers don't race over each other's columns.
+
+`backup_repo_config` reader: add `server_group_backup_config` model (likely owned by the config/onboarding
+component) — this component needs a read like `BackupConfig::all_ready(conn) -> Vec<BackupConfig>` (status =
+`'ready'`, used to enumerate groups to schedule) and `BackupConfig::by_group(conn, group_id)`. If that model
+doesn't exist yet, this component adds the read-only accessors it needs.
+
+### 3.4 Maintenance scheduler loop (`backup_maintenance.rs`)
+
+Per tick:
+
+1. `BackupConfig::all_ready(conn)` → candidate groups.
+2. For each group, decide quick vs full and due-ness:
+   - **quick**: due daily, slot-jittered by `slot_offset(group, 1 day)`; due if no successful `quick` (or
+     `full`, which subsumes quick) maintenance newer than ~1 day adjusted by slot.
+   - **full**: due weekly, slot-jittered by `slot_offset(group, 1 week)`.
+   - If both are due, run **full** (it subsumes quick).
+3. For each due group: skip if a maintenance Job for this group is already running (label selector query against
+   the kube API — avoid double-spawn) **or** if an unfinished `backup_maintenance_runs` row exists for it.
+4. `NewMaintenanceRun::start(...)` → `run_id`; spawn the Job with args including `run_id` and the callback URL
+   so the Job reports completion (see §5 contract). The scheduler **records start**; the Job (or a watch) records
+   finish.
+5. Cadence defaults: quick-daily, full-weekly, deployment-wide. Per-group override is later (design non-goal);
+   wire the default as constants, not magic numbers.
+
+**Finish recording — decision §8.** Two viable mechanisms:
+- (a) the Job POSTs an internal maintenance-report endpoint on completion (symmetrical with `backup-report`),
+  which calls `MaintenanceRun::finish`; or
+- (b) the scheduler **watches** the Jobs it spawned (`kube` watch on the `canopy-backup-kind` label) and writes
+  `finish` from observed Job status (`succeeded`/`failed`) + reads `bytes_reclaimed` from a Job
+  result/annotation.
+Recommend (b) for maintenance/inspection (no new endpoint, the loop already holds a kube client), with a
+**reconcile-on-startup** pass (like reachability's) that closes out `backup_maintenance_runs` rows whose Job is
+gone — so a scheduler restart mid-run doesn't leave a row stuck `outcome = NULL` forever.
+
+The maintenance cycle's **three steps run inside the Job** (kopia entrypoint), not the scheduler:
+`assert retention → kopia snapshot expire → kopia maintenance run [--full]`. The scheduler passes the retention
+JSON (from `server_group_backup_config.retention`, **floor-enforced in code**: never below `keep_daily 7,
+keep_weekly 4, keep_monthly 6`; a per-group value may only raise) so the declared policy — not a drifted in-repo
+one — governs. The floor-enforcement helper belongs in the shared lib (`backup::retention::enforce_floor`) so
+init and maintenance use the identical clamp.
+
+### 3.5 Inspection scheduler loop (`backup_inspection.rs`)
+
+Per tick, same enumerate-and-gate shape, on its **own cadence** (default ≈ `expected_interval`, tunable; floor
+weekly for manual-only `NULL`-interval groups that still hold backups). Spawns a **read-only** Job that:
+
+- `kopia snapshot list` → write `backup_repo_snapshots` (latest snapshot per source; parse `server_id` from
+  source).
+- repo stats (`kopia repository status` / `kopia content stats`) → `backup_repo_stats` repo fields.
+- **repo verify** (`kopia snapshot verify` / content hash check) → **poisoning/corruption detection**.
+
+**Poisoning → critical group-level alert.** On detected corruption (hash mismatch / unreadable index — the
+overwrite-poisoning signature), raise a **`Severity::Critical`** event (Critical satisfies `OPENS_INCIDENT`).
+This is a **group-level** alert that must fire **regardless of any server's `is_monitored`** — see §3.7 for the
+server-independent path; do **not** route it through a plain per-server `NewEvent` that inherits the monitored
+gate.
+
+Inspection results vs signal-1 reconciliation (report-said-success-but-no-snapshot, etc.) is **owned by the
+signal-1 staleness component**, which reads `backup_repo_snapshots`/`backup_runs`. This component's job is to
+*write the ground truth* and to raise the *corruption* alert; the cross-signal reconciliation alerts are the
+staleness component's.
+
+### 3.6 S3-metrics task (`backup_s3_metrics.rs`)
+
+Separate bin so it carries **CloudWatch** permissions the read-only inspector deliberately doesn't. Per tick (own
+cadence, ≈ `expected_interval`, weekly floor):
+
+- For each `ready` group, read CloudWatch `AWS/S3 BucketSizeBytes` (`StorageType=StandardStorage` or
+  `AllStorageTypes` per what the bucket reports — **verify which dimension the versioned bucket emits**, §8)
+  via `GetMetricStatistics`. The metric lives in the **deployment** account → a **cross-account** CloudWatch
+  read; the task either uses a dedicated least-privilege IRSA with cross-account CloudWatch, or assumes the
+  group's role for the read — **implementation choice (§8)**; design allows either ("dedicated least-privilege
+  IRSA role for the S3-metrics task or folded into a canopy-wide IRSA").
+- `RepoStats::upsert_bucket_bytes(conn, group_id, bytes)` — best-effort; on error log + continue, never alert
+  (best-effort/nullable per design).
+
+This task does **not** spawn k8s Jobs — it reads CloudWatch directly from the scheduler pod (lightweight). It is
+the one scheduler bin that needs the AWS SDK.
+
+### 3.7 Group-level alerting path (shared concern, must be settled here)
+
+Maintenance failure (stuck/failed maintenance) and inspection corruption are **group/control-plane** concerns
+that must **not** pass the per-server `is_monitored` gate (design "Group-level checks alert regardless of
+`is_monitored`"). But the incident model (`issues.rs`) is **server-keyed**: `NewEvent::save(conn, server_id,
+device_id)` and `re_evaluate_incident_membership` gate on the server's `is_monitored`. There is no
+"group-level issue with no server" path today.
+
+**This is a real mechanism gap flagged in the design and it must be resolved as part of this work** (§8). Do
+**not** silently route group-level alerts through a per-server `NewEvent` (they'd inherit the monitored gate and
+go quiet on intentionally-intermittent prods). Options to weigh and decide with the issues-model owner:
+
+- a **group-scoped incident** variant (incident keyed on `group_id`, bypassing `is_monitored`);
+- raising the event against the group rather than a member, with a membership rule that always opens for
+  control-plane `(source, ref)` pairs;
+- a dedicated control-plane alert sink that still drains to the same `slacker_outbox`.
+
+`(source, ref)` conventions for this component (mirroring reachability's `source="canopy"`):
+- maintenance stuck/failed → `ref = "backup-maintenance"`, `Severity::Error` (opens incident).
+- repo corruption/poisoning → `ref = "backup-corruption"`, `Severity::Critical`.
+Recovery is the **same `(source, ref)`** event with `active: false` / lower severity, so the issue leaves the
+incident and auto-closes (same pattern reachability uses). `slacker_outbox` drains to Slack unchanged.
+
+(The `backup_maintenance_runs` staleness scan — "a group whose maintenance silently stopped" — can live in the
+maintenance bin's loop or the signal-1 staleness component; **recommend** it lives with signal-1 so all
+staleness logic is in one place, with this component only emitting the corruption alert and writing the runs
+table. **Decision §8.**)
+
+### 3.8 Repo-creation init Job
+
+Triggered from the onboarding UI (private-server `TailscaleAdmin` handler), not on a loop. The handler calls the
+shared `backup::spawn::spawn_init_job(group_id)`:
+
+- Uses the **maintenance** IRSA SA (creating the repo format blob needs more than the no-delete device set).
+- Args: `kopia repository create` against the group's bucket/region + `assert` the floor-enforced initial
+  retention.
+- On success the handler advances `server_group_backup_config.status` `provisioning → escrow_pending` (then the
+  escrow UI flips `→ ready`). Status transitions are owned by the onboarding component; this component provides
+  the *Job spawn + completion signal*.
+
+---
+
+## 4. IaC changes (ops — `ops/pulumi/tamanu/meta`)
+
+Owned jointly with the ops/IaC spec; the canopy-jobs-relevant pieces:
+
+- **Three new single-replica `Recreate` Deployments** in `jobs.ts` mirroring `reachability`/`pingtask`:
+  `backup-maintenance` (`['backup_maintenance']`), `backup-inspection` (`['backup_inspection']`),
+  `backup-s3-metrics` (`['backup_s3_metrics']`), each `dependsOn: [migrator]`, with `costLabels`.
+- **ServiceAccount + IRSA, net-new to canopy.** `spec.ts` injects no `serviceAccountName` today. Add an optional
+  `serviceAccountName` to the `spec()` container args (or a sibling helper) and create the SAs via the existing
+  **`common/eksServiceAccount.ts`** helper (currently unused by canopy). Needed:
+  - a **scheduler SA** for the loop pods with **RBAC to create/list/watch/delete Jobs** in canopy's namespace
+    and **`get` Secrets** (to template `secretKeyRef`); plus IRSA only if the metrics task assumes via the pod
+    SA.
+  - the **Job pods'** IRSA roles — maintenance/init SA (assumes per-bucket full-access role, direct
+    web-identity), inspection SA (read-only). These trust the per-bucket roles cross-account; the per-bucket
+    role trust + reduced action set + `s3:GetBucketObjectLockConfiguration` are **`backups`-stack** changes
+    owned by the ops spec.
+  - **OIDC-provider-per-account** wiring so the Job's web-identity can assume cross-account (ops/IaC).
+- **The kopia Job image** must be published and referenceable (ops). See §5.
+- RBAC for create-Jobs and get-Secrets must be a `Role`/`RoleBinding` in the namespace (least privilege — not
+  cluster-wide).
+
+This component's canopy code must read the namespace + SA names from **env/config** (like DATABASE_URL), not
+hardcode them, so the same binary works across stacks.
+
+---
+
+## 5. Interfaces / contracts
+
+### Consumes
+
+- **DB config:** `server_group_backup_config` (read): `group_id`, `bucket`, `prefix`, `target_role_arn`,
+  `region`, `expected_interval`, `retention` (JSONB), `repo_password_ref`, `status`. Only `status = 'ready'`
+  groups are scheduled.
+- **`server_groups`:** `ServerGroup::highest_member_ranks`, `rank_priority`, `tags` (`TagMap`) for billing
+  labels.
+- **kopia repo password Secret** named by `repo_password_ref`, in canopy's namespace — mounted into Jobs via
+  `secretKeyRef`. Owned by the repo-password/onboarding component; consumed here read-only.
+- **Per-bucket IAM roles** (full-access maintenance role; read-only for inspection), trusting the Job IRSA SAs
+  cross-account. Owned by the ops `backups`-stack spec.
+- **`issues::NewEvent::save`** + the (to-be-built) group-level alert path. `Severity` from
+  `commons_types::issue` (`OPENS_INCIDENT = [Critical, Error]`).
+- **kube API** + **CloudWatch** (metrics task).
+
+### Provides
+
+- **DB writes** other components read:
+  - `backup_maintenance_runs` (start/finish; consumed by signal-1 staleness + the stats UI panel).
+  - `backup_repo_snapshots` (ground-truth inventory; consumed by signal-1/2 reconciliation + UI).
+  - `backup_repo_stats` repo fields + `bucket_bytes` (consumed by the operator stats panel).
+- **Shared library** (`commons-servers::backup_jobs` per §3.2 decision): `spawn_init_job(group_id)`,
+  `spawn_maintenance_job(...)`, `spawn_inspection_job(...)`, billing-label and retention-floor helpers — called
+  by **private-server** (init Job from the onboarding button) and the schedulers.
+- **Group-level alerts** `(source="canopy", ref ∈ {backup-maintenance, backup-corruption})` feeding the
+  existing incident → Slack pipeline.
+
+### Contract with the kopia Job image (ops-built; canopy passes args, image honours them)
+
+The scheduler builds the Job; the **image entrypoint** must accept (stable contract — agree with ops/bestool):
+
+- **All kinds:** bucket, prefix, region, target role ARN (assume via IRSA/web-identity), repo password (via
+  `secretKeyRef` env), repo source-host convention `canopy@<server-id>` for any source addressing.
+- **maint-quick / maint-full:** retention JSON to assert; run `assert-retention → snapshot expire →
+  maintenance run [--full]`; emit `bytes_reclaimed` if kopia surfaces it (annotation/exit JSON).
+- **inspect:** read-only; emit snapshot inventory (source + latest snapshot ts) and repo stats (snapshot/source
+  counts, logical/physical bytes) and a verify result; **how results return to canopy** (Job watch reading an
+  annotation/result file, vs the Job POSTing an internal endpoint) is the §3.4(a/b) decision.
+- **init:** `kopia repository create` + assert initial retention; set the repo maintenance **owner** to the
+  Canopy maintenance identity and **disable client-side maintenance/expiry** (so devices never attempt
+  delete-needing ops).
+
+If results come back via Job watch, the **completion contract** is: Job `succeeded`/`failed` Pod phase +
+optional result annotation; if via endpoint, an internal `(run_id, outcome, error, bytes/counts)` POST.
+
+---
+
+## 6. Data shapes (Rust)
+
+```rust
+// crates/jobs/src/backup/mod.rs (or commons-servers::backup_jobs)
+pub enum JobKind { MaintQuick, MaintFull, Inspect, Init }
+
+pub struct BillingLabels {
+    pub product: String,            // default "tamanu"
+    pub deployment: String,         // default = group name
+    pub stage: Option<String>,      // None => omit label (all-unranked group)
+}
+
+pub struct RetentionPolicy {        // mirrors server_group_backup_config.retention JSONB
+    pub keep_latest: u32,           // default 1, not floored
+    pub keep_daily: u32,            // floor 7
+    pub keep_weekly: u32,           // floor 4
+    pub keep_monthly: u32,          // floor 6
+    pub keep_annual: u32,           // default 0
+}
+impl RetentionPolicy { pub fn enforce_floor(self) -> Self; }
+```
+
+```rust
+// database models
+pub struct MaintenanceRun { pub id: i64, pub group_id: Uuid, pub kind: String,
+    pub started_at: Timestamp, pub finished_at: Option<Timestamp>,
+    pub outcome: Option<String>, pub error: Option<String>, pub bytes_reclaimed: Option<i64> }
+
+pub struct RepoSnapshot { pub group_id: Uuid, pub source: String,
+    pub server_id: Option<Uuid>, pub latest_snapshot_at: Option<Timestamp>, pub observed_at: Timestamp }
+
+pub struct RepoStats { pub group_id: Uuid, pub snapshot_count: Option<i32>, pub source_count: Option<i32>,
+    pub logical_bytes: Option<i64>, pub physical_bytes: Option<i64>,
+    pub bucket_bytes: Option<i64>, pub observed_at: Timestamp }
+```
+
+Kopia source parse: `canopy@<server-id>:<path>` → `server_id = Uuid::parse(...)` (best-effort; `None` if the
+host segment isn't a UUID, e.g. legacy/imported repos — store the row with `server_id = NULL` rather than
+dropping it).
+
+---
+
+## 7. Testing approach (per AGENTS.md)
+
+- **DB model tests** with `commons_tests::db::TestDb::run(|mut conn, _url| async move { … })`, calling model
+  functions directly (not HTTP), per the project rule. Cover:
+  - `NewMaintenanceRun::start` then `MaintenanceRun::finish` (success + failure rows), `latest_for_group`.
+  - `RepoSnapshot::upsert_many` idempotency on `(group_id, source)`; `server_id` parse from a real
+    `canopy@<uuid>:/path` source and from a non-UUID host (→ `NULL`).
+  - `RepoStats` **partial upserts**: `upsert_repo_fields` then `upsert_bucket_bytes` must not clobber each
+    other (the two-writer split is the load-bearing invariant — test it explicitly).
+  - retention **floor enforcement**: a policy below floor is raised; an above-floor override is preserved;
+    `keep_latest` is **not** floored.
+  - 404/absent cases (`latest_for_group` for an unknown group → `None`).
+  - Always `use database::ModelName;` imports.
+- **Pure-logic unit tests** (in the jobs lib, plain `#[test]` / `#[tokio::test(flavor = "multi_thread")]`):
+  - `slot_offset` is **stable** for a fixed UUID across calls (regression guard against a randomly-seeded
+    hasher) and spreads across the window for distinct UUIDs.
+  - `is_due` boundaries (just-before / just-after the window, full subsumes quick).
+  - **billing label mapping** — especially `Production → "prod"` (the gotcha) and all-unranked → `None`.
+  - `JobSpec` builder: asserts the manifest carries the billing labels, the `canopy-group`/`canopy-backup-kind`
+    labels, `restartPolicy: Never`, the correct SA per kind, `ttlSecondsAfterFinished`, and the password as
+    `secretKeyRef` (**never** a plain-value env / never present in args) — a snapshot/structured assertion on
+    the serialized `Job`. This is the cheap, high-value test since spawning real Jobs in CI isn't feasible.
+- **Kube interaction:** do **not** stand up a real cluster in tests. Keep the kube client behind a thin trait
+  (`JobSpawner`) so the schedulers' due-ness/spawn-decision logic is testable with a fake spawner that records
+  what would be created. Test "already-running group is skipped" and "due group spawns exactly one Job" against
+  the fake.
+- **Alerting:** assert the corruption path builds a `NewEvent` with `Severity::Critical` and `ref =
+  "backup-corruption"`, and that recovery emits the matching `active: false` event. Since the group-level path
+  is the open mechanism (§3.7), test at the `NewEvent` construction boundary until that path lands, then extend.
+- **No e2e/Playwright here** — this component has no rendered UI (the onboarding/stats UI is a separate
+  component and carries its own Playwright per AGENTS.md). The init-Job *trigger* is exercised by the
+  onboarding component's tests against the fake `JobSpawner`.
+- Run per-package while iterating: `just test-package jobs` and `just test-package database`; let CI run the
+  full suite (no final local full-suite run, per memory). `just check` for compile/warnings.
+
+---
+
+## 8. Open questions / decisions to make
+
+1. **Shared-library location** — `crates/jobs` as a lib vs `commons-servers::backup_jobs` so private-server can
+   call the init-Job spawn without depending on the `jobs` crate. *Recommend `commons-servers`.*
+2. **Maintenance/inspection completion signal** — Job-watch (kube) vs an internal maintenance-report endpoint.
+   *Recommend watch + startup reconcile to close orphaned `outcome = NULL` rows.*
+3. **Group-level alert mechanism** — the incident model is server-keyed with an `is_monitored` gate; group-level
+   maintenance/corruption alerts must bypass it. Needs a server-independent path (group-scoped incident, or a
+   membership rule for control-plane `(source, ref)`). **Must be resolved with the issues-model owner; do not
+   ship a per-server `NewEvent` workaround.**
+4. **Where the maintenance-staleness scan lives** — this bin vs the signal-1 staleness component. *Recommend
+   signal-1 owns all staleness; this component writes `backup_maintenance_runs` + emits only the corruption
+   alert.*
+5. **kopia Job image reference** — how canopy names/pins the image (shared `image()` vs a dedicated ref); the
+   entrypoint arg contract (§5) must be agreed with ops/bestool.
+6. **S3-metrics cross-account read** — dedicated least-privilege CloudWatch IRSA vs assume-the-group-role; and
+   the correct `BucketSizeBytes` `StorageType` dimension for a versioned bucket (verify empirically).
+7. **All-unranked group billing stage** — fall back to `prod` vs omit `billing.stage`. *Recommend omit.*
+8. **k8s-openapi API version** — pin to the cluster's actual control-plane version (verify; don't guess), per
+   the no-guessing-versions rule. Same for `kube`/AWS-SDK crate versions (check the registry before pinning).
+9. **Migration ownership** — confirm with the config/endpoints components whether the feature ships one
+   migration or several; this component contributes `backup_maintenance_runs` / `backup_repo_snapshots` /
+   `backup_repo_stats` either way.
+10. **Cadence/tick defaults** — quick-daily / full-weekly / inspection ≈ `expected_interval` (weekly floor) /
+    metrics ≈ `expected_interval` (weekly floor); confirmed-tunable per design but the constants live in code.
+
+---
+
+## 9. Net-new infrastructure summary (none exists in canopy today)
+
+- **Kubernetes API client** (`kube` + `k8s-openapi`) on the jobs schedulers — to create/list/watch/delete Jobs.
+- **ServiceAccount + IRSA** plumbed through `spec.ts` for the scheduler pods (create-Jobs + get-Secrets RBAC)
+  and for the Job pods (maintenance/inspection/init IRSA roles assuming per-bucket roles cross-account, direct
+  web-identity for maintenance/init, chained read-only for inspection).
+- **AWS SDK** (`aws-config` + `aws-sdk-cloudwatch`, maybe `aws-sdk-sts`) on the S3-metrics bin only.
+- **The kopia Job image** + its entrypoint arg contract (ops-built).
+- **OIDC-provider-per-account** wiring for cross-account Job web-identity (ops/IaC).
+
+These are the same net-new pieces the design's "Repo-alignment outcomes" section enumerates; this component owns
+the **jobs-side** kube client + Job-spawning IRSA, while `public-server`'s kube/AWS additions are owned by the
+endpoints component.

--- a/docs/plans/specs/canopy-jobs-maintenance-inspection.md
+++ b/docs/plans/specs/canopy-jobs-maintenance-inspection.md
@@ -544,3 +544,22 @@ dropping it).
 These are the same net-new pieces the design's "Repo-alignment outcomes" section enumerates; this component owns
 the **jobs-side** kube client + Job-spawning IRSA, while `public-server`'s kube/AWS additions are owned by the
 endpoints component.
+
+---
+
+## Backup types addendum
+
+Per the plan's "Backup types":
+
+- **Retention is per-`(group, type)`.** The maintenance cycle's
+  assert-retention step asserts *each type's* effective keep-policy
+  (`server_group_backup_schedule.retention ?? backup_type_defaults`, org
+  floor applied) as a kopia **per-source/path policy**, so `kopia snapshot
+  expire` honours the right policy per type. The maintenance *run* itself
+  stays per-group (one repo per group, shared by all types).
+- **Scheduling is per-`(group, type)`** — the maintenance/inspection
+  schedulers iterate active `(group, type)` (or per-group for the
+  repo-wide maintenance run; per-type for retention assertion).
+- **Inspection** parses the snapshot's `canopy-type` tag → writes
+  `backup_repo_snapshots.type`; `(server, type)` is one source.
+- `backup_repo_stats` stays per-group (repo is shared; size is repo-level).

--- a/docs/plans/specs/canopy-operator-ui.md
+++ b/docs/plans/specs/canopy-operator-ui.md
@@ -539,3 +539,20 @@ behaviour Rust tests can't:
    (object-locked). Decide how much of that the UI explains vs. defers to the
    runbook — at minimum a confirm dialog noting "the bucket and its locked
    objects persist; this only stops issuance".
+
+---
+
+## Backup types addendum
+
+Per the plan's "Backup types", the UI is type-aware:
+
+- **Capabilities view** per server: the registered types + an `enabled`
+  toggle (the per-server on/off; seeded from `auto_enable`).
+- **Per-`(group, type)` schedule + retention** editing
+  (`server_group_backup_schedule` overrides; show the inherited type
+  default when no override). Org retention floor enforced in the form.
+- **One-off "backup now"** picks a `(server, type)` (writes
+  `backup_requests` with the type).
+- Stats panel groups by type where useful (latest snapshot per
+  `(server, type)`).
+- (Optional, later) a small admin view of `backup_type_defaults`.

--- a/docs/plans/specs/canopy-operator-ui.md
+++ b/docs/plans/specs/canopy-operator-ui.md
@@ -1,0 +1,541 @@
+# Spec: canopy-operator-ui
+
+Implementation spec for the **operator UI** of the backup-credentials system:
+the `TailscaleAdmin`-gated private-server admin endpoints and the private-web
+React/MUI screens that drive group backup onboarding/config, repo-creation
+trigger + status, the reveal-once escrow + acknowledgment, the one-off "backup
+now" trigger, and the read-only stats panel.
+
+Authoritative design: [`../backup-credentials.md`](../backup-credentials.md)
+(see esp. "Operator workflows & repo provisioning (private-server UI)",
+"Repository password ownership" → "DR escrow", "Backup cadence and triggering"
+→ "Operator one-off", "Operational story"). This component owns **only** the
+operator-facing surface; it consumes the data model, AWS/k8s machinery,
+schedulers, and detection owned by the other backup-credentials components.
+
+This spec is scoped to repo `canopy`: `crates/private-server` (axum admin fns)
+and `private-web` (React SPA + Playwright e2e), following the patterns in
+`AGENTS.md` ("Private server architecture", "React frontend").
+
+---
+
+## 1. Purpose
+
+Make group backup onboarding a real, self-serve operator workflow in the
+existing Tailscale-gated admin SPA — *not* a SQL bootstrap. Concretely, give an
+operator the ability to:
+
+1. **Onboard / configure** a group's backup: set `bucket`, `target_role_arn`,
+   `region`, `expected_interval`, `retention`, choose from-birth vs. import
+   mode, and kick off repo creation.
+2. **See repo-creation status** and the lifecycle state machine
+   (`provisioning → escrow_pending → ready`), including init-Job failures.
+3. **Reveal the generated passphrase once** (from-birth repos), with a "saved
+   to Bitwarden" acknowledgment that flips `escrow_pending → ready`.
+4. **Trigger a one-off "backup now"** for any group (scheduled or
+   manual-only), writing a `backup_requests` row the device picks up on its
+   next ~1-minute tick.
+5. **Read a stats panel** — cached `backup_repo_stats` plus recent
+   `backup_runs` / `backup_maintenance_runs` per group.
+
+The UI is the human end of the control plane; it never talks to AWS, kopia, or
+k8s directly — it only reads/writes Canopy's database via private-server fns
+and *triggers* the init Job through a fn that the jobs-side machinery acts on.
+
+---
+
+## 2. Where it lives in the repo
+
+### Backend (private-server)
+
+- New module `crates/private-server/src/fns/backups.rs` exposing
+  `pub fn routes() -> OpenApiRouter<AppState>`, mounted under `/api/backups`
+  in `crates/private-server/src/fns/mod.rs` (add
+  `.nest("/backups", backups::routes())` and `pub mod backups;`).
+- Follows the exact handler shape used by `server_groups.rs`: bare axum
+  handlers `(State<AppState>, [TailscaleAdmin], Json<Args>) -> Result<Json<T>>`,
+  each annotated with `#[utoipa::path(post, path = "/<fn>", operation_id =
+  "backups_<fn>", tag = "backups", security(("tailscale-admin" = [])), …)]`.
+  Read-only endpoints use `security(("tailscale-user" = []))` (matching how
+  `server_groups::list`/`get` are user-gated while mutations are admin-gated).
+- DB access via `state.db.get().await?`; all model logic lives in the
+  **database crate** (`crates/database/src/`), never inline in private-server
+  (per AGENTS.md: no diesel in private-server).
+
+### Backend (database crate)
+
+The UI fns are thin wrappers over model functions. The migrations and models
+listed in §4 are **shared with the data-model component** of
+backup-credentials; if that component lands them first, this component only
+adds the *operator-facing* query/mutation methods. To avoid a silent gap, this
+spec lists the full set the UI needs; whoever lands the table owns the
+migration, and this component owns the query methods it calls. Coordinate via
+the `depends_on` contract in the orchestration metadata.
+
+### Frontend (private-web)
+
+- New route components under `private-web/src/routes/`:
+  - `BackupConfig.tsx` — onboarding / edit config form (create + edit modes,
+    mirroring `GroupEdit.tsx`'s split).
+  - `BackupEscrow.tsx` — reveal-once passphrase + ack (often rendered as a
+    section inside the group backup page, gated on `status === 'escrow_pending'`).
+  - `BackupPanel.tsx` — the per-group backup overview: status, stats, recent
+    runs, "backup now" button, links to config/escrow.
+- Surfaced from the existing **group detail page** (`GroupDetail.tsx`): add a
+  "Backups" section/card that renders `BackupPanel` (or a "Set up backups"
+  CTA when no config row exists). New routes registered in `App.tsx`:
+  - `/groups/:id/backups` → `BackupPanel`
+  - `/groups/:id/backups/config` → `BackupConfig` (create or edit)
+- Wire types come from `private-web/src/api-types.ts` (generated) re-exported
+  through `private-web/src/types.ts`. UI-only label/order constants
+  (status labels, retention field labels) go in `types.ts` below the
+  re-exports, same as `SEVERITY_INTENT` / `SERVER_RANK_ORDER`.
+- After any handler request/response change, run **`just gen-openapi`** and
+  commit both `private-web/openapi.json` and `private-web/src/api-types.ts`
+  alongside the Rust change (per AGENTS.md).
+
+### e2e
+
+- `private-web/e2e/backups.spec.ts` (new), using `./test-fixtures` +
+  `./seed.ts`. Extend `seed.ts` with `seedServerGroupBackupConfig`,
+  `seedBackupRun`, `seedBackupRepoStats`, `seedBackupRequest` helpers and add
+  the new tables to `resetSeededTables`'s `TRUNCATE` list.
+
+---
+
+## 3. Lifecycle state machine (the UI's spine)
+
+`server_group_backup_config.status ∈ { 'provisioning', 'escrow_pending',
+'ready' }`. The UI renders one of three top-level states per group, plus the
+"no config yet" zero-state and an explicit "init failed" sub-state:
+
+```
+(no row)  ──[Set up backups: create config]──►  provisioning
+provisioning  ──[init Job creates repo, from-birth]──►  escrow_pending
+provisioning  ──[init Job creates repo, import mode]──►  ready
+provisioning  ──[init Job fails]──►  provisioning + last_init_error shown (retry available)
+escrow_pending  ──[operator acks "saved to Bitwarden"]──►  ready
+ready  ──[edit non-structural config]──►  ready
+```
+
+- The UI **does not** itself run the init Job; it calls `backups.create_repo`,
+  which records intent / sets `status='provisioning'` and lets the jobs-side
+  init-Job machinery (owned by the maintenance/jobs component) pick it up. The
+  UI polls config status (`useReloadInterval`, like the incidents badge) to
+  reflect `provisioning → escrow_pending/ready`.
+- **Backups are dormant until `ready`** — this is enforced on the device path
+  (412/409), not in this UI; the UI surfaces *why* (status chip + helper text)
+  so an operator isn't confused that "configured" ≠ "live".
+- **Import mode** skips escrow: `create_repo` with `mode='import'` moves
+  `provisioning → ready` once the repo connects (operator already holds the
+  passphrase / points `repo_password_ref` at an existing Secret).
+
+How the init Job's outcome reaches `status` and `last_init_error` is the
+jobs-side component's contract (see §6 consumed contracts). The UI only reads
+those fields; it must not assume an in-process transition.
+
+---
+
+## 4. Data shapes (DB)
+
+These tables come from the backup-credentials data model; the UI reads/writes
+the subset below. Migrations are created with `just migration NAME` (never
+hand-authored — per AGENTS.md). Two of these (`status`, `last_init_error`,
+`mode`, `repo_password_ref`, escrow tracking) are the columns the UI most
+depends on, so if the base table is authored elsewhere, confirm these exist.
+
+### `server_group_backup_config` (read + write by UI)
+
+Per the main plan's schema, plus the columns the UI lifecycle needs. If the
+base table predates this work, the UI requires at minimum:
+
+```sql
+-- (from backup-credentials.md "New table: server_group_backup_config")
+group_id          UUID PRIMARY KEY REFERENCES server_groups(id) ON DELETE CASCADE,
+bucket            TEXT NOT NULL,
+prefix            TEXT NOT NULL DEFAULT '',
+target_role_arn   TEXT NOT NULL,
+region            TEXT,
+expected_interval INTERVAL,            -- NULL = manual-only
+retention         JSONB NOT NULL,      -- kopia keep-* policy
+repo_password_ref TEXT NOT NULL,
+status            TEXT NOT NULL,       -- 'provisioning'|'escrow_pending'|'ready'
+created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+-- UI/lifecycle additions this component needs (confirm/author):
+mode              TEXT NOT NULL DEFAULT 'from_birth',  -- 'from_birth' | 'import'
+last_init_error   TEXT,                -- set when the init Job fails; cleared on success/retry
+escrow_acked_at   TIMESTAMPTZ,         -- set when the operator acks the reveal-once (from-birth)
+escrow_acked_by   TEXT                 -- operator identity (from TailscaleAdmin)
+```
+
+`expected_interval` maps to/from the UI via the same minutes/seconds pattern
+`GroupEdit.tsx` uses for `slack_open_delay`, except the API column is
+`INTERVAL`. Reuse `database::pg_duration::PgDuration` (already used on
+`server_groups.slack_open_delay`) and `#[schema(value_type = Option<i64>)]`
+so the wire type is seconds. **NULL `expected_interval` = manual-only** must be
+representable distinctly from `0`; the form needs a "Manual only (no schedule)"
+toggle, not just an empty number field.
+
+`retention` is a small JSON object; on the wire model it as a typed struct
+(not raw `serde_json::Value`) so `openapi-typescript` emits a real shape:
+
+```rust
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct RetentionPolicy {
+    pub keep_latest:  i32,  // default 1 (not floor-enforced)
+    pub keep_daily:   i32,  // floor 7
+    pub keep_weekly:  i32,  // floor 4
+    pub keep_monthly: i32,  // floor 6
+    pub keep_annual:  i32,  // default 0
+}
+```
+
+The org-minimum **floor** (`keep_daily ≥ 7, keep_weekly ≥ 4, keep_monthly ≥ 6`)
+is enforced in the model/handler on create+update; the UI also validates
+client-side (helper text + disabled submit) but the server is authoritative
+(returns `400 AppError::BadRequest`-style problem-details on violation).
+
+### `backup_requests` (write + read by UI — "backup now")
+
+```sql
+CREATE TABLE backup_requests (
+    server_id    UUID NOT NULL REFERENCES servers(id),
+    purpose      TEXT NOT NULL,            -- "backup" | "restore"
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    requested_by TEXT,                     -- operator identity (TailscaleAdmin login)
+    PRIMARY KEY (server_id, purpose)
+);
+```
+
+The "backup now" button targets a **server** (the request is keyed by
+`server_id`), so the UI offers per-server one-off triggers within the group's
+backup panel (the group's member servers come from `server_groups.get`). A
+group-wide "backup all members" convenience can fan out to one row per member
+server (open question §8). Cleared by the device path on report; the UI shows
+"requested <TimeAgo>, pending" while a row exists.
+
+### Read-only display tables (read by UI)
+
+- `backup_repo_stats` (PK `group_id`): `snapshot_count`, `source_count`,
+  `logical_bytes`, `physical_bytes`, `bucket_bytes` (nullable), `observed_at`.
+- `backup_runs` (recent N per group): `device_id`, `purpose`, `outcome`,
+  `error`, `bytes_uploaded`, `snapshot_id`, `reported_at`.
+- `backup_maintenance_runs` (recent N per group): `kind`, `started_at`,
+  `finished_at`, `outcome`, `error`, `bytes_reclaimed`.
+- `backup_repo_snapshots` (optional, for a per-source "latest snapshot" list):
+  `source`, `server_id`, `latest_snapshot_at`.
+
+### Escrow secret read
+
+The reveal-once passphrase is read from the **k8s Secret** named by
+`repo_password_ref`. This requires `public-server`/the relevant pod to have a
+kube client + Secret-read RBAC — that machinery is **net-new and owned by the
+AWS/k8s-infra component**, not this UI. The escrow reveal endpoint
+(`backups.reveal_escrow`) consumes that kube-client capability on `AppState`.
+If private-server does not have the kube client at the time this lands, see
+§8 open question on where the escrow read executes.
+
+---
+
+## 5. Interfaces this component EXPOSES
+
+All under `/api/backups/<fn>`, POST, `TailscaleAdmin`-gated unless noted.
+Argument/response structs live in `backups.rs` with `#[derive(…, ToSchema)]`;
+operation ids prefixed `backups_`. Names are the contract for the React layer
+and any other consumer.
+
+| fn | gate | args | returns | purpose |
+|----|------|------|---------|---------|
+| `backups_get` | user | `{ server_group_id }` | `BackupConfigView \| null` | full config + lifecycle for a group (null = no config) |
+| `backups_list` | user | `{}` | `Vec<BackupConfigSummary>` | all configured groups (fleet overview) |
+| `backups_create` | admin | `CreateBackupConfigArgs` | `BackupConfigView` | insert config row (`status='provisioning'`), validate floor; does **not** create repo |
+| `backups_update` | admin | `UpdateBackupConfigArgs` | `BackupConfigView` | edit non-structural config (region, interval, retention) on a `ready` group |
+| `backups_create_repo` | admin | `{ server_group_id }` | `BackupConfigView` | record intent for the init Job (sets/keeps `provisioning`, clears `last_init_error`); idempotent retry |
+| `backups_reveal_escrow` | admin | `{ server_group_id }` | `RevealEscrowResponse` | reveal-once passphrase (from-birth, `escrow_pending` only); reads the k8s Secret |
+| `backups_ack_escrow` | admin | `{ server_group_id }` | `BackupConfigView` | flip `escrow_pending → ready`, stamp `escrow_acked_at/by` |
+| `backups_request_now` | admin | `{ server_id, purpose }` | `()` | upsert a `backup_requests` row (one-off "backup now") |
+| `backups_cancel_request` | admin | `{ server_id, purpose }` | `()` | delete a pending `backup_requests` row |
+| `backups_stats` | user | `{ server_group_id }` | `BackupStatsView` | `backup_repo_stats` + recent `backup_runs` + recent `backup_maintenance_runs` + pending requests |
+| `backups_delete` | admin | `{ server_group_id }` | `()` | delete the config row (decommission; see audit-table FK note in main plan) |
+
+### Response/argument shapes (wire)
+
+```rust
+pub struct BackupConfigView {
+    pub server_group_id: Uuid,
+    pub bucket: String,
+    pub prefix: String,
+    pub target_role_arn: String,
+    pub region: Option<String>,
+    #[schema(value_type = Option<i64>)]            // seconds; None = manual-only
+    pub expected_interval: Option<PgDuration>,
+    pub retention: RetentionPolicy,
+    pub mode: BackupRepoMode,                       // FromBirth | Import (serde lowercase)
+    pub status: BackupConfigStatus,                 // Provisioning | EscrowPending | Ready
+    pub last_init_error: Option<String>,
+    pub escrow_acked_at: Option<Timestamp>,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
+    // NOTE: never includes repo_password_ref's *value* — only reveal_escrow does.
+}
+
+pub struct CreateBackupConfigArgs {
+    pub server_group_id: Uuid,
+    pub bucket: String,
+    #[serde(default)] pub prefix: String,
+    pub target_role_arn: String,
+    pub region: Option<String>,
+    #[schema(value_type = Option<i64>)]
+    pub expected_interval: Option<PgDuration>,
+    pub retention: RetentionPolicy,
+    pub mode: BackupRepoMode,
+    /// Import mode only: name of a pre-existing k8s Secret holding the
+    /// passphrase. From-birth leaves this None (Canopy generates + names it).
+    pub repo_password_ref: Option<String>,
+}
+
+pub struct RevealEscrowResponse {
+    pub passphrase: String,        // shown once; UI must not persist
+    pub repo_password_ref: String, // the Secret name, for the "saved where" note
+}
+
+pub struct BackupStatsView {
+    pub stats: Option<BackupRepoStats>,            // None until first inspection
+    pub recent_runs: Vec<BackupRunRow>,            // most-recent first, capped (e.g. 20)
+    pub recent_maintenance: Vec<BackupMaintenanceRow>,
+    pub pending_requests: Vec<PendingRequestRow>,  // server_id, purpose, requested_at, requested_by
+}
+```
+
+Use `commons_types::Uuid` and `jiff::Timestamp` to match the rest of the
+codebase (`server_groups.rs` uses these). Status/mode are string enums with
+`#[serde(rename_all = "snake_case")]` so the generated TS unions read
+`"provisioning" | "escrow_pending" | "ready"` and `"from_birth" | "import"`.
+
+### Error contract (problem-details)
+
+Reuse existing `AppError` variants; map to the documented statuses in
+`#[utoipa::path(responses(...))]`:
+
+- `404` (`AppError`'s not-found path) — group / config not found in `get` when
+  the caller expects one; but `backups_get` returns `null` for "no config"
+  rather than 404, matching the "zero-state" UI. Use 404 only for a bad
+  `server_group_id` (group itself missing).
+- `400` — retention floor violation, or `create` for a group that already has
+  config. Prefer `AppError::Conflict(String)` (→ 409) for "already configured"
+  and a bad-request variant for floor violations; pick per existing
+  `commons-errors` variants and **update ERRORS.md** if a new variant is added
+  (per AGENTS.md, heading must match the problem type).
+- `409` (`AppError::Conflict`) — `reveal_escrow`/`ack_escrow` called when
+  `status != 'escrow_pending'`, or `create_repo` on an already-ready group, or
+  `update` of structural fields (bucket/role) post-creation (those are a repo
+  migration, out of scope — reject).
+- `502` — `reveal_escrow` if the k8s Secret read fails (control-plane error).
+
+---
+
+## 6. Interfaces this component CONSUMES
+
+From **other backup-credentials components** (must exist first or be stubbed):
+
+- **Data model component (canopy DB):** the migrations/tables in §4 and the
+  base `database::server_group_backup_config` / `backup_requests` /
+  `backup_runs` / `backup_maintenance_runs` / `backup_repo_stats` models.
+  Contract: model structs with the columns in §4; the UI adds query methods
+  (`get_for_group`, `list_configured`, `create`, `update`, `set_status`,
+  `ack_escrow`, recent-runs queries) — author these in the database crate.
+- **AWS/k8s-infra component:** a **kube client on `AppState`** with Secret-read
+  capability, so `backups_reveal_escrow` can read the passphrase Secret named
+  by `repo_password_ref`. This is net-new (canopy has no kube client today).
+  Contract consumed: `state.kube` (or equivalent) + a helper like
+  `read_secret(name, key) -> Result<String>`. The UI does **not** create
+  Secrets — from-birth passphrase generation + Secret creation is the init
+  Job's job; the UI only reveals.
+- **Jobs/maintenance component:** the **init Job** that performs
+  `kopia repository create` and drives `status`/`last_init_error`. Contract
+  consumed: the UI's `backups_create_repo` records intent (sets
+  `status='provisioning'`, clears `last_init_error`); the Job is expected to
+  transition the row to `escrow_pending` (from-birth) or `ready` (import), or
+  set `last_init_error` on failure. The exact handoff (a flag column, a queue,
+  or the Job polling `provisioning` rows) is the jobs component's decision —
+  this UI only depends on the *observable* `status`/`last_init_error` fields.
+- **Device path / detection components:** none consumed directly; the UI
+  surfaces their *output* (runs, staleness via the existing issues/events
+  model already shown on the server/group pages — no new wiring here).
+
+From **existing canopy code** (already present):
+
+- `commons_servers::tailscale_auth::TailscaleAdmin` extractor (gate +
+  operator identity for `requested_by` / `escrow_acked_by`). Confirm how to
+  extract the login string from it (mirror whatever `admins.rs` / audited
+  endpoints do).
+- `database::server_groups::ServerGroup` (member list for per-server "backup
+  now"; group existence checks).
+- React: `useApi` / `useApiAction` (`private-web/src/api.ts`),
+  `useIsAdmin` (`hooks/useIsAdmin.tsx`), `useReloadInterval`
+  (status polling), `TimeAgo`, `usePageTitle`, `TagsEditor` pattern.
+
+---
+
+## 7. Frontend behaviour detail
+
+### `BackupPanel` (`/groups/:id/backups`, and a card on `GroupDetail`)
+
+- `useApi("backups", "get", { server_group_id: id }, [id])`.
+  - `null` → zero-state: "Backups not set up" + admin-only "Set up backups"
+    button → `/groups/:id/backups/config`.
+  - non-null → status chip (`provisioning`/`escrow_pending`/`ready` with the
+    same intent-helper-text pattern as `SEVERITY_INTENT`), config summary
+    (bucket, region, interval or "Manual only", retention), and:
+    - `provisioning` → spinner + "Creating repository…"; if `last_init_error`,
+      an error Alert + admin "Retry repo creation" (`create_repo`).
+    - `escrow_pending` → prominent warning card → render `BackupEscrow`.
+    - `ready` → stats (`backups.stats`), recent runs table, per-server
+      "Backup now" buttons.
+- Poll status with `useReloadInterval` (e.g. 5s while `provisioning`, slower
+  when `ready`) so the operator sees the init Job land without a manual reload.
+
+### `BackupConfig` (`/groups/:id/backups/config`)
+
+- Create vs edit split like `GroupEdit.tsx` (`isCreate = no config row`).
+- Fields: bucket, target_role_arn, region (optional), **schedule mode toggle**
+  (Manual only ↔ Scheduled every N minutes — `expected_interval`), retention
+  (5 number fields with floor validation + helper text), repo mode
+  (From-birth ↔ Import; Import reveals a `repo_password_ref` field).
+- Structural fields (bucket, target_role_arn, mode) are **create-only**;
+  disabled in edit mode with helper text ("changing the bucket is a repo
+  migration — out of scope here").
+- On create success → if from-birth, `create_repo` is offered as the next step
+  (or auto-called) so the operator flows into provisioning → escrow.
+
+### `BackupEscrow`
+
+- Renders only when `status === 'escrow_pending'` and `mode === 'from_birth'`.
+- "Reveal passphrase" button → `useApiAction("backups", "reveal_escrow")`;
+  shows the passphrase in a monospace, copy-to-clipboard block with a loud
+  "Save this to Bitwarden NOW — it cannot be shown again" warning.
+- A required checkbox "I have saved this passphrase to Bitwarden" enables the
+  "Acknowledge & activate backups" button → `ack_escrow` → flips to `ready`.
+- The reveal is deliberately re-callable while `escrow_pending` (operator may
+  reload before acking); once `ready`, `reveal_escrow` returns 409.
+
+### Admin gating
+
+- Read views (`get`/`list`/`stats`) render for any Tailscale user (user-gate),
+  matching `server_groups::list`/`get`.
+- All mutating buttons gate on `useIsAdmin() === true`, mirroring
+  `GroupDetail.tsx`'s `admin && (<Button …/>)` pattern.
+
+---
+
+## 8. Testing approach (per AGENTS.md)
+
+### Rust endpoint tests (`crates/private-server/tests/`)
+
+- File `backups.rs` (no `_test` suffix). Use `commons_tests::server::run(|conn,
+  _public, private| async move { … })`. Endpoints at
+  `/api/backups/<fn>`, params via `.json(&serde_json::json!({...}))`, empty
+  body `{}` for no-arg fns.
+- Cover, with `use database::…;` imports and direct model seeding via `conn`:
+  - `create` happy path (status becomes `provisioning`); retention-floor
+    rejection → 400/expected status; duplicate-config → 409.
+  - `get` returns `null` for unconfigured group; full view once configured.
+  - `create_repo` clears `last_init_error` and is idempotent.
+  - `ack_escrow` only from `escrow_pending` (409 otherwise); stamps
+    `escrow_acked_at/by`.
+  - `request_now` upserts; `cancel_request` deletes; PK `(server_id, purpose)`
+    means re-request is a no-op upsert, not an error.
+  - `update` rejects structural-field changes (409) and accepts
+    region/interval/retention.
+  - Auth: confirm admin-gated fns reject non-admin (the test harness's auth
+    posture — match how other admin fns are tested).
+  - `reveal_escrow`: since the kube client is net-new, test against a stubbed
+    secret reader if the harness allows; otherwise gate this test on the infra
+    component and assert the 409-when-not-escrow_pending branch (which needs no
+    Secret read).
+
+### Playwright e2e (`private-web/e2e/backups.spec.ts`)
+
+Per AGENTS.md, UI features ship with e2e coverage in the same change. Seed
+state directly via `seed.ts` helpers (extend it — see §2). Cover the rendered
+behaviour Rust tests can't:
+
+- Zero-state: group with no config shows "Set up backups" (admin) /
+  hidden (non-admin).
+- Config form: create writes a `server_group_backup_config` row with the right
+  `expected_interval` (assert via `EXTRACT(EPOCH …)` like the cooldown test),
+  retention JSON, and `status='provisioning'`; floor violation blocks submit.
+- Manual-only toggle persists `expected_interval IS NULL` (distinct from 0).
+- Escrow flow: seed `status='escrow_pending'`, mode from_birth; reveal shows
+  the passphrase, ack checkbox gates the button, ack flips DB row to `ready`
+  and stamps `escrow_acked_at`. (Stub/seed the Secret value via whatever the
+  reveal path reads — coordinate with the infra component; if the kube client
+  isn't available in e2e, test the ack transition with a pre-revealed state and
+  cover reveal separately or behind a fixture flag.)
+- "Backup now": clicking writes a `backup_requests` row for the server; a
+  pending row shows "requested <ago>"; cancel deletes it.
+- Stats panel: seed `backup_repo_stats` + a couple of `backup_runs`; assert the
+  numbers and recent-run rows render; `bucket_bytes` NULL renders as "unknown",
+  not hidden (per the user's "indicators show unknown state" rule).
+
+### Frontend typecheck / unit
+
+- `just typecheck` for TS (not bare `tsc` — per AGENTS.md). Run `just
+  gen-openapi` first so `api-types.ts` matches the handlers.
+- Optional vitest unit tests for any pure helper (e.g. interval↔minutes,
+  retention-floor validation) mirroring `humanDuration` style.
+
+---
+
+## 9. Open questions / decisions to make
+
+1. **Where does `reveal_escrow` read the Secret?** The plan says the repo
+   password is a k8s Secret Canopy owns, and that `public-server` gets a kube
+   client for `/backup-target`. But escrow reveal is a **private-server**
+   (admin) concern. Decide: (a) give private-server its own kube client +
+   Secret-read RBAC, or (b) have private-server proxy to an internal endpoint,
+   or (c) store the from-birth passphrase transiently for the escrow window.
+   Leaning (a) — least machinery, and private-server is already the admin trust
+   surface. This is a dependency on the AWS/k8s-infra component.
+
+2. **One-off "backup now" granularity.** `backup_requests` is keyed by
+   `server_id`. Do we expose per-server buttons only, a group-wide "back up all
+   members" fan-out (N rows), or both? The main plan's operator-story says
+   "trigger a best-effort immediate backup for any group", implying a
+   group-level affordance. Proposal: per-server buttons + a group-level "Back
+   up all" that fans out, restore as a separate (less prominent) action.
+
+3. **Init-Job handoff signal.** This UI sets `status='provisioning'` and clears
+   `last_init_error` on `create_repo`; the exact mechanism the jobs component
+   uses to notice (poll `provisioning` rows? a dedicated `init_requested_at`
+   column? a queue table?) is the jobs component's call. Confirm so the UI
+   writes whatever field the Job reads. Default assumption: Job polls
+   `status='provisioning'` rows.
+
+4. **Retry semantics on init failure.** Is "Retry repo creation" just
+   `create_repo` again (idempotent), or does a failed repo need cleanup first
+   (e.g. a half-created kopia format blob)? UI calls `create_repo`; the Job
+   owns idempotency/cleanup. Flag for the jobs component.
+
+5. **Editing structural config.** Spec rejects bucket/role/mode edits
+   post-creation (repo migration is out of scope). Confirm with product that
+   the only "change" path for those is delete-config + re-onboard, and document
+   that in the onboarding runbook.
+
+6. **`region` change UX.** The plan notes changing region/bucket is really a
+   repo migration. `region` is editable per the config schema but pointing at a
+   different region typically means a different bucket. Decide whether the edit
+   form allows `region` edits at all, or gates them behind a warning. Proposal:
+   allow but warn loudly.
+
+7. **Group-level vs server-level stats anchor.** Stats are per-group
+   (`backup_repo_stats` PK `group_id`) but runs/requests are per-server/device.
+   The panel mixes both; confirm the grouping the operator expects (group
+   headline stats + per-server run history).
+
+8. **Decommission flow in UI.** `backups_delete` removes the config row;
+   audit tables intentionally have no CASCADE and the bucket persists
+   (object-locked). Decide how much of that the UI explains vs. defers to the
+   runbook — at minimum a confirm dialog noting "the bucket and its locked
+   objects persist; this only stops issuance".

--- a/docs/plans/specs/canopy-public-server.md
+++ b/docs/plans/specs/canopy-public-server.md
@@ -586,3 +586,23 @@ No frontend/Playwright work in this component (device API, no UI).
    `backup_credential_issuances`, `backup_runs`, the endpoints, and the
    jobs crate. Decide whether they live in `commons-types` (shared) or are
    defined per-crate. Recommend `commons-types` to avoid drift.
+
+---
+
+## Backup types addendum
+
+Per the plan's "Backup types": requests carry a `type`, and there's a new
+registration endpoint.
+
+- **New `POST /backup-capabilities`** (ServerDevice): body
+  `{ "types": [...] }`; resolve device→server; upsert
+  `server_backup_capabilities`, seeding `enabled` from each type's
+  `backup_type_defaults.auto_enable` for newly-seen types (don't clobber an
+  operator-set `enabled`). 204.
+- **`POST /backup-credentials`** body gains `"type"`; **`POST
+  /backup-report`** body gains `"type"`; both record it
+  (`backup_credential_issuances.type`, `backup_runs.type`/`server_id`).
+- Issuance/credentials gating is per `(server, type)`: the capability must
+  be `enabled` and the group `ready`.
+- Add a shared **effective-config resolver** (override ?? type-default,
+  retention floor) — also consumed by the jobs + UI components.

--- a/docs/plans/specs/canopy-public-server.md
+++ b/docs/plans/specs/canopy-public-server.md
@@ -1,0 +1,588 @@
+# Spec: canopy-public-server — device backup endpoints (backup-credentials, backup-target, backup-report)
+
+Implementation spec for the `public-server` slice of the
+[backup-credentials](../backup-credentials.md) system. This is **canopy's
+first AWS SDK usage** and its first Kubernetes API client on the
+internet-facing pod. Read the parent plan for the why; this file is the
+how, grounded in the real `crates/public-server` code.
+
+Authoritative design: [`backup-credentials.md`](../backup-credentials.md)
+(esp. "Endpoint shape", "Permission templates", "IAM model", "Repository
+password ownership", and the "Accepted stage-1 risk" note). The stage-2
+hardening that removes this component's blast radius is
+[`backup-credentials-blind-relay.md`](../backup-credentials-blind-relay.md)
+— **out of scope here**; we build the stage-1 on-demand minting path.
+
+## Purpose
+
+Add three `ServerDevice`-authenticated device endpoints to `public-server`:
+
+- `POST /backup-credentials` — mint short-lived per-group S3 creds via a
+  cross-account `sts:AssumeRole` and return them in `credential_process`
+  JSON. `restore` purpose adds a read-only session policy.
+- `GET /backup-target` — return `{storage, bucket, prefix, region,
+  repo_password}` so bestool can reconstruct the kopia repo connection on
+  every run. `repo_password` is read from a k8s Secret.
+- `POST /backup-report` — record a run outcome into `backup_runs` (the
+  "a backup actually completed" signal staleness detection reads).
+
+All three resolve `device → server (live_by_device_id) → group_id →
+server_group_backup_config` identically, returning **412** when the device
+is bound to no live server and **409** when the server is ungrouped or the
+group has no `ready` backup config.
+
+This component **owns the AWS STS client and the kube client on
+`AppState`**, plus the net-new deps to support them. It **consumes** the
+DB models (new tables defined by the canopy-database component) and the
+IAM trust / bucket config provisioned by the ops `backups` stack.
+
+## Scope boundary
+
+In scope (this component):
+- The three handlers + their module(s) under `crates/public-server/src/`.
+- Net-new workspace deps: `aws-config`, `aws-sdk-sts`, `aws-sdk-s3` (s3
+  only if a behavioural no-op lands here; see open questions), `kube`,
+  `k8s-openapi`.
+- `AppState` AWS-client + kube-client fields and their `FromRef` impls;
+  binary `init()` wiring; test-harness wiring.
+- The restore session-policy JSON builder.
+- Inserting `backup_credential_issuances` rows (capturing `AccessKeyId` +
+  best-effort `sts_request_id`).
+- A new `AppError` variant for STS/upstream failure → **502**.
+
+Out of scope (other components — depend on, don't build):
+- The table schemas/migrations and diesel models (`canopy-database`).
+- Staleness scan, maintenance/inspection/preflight Jobs, schedulers
+  (`canopy-jobs`).
+- Operator onboarding UI, escrow, one-off "backup now" (`private-server` /
+  `private-web`).
+- The ops `backups`-stack IRSA-trust + action-set + lifecycle changes, the
+  ServiceAccount/IRSA Pulumi wiring (`ops`). This spec states the contract
+  it needs from ops but does not author the Pulumi.
+- bestool's `canopy backup` / `backup-credentials` subcommands (separate
+  repo).
+
+## Where it lives in the repo
+
+`public-server` mounts feature routers in `crate::routes()`
+(`crates/public-server/src/lib.rs:24`), each module exposing
+`pub fn routes() -> OpenApiRouter<AppState>`. Existing device modules:
+`events.rs`, `tags.rs`, `statuses.rs`, `servers.rs`, `versions.rs`.
+
+Add one module, `crates/public-server/src/backup.rs`, exposing all three
+endpoints, mounted **at the root** (not nested) so the paths are exactly
+`/backup-credentials`, `/backup-target`, `/backup-report` (matching the
+plan's endpoint shape). `events.rs` is already merged at the root via
+`.merge(events::routes())` and is the pattern to copy:
+
+```rust
+// crates/public-server/src/lib.rs, in routes()
+let mut router = OpenApiRouter::new()
+    .merge(events::routes())
+    .merge(backup::routes())   // NEW — root-mounted, like events
+    .nest("/artifacts", artifacts::routes())
+    // ...
+```
+
+`backup::routes()` registers all three handlers:
+
+```rust
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(credentials)) // POST /backup-credentials
+        .routes(routes!(target))      // GET  /backup-target
+        .routes(routes!(report))      // POST /backup-report
+}
+```
+
+Add `pub mod backup;` to `lib.rs`. The module is **not** behind the `ui`
+feature (it's a device API, like `events`/`statuses`).
+
+## Net-new dependencies
+
+No AWS SDK and no kube client exist anywhere in the workspace today (the
+only `aws-*` presence is the `aws-lc-rs` crypto backend, unrelated). Add
+to the workspace `Cargo.toml` `[workspace.dependencies]` and reference
+from `crates/public-server/Cargo.toml`:
+
+- `aws-config` — default credential/region provider chain. In-cluster this
+  resolves the pod's IRSA web-identity automatically (`AWS_ROLE_ARN` +
+  `AWS_WEB_IDENTITY_TOKEN_FILE`, injected by EKS once the ServiceAccount is
+  IRSA-annotated). No explicit credential wiring in canopy code.
+- `aws-sdk-sts` — for `assume_role`.
+- `aws-sdk-s3` — **only if** a behavioural no-op (e.g. `GetBucketLocation`)
+  is performed at issuance time. The plan puts deep S3 checks in the
+  preflight Job, not the hot issuance path, so the public-server may not
+  need `aws-sdk-s3` at all. Decide per the open question below; do not add
+  it speculatively.
+- `kube` (client + `Api<Secret>`) and `k8s-openapi` (with a pinned
+  Kubernetes feature, e.g. `v1_30` — match the cluster; verify, don't
+  guess). Used by `GET /backup-target` to read the repo-password Secret.
+
+Do **not** pin AWS/kube crate versions from memory — check the registry
+(`cargo add --dry-run` / crates.io) and use the workspace's
+`[workspace.dependencies]` convention. The repo rule is "never guess
+versions; verify or ask."
+
+Feature-gating: these are core to the backup endpoints, which are always
+compiled (not `ui`-gated). Add them as unconditional `public-server` deps.
+
+## AppState changes
+
+`AppState` (`crates/public-server/src/state.rs`) is `Clone + Debug` and is
+constructed in three places: `init()` (binary), `from_db*()` (helpers),
+and the test harness (`commons-tests/src/server.rs:92` builds the struct
+literal directly). All three must stay compiling.
+
+Add two fields, both `Option<…>` so the test harness and the
+private-server's nested `/public/...` mount (which also build `AppState`)
+can leave them `None` and so a missing AWS/kube environment degrades to a
+clean error rather than a panic at startup:
+
+```rust
+pub struct AppState {
+    pub db: Db,
+    // ... existing fields ...
+
+    /// STS client built from the pod's IRSA web-identity. `None` when no
+    /// AWS environment is configured (tests, the nested private mount).
+    /// Backup-credentials issuance requires it; absent ⇒ 502 with a
+    /// clear "issuer not configured" message.
+    pub sts: Option<aws_sdk_sts::Client>,
+
+    /// Kube client for reading repo-password Secrets in canopy's
+    /// namespace. `None` in tests / non-cluster runs ⇒ `/backup-target`
+    /// 502s. The namespace to read from is fixed at construction.
+    pub kube: Option<BackupSecrets>,
+}
+```
+
+`BackupSecrets` is a small wrapper holding the `kube::Client` + the
+namespace (read from `POD_NAMESPACE` / downward-API env, default
+`canopy`), exposing `async fn read_password(&self, secret_name: &str,
+key: &str) -> Result<String>`. Keep the kube surface this narrow — the
+handler only ever does `get` on one Secret and pulls one key out.
+
+`Debug` derive: `aws_sdk_sts::Client` and `kube::Client` are `Debug`;
+`BackupSecrets` derives `Debug`. If any field isn't `Debug`, switch
+`AppState` to a manual `Debug` impl rather than dropping the derive
+elsewhere.
+
+### FromRef impls
+
+Add `FromRef<AppState>` for the two new client types so handlers can take
+them as `State<…>` extractors, mirroring the existing `Db` / `RateLimiter`
+impls (`state.rs:77-93`):
+
+```rust
+impl FromRef<AppState> for Option<aws_sdk_sts::Client> { /* clone */ }
+impl FromRef<AppState> for Option<BackupSecrets> { /* clone */ }
+```
+
+(Both AWS SDK clients and `kube::Client` are cheap to clone — they're
+`Arc`-backed handles.)
+
+### Binary init wiring
+
+In `AppState::init()` (and a new async constructor, since `aws_config::
+load_defaults` is async — `init()` is currently sync), build the clients:
+
+```rust
+let aws = aws_config::load_defaults(BehaviorVersion::latest()).await;
+let sts = Some(aws_sdk_sts::Client::new(&aws));
+let kube = match kube::Client::try_default().await {
+    Ok(c) => Some(BackupSecrets::new(c, namespace_from_env())),
+    Err(_) => None, // log; backup-target will 502 until fixed
+};
+```
+
+`init()` is called from `main.rs:49` (`AppState::init()?`). Make the
+backup wiring an **async** init path; `main` is already `#[tokio::main]`
+so awaiting is fine. Keep a sync/`None`-clients fallback constructor for
+the private-server nested mount and any non-AWS deployment.
+
+Region: per-request region comes from the group config row
+(`server_group_backup_config.region`, nullable → deployment default). The
+STS client itself uses the provider-chain region; only the eventual S3
+addressing cares about the bucket's region, and that is handed to the
+device in `GET /backup-target`. STS `AssumeRole` is global-ish; set the
+STS client region from the default provider.
+
+## Handler 1 — `POST /backup-credentials`
+
+### Request / response
+
+```rust
+#[derive(Deserialize, ToSchema)]
+pub struct CredentialsArgs {
+    #[serde(default)] pub purpose: Purpose, // default Backup
+}
+
+#[derive(Deserialize, Serialize, ToSchema, Clone, Copy, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Purpose { Backup, Restore }
+impl Default for Purpose { fn default() -> Self { Self::Backup } }
+
+// credential_process output — field names fixed by the AWS SDK.
+#[derive(Serialize, ToSchema)]
+#[serde(rename_all = "PascalCase")]
+pub struct CredentialProcessOutput {
+    pub version: u8,            // serialized as "Version": 1
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub session_token: String,
+    pub expiration: String,     // RFC3339 / ISO8601 Z
+}
+```
+
+`Version` is the literal `1`; the rename must produce exactly
+`Version/AccessKeyId/SecretAccessKey/SessionToken/Expiration` (the AWS SDK
+treats this format as fixed — see the plan's "AWS quirks"). Verify the
+`PascalCase` rename yields `AccessKeyId` not `AccessKeyId` casing drift;
+if `serde(rename_all)` doesn't produce the exact AWS casing, rename each
+field explicitly.
+
+### Handler flow (mirrors plan step list)
+
+Signature follows the bare-handler pattern (events.rs is the closest
+twin):
+
+```rust
+async fn credentials(
+    State(db): State<Db>,
+    State(sts): State<Option<aws_sdk_sts::Client>>,
+    device: ServerDevice,
+    Json(args): Json<CredentialsArgs>,
+) -> Result<Json<CredentialProcessOutput>>
+```
+
+1. `ServerDevice` authenticates (it yields only a `Device`;
+   `device.0.0.id` is the device id — same access as `events.rs:44`,
+   `statuses.rs`).
+2. Resolve server: `Server::live_by_device_id(&mut conn, device_id)`
+   (`crates/database/src/servers.rs:352`). It returns `Vec<Server>`; the
+   `servers_device_id_unique` partial index guarantees ≤1, so
+   `.into_iter().next()`. Empty ⇒ `AppError::DeviceHasNoServer` (**412**,
+   maps at `commons-errors/src/lib.rs:193`). Use `live_by_device_id` (not
+   `get_by_device_id`) so archived servers don't issue creds.
+3. Read `server.group_id: Option<Uuid>` (`servers.rs:58`). `None` ⇒
+   **409** via `AppError::Conflict("server is not in a group")`.
+4. Load `ServerGroupBackupConfig::by_group_id(&mut conn, group_id)` (model
+   provided by canopy-database). Absent ⇒ **409**
+   `AppError::Conflict("group has no backup config")`. Also gate on
+   `status == 'ready'`: a `provisioning`/`escrow_pending` row is **409**
+   (dormant). This yields `target_role_arn`, `bucket`, `prefix`, `region`.
+5. For `purpose == Restore` only: build the read-only **session policy**
+   JSON (template below). `Backup` needs none (the per-bucket role's own
+   policy is the scoping).
+6. Require `sts` is `Some`; else **502** (`AppError::Upstream(...)`,
+   "issuer not configured"). Call cross-account assume:
+   ```rust
+   sts.assume_role()
+      .role_arn(&cfg.target_role_arn)
+      .role_session_name(format!("canopy-{}-{}", purpose_str, device_id))
+      .set_policy(restore_policy_json)   // None for backup
+      .duration_seconds(3600)            // chained sessions cap at 1h anyway
+      .send().await
+   ```
+   Any SDK error ⇒ **502** (`AppError::Upstream`). Capture
+   `request_id()` (via `aws_sdk_sts::error::ProvideErrorMetadata` /
+   `RequestId` trait) best-effort for `sts_request_id`.
+7. Pull `credentials` from the response: `access_key_id`,
+   `secret_access_key`, `session_token`, `expiration`. A response missing
+   credentials ⇒ **502**.
+8. Insert `backup_credential_issuances` (canopy-database model
+   `NewBackupCredentialIssuance`): `device_id`, `group_id`,
+   `expires_at` (from STS `Expiration`), `purpose`, `sts_assumed_role`
+   (= `target_role_arn`), `sts_request_id` (nullable), `access_key_id`,
+   `bucket`/`prefix` (snapshot of config). A failed audit insert should
+   fail the request (don't hand out creds we didn't record).
+9. Return `Json(CredentialProcessOutput { version: 1, .. })`, **200**.
+
+`RoleSessionName`: `canopy-backup-<device-id>` / `canopy-restore-<device-id>`
+(decision #2; the `canopy-` prefix makes CloudTrail provenance
+unambiguous). Note `RoleSessionName` is capped at 64 chars — `canopy-` (7)
++ `restore-` (8) + a 36-char UUID = 51, within budget.
+
+### Restore session policy (normative)
+
+Authored at assume-time; ANDs down to read-only against the per-bucket
+role. `<prefix>` is normally empty (repo at bucket root). `GetBucketLocation`
+**must be its own unconditioned statement** — the `s3:prefix` context key
+isn't populated for it, so folding it under the prefix condition would
+silently deny it:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow", "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::<bucket>/<prefix>*" },
+    { "Effect": "Allow", "Action": ["s3:GetBucketLocation"],
+      "Resource": "arn:aws:s3:::<bucket>" },
+    { "Effect": "Allow", "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::<bucket>",
+      "Condition": { "StringLike": { "s3:prefix": ["<prefix>*"] } } }
+  ]
+}
+```
+
+Build this with `serde_json` (a typed struct or `json!` macro) from the
+config's `bucket`/`prefix`; pass the serialized string to `.policy(...)`.
+The **backup** permission set is **not** authored here — it's the
+per-bucket role's own policy in ops (`AWS_S3_MULTIPART_ACTIONS` is the
+source of truth). public-server only authors the restore downscope.
+
+### OpenAPI annotation
+
+`#[utoipa::path(post, path = "/backup-credentials", tag = "backup",
+security(("server-device" = [])), request_body = CredentialsArgs,
+responses((status=200, body=CredentialProcessOutput), (status=409,
+body=ProblemDetailsSchema), (status=412, body=ProblemDetailsSchema),
+(status=502, body=ProblemDetailsSchema)))]`. Run `just gen-openapi` is a
+private-web concern; the **public** server has its own `openapi.rs`
+(`ApiDoc`) — register the new tag/handlers there.
+
+## Handler 2 — `GET /backup-target`
+
+```rust
+#[derive(Serialize, ToSchema)]
+pub struct BackupTarget {
+    pub storage: String,       // "s3"
+    pub bucket: String,
+    pub prefix: String,        // normally ""
+    pub region: String,        // config.region or deployment default
+    pub repo_password: String, // read from the k8s Secret
+}
+
+async fn target(
+    State(db): State<Db>,
+    State(kube): State<Option<BackupSecrets>>,
+    device: ServerDevice,
+) -> Result<Json<BackupTarget>>
+```
+
+Flow: steps 1–4 identical to credentials (same 412/409, same `ready`
+gate). Then:
+
+5. Require `kube` is `Some` else **502**.
+6. `kube.read_password(&cfg.repo_password_ref, KEY).await?` — reads the
+   Secret named by `repo_password_ref` from canopy's namespace and pulls
+   the password key out (decide the key name — e.g. `password`; fix it as
+   a constant and document it for the operator-UI/escrow component that
+   creates the Secret). A missing Secret or key ⇒ **502** (upstream
+   misconfig), with the group named in the (server-side) log, not the
+   body.
+7. `region` = `cfg.region` or the deployment default (an env/config
+   constant; the plan calls it "deployment default (AWS region)").
+8. Return `Json(BackupTarget { storage: "s3".into(), .. })`, **200**.
+
+**Blast-radius note (carry into the PR description, accepted stage-1
+risk):** serving `repo_password` makes the internet-facing pod hold
+Secret-read for every group's repo password. The stage-1 plan
+**accepts** this; the blind-relay stub removes it later. Two invariants
+this component must not violate: it only ever does `get` on the one named
+Secret (never `list`), and it holds no delete/bypass capability.
+
+## Handler 3 — `POST /backup-report`
+
+```rust
+#[derive(Deserialize, ToSchema)]
+pub struct BackupReport {
+    pub run_id: Uuid,          // becomes backup_runs.id (client-minted)
+    pub purpose: Purpose,
+    pub outcome: Outcome,      // success | failure
+    pub error: Option<String>,
+    pub bytes_uploaded: Option<i64>,
+    pub snapshot_id: Option<String>,
+}
+
+#[derive(Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Outcome { Success, Failure }
+
+async fn report(
+    State(db): State<Db>,
+    device: ServerDevice,
+    Json(rep): Json<BackupReport>,
+) -> Result<StatusCode>  // 204
+```
+
+Flow: steps 1–3 (resolve device → live server → `group_id`; 412/409). The
+config row need **not** be `ready` to accept a report (a report is just an
+observation), but the server **must** be grouped — `device_id`/`group_id`
+come from the authenticated context, never the client's claim (per plan:
+forgery-proof attribution).
+
+Insert `backup_runs` via `NewBackupRun` (canopy-database model) with
+`id = rep.run_id` (client-supplied PK — safe: `device_id`/`group_id` are
+server-derived, and a duplicate `id` fails its **own** insert with a PK
+violation, can't overwrite another row). On a PK-conflict, return a clean
+**409** (duplicate run_id) rather than a 500 — map the diesel unique
+violation. Return **204 No Content** on success.
+
+This component **does not** run staleness detection or clear the one-off
+`backup_requests` flag — those are `canopy-jobs` / scheduler concerns that
+read the `backup_runs` rows this writes. (The plan says the one-off flag
+is "cleared when the run is reported"; whether that clear happens in this
+handler or the scheduler is an open question below.)
+
+## Error handling — new variant
+
+Add `AppError::Upstream(String)` (or `AppError::StsFailed` /
+`AppError::BadGateway`) to `crates/commons-errors/src/lib.rs`:
+
+- `IntoResponse` status map (currently `commons-errors/src/lib.rs:180+`):
+  `Self::Upstream(_) => StatusCode::BAD_GATEWAY`.
+- Problem-type slug (the `match` near `:243`): `Self::Upstream(_) =>
+  "upstream"`.
+- Add an entry to `ERRORS.md` with heading matching the slug (`upstream`)
+  — AGENTS.md requires this.
+
+Reuse existing variants where they fit: `DeviceHasNoServer` (412) and
+`Conflict(String)` (409) already exist and map correctly — do not add new
+409/412 variants. Only the 502 path is new.
+
+Keep STS/kube error **detail out of the response body** (it can name
+roles/buckets); log it server-side and return a generic upstream message.
+
+## Interfaces / contracts
+
+### Consumed (must exist first)
+
+- **canopy-database** models + migrations:
+  - `ServerGroupBackupConfig` with `by_group_id(conn, group_id) ->
+    Result<Option<Self>>`; fields `bucket`, `prefix`, `target_role_arn`,
+    `region: Option<String>`, `repo_password_ref`, `status`
+    (`provisioning|escrow_pending|ready`).
+  - `NewBackupCredentialIssuance` insert (fields per plan's
+    `backup_credential_issuances`).
+  - `NewBackupRun` insert with caller-supplied `id` (UUID PK), exposing a
+    way to distinguish a unique-violation for the 409 mapping.
+  - Re-exports in `database/src/lib.rs`.
+- **`Server::live_by_device_id`** — already exists
+  (`database/src/servers.rs:352`); `Server.group_id` already exists.
+- **ops `backups` stack** (contract, provisioned elsewhere): the
+  per-bucket `target_role_arn` **trusts canopy's IRSA principal** for
+  cross-account `AssumeRole`; the role's own policy grants the device
+  backup action set (`AWS_S3_MULTIPART_ACTIONS`, no delete) and
+  `s3:GetBucketObjectLockConfiguration`. The pod's ServiceAccount is
+  IRSA-annotated and has RBAC `get` on Secrets in canopy's namespace.
+  public-server is **never** granted `CreateBucket` / delete / bypass.
+- **Repo-password Secret**: a k8s Secret named by `repo_password_ref`,
+  with the password under an agreed key, created by the
+  onboarding/escrow component before a group reaches `ready`.
+
+### Provided (to others)
+
+- **`POST /backup-credentials`** → `credential_process` JSON
+  (`Version/AccessKeyId/SecretAccessKey/SessionToken/Expiration`); consumed
+  by bestool's `credential_process` hook. 412/409/502 contract above.
+- **`GET /backup-target`** → `{storage, bucket, prefix, region,
+  repo_password}`; consumed by bestool to build the kopia connection.
+- **`POST /backup-report`** → 204; writes `backup_runs` rows that
+  `canopy-jobs` staleness/reconciliation reads.
+- **`backup_credential_issuances` rows** — the audit log + CloudTrail join
+  key (`access_key_id`) other components/operators query.
+- **`AppError::Upstream` (502)** — reusable upstream-failure variant.
+- **`AppState.sts` / `AppState.kube`** — the AWS/kube clients now available
+  on public-server's state for any future device-facing AWS use.
+
+## Data shapes (wire)
+
+- credentials request: `{ "purpose": "backup" | "restore" }` (default
+  backup).
+- credentials response: the four-field `credential_process` JSON +
+  `Version: 1`.
+- target response: `{ "storage": "s3", "bucket": "...", "prefix": "",
+  "region": "...", "repo_password": "..." }`.
+- report request: `{ "run_id": uuid, "purpose": ..., "outcome": ...,
+  "error"?: str, "bytes_uploaded"?: int, "snapshot_id"?: str }` → 204.
+
+## Testing approach
+
+Per AGENTS.md, HTTP endpoint tests use
+`commons_tests::server::run_with_device_auth("server", |conn, cert,
+device_id, public, private| async move { ... })`, adding the
+`mtls-certificate` header on each request:
+`.add_header("mtls-certificate", &cert)`. Use
+`#[tokio::test(flavor = "multi_thread")]`. Put tests in
+`crates/public-server/tests/backup.rs` (no `_test` suffix) or an inline
+`#[cfg(test)] mod tests` as `bestool.rs` does.
+
+**The AWS/kube clients are `None` in the test harness** (the harness
+builds `AppState` directly without AWS env — `commons-tests/src/server.rs:92`).
+That cleanly tests the **resolution + error** matrix without a live AWS:
+
+- `POST /backup-credentials` with a device bound to **no live server** ⇒
+  **412** (seed a device with no server row).
+- device → **ungrouped** server ⇒ **409** (seed a server with
+  `group_id = NULL`).
+- device → grouped server but **no config row** ⇒ **409**.
+- device → grouped, config row in `provisioning`/`escrow_pending` ⇒ **409**
+  (dormant gate).
+- device → grouped, config `ready`, but `sts == None` ⇒ **502** ("issuer
+  not configured") — this is the harness default and proves the 502 path.
+- `GET /backup-target`: same 412/409 matrix; with config `ready` and
+  `kube == None` ⇒ **502**.
+- `POST /backup-report`: grouped server ⇒ row written, **204**; assert the
+  `backup_runs` row via the model (`device_id`/`group_id` from context,
+  not from body — try sending a bogus group and confirm it's ignored);
+  duplicate `run_id` ⇒ **409**; ungrouped ⇒ **409**; no live server ⇒
+  **412**.
+
+**Successful issuance (200)** needs the STS call mocked or stubbed —
+options to weigh (open question): (a) inject a stub STS behind a small
+trait so the harness can return canned creds; (b) `aws-smithy-mocks` /
+`StaticReplayClient` to replay an `AssumeRole` HTTP response with the
+`sts` client present; (c) leave the 200 path to a manual/integration test
+against a real role. Prefer (a) or (b) so the happy path + the
+issuance-audit insert + the restore-vs-backup `policy` difference are
+covered in CI. The restore session-policy JSON builder should also have a
+**pure unit test** (assert the three statements, the unconditioned
+`GetBucketLocation`, the `<prefix>*` substitution) — that's the
+correctness-critical, AWS-free piece.
+
+Seeding helpers: `run_with_device_auth` creates the device + key; insert
+the `servers` / `server_groups` / `server_group_backup_config` rows via
+the database models (add a seed helper if one doesn't exist). Use direct
+model calls for DB state, HTTP for the endpoint behaviour (AGENTS.md).
+
+No frontend/Playwright work in this component (device API, no UI).
+
+## Open questions / decisions to make
+
+1. **STS happy-path test strategy** — stub trait vs `aws-smithy-mocks`
+   replay vs manual-only. Recommend a stub trait or smithy mock so CI
+   covers 200 + audit insert + the restore/backup policy split. (Pick
+   before implementing the happy path.)
+2. **`aws-sdk-s3` on public-server at all?** The plan keeps deep S3
+   behavioural checks in the preflight Job, not the issuance hot path. If
+   issuance does **no** S3 no-op, public-server needs only `aws-sdk-sts`.
+   Confirm we are not adding a per-issuance `GetBucketLocation` here
+   (latency + an extra permission on the issuer). Default: STS only.
+3. **`AppState::init()` becomes async** — it's currently sync and called
+   `?`-style from `main`. Confirm making the AWS/kube-aware constructor
+   async (and keeping a sync `None`-clients path for the private nested
+   mount + tests) is acceptable, vs. lazily building the clients on first
+   use.
+4. **Repo-password Secret key name** — fix the data key inside the Secret
+   (e.g. `password`) and align it with the onboarding/escrow component
+   that creates the Secret. Single source of truth needed.
+5. **Deployment-default region** — where does the fallback region live
+   (env var `AWS_REGION` / a canopy config constant)? `GET /backup-target`
+   must always return a concrete region string even when
+   `config.region IS NULL`.
+6. **Who clears the one-off `backup_requests` flag** — the plan says
+   "cleared when the run is reported." Decide whether `POST /backup-report`
+   clears it (this component) or the scheduler does (`canopy-jobs`).
+   Leaning: the scheduler owns `backup_requests`; this handler just writes
+   `backup_runs`. Confirm so the flag-clear isn't dropped between
+   components.
+7. **Namespace discovery** — read `POD_NAMESPACE` via the downward API, or
+   `kube`'s in-cluster namespace inference? Pick one and set it at
+   `BackupSecrets` construction.
+8. **`Purpose`/`Outcome` shared types** — these enums recur across
+   `backup_credential_issuances`, `backup_runs`, the endpoints, and the
+   jobs crate. Decide whether they live in `commons-types` (shared) or are
+   defined per-crate. Recommend `commons-types` to avoid drift.

--- a/migrations/2026-06-12-090526-0000_backup_credentials/down.sql
+++ b/migrations/2026-06-12-090526-0000_backup_credentials/down.sql
@@ -1,0 +1,10 @@
+DROP TABLE backup_requests;
+DROP TABLE backup_repo_stats;
+DROP TABLE backup_repo_snapshots;
+DROP TABLE backup_maintenance_runs;
+DROP TABLE backup_runs;
+DROP TABLE backup_credential_issuances;
+DROP TABLE server_group_backup_schedule;
+DROP TABLE server_backup_capabilities;
+DROP TABLE backup_type_defaults;
+DROP TABLE server_group_backup_config;

--- a/migrations/2026-06-12-090526-0000_backup_credentials/up.sql
+++ b/migrations/2026-06-12-090526-0000_backup_credentials/up.sql
@@ -1,0 +1,150 @@
+-- Backup-credentials system: persistent state for the control plane that
+-- issues short-lived S3 creds to devices and owns repo maintenance.
+-- Backups are keyed (server, type): the repo is per-group/shared, the
+-- backup *type* (e.g. tamanu-postgres) is a dimension on runs/issuances/
+-- requests/snapshots. See docs/plans/backup-credentials.md.
+--
+-- FK note: server_groups / servers / devices are archived (soft-deleted),
+-- never hard-deleted, so these FKs use plain REFERENCES (no ON DELETE /
+-- ON UPDATE) — the cascade-vs-preserve distinction is moot in practice.
+
+-- Repo-level backup config for a group (one bucket/repo per group, shared by
+-- all the group's backup types). Schedule + retention live per-(group, type)
+-- in server_group_backup_schedule, not here.
+CREATE TABLE server_group_backup_config (
+	group_id          UUID PRIMARY KEY REFERENCES server_groups(id),
+	bucket            TEXT NOT NULL,
+	prefix            TEXT NOT NULL DEFAULT '',
+	target_role_arn   TEXT NOT NULL,
+	region            TEXT,
+	repo_password_ref TEXT NOT NULL,
+	status            TEXT NOT NULL CHECK (status IN ('provisioning', 'escrow_pending', 'ready')),
+	created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+	updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+SELECT diesel_manage_updated_at('server_group_backup_config');
+
+-- Canopy-wide defaults per well-known backup type. auto_enable only seeds the
+-- INITIAL enabled value on a capability at registration; it is not a perpetual
+-- override.
+CREATE TABLE backup_type_defaults (
+	type              TEXT PRIMARY KEY,
+	default_interval  INTERVAL,
+	default_retention JSONB NOT NULL CHECK (jsonb_typeof(default_retention) = 'object'),
+	auto_enable       BOOLEAN NOT NULL DEFAULT false
+);
+
+-- What each server ADVERTISES it can back up (bestool registers these), and
+-- whether it's enabled for that server. enabled is SEEDED at registration from
+-- the type's auto_enable default; thereafter it's operator-controlled state.
+CREATE TABLE server_backup_capabilities (
+	server_id     UUID NOT NULL REFERENCES servers(id),
+	type          TEXT NOT NULL,
+	enabled       BOOLEAN NOT NULL,
+	registered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+	PRIMARY KEY (server_id, type)
+);
+
+-- Per-(group, type) schedule/retention OVERRIDES. Effective value =
+-- this row ?? backup_type_defaults; org retention floor still applies (in
+-- code). Absent row → the type defaults apply.
+CREATE TABLE server_group_backup_schedule (
+	group_id          UUID NOT NULL REFERENCES server_groups(id),
+	type              TEXT NOT NULL,
+	expected_interval INTERVAL,
+	retention         JSONB CHECK (retention IS NULL OR jsonb_typeof(retention) = 'object'),
+	created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+	updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+	PRIMARY KEY (group_id, type)
+);
+SELECT diesel_manage_updated_at('server_group_backup_schedule');
+
+-- Audit log of every STS credential issuance. bucket/prefix are snapshots at
+-- issuance time; access_key_id is the durable join to downstream CloudTrail.
+CREATE TABLE backup_credential_issuances (
+	id               BIGSERIAL PRIMARY KEY,
+	device_id        UUID NOT NULL REFERENCES devices(id),
+	group_id         UUID NOT NULL REFERENCES server_groups(id),
+	type             TEXT NOT NULL,
+	issued_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+	expires_at       TIMESTAMPTZ NOT NULL,
+	purpose          TEXT NOT NULL CHECK (purpose IN ('backup', 'restore')),
+	sts_assumed_role TEXT NOT NULL,
+	sts_request_id   TEXT,
+	access_key_id    TEXT,
+	bucket           TEXT NOT NULL,
+	prefix           TEXT NOT NULL
+);
+CREATE INDEX ON backup_credential_issuances (device_id, issued_at DESC);
+CREATE INDEX ON backup_credential_issuances (group_id, issued_at DESC);
+
+-- What bestool reported per backup/restore run. id is the client-minted
+-- run-uuid (stamped into the snapshot tags before this row exists), NOT a
+-- serial — a duplicate id fails its own insert.
+CREATE TABLE backup_runs (
+	id             UUID PRIMARY KEY,
+	device_id      UUID NOT NULL REFERENCES devices(id),
+	group_id       UUID NOT NULL REFERENCES server_groups(id),
+	server_id      UUID REFERENCES servers(id),
+	type           TEXT NOT NULL,
+	purpose        TEXT NOT NULL CHECK (purpose IN ('backup', 'restore')),
+	outcome        TEXT NOT NULL CHECK (outcome IN ('success', 'failure')),
+	error          TEXT,
+	bytes_uploaded BIGINT,
+	snapshot_id    TEXT,
+	reported_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON backup_runs (group_id, reported_at DESC);
+CREATE INDEX ON backup_runs (device_id, reported_at DESC);
+CREATE INDEX ON backup_runs (server_id, type, reported_at DESC);
+
+-- Canopy-owned maintenance-Job outcomes (per-group / repo-level). outcome NULL
+-- = still running.
+CREATE TABLE backup_maintenance_runs (
+	id              BIGSERIAL PRIMARY KEY,
+	group_id        UUID NOT NULL REFERENCES server_groups(id),
+	kind            TEXT NOT NULL CHECK (kind IN ('quick', 'full')),
+	started_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+	finished_at     TIMESTAMPTZ,
+	outcome         TEXT CHECK (outcome IS NULL OR outcome IN ('success', 'failure')),
+	error           TEXT,
+	bytes_reclaimed BIGINT
+);
+CREATE INDEX ON backup_maintenance_runs (group_id, started_at DESC);
+
+-- Ground-truth inventory from the read-only inspection Job: latest snapshot
+-- per kopia source. source encodes the server id + type; (group, source) is
+-- the upsert key.
+CREATE TABLE backup_repo_snapshots (
+	group_id           UUID NOT NULL REFERENCES server_groups(id),
+	source             TEXT NOT NULL,
+	server_id          UUID REFERENCES servers(id),
+	type               TEXT,
+	latest_snapshot_at TIMESTAMPTZ,
+	observed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+	PRIMARY KEY (group_id, source)
+);
+
+-- Cached repo + bucket size/stats for operator display (per-group). Filled by
+-- two writers: the inspection Job (repo-derived fields) and the S3-metrics
+-- task (bucket_bytes, best-effort/nullable).
+CREATE TABLE backup_repo_stats (
+	group_id       UUID PRIMARY KEY REFERENCES server_groups(id),
+	snapshot_count INTEGER,
+	source_count   INTEGER,
+	logical_bytes  BIGINT,
+	physical_bytes BIGINT,
+	bucket_bytes   BIGINT,
+	observed_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Pending operator one-off "backup now" flags, per (server, type, purpose);
+-- cleared when the run is reported.
+CREATE TABLE backup_requests (
+	server_id    UUID NOT NULL REFERENCES servers(id),
+	type         TEXT NOT NULL,
+	purpose      TEXT NOT NULL CHECK (purpose IN ('backup', 'restore')),
+	requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+	requested_by TEXT,
+	PRIMARY KEY (server_id, type, purpose)
+);

--- a/migrations/2026-06-15-064431-0000_backup_group_scoped_issues/down.sql
+++ b/migrations/2026-06-15-064431-0000_backup_group_scoped_issues/down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS issues_group_last_seen;
+DROP INDEX IF EXISTS issues_group_source_ref;
+ALTER TABLE issues DROP CONSTRAINT IF EXISTS issues_scope_exactly_one;
+-- Drop group-scoped rows that can't satisfy the restored NOT NULL.
+DELETE FROM issues WHERE server_id IS NULL;
+ALTER TABLE issues
+	DROP COLUMN server_group_id,
+	ALTER COLUMN server_id SET NOT NULL;

--- a/migrations/2026-06-15-064431-0000_backup_group_scoped_issues/up.sql
+++ b/migrations/2026-06-15-064431-0000_backup_group_scoped_issues/up.sql
@@ -1,0 +1,39 @@
+-- Group-scoped issues (Option B from specs/canopy-jobs-detection-preflight.md).
+--
+-- The incident model is server-keyed today: issues.server_id is NOT NULL and
+-- every issue belongs to exactly one server. Group-level backup checks
+-- (corruption, preflight, reconcile-missing, restore-verification) must page
+-- regardless of any single server's is_monitored gate, so they need a
+-- first-class issue that points at a GROUP rather than a server.
+--
+-- This makes server_id nullable and adds a nullable server_group_id. An issue
+-- is exactly one of:
+--   * server-scoped: server_id NOT NULL, server_group_id NULL  (every issue so far)
+--   * group-scoped:  server_id NULL,     server_group_id NOT NULL
+-- enforced by a CHECK. Incidents are already group-keyed, so the existing
+-- find_or_open_incident path works unchanged; the only new piece is producing
+-- an Issue that resolves its group directly and skips the per-server
+-- is_monitored lookup.
+
+ALTER TABLE issues
+	ALTER COLUMN server_id DROP NOT NULL,
+	ADD COLUMN server_group_id UUID REFERENCES server_groups (id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Exactly-one-of: server-scoped XOR group-scoped.
+ALTER TABLE issues
+	ADD CONSTRAINT issues_scope_exactly_one CHECK (
+		(server_id IS NOT NULL AND server_group_id IS NULL)
+		OR (server_id IS NULL AND server_group_id IS NOT NULL)
+	);
+
+-- The existing UNIQUE (server_id, source, "ref") still covers server-scoped
+-- issues (NULLs are distinct in a UNIQUE, so it no longer constrains
+-- group-scoped rows). Add the matching uniqueness for group-scoped issues so
+-- raise_group_event's find-or-create keys cleanly on (group, source, ref).
+CREATE UNIQUE INDEX issues_group_source_ref
+	ON issues (server_group_id, source, "ref")
+	WHERE server_group_id IS NOT NULL;
+
+CREATE INDEX issues_group_last_seen
+	ON issues (server_group_id, last_seen DESC)
+	WHERE server_group_id IS NOT NULL;

--- a/migrations/2026-06-16-001346-0000_backup_config_lifecycle_columns/down.sql
+++ b/migrations/2026-06-16-001346-0000_backup_config_lifecycle_columns/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE server_group_backup_config
+	DROP COLUMN mode,
+	DROP COLUMN last_init_error,
+	DROP COLUMN escrow_acked_at,
+	DROP COLUMN escrow_acked_by;

--- a/migrations/2026-06-16-001346-0000_backup_config_lifecycle_columns/up.sql
+++ b/migrations/2026-06-16-001346-0000_backup_config_lifecycle_columns/up.sql
@@ -1,0 +1,14 @@
+-- Operator-UI lifecycle columns on the per-group backup config.
+--
+-- `mode` distinguishes a from-birth repo (Canopy generates the passphrase →
+-- escrow flow) from an imported one (operator already holds the passphrase →
+-- straight to ready). `last_init_error` is set by the jobs-side init Job when
+-- `kopia repository create` fails and cleared by the operator-UI on retry. The
+-- `escrow_acked_*` columns stamp who acknowledged the Bitwarden-escrow reveal
+-- and when, flipping the row from escrow_pending → ready.
+ALTER TABLE server_group_backup_config
+	ADD COLUMN mode            TEXT NOT NULL DEFAULT 'from_birth'
+		CHECK (mode IN ('from_birth', 'import')),
+	ADD COLUMN last_init_error TEXT,
+	ADD COLUMN escrow_acked_at TIMESTAMPTZ,
+	ADD COLUMN escrow_acked_by TEXT;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -5296,7 +5296,6 @@
         "type": "object",
         "required": [
           "id",
-          "server_id",
           "server_host",
           "source",
           "ref",
@@ -5406,8 +5405,12 @@
             "type": "string"
           },
           "server_id": {
-            "type": "string",
-            "format": "uuid"
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "`None` for group-scoped issues (backup control-plane alerts that point\nat a group, not a server — see the group-scoped-issues migration)."
           },
           "server_name": {
             "type": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2177,8 +2177,12 @@ export interface components {
              */
             server_group_name?: string | null;
             server_host: string;
-            /** Format: uuid */
-            server_id: string;
+            /**
+             * Format: uuid
+             * @description `None` for group-scoped issues (backup control-plane alerts that point
+             *     at a group, not a server — see the group-scoped-issues migration).
+             */
+            server_id?: string | null;
             /** @description The issue's server name (may be null — fall back to `server_host`). */
             server_name?: string | null;
             severity: components["schemas"]["Severity"];

--- a/private-web/src/components/IssueRow.tsx
+++ b/private-web/src/components/IssueRow.tsx
@@ -92,7 +92,7 @@ export default function IssueRow({
 				headerSnapshotOpen={headerSnapshotOpen}
 				toggleHeaderSnapshot={() => setHeaderSnapshotOpen((v) => !v)}
 			/>
-			{headerSnapshotOpen && (
+			{headerSnapshotOpen && issue.server_id && (
 				<StatusSnapshotPanel
 					serverId={issue.server_id}
 					at={issue.last_seen}
@@ -147,22 +147,44 @@ function Header({
 					<ExpandMoreIcon fontSize="small" />
 				)}
 			</IconButton>
-			<MuiLink
-				component={RouterLink}
-				to={`/servers/${issue.server_id}`}
-				underline="hover"
-				color="text.primary"
-				sx={{ fontWeight: 500, flexShrink: 0 }}
-			>
-				<ServerNameWithGroup
-					groupName={issue.server_group_name}
-					serverName={
-						issue.server_name && issue.server_name.trim() !== ""
-							? issue.server_name
-							: issue.server_host || "(unknown)"
-					}
-				/>
-			</MuiLink>
+			{issue.server_id != null ? (
+				<MuiLink
+					component={RouterLink}
+					to={`/servers/${issue.server_id}`}
+					underline="hover"
+					color="text.primary"
+					sx={{ fontWeight: 500, flexShrink: 0 }}
+				>
+					<ServerNameWithGroup
+						groupName={issue.server_group_name}
+						serverName={
+							issue.server_name && issue.server_name.trim() !== ""
+								? issue.server_name
+								: issue.server_host || "(unknown)"
+						}
+					/>
+				</MuiLink>
+			) : (
+				// Group-scoped issue (no server): link the group instead of a
+				// bogus `/servers/null`. Falls back to a plain label when the
+				// issue carries no group name.
+				<Box sx={{ fontWeight: 500, flexShrink: 0 }}>
+					{issue.server_group_name ? (
+						<ServerNameWithGroup
+							groupName={issue.server_group_name}
+							groupId={issue.server_group_id ?? undefined}
+							serverName="(group-wide)"
+						/>
+					) : (
+						<Typography
+							component="span"
+							color="text.secondary"
+						>
+							(group-wide)
+						</Typography>
+					)}
+				</Box>
+			)}
 			<Typography
 				variant="body2"
 				sx={{
@@ -291,7 +313,7 @@ function Body({
 					gap: 2,
 				}}
 			>
-				<EventLog issueId={issue.id} serverId={issue.server_id} />
+				<EventLog issueId={issue.id} serverId={issue.server_id ?? undefined} />
 				<NotesList
 					apiModule="issues"
 					parentKey="issue_id"
@@ -486,22 +508,24 @@ function IssueActions({
 						join incidents. Manage and un-silence from the detail page.
 					</Typography>
 					<Stack direction="row" spacing={1}>
-						<Button
-							variant="outlined"
-							size="small"
-							startIcon={<NotificationsOffOutlinedIcon />}
-							onClick={() =>
-								wrap(() =>
-									silenceServer.call({
-										server_id: issue.server_id,
-										source: issue.source,
-										ref: issue.ref,
-									}),
-								).then(() => setSilenceOpen(false))
-							}
-						>
-							For this server
-						</Button>
+						{issue.server_id != null && (
+							<Button
+								variant="outlined"
+								size="small"
+								startIcon={<NotificationsOffOutlinedIcon />}
+								onClick={() =>
+									wrap(() =>
+										silenceServer.call({
+											server_id: issue.server_id,
+											source: issue.source,
+											ref: issue.ref,
+										}),
+									).then(() => setSilenceOpen(false))
+								}
+							>
+								For this server
+							</Button>
+						)}
 						{issue.server_group_id && (
 							<Button
 								variant="outlined"
@@ -617,7 +641,7 @@ function EventLog({
 	serverId,
 }: {
 	issueId: string;
-	serverId: string;
+	serverId?: string;
 }) {
 	const [expanded, setExpanded] = useState(false);
 	const [page, setPage] = useState(0);
@@ -706,7 +730,7 @@ function EventLog({
 						<Box sx={{ minWidth: 0, overflow: "hidden" }}>
 							<MessageView message={e.message} />
 						</Box>
-						{open && (
+						{open && serverId && (
 							<StatusSnapshotPanel
 								serverId={serverId}
 								at={at}


### PR DESCRIPTION
🤖 Foundational PR for the **backup-credentials** system — Canopy issues short-lived, per-group S3 credentials to devices and owns kopia repository maintenance, so servers hold no long-lived bucket creds and a compromised device cannot destroy backups. This PR lands the plan plus the database layer that everything else builds on.

## The plan
`docs/plans/backup-credentials*` — the authoritative design doc, the eight component specs under `docs/plans/specs/`, the cross-repo implementation-order doc, and the kopia-behaviour verification spike. Components (2)–(5) land as stacked PRs on top of this.

## Component (1) — database layer
Backups are keyed `(server, type)`: one repo/bucket per group, shared by all the group's backup *types*.

- Migration `2026-06-12-090526-0000_backup_credentials` creating 10 tables: `server_group_backup_config` (repo-level), `backup_type_defaults`, `server_backup_capabilities`, `server_group_backup_schedule`, `backup_credential_issuances`, `backup_runs`, `backup_maintenance_runs`, `backup_repo_snapshots`, `backup_repo_stats`, `backup_requests`.
- FK behaviour: plain references, no cascade — groups and servers are archived (soft-deleted), never hard-deleted. Closed-set `CHECK (… IN …)` constraints; `jsonb_typeof = 'object'` on retention columns.
- Shared `commons-types::backup` enums (one definition across public-server, jobs, and the generated `api-types.ts`): `BackupPurpose`, `RunOutcome`, `MaintenanceKind`, `BackupConfigStatus` (closed, CHECK-backed) and an open `BackupType { TamanuPostgres, Custom(String) }`.
- `database::backups` models + helpers, re-exported from `lib.rs`. A duplicate client-minted `backup_runs.id` maps to `AppError::Conflict` so the endpoint can choose 409 vs idempotent 204. Retention JSONB is stored verbatim; the org floor is enforced in code.
- DB-layer tests (`crates/database/tests/backups.rs`) plus `commons-types` enum unit tests.

A separate `style: cargo fmt` commit normalises pre-existing formatting drift, kept out of the feature diff.

This is the base for the stacked component PRs: (2) public-server endpoints + AWS/kube on AppState, (3)/(4) control-plane jobs, (5) operator UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Part of TAM-6877.
