### PR TITLE
Sort skipped healthchecks last in check displays

### DIFF
--- a/private-web/e2e/health.spec.ts
+++ b/private-web/e2e/health.spec.ts
@@ -93,4 +93,42 @@ test.describe("server detail checks table", () => {
 		await expect(page.getByText("hint")).toBeVisible();
 		await expect(page.getByText("free_pct: 2")).toBeVisible();
 	});
+
+	test("sorts skipped checks last, after passing ones", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const server = await seedServer(sql, {
+			name: "skip-server",
+			kind: "central",
+		});
+		// Names are chosen so alphabetical order is the reverse of the
+		// expected result order: a discriminator proving the sort is by
+		// result, not by name.
+		await seedStatus(sql, {
+			serverId: server.id,
+			healthy: false,
+			health: [
+				{ check: "a-skips", result: "skipped" },
+				{ check: "m-passes", result: "passed" },
+				{ check: "z-fails", result: "failed" },
+			],
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		const failed = page.getByText("z-fails");
+		const passed = page.getByText("m-passes");
+		const skipped = page.getByText("a-skips");
+		await expect(failed).toBeVisible();
+		await expect(passed).toBeVisible();
+		await expect(skipped).toBeVisible();
+
+		const failedY = (await failed.boundingBox())!.y;
+		const passedY = (await passed.boundingBox())!.y;
+		const skippedY = (await skipped.boundingBox())!.y;
+		expect(failedY).toBeLessThan(passedY);
+		expect(passedY).toBeLessThan(skippedY);
+	});
 });

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -219,20 +219,21 @@ export const SEVERITY_INTENT: Record<Severity, string> = {
 /// `commons_types::status::CheckResult` (the source of truth) — the
 /// private API ships `health[]` as raw JSON, so this never appears in
 /// the generated schema. Also the UI display order: most to least
-/// urgent.
+/// urgent, with skipped checks sorted last (a skipped check ran no
+/// assertion, so it's the least interesting to surface).
 export type CheckResult =
 	| "failed"
 	| "warning"
 	| "broken"
-	| "skipped"
-	| "passed";
+	| "passed"
+	| "skipped";
 
 export const CHECK_RESULT_ORDER: CheckResult[] = [
 	"failed",
 	"warning",
 	"broken",
-	"skipped",
 	"passed",
+	"skipped",
 ];
 
 /// Normalise a raw `health[]` entry to its result. Mirror of the Rust


### PR DESCRIPTION
🤖 Sort the healthchecks so skipped ones appear at the end of the list.

`CHECK_RESULT_ORDER` drives the display sort in the server detail view's checks table (and the status snapshot, which shares the same ordering). Previously `skipped` sat between `broken` and `passed`; this moves it to the very end, since a skipped check ran no assertion and is the least interesting result to surface. Within each result group checks remain sorted alphabetically.

Added Playwright coverage in `health.spec.ts` that seeds failed/passed/skipped checks (with names whose alphabetical order is the reverse of the expected result order) and asserts the rendered vertical order is failed → passed → skipped.