### PR TITLE
ui(backups): native min= on retention inputs [TAM-6877]

### DIFF
--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -93,6 +93,19 @@ test.describe("backups zero-state + config", () => {
 		expect(rows).toHaveLength(0);
 	});
 
+	test("retention inputs carry the org minimum as a native min", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "min-attr-group" });
+		await page.goto(`/groups/${group.id}/backups/config`);
+		// The daily/weekly/monthly inputs set min= to the org floor so the
+		// stepper/native validation won't let the user go below it.
+		await expect(page.getByLabel("Daily")).toHaveAttribute("min", "7");
+		await expect(page.getByLabel("Weekly")).toHaveAttribute("min", "4");
+		await expect(page.getByLabel("Monthly")).toHaveAttribute("min", "6");
+	});
+
 	test("manual-only toggle persists a NULL interval", async ({ page, sql }) => {
 		const group = await seedServerGroup(sql, { name: "manual-group" });
 

--- a/private-web/src/routes/BackupConfig.tsx
+++ b/private-web/src/routes/BackupConfig.tsx
@@ -342,7 +342,7 @@ function RetentionField({
 			disabled={disabled}
 			error={below}
 			helperText={floor != null ? `≥ ${floor}` : undefined}
-			slotProps={{ htmlInput: { min: 0, step: 1 } }}
+			slotProps={{ htmlInput: { min: floor ?? 0, step: 1 } }}
 			sx={{ width: 110 }}
 		/>
 	);


### PR DESCRIPTION
🤖 Follow-up polish on the backup setup form's Retention section.

The daily/weekly/monthly retention fields already validated against the org minimums at submit time (submit stays disabled + a warning shows). This also sets the native HTML `min=` on each input — wired through the `RetentionField` component's existing per-field `floor` prop — so the number-stepper and browser validation refuse to go below 7/4/6 directly, rather than only catching it on submit.

Fields without a floor (latest/annual) keep their previous `min`.

Playwright coverage asserts the daily/weekly/monthly inputs carry `min` = 7/4/6.