### PR TITLE
feat(backups): probe-driven setup wizard + .storageconfig on init [TAM-6877]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,6 +4477,9 @@ name = "private-server"
 version = "6.6.6"
 dependencies = [
  "algae-cli",
+ "aws-config",
+ "aws-sdk-s3",
+ "aws-sdk-sts",
  "axum",
  "axum-client-ip",
  "axum-server-timing",

--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -232,6 +232,9 @@ where
 				ro_pool: None,
 				tailnet_directory: Some(directory),
 				kube: Some(public_server::state::BackupSecrets::memory()),
+				prober: private_server::backup_probe::BucketProber::fake(
+					private_server::backup_probe::ProbeState::Empty,
+				),
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/crates/jobs/src/backup.rs
+++ b/crates/jobs/src/backup.rs
@@ -23,3 +23,4 @@ pub mod maintenance;
 pub mod preflight;
 pub mod rotation;
 pub mod s3_metrics;
+pub mod storageconfig;

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -172,6 +172,20 @@ async fn run_init_op(worker: &Worker, config: &ServerGroupBackupConfig) -> anyho
 	)
 	.await?;
 
+	// Ensure the bucket's Intelligent-Tiering .storageconfig exists (pulumi
+	// normally writes it; create as a fallback, never overwrite). Best-effort —
+	// it only affects S3 tiering, not backup correctness.
+	if let Err(e) = super::storageconfig::ensure(
+		&config.maintenance_role_arn,
+		&config.bucket,
+		&config.prefix,
+		config.region.as_deref(),
+	)
+	.await
+	{
+		tracing::warn!(group = %config.group_id, ".storageconfig ensure failed (non-fatal): {e:#}");
+	}
+
 	// Import: Canopy never persists the operator's passphrase — immediately
 	// rotate it to a generated one (a Canopy import is a hard break for any
 	// existing consumers, which is intended).

--- a/crates/jobs/src/backup/storageconfig.rs
+++ b/crates/jobs/src/backup/storageconfig.rs
@@ -1,0 +1,78 @@
+//! Ensure the bucket's `.storageconfig` (kopia Intelligent-Tiering policy) exists.
+//!
+//! Pulumi normally writes `.storageconfig` at bucket creation; Canopy writes it
+//! as a **fallback** on repo init when it's absent, and **never overwrites** an
+//! existing one. Best-effort: a missing `.storageconfig` only affects S3 tiering,
+//! not backup correctness, so init logs + continues on failure.
+//!
+//! Schema mirrors ops (`pulumi/.../backup/kopia.ts`): data blobs (the `p`
+//! prefix) → Intelligent-Tiering; everything else → Standard so indexes stay in
+//! the frequent-access tier.
+
+use anyhow::{Context, Result};
+
+const STORAGECONFIG_JSON: &str = r#"{
+  "blobOptions": [
+    { "prefix": "p", "storageClass": "INTELLIGENT_TIERING" },
+    { "storageClass": "STANDARD" }
+  ]
+}
+"#;
+
+/// Create `<prefix>.storageconfig` if absent (assuming the maintenance role).
+/// Never overwrites an existing object.
+pub async fn ensure(
+	maintenance_role_arn: &str,
+	bucket: &str,
+	prefix: &str,
+	region: Option<&str>,
+) -> Result<()> {
+	let sdk = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+	let sts = aws_sdk_sts::Client::new(&sdk);
+	let assumed = sts
+		.assume_role()
+		.role_arn(maintenance_role_arn)
+		.role_session_name("canopy-storageconfig")
+		.send()
+		.await
+		.context("assume maintenance role")?;
+	let c = assumed
+		.credentials()
+		.context("AssumeRole returned no credentials")?;
+	let creds = aws_sdk_s3::config::Credentials::new(
+		c.access_key_id(),
+		c.secret_access_key(),
+		Some(c.session_token().to_string()),
+		None,
+		"canopy-storageconfig",
+	);
+	let mut b = aws_sdk_s3::config::Builder::from(&sdk).credentials_provider(creds);
+	if let Some(region) = region {
+		b = b.region(aws_sdk_s3::config::Region::new(region.to_string()));
+	}
+	let s3 = aws_sdk_s3::Client::from_conf(b.build());
+
+	let key = format!("{prefix}.storageconfig");
+	// Never overwrite an existing config.
+	if s3
+		.head_object()
+		.bucket(bucket)
+		.key(&key)
+		.send()
+		.await
+		.is_ok()
+	{
+		return Ok(());
+	}
+	s3.put_object()
+		.bucket(bucket)
+		.key(&key)
+		.body(aws_sdk_s3::primitives::ByteStream::from_static(
+			STORAGECONFIG_JSON.as_bytes(),
+		))
+		.content_type("application/json")
+		.send()
+		.await
+		.context("put .storageconfig")?;
+	Ok(())
+}

--- a/crates/private-server/Cargo.toml
+++ b/crates/private-server/Cargo.toml
@@ -11,6 +11,9 @@ authors = [
 ]
 
 [dependencies]
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
+aws-sdk-sts.workspace = true
 axum = { workspace = true, features = ["json", "macros"] }
 axum-client-ip = { version = "1.3.1", features = ["forwarded-header"] }
 axum-server-timing = "3.0.1"

--- a/crates/private-server/src/backup_probe.rs
+++ b/crates/private-server/src/backup_probe.rs
@@ -1,0 +1,192 @@
+//! Synchronous bucket probe for the setup wizard.
+//!
+//! Before a config is saved, the wizard assumes the group's **maintenance** role
+//! and inspects the target bucket/prefix so the operator gets immediate
+//! feedback: empty, an existing kopia repo, other (forgotten) content, or
+//! inaccessible. This is **inspect-only** (S3 `HeadObject`/`ListObjectsV2`) —
+//! private-server has no kopia binary, so a typed passphrase is verified later
+//! at init time (wrong passphrase → `last_init_error`), not here.
+//!
+//! `Aws` is the real prober; `Fake` is an injectable canned result for tests and
+//! the e2e binary (gated by `CANOPY_BACKUP_PROBER_FAKE`), mirroring
+//! [`commons_servers::backup_secrets::BackupSecrets`].
+
+use commons_errors::Result;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Env var that forces the fake prober (no AWS needed). Set by the e2e fixture.
+const FAKE_ENV: &str = "CANOPY_BACKUP_PROBER_FAKE";
+
+/// What the probe found at `bucket/prefix`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeState {
+	/// Nothing there (or only a `.storageconfig`) — safe to create from-birth.
+	Empty,
+	/// An existing kopia repo (`<prefix>kopia.repository` present) — import only.
+	KopiaRepo,
+	/// Non-kopia objects present — block; operator must clear it or pick another
+	/// prefix/bucket.
+	OtherContent,
+	/// Couldn't assume the role or list the bucket (creds/role/bucket/region).
+	Inaccessible,
+}
+
+/// Result of an inspect probe. `already_configured` is filled by the handler
+/// (a DB check), not the prober.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ProbeResult {
+	#[schema(value_type = String)]
+	pub state: ProbeState,
+	/// Present for `Inaccessible`: the assume/list failure, surfaced-ish.
+	pub error: Option<String>,
+	/// A few object keys, for the `OtherContent` warning.
+	pub object_sample: Vec<String>,
+}
+
+impl ProbeResult {
+	fn state(state: ProbeState) -> Self {
+		Self {
+			state,
+			error: None,
+			object_sample: Vec::new(),
+		}
+	}
+}
+
+/// Bucket prober. `Aws` assumes the role + inspects S3; `Fake` returns a canned
+/// result for tests / the e2e binary.
+#[derive(Clone)]
+pub enum BucketProber {
+	Aws(aws_config::SdkConfig),
+	Fake(ProbeState),
+}
+
+impl std::fmt::Debug for BucketProber {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Aws(_) => f.write_str("BucketProber::Aws"),
+			Self::Fake(s) => write!(f, "BucketProber::Fake({s:?})"),
+		}
+	}
+}
+
+impl BucketProber {
+	/// Build from the ambient AWS config, or the fake prober if `FAKE_ENV` is set.
+	pub async fn try_default() -> Self {
+		if std::env::var_os(FAKE_ENV).is_some() {
+			tracing::warn!("{FAKE_ENV} set; using fake bucket prober (always empty)");
+			return Self::Fake(ProbeState::Empty);
+		}
+		Self::Aws(aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await)
+	}
+
+	/// A fake prober returning `state` (for tests).
+	pub fn fake(state: ProbeState) -> Self {
+		Self::Fake(state)
+	}
+
+	/// Inspect `bucket/prefix` by assuming `maintenance_role_arn`. Never errors
+	/// out — an assume/list failure becomes `Inaccessible` with the message.
+	pub async fn probe(
+		&self,
+		bucket: &str,
+		prefix: &str,
+		region: Option<&str>,
+		maintenance_role_arn: &str,
+	) -> Result<ProbeResult> {
+		match self {
+			Self::Fake(state) => Ok(ProbeResult::state(*state)),
+			Self::Aws(sdk) => {
+				Ok(probe_aws(sdk, bucket, prefix, region, maintenance_role_arn).await)
+			}
+		}
+	}
+}
+
+async fn probe_aws(
+	sdk: &aws_config::SdkConfig,
+	bucket: &str,
+	prefix: &str,
+	region: Option<&str>,
+	role_arn: &str,
+) -> ProbeResult {
+	let inaccessible = |e: String| ProbeResult {
+		state: ProbeState::Inaccessible,
+		error: Some(e),
+		object_sample: Vec::new(),
+	};
+
+	// Assume the maintenance role (full read) for the inspect.
+	let sts = aws_sdk_sts::Client::new(sdk);
+	let assumed = match sts
+		.assume_role()
+		.role_arn(role_arn)
+		.role_session_name("canopy-probe")
+		.send()
+		.await
+	{
+		Ok(r) => r,
+		Err(e) => return inaccessible(format!("AssumeRole failed: {e}")),
+	};
+	let Some(creds) = assumed.credentials() else {
+		return inaccessible("AssumeRole returned no credentials".into());
+	};
+	let s3_creds = aws_sdk_s3::config::Credentials::new(
+		creds.access_key_id(),
+		creds.secret_access_key(),
+		Some(creds.session_token().to_string()),
+		None,
+		"canopy-probe",
+	);
+	let mut b = aws_sdk_s3::config::Builder::from(sdk).credentials_provider(s3_creds);
+	if let Some(region) = region {
+		b = b.region(aws_sdk_s3::config::Region::new(region.to_string()));
+	}
+	let s3 = aws_sdk_s3::Client::from_conf(b.build());
+
+	// An existing kopia repo writes its format blob at `<prefix>kopia.repository`.
+	let marker = format!("{prefix}kopia.repository");
+	if s3
+		.head_object()
+		.bucket(bucket)
+		.key(&marker)
+		.send()
+		.await
+		.is_ok()
+	{
+		return ProbeResult::state(ProbeState::KopiaRepo);
+	}
+
+	// List a few objects to distinguish empty (or `.storageconfig`-only) from
+	// other content.
+	let listed = match s3
+		.list_objects_v2()
+		.bucket(bucket)
+		.prefix(prefix)
+		.max_keys(20)
+		.send()
+		.await
+	{
+		Ok(o) => o,
+		Err(e) => return inaccessible(format!("ListObjectsV2 failed: {e}")),
+	};
+	let storageconfig = format!("{prefix}.storageconfig");
+	let other: Vec<String> = listed
+		.contents()
+		.iter()
+		.filter_map(|o| o.key().map(str::to_string))
+		.filter(|k| *k != storageconfig)
+		.collect();
+
+	if other.is_empty() {
+		ProbeResult::state(ProbeState::Empty)
+	} else {
+		ProbeResult {
+			state: ProbeState::OtherContent,
+			error: None,
+			object_sample: other.into_iter().take(5).collect(),
+		}
+	}
+}

--- a/crates/private-server/src/backup_probe.rs
+++ b/crates/private-server/src/backup_probe.rs
@@ -56,11 +56,13 @@ impl ProbeResult {
 }
 
 /// Bucket prober. `Aws` assumes the role + inspects S3; `Fake` returns a canned
-/// result for tests / the e2e binary.
+/// result for tests / the e2e binary. `Fake(Some(state))` is a fixed result
+/// (Rust unit tests); `Fake(None)` derives the state from the bucket name (e2e,
+/// so one binary can exercise every wizard branch — see [`fake_state_for`]).
 #[derive(Clone)]
 pub enum BucketProber {
 	Aws(aws_config::SdkConfig),
-	Fake(ProbeState),
+	Fake(Option<ProbeState>),
 }
 
 impl std::fmt::Debug for BucketProber {
@@ -73,18 +75,33 @@ impl std::fmt::Debug for BucketProber {
 }
 
 impl BucketProber {
-	/// Build from the ambient AWS config, or the fake prober if `FAKE_ENV` is set.
+	/// Build from the ambient AWS config, or the bucket-name-derived fake prober
+	/// if `FAKE_ENV` is set (for the e2e binary).
 	pub async fn try_default() -> Self {
 		if std::env::var_os(FAKE_ENV).is_some() {
-			tracing::warn!("{FAKE_ENV} set; using fake bucket prober (always empty)");
-			return Self::Fake(ProbeState::Empty);
+			// Debug-only (tests, e2e, local dev). The fake prober can't be
+			// constructed in release builds (attribute-`cfg`), so canned probe
+			// results can't be swapped in by accident in production — where they'd
+			// let onboarding write over a non-empty bucket.
+			#[cfg(debug_assertions)]
+			{
+				tracing::warn!("{FAKE_ENV} set; using fake bucket prober (state from bucket name)");
+				return Self::Fake(None);
+			}
+			#[cfg(not(debug_assertions))]
+			tracing::error!(
+				"{FAKE_ENV} is set but IGNORED: the fake bucket prober is debug-only and is never used in release builds"
+			);
 		}
 		Self::Aws(aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await)
 	}
 
-	/// A fake prober returning `state` (for tests).
+	/// A fake prober returning a fixed `state` (for Rust unit tests). **Debug-only**:
+	/// the constructor doesn't exist in release builds, so a canned prober can't be
+	/// swapped in in production.
+	#[cfg(debug_assertions)]
 	pub fn fake(state: ProbeState) -> Self {
-		Self::Fake(state)
+		Self::Fake(Some(state))
 	}
 
 	/// Inspect `bucket/prefix` by assuming `maintenance_role_arn`. Never errors
@@ -97,11 +114,26 @@ impl BucketProber {
 		maintenance_role_arn: &str,
 	) -> Result<ProbeResult> {
 		match self {
-			Self::Fake(state) => Ok(ProbeResult::state(*state)),
+			Self::Fake(Some(state)) => Ok(ProbeResult::state(*state)),
+			Self::Fake(None) => Ok(ProbeResult::state(fake_state_for(bucket))),
 			Self::Aws(sdk) => {
 				Ok(probe_aws(sdk, bucket, prefix, region, maintenance_role_arn).await)
 			}
 		}
+	}
+}
+
+/// Bucket-name → fake state, so the e2e suite can drive each wizard branch by
+/// naming its bucket (e.g. `…existing…` → an existing repo). Default: `Empty`.
+fn fake_state_for(bucket: &str) -> ProbeState {
+	if bucket.contains("existing") {
+		ProbeState::KopiaRepo
+	} else if bucket.contains("other") {
+		ProbeState::OtherContent
+	} else if bucket.contains("denied") {
+		ProbeState::Inaccessible
+	} else {
+		ProbeState::Empty
 	}
 }
 

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -42,6 +42,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(get))
 		.routes(routes!(list))
 		.routes(routes!(create))
+		.routes(routes!(probe))
 		.routes(routes!(update))
 		.routes(routes!(set_schedule))
 		.routes(routes!(create_repo))
@@ -359,6 +360,72 @@ pub async fn create(
 		.await?;
 
 	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct ProbeArgs {
+	pub bucket: String,
+	#[serde(default)]
+	pub prefix: String,
+	pub region: Option<String>,
+	/// Maintenance role to assume for the inspect (full read).
+	pub maintenance_role_arn: String,
+}
+
+/// Inspect-probe result for the wizard: what's at `bucket/prefix`, plus whether
+/// Canopy already has a config for it.
+#[derive(Serialize, ToSchema)]
+pub struct ProbeResponse {
+	#[schema(value_type = String)]
+	pub state: crate::backup_probe::ProbeState,
+	/// Present for `inaccessible`: the assume/list failure.
+	pub error: Option<String>,
+	/// A few keys, for the `other_content` warning.
+	pub object_sample: Vec<String>,
+	/// Group id if a config already exists for this exact bucket+prefix.
+	pub already_configured: Option<Uuid>,
+}
+
+/// Synchronous setup-wizard probe: assume the maintenance role and inspect the
+/// bucket/prefix (empty / kopia_repo / other_content / inaccessible), and report
+/// whether Canopy already has a config for it. Read-only; never mutates.
+#[utoipa::path(
+	post,
+	path = "/probe",
+	operation_id = "backups_probe",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = ProbeArgs,
+	responses((status = 200, body = ProbeResponse)),
+)]
+pub async fn probe(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<ProbeArgs>,
+) -> Result<Json<ProbeResponse>> {
+	let result = state
+		.prober
+		.probe(
+			&args.bucket,
+			&args.prefix,
+			args.region.as_deref(),
+			&args.maintenance_role_arn,
+		)
+		.await?;
+
+	let mut conn = state.db.get().await?;
+	let already_configured = ServerGroupBackupConfig::list(&mut conn)
+		.await?
+		.into_iter()
+		.find(|c| c.bucket == args.bucket && c.prefix == args.prefix)
+		.map(|c| c.group_id);
+
+	Ok(Json(ProbeResponse {
+		state: result.state,
+		error: result.error,
+		object_sample: result.object_sample,
+		already_configured,
+	}))
 }
 
 /// Edit the non-structural config (region). Structural fields

--- a/crates/private-server/src/lib.rs
+++ b/crates/private-server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backup_probe;
 pub mod fns;
 pub mod openapi;
 pub mod spa;

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -5,6 +5,8 @@ use commons_servers::tailnet_directory::{TailnetDirectory, TailnetDirectoryConfi
 use database::Db;
 use public_server::state::BackupSecrets;
 
+use crate::backup_probe::BucketProber;
+
 #[derive(Clone, Debug, FromRef)]
 pub struct AppState {
 	pub db: Db,
@@ -14,6 +16,9 @@ pub struct AppState {
 	/// them here). `None` in non-cluster runs ⇒ onboarding returns 502. Reuses
 	/// the public-server's `BackupSecrets` (kube or in-memory).
 	pub kube: Option<BackupSecrets>,
+	/// Bucket prober for the setup wizard (assume role + inspect S3). `Aws` in
+	/// prod; a `Fake` canned result in tests / the e2e binary.
+	pub prober: BucketProber,
 }
 
 impl AppState {
@@ -30,12 +35,14 @@ impl AppState {
 		};
 
 		let kube = BackupSecrets::try_default().await;
+		let prober = BucketProber::try_default().await;
 
 		Ok(Self {
 			db: database::init(),
 			ro_pool,
 			tailnet_directory,
 			kube,
+			prober,
 		})
 	}
 
@@ -51,6 +58,8 @@ impl AppState {
 			// In-memory secret store so onboarding (Secret creation) is exercised
 			// in tests without a cluster.
 			kube: Some(BackupSecrets::memory()),
+			// Fake prober (default empty) so the wizard probe works in tests.
+			prober: BucketProber::fake(crate::backup_probe::ProbeState::Empty),
 		})
 	}
 }

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -290,6 +290,54 @@ async fn passphrase_mode_requires_a_passphrase() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn probe_reports_state_and_already_configured() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+
+		// The test harness uses the fake prober (always Empty).
+		let resp = private
+			.post("/api/backups/probe")
+			.json(&serde_json::json!({
+				"bucket": "fresh",
+				"prefix": "",
+				"maintenance_role_arn": "maint",
+			}))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert_eq!(body["state"], "empty");
+		assert!(body["already_configured"].is_null());
+
+		// A config for this bucket+prefix → the probe reports its group.
+		private
+			.post("/api/backups/create")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "taken",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint-arn",
+				"mode": "from_birth",
+			}))
+			.await
+			.assert_status_ok();
+		let resp = private
+			.post("/api/backups/probe")
+			.json(&serde_json::json!({
+				"bucket": "taken",
+				"prefix": "",
+				"maintenance_role_arn": "maint",
+			}))
+			.await;
+		resp.assert_status_ok();
+		assert_eq!(
+			resp.json::<serde_json::Value>()["already_configured"],
+			group_id.to_string()
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn request_now_upserts_and_cancel_deletes() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		// Server in a group so we can read the pending request back via stats.

--- a/crates/private-server/tests/device_admin_endpoints.rs
+++ b/crates/private-server/tests/device_admin_endpoints.rs
@@ -37,6 +37,9 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 			ro_pool: None,
 			tailnet_directory: Some(directory),
 			kube: None,
+			prober: private_server::backup_probe::BucketProber::fake(
+				private_server::backup_probe::ProbeState::Empty,
+			),
 		})
 		.unwrap(),
 		ClientIpSource::RightmostForwarded,

--- a/crates/private-server/tests/tailnet_device_auth.rs
+++ b/crates/private-server/tests/tailnet_device_auth.rs
@@ -83,6 +83,9 @@ async fn unknown_tailnet_node_auto_creates_untrusted_then_403s_role_gate() {
 				ro_pool: None,
 				tailnet_directory: Some(directory),
 				kube: None,
+				prober: private_server::backup_probe::BucketProber::fake(
+					private_server::backup_probe::ProbeState::Empty,
+				),
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -36,7 +36,22 @@ test.describe("backups zero-state + config", () => {
 		await expect(page.getByText(/backups not set up/i)).toBeVisible();
 	});
 
-	test("create writes config row with interval, retention and provisioning status", async ({
+	// Walk the wizard's step 0 (target) → step 2 (schedule) for an empty bucket
+	// (the fake prober reports `empty` for buckets without a marker). Leaves the
+	// page on the schedule/retention step.
+	async function emptyBucketToSchedule(
+		page: import("@playwright/test").Page,
+		bucket = "bes-empty",
+	) {
+		await page.getByLabel("Bucket").fill(bucket);
+		await page.getByLabel("Target role ARN").fill("arn");
+		await page.getByLabel("Maintenance role ARN").fill("maint-arn");
+		await page.getByRole("button", { name: /check bucket/i }).click();
+		await expect(page.getByText(/empty bucket/i)).toBeVisible();
+		await page.getByRole("button", { name: /^continue$/i }).click();
+	}
+
+	test("wizard create (empty bucket) writes a from-birth config row", async ({
 		page,
 		sql,
 	}) => {
@@ -50,7 +65,10 @@ test.describe("backups zero-state + config", () => {
 		await page
 			.getByLabel("Maintenance role ARN")
 			.fill("arn:aws:iam::999:role/created-maint");
-		// Default schedule is on at 60 minutes; default retention meets floors.
+		await page.getByRole("button", { name: /check bucket/i }).click();
+		await expect(page.getByText(/empty bucket/i)).toBeVisible();
+		await page.getByRole("button", { name: /^continue$/i }).click();
+		// Step 2: defaults (schedule on at 60m, retention meets floors).
 		await page.getByRole("button", { name: /create & provision/i }).click();
 
 		await expect(page).toHaveURL(new RegExp(`/groups/${group.id}/backups$`));
@@ -58,11 +76,12 @@ test.describe("backups zero-state + config", () => {
 		const rows = await sql.query<{
 			status: string;
 			bucket: string;
+			mode: string;
 			maintenance_role_arn: string;
 			secs: string | null;
 			retention: { keep_daily: number };
 		}>(
-			`SELECT c.status, c.bucket, c.maintenance_role_arn,
+			`SELECT c.status, c.bucket, c.mode, c.maintenance_role_arn,
 			        EXTRACT(EPOCH FROM s.expected_interval)::text AS secs,
 			        s.retention
 			 FROM server_group_backup_config c
@@ -72,7 +91,7 @@ test.describe("backups zero-state + config", () => {
 		);
 		expect(rows).toHaveLength(1);
 		expect(rows[0]!.status).toBe("provisioning");
-		expect(rows[0]!.bucket).toBe("bes-kopia-created");
+		expect(rows[0]!.mode).toBe("from_birth");
 		expect(rows[0]!.maintenance_role_arn).toBe(
 			"arn:aws:iam::999:role/created-maint",
 		);
@@ -80,28 +99,29 @@ test.describe("backups zero-state + config", () => {
 		expect(rows[0]!.retention.keep_daily).toBe(7);
 	});
 
-	test("passphrase mode requires a passphrase and persists mode", async ({
+	test("wizard create (existing repo) requires a passphrase and persists passphrase mode", async ({
 		page,
 		sql,
 	}) => {
 		const group = await seedServerGroup(sql, { name: "passphrase-group" });
 		await page.goto(`/groups/${group.id}/backups/config`);
-		await page.getByLabel("Bucket").fill("bes-kopia-existing");
+		// `…existing…` → the fake prober reports an existing kopia repo.
+		await page.getByLabel("Bucket").fill("bes-existing-repo");
 		await page.getByLabel("Target role ARN").fill("arn:aws:iam::999:role/dev");
 		await page
 			.getByLabel("Maintenance role ARN")
 			.fill("arn:aws:iam::999:role/maint");
+		await page.getByRole("button", { name: /check bucket/i }).click();
 
-		// Switch to "Existing repository" (passphrase) mode.
-		await page.getByLabel("Repository mode").click();
-		await page
-			.getByRole("option", { name: /existing repository/i })
-			.click();
-
-		// The passphrase field is required: submit is blocked until it's filled.
+		await expect(page.getByText(/existing kopia repository/i)).toBeVisible();
+		// Continue is gated on the passphrase.
+		await expect(
+			page.getByRole("button", { name: /^continue$/i }),
+		).toBeDisabled();
 		await page
 			.getByLabel("Existing repository passphrase")
 			.fill("an-existing-repo-passphrase");
+		await page.getByRole("button", { name: /^continue$/i }).click();
 		await page.getByRole("button", { name: /create & provision/i }).click();
 
 		await expect(page).toHaveURL(new RegExp(`/groups/${group.id}/backups$`));
@@ -112,12 +132,27 @@ test.describe("backups zero-state + config", () => {
 		expect(rows[0]!.mode).toBe("passphrase");
 	});
 
+	test("wizard blocks other (non-kopia) content", async ({ page, sql }) => {
+		const group = await seedServerGroup(sql, { name: "other-group" });
+		await page.goto(`/groups/${group.id}/backups/config`);
+		// `…other…` → the fake prober reports non-kopia content.
+		await page.getByLabel("Bucket").fill("bes-other-stuff");
+		await page.getByLabel("Target role ARN").fill("arn");
+		await page.getByLabel("Maintenance role ARN").fill("maint-arn");
+		await page.getByRole("button", { name: /check bucket/i }).click();
+
+		await expect(page.getByText(/other \(non-kopia\) content/i)).toBeVisible();
+		// No proceeding: Continue is disabled, Re-check is offered.
+		await expect(
+			page.getByRole("button", { name: /^continue$/i }),
+		).toBeDisabled();
+		await expect(page.getByRole("button", { name: /re-check/i })).toBeVisible();
+	});
+
 	test("retention floor violation blocks submit", async ({ page, sql }) => {
 		const group = await seedServerGroup(sql, { name: "floor-group" });
-
 		await page.goto(`/groups/${group.id}/backups/config`);
-		await page.getByLabel("Bucket").fill("b");
-		await page.getByLabel("Target role ARN").fill("arn");
+		await emptyBucketToSchedule(page);
 		await page.getByLabel("Daily").fill("2"); // below floor of 7
 
 		const submit = page.getByRole("button", { name: /create & provision/i });
@@ -138,8 +173,8 @@ test.describe("backups zero-state + config", () => {
 	}) => {
 		const group = await seedServerGroup(sql, { name: "min-attr-group" });
 		await page.goto(`/groups/${group.id}/backups/config`);
-		// The daily/weekly/monthly inputs set min= to the org floor so the
-		// stepper/native validation won't let the user go below it.
+		await emptyBucketToSchedule(page);
+		// The daily/weekly/monthly inputs set min= to the org floor.
 		await expect(page.getByLabel("Daily")).toHaveAttribute("min", "7");
 		await expect(page.getByLabel("Weekly")).toHaveAttribute("min", "4");
 		await expect(page.getByLabel("Monthly")).toHaveAttribute("min", "6");
@@ -147,13 +182,9 @@ test.describe("backups zero-state + config", () => {
 
 	test("manual-only toggle persists a NULL interval", async ({ page, sql }) => {
 		const group = await seedServerGroup(sql, { name: "manual-group" });
-
 		await page.goto(`/groups/${group.id}/backups/config`);
-		await page.getByLabel("Bucket").fill("b");
-		await page.getByLabel("Target role ARN").fill("arn");
-		await page.getByLabel("Maintenance role ARN").fill("maint-arn");
-		// Toggle the schedule switch off → manual only. MUI Switch exposes a
-		// checkbox role; click the "Scheduled" label to flip it.
+		await emptyBucketToSchedule(page);
+		// Toggle the schedule switch off → manual only.
 		await page.getByText("Scheduled", { exact: true }).click();
 		await page.getByRole("button", { name: /create & provision/i }).click();
 

--- a/private-web/e2e/fixture.ts
+++ b/private-web/e2e/fixture.ts
@@ -190,6 +190,10 @@ export async function startStack(opts: StartOptions = {}): Promise<StackHandle> 
 				// No cluster in e2e: use the in-memory backup Secret store so
 				// onboarding (Secret creation) works against the real binary.
 				CANOPY_BACKUP_SECRETS_MEMORY: "1",
+				// No AWS in e2e: fake bucket prober — wizard state is derived from
+				// the bucket name (…existing… → kopia repo, …other… → other content,
+				// …denied… → inaccessible, else empty).
+				CANOPY_BACKUP_PROBER_FAKE: "1",
 				// Needed by mint_enrollment to build the ticket's api_url; the
 				// setup-instructions flow auto-mints on an unregistered server.
 				PUBLIC_URL: process.env.PUBLIC_URL ?? "https://api.e2e.invalid",

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -476,6 +476,42 @@
         ]
       }
     },
+    "/api/backups/probe": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Synchronous setup-wizard probe: assume the maintenance role and inspect the\nbucket/prefix (empty / kopia_repo / other_content / inaccessible), and report\nwhether Canopy already has a config for it. Read-only; never mutates.",
+        "operationId": "backups_probe",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProbeArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProbeResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/backups/request_now": {
       "post": {
         "tags": [
@@ -7248,6 +7284,66 @@
             "format": "uuid"
           },
           "type": {
+            "type": "string"
+          }
+        }
+      },
+      "ProbeArgs": {
+        "type": "object",
+        "required": [
+          "bucket",
+          "maintenance_role_arn"
+        ],
+        "properties": {
+          "bucket": {
+            "type": "string"
+          },
+          "maintenance_role_arn": {
+            "type": "string",
+            "description": "Maintenance role to assume for the inspect (full read)."
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "region": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ProbeResponse": {
+        "type": "object",
+        "description": "Inspect-probe result for the wizard: what's at `bucket/prefix`, plus whether\nCanopy already has a config for it.",
+        "required": [
+          "state",
+          "object_sample"
+        ],
+        "properties": {
+          "already_configured": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Group id if a config already exists for this exact bucket+prefix."
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Present for `inaccessible`: the assume/list failure."
+          },
+          "object_sample": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A few keys, for the `other_content` warning."
+          },
+          "state": {
             "type": "string"
           }
         }

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -187,6 +187,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/backups/probe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Synchronous setup-wizard probe: assume the maintenance role and inspect the
+         *     bucket/prefix (empty / kopia_repo / other_content / inaccessible), and report
+         *     whether Canopy already has a config for it. Read-only; never mutates.
+         */
+        post: operations["backups_probe"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/backups/request_now": {
         parameters: {
             query?: never;
@@ -2875,6 +2896,29 @@ export interface components {
             server_id: string;
             type: string;
         };
+        ProbeArgs: {
+            bucket: string;
+            /** @description Maintenance role to assume for the inspect (full read). */
+            maintenance_role_arn: string;
+            prefix?: string;
+            region?: string | null;
+        };
+        /**
+         * @description Inspect-probe result for the wizard: what's at `bucket/prefix`, plus whether
+         *     Canopy already has a config for it.
+         */
+        ProbeResponse: {
+            /**
+             * Format: uuid
+             * @description Group id if a config already exists for this exact bucket+prefix.
+             */
+            already_configured?: string | null;
+            /** @description Present for `inaccessible`: the assume/list failure. */
+            error?: string | null;
+            /** @description A few keys, for the `other_content` warning. */
+            object_sample: string[];
+            state: string;
+        };
         /**
          * @description Wire-shape mirror of [`problem_details::ProblemDetails`] for OpenAPI.
          *
@@ -3856,6 +3900,29 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BackupConfigSummary"][];
+                };
+            };
+        };
+    };
+    backups_probe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProbeArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProbeResponse"];
                 };
             };
         };

--- a/private-web/src/routes/BackupConfig.tsx
+++ b/private-web/src/routes/BackupConfig.tsx
@@ -4,19 +4,21 @@ import {
 	Divider,
 	FormControlLabel,
 	LinearProgress,
-	MenuItem,
+	Link as MuiLink,
 	Paper,
 	Stack,
+	Step,
+	StepLabel,
+	Stepper,
 	Switch,
 	TextField,
 	Typography,
 } from "@mui/material";
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
 import {
-	BACKUP_MODE_LABEL,
 	RETENTION_FLOORS,
 	type BackupConfigView,
 	type BackupRepoMode,
@@ -31,12 +33,23 @@ const DEFAULT_RETENTION: RetentionPolicy = {
 	keep_annual: 0,
 };
 
+/// Most buckets live here, so default the region to it.
+const DEFAULT_REGION = "ap-southeast-2";
 const WELL_KNOWN_TYPE = "tamanu-postgres";
 
-/// Onboarding (create) / edit form for a group's backup config. Structural
-/// fields (bucket, role, mode) are create-only; in edit mode they're shown
-/// disabled. Interval + retention are persisted per-(group,type) via
-/// `set_schedule` after the config row exists.
+/// Probe response shape (wire type is generated; this is the UI-facing subset).
+type ProbeResult = {
+	state: "empty" | "kopia_repo" | "other_content" | "inaccessible";
+	error: string | null;
+	object_sample: string[];
+	already_configured: string | null;
+};
+
+/// Onboarding (create) / edit form for a group's backup config. Create is a
+/// probe-driven wizard: enter the bucket + roles, Canopy inspects it, and the
+/// repo mode is derived from what's there (empty → from-birth; existing kopia
+/// repo → import by passphrase; other content / inaccessible → blocked). Edit is
+/// a flat form (structural fields are create-only).
 export default function BackupConfig() {
 	const { id = "" } = useParams<{ id: string }>();
 	const existing = useApi("backups", "get", { server_group_id: id }, [id]);
@@ -64,6 +77,7 @@ function ConfigForm({
 	const update = useApiAction("backups", "update");
 	const setSchedule = useApiAction("backups", "set_schedule");
 	const createRepo = useApiAction("backups", "create_repo");
+	const probeAction = useApiAction("backups", "probe");
 
 	const wellKnown = existing?.schedules.find((s) => s.type === WELL_KNOWN_TYPE);
 
@@ -73,10 +87,7 @@ function ConfigForm({
 	const [maintenanceRoleArn, setMaintenanceRoleArn] = useState(
 		existing?.maintenance_role_arn ?? "",
 	);
-	const [region, setRegion] = useState(existing?.region ?? "");
-	const [mode, setMode] = useState<BackupRepoMode>(
-		(existing?.mode as BackupRepoMode) ?? "from_birth",
-	);
+	const [region, setRegion] = useState(existing?.region ?? DEFAULT_REGION);
 	const [passphrase, setPassphrase] = useState("");
 	const [scheduled, setScheduled] = useState(
 		wellKnown ? wellKnown.expected_interval != null : true,
@@ -89,12 +100,43 @@ function ConfigForm({
 	const initialRetention = wellKnown?.retention ?? DEFAULT_RETENTION;
 	const [retention, setRetention] = useState<RetentionPolicy>(initialRetention);
 
+	// Wizard state (create only).
+	const [step, setStep] = useState(0);
+	const [probe, setProbe] = useState<ProbeResult | null>(null);
+
 	const floorErrors = retentionFloorErrors(retention);
 	const hasFloorError = floorErrors.length > 0;
 
-	const onSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
-		if (hasFloorError) return;
+	// Probe-derived repo mode: an existing kopia repo is imported by passphrase;
+	// an empty bucket is created from-birth. (Canopy never lets the operator pick
+	// the passphrase for a repo it creates.)
+	const mode: BackupRepoMode =
+		probe?.state === "kopia_repo" ? "passphrase" : "from_birth";
+
+	const pending =
+		create.pending ||
+		update.pending ||
+		setSchedule.pending ||
+		createRepo.pending;
+	const error =
+		create.error || update.error || setSchedule.error || createRepo.error;
+
+	const runProbe = async () => {
+		try {
+			const result = (await probeAction.call({
+				bucket,
+				prefix,
+				region: region.trim() === "" ? null : region,
+				maintenance_role_arn: maintenanceRoleArn,
+			})) as ProbeResult;
+			setProbe(result);
+			setStep(1);
+		} catch {
+			/* surfaced via probeAction.error */
+		}
+	};
+
+	const persist = async () => {
 		try {
 			if (isCreate) {
 				await create.call({
@@ -122,8 +164,6 @@ function ConfigForm({
 				retention,
 			});
 			if (isCreate) {
-				// Kick repo init (provisioning → ready). Canopy owns + rotates the
-				// passphrase, so there's no escrow step either way.
 				await createRepo.call({ server_group_id: groupId });
 			}
 			navigate(`/groups/${groupId}/backups`);
@@ -132,209 +172,349 @@ function ConfigForm({
 		}
 	};
 
-	const pending =
-		create.pending ||
-		update.pending ||
-		setSchedule.pending ||
-		createRepo.pending;
-	const error =
-		create.error || update.error || setSchedule.error || createRepo.error;
+	const scheduleAndRetention = (
+		<>
+			<Typography variant="subtitle1">Schedule</Typography>
+			<FormControlLabel
+				control={
+					<Switch
+						checked={scheduled}
+						onChange={(e) => setScheduled(e.target.checked)}
+						disabled={pending}
+					/>
+				}
+				label={scheduled ? "Scheduled" : "Manual only (no schedule)"}
+			/>
+			{scheduled && (
+				<TextField
+					label="Back up every (minutes)"
+					type="number"
+					value={intervalMinutes}
+					onChange={(e) => setIntervalMinutes(e.target.value)}
+					disabled={pending}
+					slotProps={{ htmlInput: { min: 1, step: 1 } }}
+					sx={{ width: 220 }}
+				/>
+			)}
+
+			<Divider />
+
+			<Typography variant="subtitle1">Retention</Typography>
+			<Typography variant="caption" color="text.secondary">
+				kopia keep-* policy. Org minimums: keep_daily ≥{" "}
+				{RETENTION_FLOORS.keep_daily}, keep_weekly ≥{" "}
+				{RETENTION_FLOORS.keep_weekly}, keep_monthly ≥{" "}
+				{RETENTION_FLOORS.keep_monthly}.
+			</Typography>
+			<Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+				<RetentionField
+					label="Latest"
+					value={retention.keep_latest}
+					onChange={(v) => setRetention({ ...retention, keep_latest: v })}
+					disabled={pending}
+				/>
+				<RetentionField
+					label="Daily"
+					value={retention.keep_daily}
+					onChange={(v) => setRetention({ ...retention, keep_daily: v })}
+					disabled={pending}
+					floor={RETENTION_FLOORS.keep_daily}
+				/>
+				<RetentionField
+					label="Weekly"
+					value={retention.keep_weekly}
+					onChange={(v) => setRetention({ ...retention, keep_weekly: v })}
+					disabled={pending}
+					floor={RETENTION_FLOORS.keep_weekly}
+				/>
+				<RetentionField
+					label="Monthly"
+					value={retention.keep_monthly}
+					onChange={(v) => setRetention({ ...retention, keep_monthly: v })}
+					disabled={pending}
+					floor={RETENTION_FLOORS.keep_monthly}
+				/>
+				<RetentionField
+					label="Annual"
+					value={retention.keep_annual}
+					onChange={(v) => setRetention({ ...retention, keep_annual: v })}
+					disabled={pending}
+				/>
+			</Stack>
+			{hasFloorError && (
+				<Alert severity="warning">{floorErrors.join("; ")}</Alert>
+			)}
+		</>
+	);
+
+	// ── Edit mode: flat form (structural fields are create-only) ───────────────
+	if (!isCreate) {
+		return (
+			<Paper variant="outlined" sx={{ p: 3 }}>
+				<Stack spacing={2}>
+					<Typography variant="h5" component="h1">
+						Edit backup config
+					</Typography>
+					<TextField label="Bucket" value={bucket} disabled />
+					<TextField label="Target role ARN" value={roleArn} disabled />
+					<TextField
+						label="Maintenance role ARN"
+						value={maintenanceRoleArn}
+						disabled
+					/>
+					<TextField
+						label="Region"
+						value={region}
+						onChange={(e) => setRegion(e.target.value)}
+						disabled={pending}
+						helperText="Changing region typically implies a different bucket — change with care."
+					/>
+					<Divider />
+					{scheduleAndRetention}
+					{error && <Alert severity="error">{error.message}</Alert>}
+					<Stack direction="row" spacing={1}>
+						<Button
+							variant="contained"
+							onClick={persist}
+							disabled={pending || hasFloorError}
+						>
+							{pending ? "Saving…" : "Save"}
+						</Button>
+						<Button
+							variant="outlined"
+							color="error"
+							onClick={() => navigate(`/groups/${groupId}/backups`)}
+							disabled={pending}
+						>
+							Cancel
+						</Button>
+					</Stack>
+				</Stack>
+			</Paper>
+		);
+	}
+
+	// ── Create mode: probe-driven wizard ───────────────────────────────────────
+	const canCheck =
+		bucket.trim() !== "" &&
+		roleArn.trim() !== "" &&
+		maintenanceRoleArn.trim() !== "";
+	const canContinueReview =
+		probe != null &&
+		probe.already_configured == null &&
+		(probe.state === "empty" ||
+			(probe.state === "kopia_repo" && passphrase.trim() !== ""));
 
 	return (
-		<Paper
-			variant="outlined"
-			sx={{ p: 3 }}
-			component="form"
-			onSubmit={onSubmit}
-		>
-			<Stack spacing={2}>
+		<Paper variant="outlined" sx={{ p: 3 }}>
+			<Stack spacing={3}>
 				<Typography variant="h5" component="h1">
-					{isCreate ? "Set up backups" : "Edit backup config"}
+					Set up backups
 				</Typography>
+				<Stepper activeStep={step}>
+					<Step>
+						<StepLabel>Target bucket</StepLabel>
+					</Step>
+					<Step>
+						<StepLabel>Review</StepLabel>
+					</Step>
+					<Step>
+						<StepLabel>Schedule &amp; retention</StepLabel>
+					</Step>
+				</Stepper>
 
-				<TextField
-					label="Bucket"
-					value={bucket}
-					onChange={(e) => setBucket(e.target.value)}
-					disabled={pending || !isCreate}
-					required
-					helperText={
-						isCreate
-							? "S3 bucket holding this group's kopia repository."
-							: "Changing the bucket is a repo migration — out of scope here."
-					}
-				/>
-				<TextField
-					label="Prefix"
-					value={prefix}
-					onChange={(e) => setPrefix(e.target.value)}
-					disabled={pending || !isCreate}
-					helperText="Optional key prefix within the bucket."
-				/>
-				<TextField
-					label="Target role ARN"
-					value={roleArn}
-					onChange={(e) => setRoleArn(e.target.value)}
-					disabled={pending || !isCreate}
-					required
-					helperText={
-						isCreate
-							? "IAM role Canopy assumes to mint device credentials."
-							: "Changing the role is a repo migration — out of scope here."
-					}
-				/>
-				<TextField
-					label="Maintenance role ARN"
-					value={maintenanceRoleArn}
-					onChange={(e) => setMaintenanceRoleArn(e.target.value)}
-					disabled={pending || !isCreate}
-					required
-					helperText={
-						isCreate
-							? "IAM role the backups pod assumes for maintenance (s3:* + delete + CloudWatch)."
-							: "Changing the role is a repo migration — out of scope here."
-					}
-				/>
-				<TextField
-					label="Region"
-					value={region}
-					onChange={(e) => setRegion(e.target.value)}
-					disabled={pending}
-					helperText="Optional. Changing region typically implies a different bucket — change with care."
-				/>
+				{step === 0 && (
+					<Stack spacing={2}>
+						<TextField
+							label="Bucket"
+							value={bucket}
+							onChange={(e) => setBucket(e.target.value)}
+							disabled={probeAction.pending}
+							required
+							helperText="S3 bucket holding this group's kopia repository."
+						/>
+						<TextField
+							label="Prefix"
+							value={prefix}
+							onChange={(e) => setPrefix(e.target.value)}
+							disabled={probeAction.pending}
+							helperText="Optional key prefix within the bucket."
+						/>
+						<TextField
+							label="Region"
+							value={region}
+							onChange={(e) => setRegion(e.target.value)}
+							disabled={probeAction.pending}
+							helperText="Defaults to ap-southeast-2."
+						/>
+						<TextField
+							label="Target role ARN"
+							value={roleArn}
+							onChange={(e) => setRoleArn(e.target.value)}
+							disabled={probeAction.pending}
+							required
+							helperText="IAM role Canopy assumes to mint device credentials (no delete)."
+						/>
+						<TextField
+							label="Maintenance role ARN"
+							value={maintenanceRoleArn}
+							onChange={(e) => setMaintenanceRoleArn(e.target.value)}
+							disabled={probeAction.pending}
+							required
+							helperText="IAM role for maintenance + this check (s3:* + delete + CloudWatch)."
+						/>
+						{probeAction.error && (
+							<Alert severity="error">{probeAction.error.message}</Alert>
+						)}
+						<Stack direction="row" spacing={1}>
+							<Button
+								variant="contained"
+								onClick={runProbe}
+								disabled={!canCheck || probeAction.pending}
+							>
+								{probeAction.pending ? "Checking…" : "Check bucket"}
+							</Button>
+							<Button
+								variant="outlined"
+								color="error"
+								onClick={() => navigate(`/groups/${groupId}/backups`)}
+								disabled={probeAction.pending}
+							>
+								Cancel
+							</Button>
+						</Stack>
+					</Stack>
+				)}
 
-				<TextField
-					select
-					label="Repository mode"
-					value={mode}
-					onChange={(e) => setMode(e.target.value as BackupRepoMode)}
-					disabled={pending || !isCreate}
-					helperText={
-						isCreate
-							? "From birth: Canopy generates the passphrase for a new repo. Existing repository: connect by supplying its passphrase."
-							: "Mode is fixed after creation."
-					}
+				{step === 1 && probe && (
+					<Stack spacing={2}>
+						<ProbeReview
+							probe={probe}
+							groupId={groupId}
+							passphrase={passphrase}
+							setPassphrase={setPassphrase}
+						/>
+						<Stack direction="row" spacing={1}>
+							<Button variant="outlined" onClick={() => setStep(0)}>
+								Back
+							</Button>
+							{(probe.state === "other_content" ||
+								probe.state === "inaccessible") && (
+								<Button variant="contained" onClick={runProbe}>
+									Re-check
+								</Button>
+							)}
+							<Button
+								variant="contained"
+								onClick={() => setStep(2)}
+								disabled={!canContinueReview}
+							>
+								Continue
+							</Button>
+						</Stack>
+					</Stack>
+				)}
+
+				{step === 2 && (
+					<Stack spacing={2}>
+						{scheduleAndRetention}
+						{error && <Alert severity="error">{error.message}</Alert>}
+						<Stack direction="row" spacing={1}>
+							<Button
+								variant="outlined"
+								onClick={() => setStep(1)}
+								disabled={pending}
+							>
+								Back
+							</Button>
+							<Button
+								variant="contained"
+								onClick={persist}
+								disabled={pending || hasFloorError}
+							>
+								{pending ? "Saving…" : "Create & provision"}
+							</Button>
+						</Stack>
+					</Stack>
+				)}
+			</Stack>
+		</Paper>
+	);
+}
+
+/// Step-2 review: explain what the probe found and gate the next action.
+function ProbeReview({
+	probe,
+	groupId,
+	passphrase,
+	setPassphrase,
+}: {
+	probe: ProbeResult;
+	groupId: string;
+	passphrase: string;
+	setPassphrase: (v: string) => void;
+}) {
+	if (
+		probe.already_configured != null &&
+		probe.already_configured !== groupId
+	) {
+		return (
+			<Alert severity="error">
+				This bucket + prefix is already configured for another group.{" "}
+				<MuiLink
+					component={RouterLink}
+					to={`/groups/${probe.already_configured}/backups`}
 				>
-					<MenuItem value="from_birth">
-						{BACKUP_MODE_LABEL.from_birth}
-					</MenuItem>
-					<MenuItem value="passphrase">
-						{BACKUP_MODE_LABEL.passphrase}
-					</MenuItem>
-				</TextField>
-
-				{isCreate && mode === "passphrase" && (
+					View that config
+				</MuiLink>
+				. Use a different prefix or bucket.
+			</Alert>
+		);
+	}
+	switch (probe.state) {
+		case "inaccessible":
+			return (
+				<Alert severity="error">
+					Couldn't access the bucket: {probe.error ?? "unknown error"}. Check
+					the role ARN, bucket, and region, then re-check.
+				</Alert>
+			);
+		case "other_content":
+			return (
+				<Alert severity="warning">
+					The bucket/prefix already holds other (non-kopia) content
+					{probe.object_sample.length > 0 && (
+						<> — e.g. {probe.object_sample.join(", ")}</>
+					)}
+					. Canopy won't write over it: clear the prefix, or use a different
+					prefix/bucket, then re-check.
+				</Alert>
+			);
+		case "empty":
+			return (
+				<Alert severity="info">
+					Empty bucket. Canopy will create a new repository and generate its
+					passphrase (from-birth), then rotate it regularly.
+				</Alert>
+			);
+		case "kopia_repo":
+			return (
+				<Stack spacing={2}>
+					<Alert severity="info">
+						An existing kopia repository is here. Supply its passphrase to
+						import it; Canopy verifies it at init and then rotates it to a
+						Canopy-owned passphrase (a hard break for any existing consumers).
+					</Alert>
 					<TextField
 						label="Existing repository passphrase"
 						type="password"
 						value={passphrase}
 						onChange={(e) => setPassphrase(e.target.value)}
-						disabled={pending}
 						required
-						helperText="Connect to an existing kopia repository by supplying its passphrase. New repositories use “From birth” (Canopy generates the passphrase)."
-					/>
-				)}
-
-				<Divider />
-
-				<Typography variant="subtitle1">Schedule</Typography>
-				<FormControlLabel
-					control={
-						<Switch
-							checked={scheduled}
-							onChange={(e) => setScheduled(e.target.checked)}
-							disabled={pending}
-						/>
-					}
-					label={scheduled ? "Scheduled" : "Manual only (no schedule)"}
-				/>
-				{scheduled && (
-					<TextField
-						label="Back up every (minutes)"
-						type="number"
-						value={intervalMinutes}
-						onChange={(e) => setIntervalMinutes(e.target.value)}
-						disabled={pending}
-						slotProps={{ htmlInput: { min: 1, step: 1 } }}
-						sx={{ width: 220 }}
-					/>
-				)}
-
-				<Divider />
-
-				<Typography variant="subtitle1">Retention</Typography>
-				<Typography variant="caption" color="text.secondary">
-					kopia keep-* policy. Org minimums: keep_daily ≥{" "}
-					{RETENTION_FLOORS.keep_daily}, keep_weekly ≥{" "}
-					{RETENTION_FLOORS.keep_weekly}, keep_monthly ≥{" "}
-					{RETENTION_FLOORS.keep_monthly}.
-				</Typography>
-				<Stack direction={{ xs: "column", md: "row" }} spacing={2}>
-					<RetentionField
-						label="Latest"
-						value={retention.keep_latest}
-						onChange={(v) => setRetention({ ...retention, keep_latest: v })}
-						disabled={pending}
-					/>
-					<RetentionField
-						label="Daily"
-						value={retention.keep_daily}
-						onChange={(v) => setRetention({ ...retention, keep_daily: v })}
-						disabled={pending}
-						floor={RETENTION_FLOORS.keep_daily}
-					/>
-					<RetentionField
-						label="Weekly"
-						value={retention.keep_weekly}
-						onChange={(v) => setRetention({ ...retention, keep_weekly: v })}
-						disabled={pending}
-						floor={RETENTION_FLOORS.keep_weekly}
-					/>
-					<RetentionField
-						label="Monthly"
-						value={retention.keep_monthly}
-						onChange={(v) => setRetention({ ...retention, keep_monthly: v })}
-						disabled={pending}
-						floor={RETENTION_FLOORS.keep_monthly}
-					/>
-					<RetentionField
-						label="Annual"
-						value={retention.keep_annual}
-						onChange={(v) => setRetention({ ...retention, keep_annual: v })}
-						disabled={pending}
 					/>
 				</Stack>
-				{hasFloorError && (
-					<Alert severity="warning">{floorErrors.join("; ")}</Alert>
-				)}
-
-				{error && <Alert severity="error">{error.message}</Alert>}
-
-				<Stack direction="row" spacing={1}>
-					<Button
-						type="submit"
-						variant="contained"
-						disabled={pending || hasFloorError}
-					>
-						{pending
-							? "Saving…"
-							: isCreate
-								? "Create & provision"
-								: "Save"}
-					</Button>
-					<Button
-						type="button"
-						variant="outlined"
-						color="error"
-						onClick={() => navigate(`/groups/${groupId}/backups`)}
-						disabled={pending}
-					>
-						Cancel
-					</Button>
-				</Stack>
-			</Stack>
-		</Paper>
-	);
+			);
+	}
 }
 
 function RetentionField({


### PR DESCRIPTION
🤖 The final piece of the backup onboarding stack: a probe-driven setup wizard, plus Intelligent-Tiering `.storageconfig` creation at repo init.

## Setup wizard

Onboarding a group's backup config is now a 3-step wizard instead of a single form:

1. **Target bucket** — enter the bucket, prefix, region (defaults to `ap-southeast-2`), and the two role ARNs, then *Check bucket*.
2. **Review** — Canopy assumes the *maintenance* role and inspects the bucket/prefix (inspect-only `HeadObject`/`ListObjectsV2`; private-server has no kopia binary). The repo mode is **derived** from what's there:
   - empty (or `.storageconfig`-only) → from-birth (Canopy creates the repo and generates + rotates its passphrase),
   - existing kopia repo → import by passphrase (verified at init, then rotated to a Canopy-owned passphrase),
   - other content / inaccessible → blocked with a re-check,
   - already configured for another group → blocked with a link to that config.
3. **Schedule & retention** — unchanged, with the org retention floors enforced.

Edit mode stays a flat form (structural fields are create-only).

The fake bucket prober now derives its state from the bucket name when given no fixed state, so the e2e suite drives every wizard branch from one binary (`…existing…` → kopia repo, `…other…` → other content, `…denied…` → inaccessible, else empty). The create/passphrase/floor/min/manual specs are rewritten for the wizard flow and other-content coverage is added.

## `.storageconfig` on init

On repo init, Canopy ensures `<prefix>.storageconfig` exists so kopia data blobs (the `p` prefix) land in S3 Intelligent-Tiering while indexes stay Standard. Pulumi normally writes this at bucket creation; Canopy writes it as a fallback when absent and never overwrites an existing one. Best-effort — it only affects tiering, not correctness, so init logs and continues on failure. Uses the maintenance role.

Stacked on #235.