### PR TITLE
feat(backups): Canopy-owned passphrases — passphrase mode + Secret creation [TAM-6877]

### DIFF
--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -231,7 +231,7 @@ where
 				db: database::init_to(&url),
 				ro_pool: None,
 				tailnet_directory: Some(directory),
-				kube: None,
+				kube: Some(public_server::state::BackupSecrets::memory()),
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/crates/commons-types/src/backup.rs
+++ b/crates/commons-types/src/backup.rs
@@ -137,11 +137,12 @@ text_enum! {
 
 text_enum! {
 	/// How a group's repo passphrase is sourced. Canopy owns every passphrase
-	/// Secret either way. `FromBirth` means Canopy generates the passphrase, then
-	/// the operator escrows it via the reveal-once flow (`escrow_pending`).
-	/// `Passphrase` means the operator supplies the passphrase (for a fresh repo
-	/// or to connect an existing one); Canopy stores it and skips escrow (straight
-	/// to `Ready`).
+	/// Secret either way. `FromBirth` means Canopy generates the passphrase for a
+	/// *new* repo, then the operator escrows it via the reveal-once flow
+	/// (`escrow_pending`). `Passphrase` means the operator supplies the passphrase
+	/// of an *existing* repo to connect to it; Canopy stores it and skips escrow
+	/// (straight to `Ready`). Canopy never lets the operator choose the passphrase
+	/// for a repo it creates — that is always from-birth.
 	pub enum BackupRepoMode {
 		FromBirth = "from_birth",
 		Passphrase = "passphrase",

--- a/crates/commons-types/src/backup.rs
+++ b/crates/commons-types/src/backup.rs
@@ -136,17 +136,18 @@ text_enum! {
 }
 
 text_enum! {
-	/// How a group's repo passphrase is sourced. `FromBirth` means Canopy
-	/// generates the passphrase + names the Secret (operator must escrow it →
-	/// the reveal-once flow); `Import` means the operator already holds the
-	/// passphrase and points `repo_password_ref` at a pre-existing Secret (skips
-	/// escrow, goes straight to `Ready`).
+	/// How a group's repo passphrase is sourced. Canopy owns every passphrase
+	/// Secret either way. `FromBirth` means Canopy generates the passphrase, then
+	/// the operator escrows it via the reveal-once flow (`escrow_pending`).
+	/// `Passphrase` means the operator supplies the passphrase (for a fresh repo
+	/// or to connect an existing one); Canopy stores it and skips escrow (straight
+	/// to `Ready`).
 	pub enum BackupRepoMode {
 		FromBirth = "from_birth",
-		Import = "import",
+		Passphrase = "passphrase",
 	}
 	default = FromBirth;
-	error BackupRepoModeFromStringError = "invalid backup repo mode; expected one of: from_birth, import";
+	error BackupRepoModeFromStringError = "invalid backup repo mode; expected one of: from_birth, passphrase";
 }
 
 text_enum! {

--- a/crates/jobs/src/backup/complete.rs
+++ b/crates/jobs/src/backup/complete.rs
@@ -36,8 +36,9 @@ pub(crate) async fn complete_maint(
 /// Advance a group's backup config after its init op finishes. On success the
 /// next status depends on how the passphrase is sourced: `from_birth` repos
 /// still need the operator to escrow the canopy-generated passphrase
-/// (`escrow_pending`), whereas `import` repos already hold it (`ready`). On
-/// failure we surface the error and leave the row in `provisioning`.
+/// (`escrow_pending`), whereas `passphrase` repos (operator-supplied) skip
+/// escrow and go straight to `ready`. On failure we surface the error and leave
+/// the row in `provisioning`.
 pub(crate) async fn complete_init(
 	db: &mut AsyncPgConnection,
 	group_id: Uuid,
@@ -51,7 +52,7 @@ pub(crate) async fn complete_init(
 			.map_err(|e| e.to_string())?;
 		let next = match config.mode {
 			BackupRepoMode::FromBirth => BackupConfigStatus::EscrowPending,
-			BackupRepoMode::Import => BackupConfigStatus::Ready,
+			BackupRepoMode::Passphrase => BackupConfigStatus::Ready,
 		};
 		ServerGroupBackupConfig::set_status(db, group_id, next)
 			.await

--- a/crates/jobs/src/backup/kopia.rs
+++ b/crates/jobs/src/backup/kopia.rs
@@ -395,37 +395,49 @@ async fn apply_policy(env: &KopiaEnv, target: &str, policy: &Policy) -> Result<(
 // Per-kind orchestration.
 // ===========================================================================
 
-/// Create (or connect to an existing) repo and set the canopy maintenance
-/// identity + global baseline policy.
+/// Initialise a group's repo and set the canopy maintenance identity + global
+/// baseline policy.
 ///
-/// `repository create` exits non-zero when the repo already exists; we fall back
-/// to connect and treat that as success.
+/// `create_new` is true for from-birth (Canopy generates the passphrase for a
+/// *new* repo): `repository create` runs, falling back to connect if the repo
+/// already exists (idempotent retry). It is false for passphrase mode (connect
+/// to an *existing* repo with the operator's passphrase): we **never** create —
+/// Canopy must not mint a repo under an operator-chosen passphrase, so a missing
+/// repo or wrong passphrase surfaces as an init failure.
 pub async fn run_init(
 	env: &KopiaEnv,
 	bucket: &str,
 	prefix: &str,
 	region: &str,
 	retention: &RetentionMap,
+	create_new: bool,
 ) -> Result<()> {
-	let create = run_kopia(
-		env,
-		&[
-			"repository",
-			"create",
-			"s3",
-			"--bucket",
-			bucket,
-			"--prefix",
-			prefix,
-			"--region",
-			region,
-		],
-	)
-	.await?;
-	if !create.status.success() {
-		connect(env, bucket, prefix, region)
-			.await
-			.context("repository create failed and connect fallback failed")?;
+	if create_new {
+		let create = run_kopia(
+			env,
+			&[
+				"repository",
+				"create",
+				"s3",
+				"--bucket",
+				bucket,
+				"--prefix",
+				prefix,
+				"--region",
+				region,
+			],
+		)
+		.await?;
+		if !create.status.success() {
+			connect(env, bucket, prefix, region)
+				.await
+				.context("repository create failed and connect fallback failed")?;
+		}
+	} else {
+		// Passphrase mode: connect to the existing repo only — never create.
+		connect(env, bucket, prefix, region).await.context(
+			"connect to existing repository failed (passphrase mode never creates a repo)",
+		)?;
 	}
 
 	// Connect with the fixed canopy identity (create leaves us connected, but be

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -18,7 +18,8 @@ use std::{collections::HashSet, time::Duration};
 
 use commons_servers::backup_jobs::{JobKind, effective_retention_for_group, is_due, slot_is_due};
 use database::{
-	BackupConfigStatus, BackupMaintenanceRun, MaintenanceKind, RunOutcome, ServerGroupBackupConfig,
+	BackupConfigStatus, BackupMaintenanceRun, BackupRepoMode, MaintenanceKind, RunOutcome,
+	ServerGroupBackupConfig,
 };
 use jiff::Timestamp;
 use tokio::{
@@ -158,7 +159,18 @@ async fn run_init_op(worker: &Worker, config: &ServerGroupBackupConfig) -> anyho
 			.map_err(|e| anyhow::anyhow!(e))?
 	};
 	let region = config.region.as_deref().unwrap_or_default();
-	kopia::run_init(&env, &config.bucket, &config.prefix, region, &retention).await
+	// from-birth creates the repo; passphrase mode connects to an existing one
+	// only (Canopy never creates a repo under an operator-chosen passphrase).
+	let create_new = matches!(config.mode, BackupRepoMode::FromBirth);
+	kopia::run_init(
+		&env,
+		&config.bucket,
+		&config.prefix,
+		region,
+		&retention,
+		create_new,
+	)
+	.await
 }
 
 /// Run a maintenance op in a spawned task: start the run row, read the password,

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -159,6 +159,9 @@ pub struct CreateBackupConfigArgs {
 	pub region: Option<String>,
 	#[schema(value_type = String)]
 	pub mode: BackupRepoMode,
+	/// Passphrase mode only: the operator-supplied repo passphrase Canopy stores.
+	/// From-birth ignores this (Canopy generates one).
+	pub passphrase: Option<String>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -331,10 +334,30 @@ pub async fn create(
 	let mut conn = state.db.get().await?;
 	ServerGroup::get_by_id(&mut conn, args.server_group_id).await?;
 
-	// Canopy owns the passphrase Secret for both modes; it's stored under a
-	// deterministic, group-keyed name.
+	let kube = state.kube.as_ref().ok_or_else(|| {
+		AppError::Upstream("secret store not configured; cannot create repo passphrase".into())
+	})?;
+
+	// Canopy owns the passphrase Secret for both modes: generate one for
+	// from-birth, take the operator's for passphrase mode.
+	let passphrase = match args.mode {
+		BackupRepoMode::FromBirth => generate_repo_passphrase(),
+		BackupRepoMode::Passphrase => {
+			let p = args.passphrase.clone().unwrap_or_default();
+			if p.is_empty() {
+				return Err(AppError::BadRequest(
+					"passphrase mode requires a passphrase".into(),
+				));
+			}
+			p
+		}
+	};
+
+	// Stored under a deterministic, group-keyed Secret name.
 	let repo_password_ref = format!("backup-repo-{}", args.server_group_id);
 
+	// Insert the config first (PK-guards a duplicate create → 409), then store
+	// the passphrase Secret Canopy owns.
 	let config = ServerGroupBackupConfig::insert(
 		&mut conn,
 		NewServerGroupBackupConfig {
@@ -344,13 +367,32 @@ pub async fn create(
 			target_role_arn: args.target_role_arn,
 			maintenance_role_arn: args.maintenance_role_arn,
 			region: args.region,
-			repo_password_ref,
+			repo_password_ref: repo_password_ref.clone(),
 			status: BackupConfigStatus::Provisioning,
 			mode: args.mode,
 		},
 	)
 	.await?;
+	kube.create_password(&repo_password_ref, REPO_PASSWORD_SECRET_KEY, &passphrase)
+		.await?;
+
 	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
+}
+
+/// Generate a strong from-birth repo passphrase: 8 words from the EFF large
+/// wordlist (~103 bits), hyphen-separated — high entropy but still transcribable
+/// for the operator to escrow (reveal-once → Bitwarden).
+fn generate_repo_passphrase() -> String {
+	use chbs::{config::BasicConfig, prelude::*, probability::Probability, word::WordList};
+
+	let config = BasicConfig {
+		words: 8,
+		word_provider: WordList::builtin_eff_large().sampler(),
+		separator: "-".into(),
+		capitalize_first: Probability::Never,
+		capitalize_words: Probability::Never,
+	};
+	config.to_scheme().generate()
 }
 
 /// Edit the non-structural config (region). Structural fields

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -159,10 +159,6 @@ pub struct CreateBackupConfigArgs {
 	pub region: Option<String>,
 	#[schema(value_type = String)]
 	pub mode: BackupRepoMode,
-	/// Import mode only: name of a pre-existing k8s Secret holding the
-	/// passphrase. From-birth leaves this None (Canopy generates + names it),
-	/// in which case a placeholder ref keyed on the group is recorded.
-	pub repo_password_ref: Option<String>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -335,18 +331,9 @@ pub async fn create(
 	let mut conn = state.db.get().await?;
 	ServerGroup::get_by_id(&mut conn, args.server_group_id).await?;
 
-	// Import mode must supply the existing Secret name. From-birth records a
-	// deterministic placeholder ref the init Job is expected to create.
-	let repo_password_ref = match args.mode {
-		BackupRepoMode::Import => args
-			.repo_password_ref
-			.clone()
-			.ok_or_else(|| AppError::BadRequest("import mode requires repo_password_ref".into()))?,
-		BackupRepoMode::FromBirth => args
-			.repo_password_ref
-			.clone()
-			.unwrap_or_else(|| format!("backup-repo-{}", args.server_group_id)),
-	};
+	// Canopy owns the passphrase Secret for both modes; it's stored under a
+	// deterministic, group-keyed name.
+	let repo_password_ref = format!("backup-repo-{}", args.server_group_id);
 
 	let config = ServerGroupBackupConfig::insert(
 		&mut conn,

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -44,7 +44,9 @@ impl AppState {
 			db: database::init_to(url),
 			ro_pool: None,
 			tailnet_directory: None,
-			kube: None,
+			// In-memory secret store so onboarding (Secret creation) + escrow
+			// reveal are exercised in tests without a cluster.
+			kube: Some(BackupSecrets::memory()),
 		})
 	}
 }

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -102,25 +102,6 @@ async fn create_missing_group_is_404() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn import_mode_requires_secret_ref() {
-	commons_tests::server::run(async |mut conn, _public, private| {
-		let group_id = seed_group(&mut conn).await;
-		let resp = private
-			.post("/api/backups/create")
-			.json(&serde_json::json!({
-				"server_group_id": group_id,
-				"bucket": "b",
-				"target_role_arn": "arn",
-				"maintenance_role_arn": "maint-arn",
-				"mode": "import",
-			}))
-			.await;
-		resp.assert_status_bad_request();
-	})
-	.await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn set_schedule_floor_rejected_and_accepted() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -1,8 +1,8 @@
 //! Endpoint tests for the operator-facing `/api/backups/*` fns.
 //!
-//! The kube client is `None` in the test harness, so `reveal_escrow` can only
-//! be exercised on its `409-when-not-escrow_pending` branch (which needs no
-//! Secret read). The escrow *ack* transition is covered directly.
+//! The test harness uses the in-memory backup Secret store, so onboarding
+//! (Canopy generating/storing the repo passphrase) and the escrow reveal are
+//! exercised end-to-end without a cluster.
 
 use commons_tests::diesel_async::SimpleAsyncConnection;
 use uuid::Uuid;
@@ -317,6 +317,78 @@ async fn reveal_escrow_409_when_not_escrow_pending() {
 			.json(&serde_json::json!({ "server_group_id": group_id }))
 			.await;
 		resp.assert_status_conflict();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn from_birth_create_generates_a_revealable_passphrase() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		private
+			.post("/api/backups/create")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "b",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint-arn",
+				"mode": "from_birth",
+			}))
+			.await
+			.assert_status_ok();
+
+		// Move to escrow_pending so reveal is allowed, then reveal the
+		// canopy-generated passphrase from the (in-memory) Secret store.
+		conn.batch_execute(&format!(
+			"UPDATE server_group_backup_config SET status = 'escrow_pending' WHERE group_id = '{group_id}';"
+		))
+		.await
+		.expect("escrow_pending");
+		let resp = private
+			.post("/api/backups/reveal_escrow")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert!(
+			!body["passphrase"].as_str().unwrap_or_default().is_empty(),
+			"a non-empty generated passphrase is revealed"
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn passphrase_mode_requires_a_passphrase() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		// No passphrase supplied → 400.
+		private
+			.post("/api/backups/create")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "b",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint-arn",
+				"mode": "passphrase",
+			}))
+			.await
+			.assert_status_bad_request();
+
+		// With a passphrase → created (skips escrow; provisioning until init).
+		let resp = private
+			.post("/api/backups/create")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "b",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint-arn",
+				"mode": "passphrase",
+				"passphrase": "an-existing-repo-passphrase",
+			}))
+			.await;
+		resp.assert_status_ok();
+		assert_eq!(resp.json::<serde_json::Value>()["mode"], "passphrase");
 	})
 	.await;
 }

--- a/crates/public-server/src/state.rs
+++ b/crates/public-server/src/state.rs
@@ -1,5 +1,7 @@
-#[cfg(feature = "ui")]
-use std::sync::Arc;
+use std::{
+	collections::BTreeMap,
+	sync::{Arc, Mutex},
+};
 
 use axum::extract::FromRef;
 use commons_errors::{AppError, Result};
@@ -8,66 +10,140 @@ use database::Db;
 #[cfg(feature = "ui")]
 use tera::Tera;
 
-/// Narrow wrapper over a [`kube::Client`] + the namespace to read from. The
-/// only operation it exposes is `get` on a single named Secret, pulling one
-/// key out — the minimal surface `GET /backup-target` needs. It never lists or
-/// mutates Secrets.
+/// Env var that forces the in-memory secret store (no cluster needed). Set by the
+/// e2e fixture so the create/reveal paths work against the real binary; tests use
+/// [`BackupSecrets::memory`] directly.
+const MEMORY_ENV: &str = "CANOPY_BACKUP_SECRETS_MEMORY";
+
+type MemoryStore = Arc<Mutex<BTreeMap<String, BTreeMap<String, String>>>>;
+
+/// Reader/writer for the per-group repo-password Secrets. The surface is
+/// deliberately narrow: read one key, create one Secret. Real deployments use
+/// `Kube` (a namespaced [`kube::Client`]); tests and the e2e binary use the
+/// in-memory `Memory` store so the create + escrow-reveal paths are exercised
+/// without a cluster. Shared by the public-server (`/backup-target`) and the
+/// private-server (escrow reveal + onboarding Secret creation).
 #[derive(Clone)]
-pub struct BackupSecrets {
-	client: kube::Client,
-	namespace: String,
+pub enum BackupSecrets {
+	Kube {
+		client: kube::Client,
+		namespace: String,
+	},
+	Memory(MemoryStore),
 }
 
 impl std::fmt::Debug for BackupSecrets {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("BackupSecrets")
-			.field("namespace", &self.namespace)
-			.finish_non_exhaustive()
+		match self {
+			Self::Kube { namespace, .. } => f
+				.debug_struct("BackupSecrets::Kube")
+				.field("namespace", namespace)
+				.finish_non_exhaustive(),
+			Self::Memory(_) => f.write_str("BackupSecrets::Memory"),
+		}
 	}
 }
 
 impl BackupSecrets {
 	pub fn new(client: kube::Client, namespace: String) -> Self {
-		Self { client, namespace }
+		Self::Kube { client, namespace }
 	}
 
-	/// Build a secret reader from the ambient cluster config (in-cluster the
-	/// pod's service account; locally `~/.kube/config`), reading from the
-	/// `POD_NAMESPACE` namespace (default `canopy`). Returns `None` (logged)
-	/// when no cluster config is available, so callers degrade to 502 rather
-	/// than failing startup. Shared by both the public-server (`/backup-target`)
-	/// and the private-server (admin escrow reveal).
+	/// An in-memory store for tests / the e2e binary.
+	pub fn memory() -> Self {
+		Self::Memory(Arc::new(Mutex::new(BTreeMap::new())))
+	}
+
+	/// Build a secret store from the ambient cluster config (in-cluster the pod's
+	/// service account; locally `~/.kube/config`), reading from the
+	/// `POD_NAMESPACE` namespace (default `canopy`). If `MEMORY_ENV` is set,
+	/// returns the in-memory store instead. Returns `None` (logged) when no
+	/// cluster config is available, so callers degrade to 502 rather than failing
+	/// startup.
 	pub async fn try_default() -> Option<Self> {
+		if std::env::var_os(MEMORY_ENV).is_some() {
+			tracing::warn!("{MEMORY_ENV} set; using in-memory backup Secret store");
+			return Some(Self::memory());
+		}
 		match kube::Client::try_default().await {
-			Ok(client) => Some(Self::new(client, namespace_from_env())),
+			Ok(client) => Some(Self::Kube {
+				client,
+				namespace: namespace_from_env(),
+			}),
 			Err(err) => {
-				tracing::warn!(error = ?err, "kube client unavailable; backup Secret reads will 502");
+				tracing::warn!(error = ?err, "kube client unavailable; backup Secret ops will 502");
 				None
 			}
 		}
 	}
 
-	/// Read one key out of the named Secret in the configured namespace. Maps
-	/// every failure (missing Secret, missing key, non-utf8, API error) to
-	/// [`AppError::Upstream`] so the handler returns 502 with a generic body.
+	/// Read one key out of the named Secret. Maps every failure (missing Secret,
+	/// missing key, non-utf8, API error) to [`AppError::Upstream`] so handlers
+	/// return 502 with a generic body.
 	pub async fn read_password(&self, secret_name: &str, key: &str) -> Result<String> {
-		use k8s_openapi::api::core::v1::Secret;
-		use kube::Api;
+		match self {
+			Self::Kube { client, namespace } => {
+				use k8s_openapi::api::core::v1::Secret;
+				use kube::Api;
 
-		let api: Api<Secret> = Api::namespaced(self.client.clone(), &self.namespace);
-		let secret = api
-			.get(secret_name)
-			.await
-			.map_err(|e| AppError::Upstream(format!("secret get failed: {e}")))?;
+				let api: Api<Secret> = Api::namespaced(client.clone(), namespace);
+				let secret = api
+					.get(secret_name)
+					.await
+					.map_err(|e| AppError::Upstream(format!("secret get failed: {e}")))?;
+				let data = secret
+					.data
+					.ok_or_else(|| AppError::Upstream("secret has no data".into()))?;
+				let bytes = data
+					.get(key)
+					.ok_or_else(|| AppError::Upstream(format!("secret has no key {key}")))?;
+				String::from_utf8(bytes.0.clone())
+					.map_err(|_| AppError::Upstream("secret value is not valid utf-8".into()))
+			}
+			Self::Memory(store) => store
+				.lock()
+				.unwrap()
+				.get(secret_name)
+				.and_then(|m| m.get(key))
+				.cloned()
+				.ok_or_else(|| AppError::Upstream(format!("secret get failed: {secret_name}"))),
+		}
+	}
 
-		let data = secret
-			.data
-			.ok_or_else(|| AppError::Upstream("secret has no data".into()))?;
-		let bytes = data
-			.get(key)
-			.ok_or_else(|| AppError::Upstream(format!("secret has no key {key}")))?;
-		String::from_utf8(bytes.0.clone())
-			.map_err(|_| AppError::Upstream("secret value is not valid utf-8".into()))
+	/// Create the named Secret holding `value` under `key`. Maps failures to
+	/// [`AppError::Upstream`]. Used by the private-server onboarding path (Canopy
+	/// owns the repo passphrase Secret for both modes).
+	pub async fn create_password(&self, secret_name: &str, key: &str, value: &str) -> Result<()> {
+		match self {
+			Self::Kube { client, namespace } => {
+				use k8s_openapi::api::core::v1::Secret;
+				use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+				use kube::{Api, api::PostParams};
+
+				let api: Api<Secret> = Api::namespaced(client.clone(), namespace);
+				let secret = Secret {
+					metadata: ObjectMeta {
+						name: Some(secret_name.to_string()),
+						..Default::default()
+					},
+					string_data: Some(BTreeMap::from([(key.to_string(), value.to_string())])),
+					..Default::default()
+				};
+				api.create(&PostParams::default(), &secret)
+					.await
+					.map_err(|e| AppError::Upstream(format!("secret create failed: {e}")))?;
+				Ok(())
+			}
+			Self::Memory(store) => {
+				store
+					.lock()
+					.unwrap()
+					.entry(secret_name.to_string())
+					.or_default()
+					.insert(key.to_string(), value.to_string());
+				Ok(())
+			}
+		}
 	}
 }
 

--- a/crates/public-server/tests/backup_secrets.rs
+++ b/crates/public-server/tests/backup_secrets.rs
@@ -1,0 +1,26 @@
+//! The in-memory [`BackupSecrets`] store backs onboarding Secret creation +
+//! escrow reveal in tests and the e2e binary, so cover its round-trip + the
+//! missing-secret error path here (the Kube variant needs a live cluster).
+
+use public_server::state::BackupSecrets;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn memory_store_round_trips_and_errors_on_missing() {
+	let store = BackupSecrets::memory();
+
+	store
+		.create_password("backup-repo-x", "password", "correct-horse")
+		.await
+		.expect("create");
+	assert_eq!(
+		store
+			.read_password("backup-repo-x", "password")
+			.await
+			.expect("read back"),
+		"correct-horse"
+	);
+
+	// Missing Secret and missing key both surface as errors (→ 502 in handlers).
+	assert!(store.read_password("missing", "password").await.is_err());
+	assert!(store.read_password("backup-repo-x", "nope").await.is_err());
+}

--- a/migrations/2026-06-20-035900-0000_change_backup_mode_to_passphrase/down.sql
+++ b/migrations/2026-06-20-035900-0000_change_backup_mode_to_passphrase/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE server_group_backup_config
+	DROP CONSTRAINT server_group_backup_config_mode_check,
+	ADD CONSTRAINT server_group_backup_config_mode_check
+		CHECK (mode IN ('from_birth', 'import'));

--- a/migrations/2026-06-20-035900-0000_change_backup_mode_to_passphrase/up.sql
+++ b/migrations/2026-06-20-035900-0000_change_backup_mode_to_passphrase/up.sql
@@ -1,0 +1,7 @@
+-- Canopy now owns every repo passphrase Secret: drop the import-an-existing-
+-- Secret mode in favour of `passphrase` (operator supplies the passphrase,
+-- Canopy stores it). No existing rows, so no data migration is needed.
+ALTER TABLE server_group_backup_config
+	DROP CONSTRAINT server_group_backup_config_mode_check,
+	ADD CONSTRAINT server_group_backup_config_mode_check
+		CHECK (mode IN ('from_birth', 'passphrase'));

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -80,6 +80,38 @@ test.describe("backups zero-state + config", () => {
 		expect(rows[0]!.retention.keep_daily).toBe(7);
 	});
 
+	test("passphrase mode requires a passphrase and persists mode", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "passphrase-group" });
+		await page.goto(`/groups/${group.id}/backups/config`);
+		await page.getByLabel("Bucket").fill("bes-kopia-existing");
+		await page.getByLabel("Target role ARN").fill("arn:aws:iam::999:role/dev");
+		await page
+			.getByLabel("Maintenance role ARN")
+			.fill("arn:aws:iam::999:role/maint");
+
+		// Switch to "Existing repository" (passphrase) mode.
+		await page.getByLabel("Repository mode").click();
+		await page
+			.getByRole("option", { name: /existing repository/i })
+			.click();
+
+		// The passphrase field is required: submit is blocked until it's filled.
+		await page
+			.getByLabel("Existing repository passphrase")
+			.fill("an-existing-repo-passphrase");
+		await page.getByRole("button", { name: /create & provision/i }).click();
+
+		await expect(page).toHaveURL(new RegExp(`/groups/${group.id}/backups$`));
+		const rows = await sql.query<{ mode: string }>(
+			`SELECT mode FROM server_group_backup_config WHERE group_id = $1`,
+			[group.id],
+		);
+		expect(rows[0]!.mode).toBe("passphrase");
+	});
+
 	test("retention floor violation blocks submit", async ({ page, sql }) => {
 		const group = await seedServerGroup(sql, { name: "floor-group" });
 

--- a/private-web/e2e/fixture.ts
+++ b/private-web/e2e/fixture.ts
@@ -187,6 +187,9 @@ export async function startStack(opts: StartOptions = {}): Promise<StackHandle> 
 				...process.env,
 				DATABASE_URL: databaseUrl,
 				BIND_ADDRESS: `127.0.0.1:${apiPort}`,
+				// No cluster in e2e: use the in-memory backup Secret store so
+				// onboarding (Secret creation) works against the real binary.
+				CANOPY_BACKUP_SECRETS_MEMORY: "1",
 				// Needed by mint_enrollment to build the ticket's api_url; the
 				// setup-instructions flow auto-mints on an unregistered server.
 				PUBLIC_URL: process.env.PUBLIC_URL ?? "https://api.e2e.invalid",

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -335,7 +335,7 @@ export async function seedVersion(
 // ── Backup-credentials seeding ──────────────────────────────────────────────
 
 export type BackupConfigStatus = "provisioning" | "escrow_pending" | "ready";
-export type BackupRepoMode = "from_birth" | "import";
+export type BackupRepoMode = "from_birth" | "passphrase";
 
 /** Seed a `server_group_backup_config` row for a group, optionally with a
  * `(group, tamanu-postgres)` schedule. */

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -5381,13 +5381,6 @@
               "null"
             ]
           },
-          "repo_password_ref": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Import mode only: name of a pre-existing k8s Secret holding the\npassphrase. From-birth leaves this None (Canopy generates + names it),\nin which case a placeholder ref keyed on the group is recorded."
-          },
           "server_group_id": {
             "type": "string",
             "format": "uuid"

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -5372,6 +5372,13 @@
           "mode": {
             "type": "string"
           },
+          "passphrase": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Passphrase mode only: the operator-supplied repo passphrase Canopy stores.\nFrom-birth ignores this (Canopy generates one)."
+          },
           "prefix": {
             "type": "string"
           },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2160,6 +2160,11 @@ export interface components {
              */
             maintenance_role_arn: string;
             mode: string;
+            /**
+             * @description Passphrase mode only: the operator-supplied repo passphrase Canopy stores.
+             *     From-birth ignores this (Canopy generates one).
+             */
+            passphrase?: string | null;
             prefix?: string;
             region?: string | null;
             /** Format: uuid */

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2162,12 +2162,6 @@ export interface components {
             mode: string;
             prefix?: string;
             region?: string | null;
-            /**
-             * @description Import mode only: name of a pre-existing k8s Secret holding the
-             *     passphrase. From-birth leaves this None (Canopy generates + names it),
-             *     in which case a placeholder ref keyed on the group is recorded.
-             */
-            repo_password_ref?: string | null;
             /** Format: uuid */
             server_group_id: string;
             /** @description Device role: public-server assumes this to mint device creds (no delete). */

--- a/private-web/src/routes/BackupConfig.tsx
+++ b/private-web/src/routes/BackupConfig.tsx
@@ -77,6 +77,7 @@ function ConfigForm({
 	const [mode, setMode] = useState<BackupRepoMode>(
 		(existing?.mode as BackupRepoMode) ?? "from_birth",
 	);
+	const [passphrase, setPassphrase] = useState("");
 	const [scheduled, setScheduled] = useState(
 		wellKnown ? wellKnown.expected_interval != null : true,
 	);
@@ -104,6 +105,7 @@ function ConfigForm({
 					maintenance_role_arn: maintenanceRoleArn,
 					region: region.trim() === "" ? null : region,
 					mode,
+					passphrase: mode === "passphrase" ? passphrase : null,
 				});
 			} else {
 				await update.call({
@@ -209,7 +211,7 @@ function ConfigForm({
 					disabled={pending || !isCreate}
 					helperText={
 						isCreate
-							? "From-birth: Canopy generates the passphrase (escrow flow). Passphrase: you supply it; Canopy stores it."
+							? "From birth: Canopy generates the passphrase for a new repo (escrow flow). Existing repository: connect by supplying its passphrase."
 							: "Mode is fixed after creation."
 					}
 				>
@@ -220,6 +222,18 @@ function ConfigForm({
 						{BACKUP_MODE_LABEL.passphrase}
 					</MenuItem>
 				</TextField>
+
+				{isCreate && mode === "passphrase" && (
+					<TextField
+						label="Existing repository passphrase"
+						type="password"
+						value={passphrase}
+						onChange={(e) => setPassphrase(e.target.value)}
+						disabled={pending}
+						required
+						helperText="Connect to an existing kopia repository by supplying its passphrase. New repositories use “From birth” (Canopy generates the passphrase)."
+					/>
+				)}
 
 				<Divider />
 

--- a/private-web/src/routes/BackupConfig.tsx
+++ b/private-web/src/routes/BackupConfig.tsx
@@ -77,7 +77,6 @@ function ConfigForm({
 	const [mode, setMode] = useState<BackupRepoMode>(
 		(existing?.mode as BackupRepoMode) ?? "from_birth",
 	);
-	const [secretRef, setSecretRef] = useState("");
 	const [scheduled, setScheduled] = useState(
 		wellKnown ? wellKnown.expected_interval != null : true,
 	);
@@ -105,8 +104,6 @@ function ConfigForm({
 					maintenance_role_arn: maintenanceRoleArn,
 					region: region.trim() === "" ? null : region,
 					mode,
-					repo_password_ref:
-						mode === "import" ? secretRef : null,
 				});
 			} else {
 				await update.call({
@@ -123,8 +120,8 @@ function ConfigForm({
 				retention,
 			});
 			if (isCreate) {
-				// From-birth flows straight into provisioning → escrow; import
-				// also kicks the init Job (which moves it to ready on connect).
+				// From-birth provisions → escrow; passphrase provisions → ready
+				// (no escrow). Either way this kicks repo init.
 				await createRepo.call({ server_group_id: groupId });
 			}
 			navigate(`/groups/${groupId}/backups`);
@@ -212,26 +209,17 @@ function ConfigForm({
 					disabled={pending || !isCreate}
 					helperText={
 						isCreate
-							? "From-birth: Canopy generates the passphrase (escrow flow). Import: you supply an existing Secret."
+							? "From-birth: Canopy generates the passphrase (escrow flow). Passphrase: you supply it; Canopy stores it."
 							: "Mode is fixed after creation."
 					}
 				>
 					<MenuItem value="from_birth">
 						{BACKUP_MODE_LABEL.from_birth}
 					</MenuItem>
-					<MenuItem value="import">{BACKUP_MODE_LABEL.import}</MenuItem>
+					<MenuItem value="passphrase">
+						{BACKUP_MODE_LABEL.passphrase}
+					</MenuItem>
 				</TextField>
-
-				{isCreate && mode === "import" && (
-					<TextField
-						label="Existing passphrase Secret name"
-						value={secretRef}
-						onChange={(e) => setSecretRef(e.target.value)}
-						disabled={pending}
-						required
-						helperText="k8s Secret holding the repo passphrase you already own."
-					/>
-				)}
 
 				<Divider />
 

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -368,7 +368,7 @@ export const BACKUP_STATUS_HELP: Record<BackupConfigStatus, string> = {
 
 export const BACKUP_MODE_LABEL: Record<BackupRepoMode, string> = {
 	from_birth: "From birth (Canopy generates the passphrase)",
-	passphrase: "Passphrase (you supply it; Canopy stores it)",
+	passphrase: "Existing repository (connect with its passphrase)",
 };
 
 /// Org-minimum retention floors, enforced server-side and mirrored client-side

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -150,7 +150,7 @@ export type ServerBackupCapabilityView = Solidify<
 // `mode`/`status` arrive as plain strings on the wire (the Rust enums use a
 // custom Text serializer, so utoipa emits `string`). Narrow them in the UI so
 // switch/label maps are exhaustive.
-export type BackupRepoMode = "from_birth" | "import";
+export type BackupRepoMode = "from_birth" | "passphrase";
 export type BackupConfigStatus = "provisioning" | "escrow_pending" | "ready";
 
 // ── Pagination wrapper ─────────────────────────────────────────────────────
@@ -368,7 +368,7 @@ export const BACKUP_STATUS_HELP: Record<BackupConfigStatus, string> = {
 
 export const BACKUP_MODE_LABEL: Record<BackupRepoMode, string> = {
 	from_birth: "From birth (Canopy generates the passphrase)",
-	import: "Import (operator-supplied passphrase)",
+	passphrase: "Passphrase (you supply it; Canopy stores it)",
 };
 
 /// Org-minimum retention floors, enforced server-side and mirrored client-side


### PR DESCRIPTION
🤖 Stacked on #233 (base = `backups-cred-model`). Canopy now owns every repo passphrase Secret.

## What changes

- **Drops the import-an-existing-Secret mode.** `BackupRepoMode` is now `from_birth` | `passphrase`; a migration swaps the `mode` CHECK. `from_birth` generates the passphrase (escrow flow); `passphrase` is for connecting to an **existing** repo by supplying *its* passphrase (Canopy never lets an operator choose the passphrase for a repo it creates).
- **Canopy creates the Secret on onboarding** — generating a strong 8-word passphrase for from-birth (closing a pre-existing gap where from-birth never actually created its Secret) and storing the operator-supplied one for passphrase mode.
- **`run_init` is mode-aware**: from-birth creates the repo; passphrase mode connects-only and never creates one.
- **Injectable secret store**: `BackupSecrets` becomes an enum (`Kube` | in-memory `Memory`, gated by `CANOPY_BACKUP_SECRETS_MEMORY`) with `create_password`, so onboarding + escrow reveal are exercised by tests and the e2e binary without a cluster.
- Form: the import Secret-name field is replaced by a passphrase field (shown for passphrase mode); the mode labels make clear passphrase = existing repository.

Covered by public-server, private-server, and Playwright tests.