### PR TITLE
Reject /status pushes without a healthcheck array

### DIFF
--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -348,7 +348,7 @@
           }
         ],
         "requestBody": {
-          "description": "Status push. Empty body or JSON `null` are both treated as `{}` (all fields default).",
+          "description": "Status push. A `health` array is required (it may be empty); a body without it is rejected with 400.",
           "content": {
             "application/json": {
               "schema": {
@@ -1204,16 +1204,16 @@
           },
           {
             "type": "object",
+            "required": [
+              "health"
+            ],
             "properties": {
               "health": {
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": "array",
                 "items": {
                   "$ref": "#/components/schemas/HealthCheck"
                 },
-                "description": "Per-check breakdown. Each entry must include `check` (non-empty)\nand exactly one of `result` / `healthy`; arbitrary additional\nfields per check (latency, free disk %, certificate expiry,\netc.) are passed through verbatim and surfaced in the status\nsnapshot UI.\n\nEach check name seen — whatever its result — upserts into\n`healthcheck_severities` so operators can review and adjust the\nseverity assigned to its failures. Failed checks file (or keep\nactive) an issue at `(status, health/<check>)` using the\ncatalog's current severity for that check name; broken checks\nfile at `(status, health-broken/<check>)` at a fixed Warning."
+                "description": "Per-check breakdown. **Required** — a push without a `health`\narray is rejected with `400`. May be empty (`[]`) for a server\nthat genuinely runs no checks. Each entry must include `check`\n(non-empty) and exactly one of `result` / `healthy`; arbitrary\nadditional fields per check (latency, free disk %, certificate\nexpiry, etc.) are passed through verbatim and surfaced in the\nstatus snapshot UI.\n\nEach check name seen — whatever its result — upserts into\n`healthcheck_severities` so operators can review and adjust the\nseverity assigned to its failures. Failed checks file (or keep\nactive) an issue at `(status, health/<check>)` using the\ncatalog's current severity for that check name; broken checks\nfile at `(status, health-broken/<check>)` at a fixed Warning."
               },
               "healthy": {
                 "type": [

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -44,11 +44,13 @@ pub struct StatusPayload {
 	/// `docs/plans/healthcheck-severity-catalog.md`.
 	pub healthy: Option<bool>,
 
-	/// Per-check breakdown. Each entry must include `check` (non-empty)
-	/// and exactly one of `result` / `healthy`; arbitrary additional
-	/// fields per check (latency, free disk %, certificate expiry,
-	/// etc.) are passed through verbatim and surfaced in the status
-	/// snapshot UI.
+	/// Per-check breakdown. **Required** — a push without a `health`
+	/// array is rejected with `400`. May be empty (`[]`) for a server
+	/// that genuinely runs no checks. Each entry must include `check`
+	/// (non-empty) and exactly one of `result` / `healthy`; arbitrary
+	/// additional fields per check (latency, free disk %, certificate
+	/// expiry, etc.) are passed through verbatim and surfaced in the
+	/// status snapshot UI.
 	///
 	/// Each check name seen — whatever its result — upserts into
 	/// `healthcheck_severities` so operators can review and adjust the
@@ -56,7 +58,7 @@ pub struct StatusPayload {
 	/// active) an issue at `(status, health/<check>)` using the
 	/// catalog's current severity for that check name; broken checks
 	/// file at `(status, health-broken/<check>)` at a fixed Warning.
-	pub health: Option<Vec<HealthCheck>>,
+	pub health: Vec<HealthCheck>,
 
 	/// Free-form additional data (uptime, postgres version, timezone,
 	/// hostname, etc.). Stored verbatim in `statuses.extra` and
@@ -120,7 +122,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 	),
 	request_body(
 		content = StatusPayload,
-		description = "Status push. Empty body or JSON `null` are both treated as `{}` (all fields default).",
+		description = "Status push. A `health` array is required (it may be empty); a body without it is rejected with 400.",
 	),
 	responses(
 		(status = 200, body = Status),
@@ -443,9 +445,9 @@ fn split_health_from_extra(
 		Some(_) => return Err(AppError::BadRequest("`healthy` must be a boolean".into())),
 	};
 
-	let health_value = obj
-		.remove("health")
-		.unwrap_or(serde_json::Value::Array(Default::default()));
+	let health_value = obj.remove("health").ok_or_else(|| {
+		AppError::BadRequest("`health` array is required".into())
+	})?;
 	let health_arr = match health_value {
 		serde_json::Value::Array(a) => a,
 		_ => return Err(AppError::BadRequest("`health` must be an array".into())),

--- a/crates/public-server/tests/device_key_auth.rs
+++ b/crates/public-server/tests/device_key_auth.rs
@@ -251,7 +251,7 @@ async fn key_deactivation_works() {
 			let response_before = public
 				.post("/status/77777777-7777-7777-7777-777777777777")
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({"uptime": 3600}))
+				.json(&serde_json::json!({"uptime": 3600, "health": []}))
 				.await;
 			response_before.assert_status_ok();
 
@@ -360,7 +360,7 @@ async fn key_rotation_scenario() {
 			let response_initial = public
 				.post("/status/99999999-9999-9999-9999-999999999999")
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({"uptime": 1800}))
+				.json(&serde_json::json!({"uptime": 1800, "health": []}))
 				.await;
 			response_initial.assert_status_ok();
 
@@ -379,13 +379,13 @@ async fn key_rotation_scenario() {
 			let response = public
 				.post("/status/99999999-9999-9999-9999-999999999999")
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({"uptime": 3600}))
+				.json(&serde_json::json!({"uptime": 3600, "health": []}))
 				.await;
 			response.assert_status_ok();
 			let response = public
 				.post("/status/99999999-9999-9999-9999-999999999999")
 				.add_header("mtls-certificate", &new_cert)
-				.json(&serde_json::json!({"uptime": 5400}))
+				.json(&serde_json::json!({"uptime": 5400, "health": []}))
 				.await;
 			response.assert_status_ok();
 
@@ -406,7 +406,7 @@ async fn key_rotation_scenario() {
 			let response = public
 				.post("/status/99999999-9999-9999-9999-999999999999")
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({"uptime": 5400}))
+				.json(&serde_json::json!({"uptime": 5400, "health": []}))
 				.await;
 			response.assert_status_not_ok();
 
@@ -414,7 +414,7 @@ async fn key_rotation_scenario() {
 			let response = public
 				.post("/status/99999999-9999-9999-9999-999999999999")
 				.add_header("mtls-certificate", &new_cert)
-				.json(&serde_json::json!({"uptime": 5400}))
+				.json(&serde_json::json!({"uptime": 5400, "health": []}))
 				.await;
 			response.assert_status_ok();
 		},

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -142,7 +142,7 @@ async fn submit_status() {
 			let response = public
 				.post(&format!("/status/{}", server_id))
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({ "uptime": 3600 }))
+				.json(&serde_json::json!({ "uptime": 3600, "health": [] }))
 				.await;
 			response.assert_status_ok();
 			response.assert_header("content-type", "application/json");
@@ -208,7 +208,7 @@ async fn submit_status_with_geolocation() {
 			let response = public
 				.post(&format!("/status/{}", server_id))
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({ "uptime": 7200, "version": "2.8.1" }))
+				.json(&serde_json::json!({ "uptime": 7200, "version": "2.8.1", "health": [] }))
 				.await;
 			response.assert_status_ok();
 			response.assert_header("content-type", "application/json");
@@ -303,7 +303,7 @@ async fn submit_status_with_cloud() {
 			let response = public
 				.post(&format!("/status/{}", server_id))
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({ "uptime": 4800, "platform": "Linux" }))
+				.json(&serde_json::json!({ "uptime": 4800, "platform": "Linux", "health": [] }))
 				.await;
 			response.assert_status_ok();
 			response.assert_header("content-type", "application/json");
@@ -403,7 +403,7 @@ async fn submit_status_with_geolocation_and_cloud() {
 				.post(&format!("/status/{}", server_id))
 				.add_header("mtls-certificate", &cert)
 				.json(
-					&serde_json::json!({ "uptime": 10000, "version": "3.0.0", "timezone": "America/New_York" }),
+					&serde_json::json!({ "uptime": 10000, "version": "3.0.0", "timezone": "America/New_York", "health": [] }),
 				)
 				.await;
 			response.assert_status_ok();
@@ -563,7 +563,7 @@ async fn submit_status_legacy_no_healthy_field() {
 			let response = public
 				.post(&format!("/status/{}", server_id))
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({ "uptime": 100 }))
+				.json(&serde_json::json!({ "uptime": 100, "health": [] }))
 				.await;
 			response.assert_status_ok();
 
@@ -590,7 +590,7 @@ async fn submit_status_with_healthy_true_no_checks() {
 			let response = public
 				.post(&format!("/status/{}", server_id))
 				.add_header("mtls-certificate", &cert)
-				.json(&serde_json::json!({ "healthy": true }))
+				.json(&serde_json::json!({ "healthy": true, "health": [] }))
 				.await;
 			response.assert_status_ok();
 
@@ -616,6 +616,7 @@ async fn submit_status_with_healthy_false_persists() {
 				.json(&serde_json::json!({
 					"healthy": false,
 					"uptime": 42,
+					"health": [],
 				}))
 				.await;
 			response.assert_status_ok();
@@ -683,6 +684,34 @@ async fn submit_status_rejects_non_bool_healthy() {
 				.post(&format!("/status/{}", server_id))
 				.add_header("mtls-certificate", &cert)
 				.json(&serde_json::json!({ "healthy": "yes" }))
+				.await;
+			response.assert_status_bad_request();
+		},
+	)
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn submit_status_rejects_missing_health() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+
+			// A push that carries no `health` array at all is rejected
+			// outright — even though `healthy` and other fields are valid.
+			let response = public
+				.post(&format!("/status/{}", server_id))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "healthy": true, "uptime": 1 }))
+				.await;
+			response.assert_status_bad_request();
+
+			// An empty body (⇒ `{}`) is rejected for the same reason.
+			let response = public
+				.post(&format!("/status/{}", server_id))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({}))
 				.await;
 			response.assert_status_bad_request();
 		},
@@ -777,7 +806,7 @@ async fn submit_status_legacy_files_no_health_issues() {
 				&public,
 				&cert,
 				server_id,
-				serde_json::json!({ "uptime": 1 }),
+				serde_json::json!({ "uptime": 1, "health": [] }),
 			)
 			.await;
 
@@ -905,7 +934,7 @@ async fn submit_status_unhealthy_no_checks_files_nothing() {
 				&public,
 				&cert,
 				server_id,
-				serde_json::json!({ "healthy": false }),
+				serde_json::json!({ "healthy": false, "health": [] }),
 			)
 			.await;
 


### PR DESCRIPTION
🤖 The public-server `/status` endpoint previously treated a missing `health` field as an empty array, silently accepting status pushes that carried no healthcheck data. This makes the array required: a push without `health` is now rejected with `400`. An empty array (`[]`) is still accepted, for servers that genuinely run no checks.

This means that we stop bouncing status up/down when someone deploys the NEW status sender and forgets to stop the OLD one.