### PR TITLE
feat(backups): machine config-as-a-resource API for ops/pulumi [TAM-6877]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
 name = "commons-servers"
 version = "6.6.6"
 dependencies = [
+ "age",
  "axum",
  "axum-client-ip",
  "axum-server-timing",

--- a/crates/commons-servers/Cargo.toml
+++ b/crates/commons-servers/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 
 [dependencies]
+age = { version = "0.11.3", default-features = false }
 axum = { workspace = true, features = ["json", "macros"] }
 axum-client-ip = { version = "1.3.1", features = ["forwarded-header"] }
 axum-server-timing = "3.0.1"

--- a/crates/commons-servers/src/backup_secrets.rs
+++ b/crates/commons-servers/src/backup_secrets.rs
@@ -2,8 +2,9 @@
 //!
 //! Canopy owns every repo passphrase Secret. This narrow store exposes exactly
 //! what the components need: read one key (public-server `/backup-target`,
-//! jobs maintenance), create one Secret (private-server onboarding), and
-//! create-or-replace one (the jobs rotation loop). Real deployments use the
+//! jobs maintenance), create one Secret (private-server onboarding),
+//! create-or-replace one (the jobs rotation loop), and delete one (private-server
+//! config decommission). Real deployments use the
 //! `Kube` variant; tests and the e2e binary use the in-memory `Memory` store
 //! (gated by `CANOPY_BACKUP_SECRETS_MEMORY`) so these paths are exercised
 //! without a cluster.
@@ -156,6 +157,30 @@ impl BackupSecrets {
 		}
 	}
 
+	/// Delete the named Secret — used when a config is decommissioned (the
+	/// Canopy-owned passphrase should not outlive its config). Idempotent: an
+	/// already-absent Secret is a success.
+	pub async fn delete_password(&self, secret_name: &str) -> Result<()> {
+		match self {
+			Self::Kube { client, namespace } => {
+				use k8s_openapi::api::core::v1::Secret;
+				use kube::{Api, api::DeleteParams};
+
+				let api: Api<Secret> = Api::namespaced(client.clone(), namespace);
+				match api.delete(secret_name, &DeleteParams::default()).await {
+					Ok(_) => Ok(()),
+					// Already gone — decommission is idempotent.
+					Err(kube::Error::Api(e)) if e.code == 404 => Ok(()),
+					Err(e) => Err(AppError::Upstream(format!("secret delete failed: {e}"))),
+				}
+			}
+			Self::Memory(store) => {
+				store.lock().unwrap().remove(secret_name);
+				Ok(())
+			}
+		}
+	}
+
 	/// Read all string keys of the named Secret — for the rotation dual-key state
 	/// machine (`password` + `password_next`). Missing Secret → Err; absent keys
 	/// are simply not in the map.
@@ -250,6 +275,39 @@ fn secret_object(secret_name: &str, key: &str, value: &str) -> k8s_openapi::api:
 /// downward API), defaulting to `canopy`.
 fn namespace_from_env() -> String {
 	std::env::var("POD_NAMESPACE").unwrap_or_else(|_| "canopy".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn memory_create_read_delete_roundtrip() {
+		let secrets = BackupSecrets::memory();
+		secrets
+			.create_password("backup-repo-x", "password", "hunter2")
+			.await
+			.unwrap();
+		assert_eq!(
+			secrets
+				.read_password("backup-repo-x", "password")
+				.await
+				.unwrap(),
+			"hunter2"
+		);
+
+		// Decommission removes the Secret entirely.
+		secrets.delete_password("backup-repo-x").await.unwrap();
+		assert!(
+			secrets
+				.read_password("backup-repo-x", "password")
+				.await
+				.is_err()
+		);
+
+		// Deleting an already-absent Secret is a no-op success.
+		secrets.delete_password("backup-repo-x").await.unwrap();
+	}
 }
 
 /// Generate a strong repo passphrase: 8 words from the EFF large wordlist

--- a/crates/commons-servers/src/lib.rs
+++ b/crates/commons-servers/src/lib.rs
@@ -17,6 +17,7 @@ pub mod backup_secrets;
 pub mod device_auth;
 pub mod headers;
 pub mod health;
+pub mod recovery_vault;
 pub mod tailnet_directory;
 pub mod tailnet_guard;
 pub mod tailnet_sweeps;

--- a/crates/commons-servers/src/recovery_vault.rs
+++ b/crates/commons-servers/src/recovery_vault.rs
@@ -1,0 +1,160 @@
+//! Shared `age` helper for the recovery secret vault.
+//!
+//! Canopy owns every repo passphrase with no human copy, so it backs up its
+//! recovery-critical state to an object-locked S3 bucket — but encrypted with **`age`
+//! asymmetric** crypto to one or more recipient public keys whose private keys
+//! Canopy never holds. Canopy can *write* the vault but cannot *read* it back, so
+//! a full Canopy compromise can't disclose the historical secrets.
+//!
+//! This module is the recipient/encryption half, shared by the jobs writer
+//! ([`crate::backup_secrets`]-adjacent) and the private-server verification
+//! ceremony. The S3 write + the operator-facing challenge/verify live in their
+//! respective crates.
+//!
+//! Recipients come from `CANOPY_RECOVERY_VAULT_KEYS` (whitespace/comma-separated
+//! `age1…` public keys). The "fingerprint" of a recipient is simply its public
+//! `age1…` string — it's public and uniquely identifying, and lets the ceremony
+//! detect when the recipient set has changed.
+//!
+//! ## bestool compatibility
+//!
+//! Output is **standard `age` v1** to `x25519` recipients — the exact same crate
+//! (`age` 0.11.3) and format BES's `algae-cli` uses. So a vault object is
+//! decryptable by **`bestool crypto decrypt`** (algae) and by plain `age`/`rage`,
+//! and the recipient keys are whatever `bestool crypto keygen` emits. Recovery
+//! uses one of the recipients' (offline) private keys with `bestool crypto
+//! decrypt`. We don't depend on `algae-cli` directly: it's CLI/async-stream
+//! shaped and single-recipient, whereas this is a small sync multi-recipient
+//! helper — but the on-the-wire format is identical (asserted in the tests).
+
+use std::str::FromStr;
+
+use commons_errors::{AppError, Result};
+
+/// Env var holding the whitespace/comma-separated `age1…` recipient public keys.
+pub const RECIPIENTS_ENV: &str = "CANOPY_RECOVERY_VAULT_KEYS";
+
+/// One or more `age` recipients Canopy encrypts the recovery vault to. Holds the parsed
+/// keys plus their canonical `age1…` strings (used as stable fingerprints).
+#[derive(Clone)]
+pub struct Recipients {
+	keys: Vec<age::x25519::Recipient>,
+	fingerprints: Vec<String>,
+}
+
+impl std::fmt::Debug for Recipients {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Recipients")
+			.field("fingerprints", &self.fingerprints)
+			.finish()
+	}
+}
+
+impl Recipients {
+	/// Parse from a whitespace/comma-separated list of `age1…` keys. Errors if any
+	/// token fails to parse or the list is empty.
+	pub fn parse(list: &str) -> Result<Self> {
+		let mut keys = Vec::new();
+		let mut fingerprints = Vec::new();
+		for tok in list.split([',', ' ', '\t', '\n', '\r']) {
+			let tok = tok.trim();
+			if tok.is_empty() {
+				continue;
+			}
+			let key = age::x25519::Recipient::from_str(tok)
+				.map_err(|e| AppError::BadRequest(format!("invalid age recipient {tok:?}: {e}")))?;
+			fingerprints.push(tok.to_string());
+			keys.push(key);
+		}
+		if keys.is_empty() {
+			return Err(AppError::BadRequest("no age recipients configured".into()));
+		}
+		Ok(Self { keys, fingerprints })
+	}
+
+	/// Parse from `CANOPY_RECOVERY_VAULT_KEYS`. `Ok(None)` if unset/blank;
+	/// `Err` if set but unparseable.
+	pub fn from_env() -> Result<Option<Self>> {
+		match std::env::var(RECIPIENTS_ENV) {
+			Err(_) => Ok(None),
+			Ok(v) if v.trim().is_empty() => Ok(None),
+			Ok(v) => Self::parse(&v).map(Some),
+		}
+	}
+
+	/// The recipients' `age1…` strings — stable, public identifiers the ceremony
+	/// compares to detect a changed recipient set.
+	pub fn fingerprints(&self) -> &[String] {
+		&self.fingerprints
+	}
+
+	pub fn len(&self) -> usize {
+		self.keys.len()
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.keys.is_empty()
+	}
+
+	/// Encrypt `plaintext` to all recipients (binary `age` format). Any one of the
+	/// recipients' private keys can later decrypt it.
+	pub fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
+		use std::io::Write;
+
+		let encryptor =
+			age::Encryptor::with_recipients(self.keys.iter().map(|r| r as &dyn age::Recipient))
+				.map_err(|e| AppError::Upstream(format!("age encryptor: {e}")))?;
+		let mut out = Vec::new();
+		let mut writer = encryptor
+			.wrap_output(&mut out)
+			.map_err(|e| AppError::Upstream(format!("age wrap_output: {e}")))?;
+		writer
+			.write_all(plaintext)
+			.map_err(|e| AppError::Upstream(format!("age write: {e}")))?;
+		writer
+			.finish()
+			.map_err(|e| AppError::Upstream(format!("age finish: {e}")))?;
+		Ok(out)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::io::Read;
+
+	#[test]
+	fn parse_rejects_garbage_and_empty() {
+		assert!(Recipients::parse("not-an-age-key").is_err());
+		assert!(Recipients::parse("   ").is_err());
+	}
+
+	#[test]
+	fn encrypt_roundtrips_with_any_recipient_key() {
+		// Two recipients; either private key must decrypt the same ciphertext.
+		let id_a = age::x25519::Identity::generate();
+		let id_b = age::x25519::Identity::generate();
+		let list = format!("{} {}", id_a.to_public(), id_b.to_public());
+
+		let recipients = Recipients::parse(&list).unwrap();
+		assert_eq!(recipients.len(), 2);
+		assert_eq!(recipients.fingerprints().len(), 2);
+
+		let plaintext = br#"{"hello":"recovery-vault"}"#;
+		let ciphertext = recipients.encrypt(plaintext).unwrap();
+		assert_ne!(&ciphertext[..], &plaintext[..]);
+		// Standard age v1 framing → decryptable by `bestool crypto decrypt`
+		// (algae-cli) and `age`/`rage`, not a bespoke envelope.
+		assert!(ciphertext.starts_with(b"age-encryption.org/v1\n"));
+
+		for id in [&id_a, &id_b] {
+			let decryptor = age::Decryptor::new_buffered(&ciphertext[..]).unwrap();
+			let mut reader = decryptor
+				.decrypt(std::iter::once(id as &dyn age::Identity))
+				.unwrap();
+			let mut got = Vec::new();
+			reader.read_to_end(&mut got).unwrap();
+			assert_eq!(got, plaintext);
+		}
+	}
+}

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -238,6 +238,31 @@ impl ServerGroupBackupConfig {
 			.map_err(AppError::from)
 	}
 
+	/// Update the mutable structural fields for the machine config-as-a-resource
+	/// upsert: the two role ARNs + region. Bucket/prefix/mode stay immutable (the
+	/// handler rejects changes to those before calling here).
+	pub async fn update_roles_region(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		target_role_arn: &str,
+		maintenance_role_arn: &str,
+		region: Option<&str>,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::update(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.set((
+				dsl::target_role_arn.eq(target_role_arn),
+				dsl::maintenance_role_arn.eq(maintenance_role_arn),
+				dsl::region.eq(region),
+				dsl::updated_at.eq(now),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
 	/// Advance (or reset) the lifecycle status (repo-init flow).
 	pub async fn set_status(
 		db: &mut AsyncPgConnection,

--- a/crates/jobs/src/backup.rs
+++ b/crates/jobs/src/backup.rs
@@ -16,6 +16,7 @@
 pub mod complete;
 pub mod creds_server;
 pub mod kopia;
+pub mod recovery_snapshot;
 pub mod worker;
 
 pub mod inspection;

--- a/crates/jobs/src/backup/recovery_snapshot.rs
+++ b/crates/jobs/src/backup/recovery_snapshot.rs
@@ -1,0 +1,296 @@
+//! Recovery vault writer.
+//!
+//! Canopy owns every repo passphrase with no human copy, so it periodically
+//! snapshots its recovery-critical state — server groups, backup configs with their
+//! per-group passphrase keysets + repo coordinates, schedules, capabilities, and
+//! the server list — and writes it, **`age`-encrypted to recipient public keys
+//! Canopy never holds the private half of** ([`commons_servers::recovery_vault`]), to a
+//! **versioned, object-locked** S3 bucket. Canopy can write the vault but cannot
+//! read it back: a full Canopy compromise can't disclose the historical secrets,
+//! and object-lock means even root can't delete a version before it expires.
+//!
+//! Recipients are **mandatory** (`CANOPY_RECOVERY_VAULT_KEYS`) — the backups pod
+//! refuses to start without them (see the `backups` bin). The blob is written to
+//! the same key each tick; bucket versioning keeps the history.
+
+use std::{collections::BTreeMap, time::Duration};
+
+use anyhow::{Context, Result};
+use commons_servers::{backup_secrets::BackupSecrets, recovery_vault::Recipients};
+use database::{
+	ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
+	server_groups::ServerGroup, servers::Server,
+};
+use jiff::Timestamp;
+use serde::Serialize;
+use tokio::{
+	task::{self, JoinHandle},
+	time::sleep,
+};
+use tracing::{error, info, warn};
+
+use super::worker::Worker;
+
+/// The vault object key (path within the bucket). Not configurable — there's only
+/// ever one recovery-state object per bucket; bucket versioning keeps the history.
+const VAULT_OBJECT_KEY: &str = "canopy-recovery/state.age";
+const DEFAULT_SNAPSHOT_HOURS: u64 = 24;
+const SCHEMA_VERSION: u32 = 1;
+
+/// Where + how the recovery vault is written. Recipients are mandatory; the rest
+/// comes from `CANOPY_RECOVERY_VAULT_*`.
+#[derive(Clone, Debug)]
+pub struct RecoveryVaultConfig {
+	pub recipients: Recipients,
+	pub bucket: String,
+	pub region: Option<String>,
+	/// Role to assume for the PutObject (the vault bucket lives in a separate
+	/// account). `None` → use the pod's default credential chain directly.
+	pub role_arn: Option<String>,
+	pub period: Duration,
+}
+
+impl RecoveryVaultConfig {
+	/// Build from the environment. `Err` (not `None`) if the mandatory recipients
+	/// or bucket are missing — the backups pod must not run a silent recovery gap.
+	pub fn from_env() -> std::result::Result<Self, String> {
+		let recipients = Recipients::from_env()
+			.map_err(|e| e.to_string())?
+			.ok_or_else(|| {
+				format!(
+					"{} must be set — the recovery vault recipients are mandatory",
+					commons_servers::recovery_vault::RECIPIENTS_ENV
+				)
+			})?;
+		let bucket = std::env::var("CANOPY_RECOVERY_VAULT_BUCKET").map_err(|_| {
+			"CANOPY_RECOVERY_VAULT_BUCKET must be set for the recovery vault".to_string()
+		})?;
+		let region = std::env::var("CANOPY_RECOVERY_VAULT_REGION").ok();
+		let role_arn = std::env::var("CANOPY_RECOVERY_VAULT_ROLE_ARN").ok();
+		let hours = std::env::var("CANOPY_RECOVERY_VAULT_SNAPSHOT_HOURS")
+			.ok()
+			.and_then(|s| s.parse::<u64>().ok())
+			.filter(|h| *h > 0)
+			.unwrap_or(DEFAULT_SNAPSHOT_HOURS);
+		Ok(Self {
+			recipients,
+			bucket,
+			region,
+			role_arn,
+			period: Duration::from_secs(hours * 3600),
+		})
+	}
+}
+
+// ── Snapshot shape ─────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct RecoverySnapshot {
+	schema_version: u32,
+	taken_at: String,
+	groups: Vec<RecoveryGroup>,
+	servers: Vec<Server>,
+	enabled_capabilities: Vec<ServerBackupCapability>,
+}
+
+#[derive(Serialize)]
+struct RecoveryGroup {
+	#[serde(flatten)]
+	group: ServerGroup,
+	config: Option<RecoveryConfig>,
+}
+
+#[derive(Serialize)]
+struct RecoveryConfig {
+	#[serde(flatten)]
+	config: ServerGroupBackupConfig,
+	/// The Secret's keyset (`password`, and `password_next` mid-rotation) — the
+	/// whole point of the vault. Empty (logged) if the Secret can't be read.
+	keys: BTreeMap<String, String>,
+	schedules: Vec<ServerGroupBackupSchedule>,
+}
+
+/// Gather the recovery-critical state and serialise it to JSON bytes (plaintext, before
+/// encryption). Reads the passphrase keyset per group; a missing/unreadable
+/// Secret is logged and left empty rather than failing the whole snapshot.
+pub async fn build_snapshot_json(
+	db: &mut database::diesel_async::AsyncPgConnection,
+	secrets: &BackupSecrets,
+	now: Timestamp,
+) -> Result<Vec<u8>> {
+	let groups = ServerGroup::list_all(db).await.context("list groups")?;
+	let configs: BTreeMap<_, _> = ServerGroupBackupConfig::list(db)
+		.await
+		.context("list configs")?
+		.into_iter()
+		.map(|c| (c.group_id, c))
+		.collect();
+
+	let mut recovery_groups = Vec::with_capacity(groups.len());
+	let mut servers: Vec<Server> = Vec::new();
+	for group in groups {
+		servers.extend(group.list_servers(db).await.context("list group servers")?);
+
+		let config = match configs.get(&group.id) {
+			Some(config) => {
+				let keys = match secrets.read_keys(&config.repo_password_ref).await {
+					Ok(keys) => keys,
+					Err(e) => {
+						warn!(group = %group.id, "recovery-snapshot: keyset unreadable ({e}); storing empty");
+						BTreeMap::new()
+					}
+				};
+				let schedules = ServerGroupBackupSchedule::list_for_group(db, group.id)
+					.await
+					.context("list schedules")?;
+				Some(RecoveryConfig {
+					config: config.clone(),
+					keys,
+					schedules,
+				})
+			}
+			None => None,
+		};
+		recovery_groups.push(RecoveryGroup { group, config });
+	}
+	servers.extend(
+		Server::list_ungrouped(db)
+			.await
+			.context("list ungrouped servers")?,
+	);
+
+	let snapshot = RecoverySnapshot {
+		schema_version: SCHEMA_VERSION,
+		taken_at: now.to_string(),
+		groups: recovery_groups,
+		servers,
+		enabled_capabilities: ServerBackupCapability::list_enabled(db)
+			.await
+			.context("list capabilities")?,
+	};
+	serde_json::to_vec(&snapshot).context("serialise snapshot")
+}
+
+/// Encrypt the ciphertext and PUT it to the (versioned, object-locked) vault.
+async fn write_vault(config: &RecoveryVaultConfig, ciphertext: Vec<u8>) -> Result<()> {
+	let sdk = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+	let mut builder = aws_sdk_s3::config::Builder::from(&sdk);
+	if let Some(role_arn) = &config.role_arn {
+		let sts = aws_sdk_sts::Client::new(&sdk);
+		let assumed = sts
+			.assume_role()
+			.role_arn(role_arn)
+			.role_session_name("canopy-recovery-vault")
+			.send()
+			.await
+			.context("assume recovery vault role")?;
+		let c = assumed
+			.credentials()
+			.context("AssumeRole returned no credentials")?;
+		builder = builder.credentials_provider(aws_sdk_s3::config::Credentials::new(
+			c.access_key_id(),
+			c.secret_access_key(),
+			Some(c.session_token().to_string()),
+			None,
+			"canopy-recovery-vault",
+		));
+	}
+	if let Some(region) = &config.region {
+		builder = builder.region(aws_sdk_s3::config::Region::new(region.clone()));
+	}
+	let s3 = aws_sdk_s3::Client::from_conf(builder.build());
+
+	s3.put_object()
+		.bucket(&config.bucket)
+		.key(VAULT_OBJECT_KEY)
+		.body(ciphertext.into())
+		.content_type("application/age")
+		.send()
+		.await
+		.context("put recovery vault object")?;
+	Ok(())
+}
+
+async fn tick(worker: &Worker, config: &RecoveryVaultConfig) -> Result<()> {
+	let mut db = worker
+		.pool
+		.get()
+		.await
+		.map_err(|e| anyhow::anyhow!("db: {e}"))?;
+	let plaintext = build_snapshot_json(&mut db, &worker.secrets, Timestamp::now()).await?;
+	let ciphertext = config
+		.recipients
+		.encrypt(&plaintext)
+		.map_err(|e| anyhow::anyhow!("encrypt: {e}"))?;
+	let bytes = ciphertext.len();
+	write_vault(config, ciphertext).await?;
+	info!(
+		bucket = %config.bucket,
+		key = VAULT_OBJECT_KEY,
+		recipients = config.recipients.len(),
+		bytes,
+		"recovery-snapshot: wrote encrypted vault object"
+	);
+	Ok(())
+}
+
+pub fn spawn(worker: Worker, config: RecoveryVaultConfig) -> JoinHandle<()> {
+	task::spawn(async move {
+		info!(
+			period_secs = config.period.as_secs(),
+			recipients = config.recipients.len(),
+			"recovery-snapshot writer started"
+		);
+		loop {
+			if let Err(e) = tick(&worker, &config).await {
+				error!("recovery-snapshot tick failed: {e:#}");
+			}
+			sleep(config.period).await;
+		}
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use commons_tests::db::TestDb;
+	use database::diesel_async::SimpleAsyncConnection;
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn snapshot_includes_group_config_and_keyset() {
+		TestDb::run(|mut conn, _url| async move {
+			let group_id = uuid::Uuid::new_v4();
+			conn.batch_execute(&format!(
+				"INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g');
+				 INSERT INTO server_group_backup_config
+				   (group_id, bucket, prefix, target_role_arn, maintenance_role_arn,
+				    repo_password_ref, status, mode)
+				 VALUES ('{group_id}', 'bkt', 'p/', 'arn:dev', 'arn:maint',
+				    'backup-repo-{group_id}', 'ready', 'from_birth');"
+			))
+			.await
+			.unwrap();
+
+			// Seed the passphrase keyset in the in-memory secret store.
+			let secrets = BackupSecrets::memory();
+			secrets
+				.create_password(&format!("backup-repo-{group_id}"), "password", "sekret")
+				.await
+				.unwrap();
+
+			let json = build_snapshot_json(&mut conn, &secrets, Timestamp::now())
+				.await
+				.unwrap();
+			let value: serde_json::Value = serde_json::from_slice(&json).unwrap();
+
+			assert_eq!(value["schema_version"], SCHEMA_VERSION);
+			let group = &value["groups"][0];
+			assert_eq!(group["id"], group_id.to_string());
+			assert_eq!(group["config"]["bucket"], "bkt");
+			assert_eq!(group["config"]["maintenance_role_arn"], "arn:maint");
+			// The passphrase keyset is the whole point — it must be present.
+			assert_eq!(group["config"]["keys"]["password"], "sekret");
+		})
+		.await;
+	}
+}

--- a/crates/jobs/src/bin/backups.rs
+++ b/crates/jobs/src/bin/backups.rs
@@ -5,7 +5,11 @@
 //! - upstream preflight ([`jobs::backup::preflight`]),
 //! - kopia maintenance scheduler ([`jobs::backup::maintenance`]),
 //! - read-only inspection scheduler ([`jobs::backup::inspection`]),
-//! - S3 CloudWatch metrics task ([`jobs::backup::s3_metrics`]).
+//! - passphrase rotation loop ([`jobs::backup::rotation`]),
+//! - S3 CloudWatch metrics task ([`jobs::backup::s3_metrics`]),
+//! - recovery vault writer ([`jobs::backup::recovery_snapshot`]) — encrypts a state snapshot
+//!   to `age` recipients and writes it to object-locked S3. Its recipients are
+//!   mandatory, so the pod refuses to start if they're unset.
 //!
 //! The maintenance + inspection loops run kopia **in-process** (subprocesses)
 //! rather than spawning Kubernetes Jobs; they share a [`jobs::backup::worker::Worker`]
@@ -56,11 +60,25 @@ async fn main() -> miette::Result<()> {
 		.map_err(|e| miette!("container-creds endpoint init failed: {e}"))?;
 	let worker = Worker::new(pool, secrets, Cfg::from_env(), creds);
 
+	// recovery vault recipients are MANDATORY — refuse to start without them so there's
+	// never a silent recovery gap (Canopy owns every passphrase).
+	let recovery_config = jobs::backup::recovery_snapshot::RecoveryVaultConfig::from_env()
+		.map_err(|e| miette!("recovery vault misconfigured: {e}"))?;
+
 	let preflight = jobs::backup::preflight::spawn();
 	let maintenance = jobs::backup::maintenance::spawn(worker.clone());
 	let inspection = jobs::backup::inspection::spawn(worker.clone());
-	let rotation = jobs::backup::rotation::spawn(worker);
+	let rotation = jobs::backup::rotation::spawn(worker.clone());
 	let s3_metrics = jobs::backup::s3_metrics::spawn();
-	tokio::try_join!(preflight, maintenance, inspection, rotation, s3_metrics).into_diagnostic()?;
+	let recovery_snapshot = jobs::backup::recovery_snapshot::spawn(worker, recovery_config);
+	tokio::try_join!(
+		preflight,
+		maintenance,
+		inspection,
+		rotation,
+		s3_metrics,
+		recovery_snapshot
+	)
+	.into_diagnostic()?;
 	Ok(())
 }

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -42,6 +42,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(get))
 		.routes(routes!(list))
 		.routes(routes!(create))
+		.routes(routes!(upsert))
 		.routes(routes!(probe))
 		.routes(routes!(update))
 		.routes(routes!(set_schedule))
@@ -153,6 +154,38 @@ pub struct CreateBackupConfigArgs {
 	/// Passphrase mode only: the operator-supplied repo passphrase Canopy stores.
 	/// From-birth ignores this (Canopy generates one).
 	pub passphrase: Option<String>,
+}
+
+/// Machine-facing config-as-a-resource upsert (ops/pulumi). `mode` is implicit
+/// — always from-birth — so the bucket must be empty and no passphrase is
+/// supplied (importing an existing repo stays an interactive operator action).
+/// `bucket`/`prefix` are the identity and immutable on re-apply; role ARNs,
+/// region, schedule and retention are reconciled to the request each time.
+#[derive(Deserialize, ToSchema)]
+pub struct UpsertBackupConfigArgs {
+	pub server_group_id: Uuid,
+	pub bucket: String,
+	#[serde(default)]
+	pub prefix: String,
+	/// Device role: public-server assumes this to mint device creds (no delete).
+	pub target_role_arn: String,
+	/// Maintenance role: the backups pod assumes this for maintenance/inspection/
+	/// s3-metrics (s3:* + delete + CloudWatch).
+	pub maintenance_role_arn: String,
+	pub region: Option<String>,
+	/// Schedule type to reconcile (defaults to `tamanu-postgres`).
+	#[serde(rename = "type", default = "default_backup_type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	/// Seconds between scheduled runs; None = manual-only (no schedule).
+	#[schema(value_type = Option<i64>, format = "int64")]
+	pub expected_interval: Option<PgDuration>,
+	/// None = inherit the type default. A present policy is floor-validated.
+	pub retention: Option<RetentionPolicy>,
+}
+
+fn default_backup_type() -> BackupType {
+	BackupType::TamanuPostgres
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -359,6 +392,154 @@ pub async fn create(
 	kube.create_password(&repo_password_ref, REPO_PASSWORD_SECRET_KEY, &passphrase)
 		.await?;
 
+	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
+}
+
+/// Machine-facing config-as-a-resource upsert for ops/pulumi: declaratively
+/// register/converge a group's backup config in one idempotent call (config +
+/// generated passphrase Secret + schedule/retention + auto-provision). Creating
+/// is from-birth onto an empty bucket only — a non-empty/existing-repo/
+/// inaccessible bucket is rejected. Re-applying reconciles the role ARNs,
+/// region, schedule and retention; `bucket`/`prefix` are immutable.
+#[utoipa::path(
+	post,
+	path = "/upsert",
+	operation_id = "backups_upsert",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = UpsertBackupConfigArgs,
+	responses(
+		(status = 200, body = BackupConfigView),
+		(status = 400, body = ProblemDetailsSchema),
+		(status = 404, body = ProblemDetailsSchema),
+		(status = 409, body = ProblemDetailsSchema),
+		(status = 502, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn upsert(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<UpsertBackupConfigArgs>,
+) -> Result<Json<BackupConfigView>> {
+	use crate::backup_probe::ProbeState;
+
+	let mut conn = state.db.get().await?;
+	ServerGroup::get_by_id(&mut conn, args.server_group_id).await?;
+
+	if let Some(policy) = &args.retention {
+		policy.validate_floor()?;
+	}
+
+	match ServerGroupBackupConfig::get(&mut conn, args.server_group_id).await? {
+		// Update path: reconcile the mutable fields; bucket/prefix are immutable.
+		Some(existing) => {
+			if existing.bucket != args.bucket || existing.prefix != args.prefix {
+				return Err(AppError::Conflict(
+					"bucket and prefix are immutable; delete the config and recreate it to change them"
+						.into(),
+				));
+			}
+			ServerGroupBackupConfig::update_roles_region(
+				&mut conn,
+				args.server_group_id,
+				&args.target_role_arn,
+				&args.maintenance_role_arn,
+				args.region.as_deref(),
+			)
+			.await?;
+			// Re-apply retries an incomplete/failed provision; a ready repo is
+			// left untouched.
+			let cfg = require_config(&mut conn, args.server_group_id).await?;
+			if cfg.status != BackupConfigStatus::Ready {
+				ServerGroupBackupConfig::mark_provisioning(&mut conn, args.server_group_id).await?;
+			}
+		}
+		// Create path: from-birth onto an empty, unclaimed bucket only.
+		None => {
+			let probe = state
+				.prober
+				.probe(
+					&args.bucket,
+					&args.prefix,
+					args.region.as_deref(),
+					&args.maintenance_role_arn,
+				)
+				.await?;
+			match probe.state {
+				ProbeState::Empty => {}
+				ProbeState::KopiaRepo => {
+					return Err(AppError::Conflict(
+						"an existing kopia repository is here; import it with the interactive setup wizard, not the machine API"
+							.into(),
+					));
+				}
+				ProbeState::OtherContent => {
+					return Err(AppError::Conflict(
+						"bucket/prefix holds other (non-kopia) content; Canopy won't write over it"
+							.into(),
+					));
+				}
+				ProbeState::Inaccessible => {
+					return Err(AppError::Upstream(format!(
+						"cannot access the bucket: {}",
+						probe.error.unwrap_or_else(|| "unknown error".into())
+					)));
+				}
+			}
+			if let Some(other) = ServerGroupBackupConfig::list(&mut conn)
+				.await?
+				.into_iter()
+				.find(|c| c.bucket == args.bucket && c.prefix == args.prefix)
+			{
+				return Err(AppError::Conflict(format!(
+					"bucket/prefix already configured for group {}",
+					other.group_id
+				)));
+			}
+
+			let kube = state.kube.as_ref().ok_or_else(|| {
+				AppError::Upstream(
+					"secret store not configured; cannot create repo passphrase".into(),
+				)
+			})?;
+			let repo_password_ref = format!("backup-repo-{}", args.server_group_id);
+			ServerGroupBackupConfig::insert(
+				&mut conn,
+				NewServerGroupBackupConfig {
+					group_id: args.server_group_id,
+					bucket: args.bucket.clone(),
+					prefix: args.prefix.clone(),
+					target_role_arn: args.target_role_arn.clone(),
+					maintenance_role_arn: args.maintenance_role_arn.clone(),
+					region: args.region.clone(),
+					repo_password_ref: repo_password_ref.clone(),
+					status: BackupConfigStatus::Provisioning,
+					mode: BackupRepoMode::FromBirth,
+				},
+			)
+			.await?;
+			kube.create_password(
+				&repo_password_ref,
+				REPO_PASSWORD_SECRET_KEY,
+				&commons_servers::backup_secrets::generate_passphrase(),
+			)
+			.await?;
+		}
+	}
+
+	// Reconcile the schedule/retention in both paths.
+	ServerGroupBackupSchedule::upsert(
+		&mut conn,
+		NewServerGroupBackupSchedule {
+			group_id: args.server_group_id,
+			r#type: args.r#type,
+			expected_interval: args.expected_interval,
+			retention: args.retention.map(|r| r.to_json()),
+		},
+	)
+	.await?;
+
+	let config = require_config(&mut conn, args.server_group_id).await?;
 	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
 }
 
@@ -678,7 +859,8 @@ pub async fn set_capability(
 }
 
 /// Delete a group's config row (decommission). The bucket and its object-locked
-/// objects persist; this only stops credential issuance.
+/// objects persist; this only stops credential issuance and removes the
+/// Canopy-owned passphrase Secret (which must not outlive its config).
 #[utoipa::path(
 	post,
 	path = "/delete",
@@ -694,8 +876,12 @@ pub async fn delete(
 	Json(args): Json<GroupArgs>,
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
-	require_config(&mut conn, args.server_group_id).await?;
+	let config = require_config(&mut conn, args.server_group_id).await?;
 	ServerGroupBackupConfig::delete(&mut conn, args.server_group_id).await?;
+	// The Canopy-owned passphrase Secret should not outlive its config.
+	if let Some(kube) = state.kube.as_ref() {
+		kube.delete_password(&config.repo_password_ref).await?;
+	}
 	Ok(Json(()))
 }
 

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -58,8 +58,10 @@ impl AppState {
 			// In-memory secret store so onboarding (Secret creation) is exercised
 			// in tests without a cluster.
 			kube: Some(BackupSecrets::memory()),
-			// Fake prober (default empty) so the wizard probe works in tests.
-			prober: BucketProber::fake(crate::backup_probe::ProbeState::Empty),
+			// Bucket-name-derived fake prober (matches the e2e fixture): a test
+			// drives each probe state by naming the bucket — `…existing…` → kopia
+			// repo, `…other…` → other content, `…denied…` → inaccessible, else empty.
+			prober: BucketProber::Fake(None),
 		})
 	}
 }

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -28,6 +28,22 @@ fn retention_json() -> serde_json::Value {
 	})
 }
 
+/// Assert a group has no backup config — a rejected upsert must not partially
+/// write. (A macro, not a fn, to avoid naming `axum_test::TestServer`.)
+macro_rules! assert_no_config {
+	($private:expr, $group:expr) => {{
+		let resp = $private
+			.post("/api/backups/get")
+			.json(&serde_json::json!({ "server_group_id": $group }))
+			.await;
+		resp.assert_status_ok();
+		assert!(
+			resp.json::<serde_json::Value>().is_null(),
+			"expected no config to be written"
+		);
+	}};
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn create_get_zero_state_and_full_view() {
 	commons_tests::server::run(async |mut conn, _public, private| {
@@ -294,7 +310,8 @@ async fn probe_reports_state_and_already_configured() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;
 
-		// The test harness uses the fake prober (always Empty).
+		// The harness uses the bucket-name-derived fake prober; "fresh" has no
+		// marker, so it reads empty.
 		let resp = private
 			.post("/api/backups/probe")
 			.json(&serde_json::json!({
@@ -561,6 +578,152 @@ async fn upsert_missing_group_is_404() {
 			}))
 			.await;
 		resp.assert_status_not_found();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_rejects_below_floor_retention() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "bes-iac",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint",
+				"retention": {
+					"keep_latest": 1, "keep_daily": 1, "keep_weekly": 1,
+					"keep_monthly": 1, "keep_annual": 0
+				},
+			}))
+			.await;
+		resp.assert_status_bad_request();
+		// Floor is checked before anything is written.
+		assert_no_config!(private, group_id);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_rejects_prefix_change() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let base = serde_json::json!({
+			"server_group_id": group_id,
+			"bucket": "bes-iac",
+			"prefix": "a/",
+			"target_role_arn": "arn",
+			"maintenance_role_arn": "maint",
+		});
+		private
+			.post("/api/backups/upsert")
+			.json(&base)
+			.await
+			.assert_status_ok();
+
+		// Same bucket, different prefix → prefix is part of the immutable identity.
+		let mut moved = base.clone();
+		moved["prefix"] = serde_json::json!("b/");
+		private
+			.post("/api/backups/upsert")
+			.json(&moved)
+			.await
+			.assert_status_conflict();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_rejects_existing_repo() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		// `…existing…` → the fake prober reports an existing kopia repo. The
+		// machine API never imports; that's an interactive wizard action.
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "bes-existing-repo",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint",
+			}))
+			.await;
+		resp.assert_status_conflict();
+		assert_no_config!(private, group_id);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_rejects_other_content() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "bes-other-stuff",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint",
+			}))
+			.await;
+		resp.assert_status_conflict();
+		assert_no_config!(private, group_id);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_rejects_inaccessible_bucket() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "bes-denied",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint",
+			}))
+			.await;
+		// Inaccessible → AppError::Upstream → 502.
+		assert_eq!(resp.status_code().as_u16(), 502);
+		assert_no_config!(private, group_id);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_rejects_bucket_already_configured_for_another_group() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_a = seed_group(&mut conn).await;
+		let group_b = seed_group(&mut conn).await;
+
+		private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_a,
+				"bucket": "bes-shared",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint",
+			}))
+			.await
+			.assert_status_ok();
+
+		// A different group can't claim the same bucket/prefix.
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_b,
+				"bucket": "bes-shared",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint",
+			}))
+			.await;
+		resp.assert_status_conflict();
+		assert_no_config!(private, group_b);
 	})
 	.await;
 }

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -478,3 +478,89 @@ async fn update_region_and_delete() {
 	})
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_creates_then_reapplies_idempotently() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+
+		// First apply → creates from-birth (the fake prober reports empty),
+		// provisions, and sets the schedule.
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "bes-iac",
+				"prefix": "p/",
+				"target_role_arn": "arn:aws:iam::123:role/dev",
+				"maintenance_role_arn": "arn:aws:iam::123:role/maint",
+				"region": "ap-southeast-2",
+				"expected_interval": 3600,
+				"retention": retention_json(),
+			}))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert_eq!(body["status"], "provisioning");
+		assert_eq!(body["mode"], "from_birth");
+		assert_eq!(body["maintenance_role_arn"], "arn:aws:iam::123:role/maint");
+		let schedule = &body["schedules"][0];
+		assert_eq!(schedule["type"], "tamanu-postgres");
+		assert_eq!(schedule["expected_interval"], 3600);
+
+		// Re-apply with changed mutable fields → updates in place, no duplicate.
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "bes-iac",
+				"prefix": "p/",
+				"target_role_arn": "arn:aws:iam::123:role/dev2",
+				"maintenance_role_arn": "arn:aws:iam::123:role/maint2",
+				"region": "us-east-1",
+				"expected_interval": null,
+				"retention": retention_json(),
+			}))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert_eq!(body["maintenance_role_arn"], "arn:aws:iam::123:role/maint2");
+		assert_eq!(body["target_role_arn"], "arn:aws:iam::123:role/dev2");
+		assert_eq!(body["region"], "us-east-1");
+		// Manual-only now. (That this second apply returns 200 with updated
+		// fields — rather than the 409 a duplicate create would — is what proves
+		// it took the in-place update path, i.e. no duplicate row.)
+		assert!(body["schedules"][0]["expected_interval"].is_null());
+
+		// Changing the bucket (identity) is rejected.
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "bes-iac-moved",
+				"prefix": "p/",
+				"target_role_arn": "arn:aws:iam::123:role/dev2",
+				"maintenance_role_arn": "arn:aws:iam::123:role/maint2",
+			}))
+			.await;
+		resp.assert_status_conflict();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_missing_group_is_404() {
+	commons_tests::server::run(async |_conn, _public, private| {
+		let resp = private
+			.post("/api/backups/upsert")
+			.json(&serde_json::json!({
+				"server_group_id": Uuid::new_v4(),
+				"bucket": "b",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint-arn",
+			}))
+			.await;
+		resp.assert_status_not_found();
+	})
+	.await;
+}

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -352,7 +352,7 @@
         "tags": [
           "backups"
         ],
-        "summary": "Delete a group's config row (decommission). The bucket and its object-locked\nobjects persist; this only stops credential issuance.",
+        "summary": "Delete a group's config row (decommission). The bucket and its object-locked\nobjects persist; this only stops credential issuance and removes the\nCanopy-owned passphrase Secret (which must not outlive its config).",
         "operationId": "backups_delete",
         "requestBody": {
           "content": {
@@ -721,6 +721,82 @@
             }
           },
           "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/backups/upsert": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Machine-facing config-as-a-resource upsert for ops/pulumi: declaratively\nregister/converge a group's backup config in one idempotent call (config +\ngenerated passphrase Secret + schedule/retention + auto-provision). Creating\nis from-birth onto an empty bucket only — a non-empty/existing-repo/\ninaccessible bucket is rejected. Re-applying reconciles the role ARNs,\nregion, schedule and retention; `bucket`/`prefix` are immutable.",
+        "operationId": "backups_upsert",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertBackupConfigArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupConfigView"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "502": {
             "description": "",
             "content": {
               "application/json": {
@@ -8914,6 +8990,65 @@
           },
           "version": {
             "type": "string"
+          }
+        }
+      },
+      "UpsertBackupConfigArgs": {
+        "type": "object",
+        "description": "Machine-facing config-as-a-resource upsert (ops/pulumi). `mode` is implicit\n— always from-birth — so the bucket must be empty and no passphrase is\nsupplied (importing an existing repo stays an interactive operator action).\n`bucket`/`prefix` are the identity and immutable on re-apply; role ARNs,\nregion, schedule and retention are reconciled to the request each time.",
+        "required": [
+          "server_group_id",
+          "bucket",
+          "target_role_arn",
+          "maintenance_role_arn"
+        ],
+        "properties": {
+          "bucket": {
+            "type": "string"
+          },
+          "expected_interval": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Seconds between scheduled runs; None = manual-only (no schedule)."
+          },
+          "maintenance_role_arn": {
+            "type": "string",
+            "description": "Maintenance role: the backups pod assumes this for maintenance/inspection/\ns3-metrics (s3:* + delete + CloudWatch)."
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "region": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "retention": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RetentionPolicy",
+                "description": "None = inherit the type default. A present policy is floor-validated."
+              }
+            ]
+          },
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "target_role_arn": {
+            "type": "string",
+            "description": "Device role: public-server assumes this to mint device creds (no delete)."
+          },
+          "type": {
+            "type": "string",
+            "description": "Schedule type to reconcile (defaults to `tamanu-postgres`)."
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -141,7 +141,8 @@ export interface paths {
         put?: never;
         /**
          * Delete a group's config row (decommission). The bucket and its object-locked
-         *     objects persist; this only stops credential issuance.
+         *     objects persist; this only stops credential issuance and removes the
+         *     Canopy-owned passphrase Secret (which must not outlive its config).
          */
         post: operations["backups_delete"];
         delete?: never;
@@ -300,6 +301,30 @@ export interface paths {
          *     `set_schedule`.
          */
         post: operations["backups_update"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/backups/upsert": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Machine-facing config-as-a-resource upsert for ops/pulumi: declaratively
+         *     register/converge a group's backup config in one idempotent call (config +
+         *     generated passphrase Secret + schedule/retention + auto-provision). Creating
+         *     is from-birth onto an empty bucket only — a non-empty/existing-repo/
+         *     inaccessible bucket is rejected. Re-applying reconciles the role ARNs,
+         *     region, schedule and retention; `bucket`/`prefix` are immutable.
+         */
+        post: operations["backups_upsert"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3518,6 +3543,35 @@ export interface components {
             status: string;
             version: string;
         };
+        /**
+         * @description Machine-facing config-as-a-resource upsert (ops/pulumi). `mode` is implicit
+         *     — always from-birth — so the bucket must be empty and no passphrase is
+         *     supplied (importing an existing repo stays an interactive operator action).
+         *     `bucket`/`prefix` are the identity and immutable on re-apply; role ARNs,
+         *     region, schedule and retention are reconciled to the request each time.
+         */
+        UpsertBackupConfigArgs: {
+            bucket: string;
+            /**
+             * Format: int64
+             * @description Seconds between scheduled runs; None = manual-only (no schedule).
+             */
+            expected_interval?: number | null;
+            /**
+             * @description Maintenance role: the backups pod assumes this for maintenance/inspection/
+             *     s3-metrics (s3:* + delete + CloudWatch).
+             */
+            maintenance_role_arn: string;
+            prefix?: string;
+            region?: string | null;
+            retention?: null | components["schemas"]["RetentionPolicy"];
+            /** Format: uuid */
+            server_group_id: string;
+            /** @description Device role: public-server assumes this to mint device creds (no delete). */
+            target_role_arn: string;
+            /** @description Schedule type to reconcile (defaults to `tamanu-postgres`). */
+            type?: string;
+        };
         Value: unknown;
         VersionData: {
             /** Format: date-time */
@@ -4077,6 +4131,61 @@ export interface operations {
                 };
             };
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    backups_upsert: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpsertBackupConfigArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupConfigView"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            502: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
🤖 A declarative config endpoint so ops/pulumi can register a group's backup config instead of hand-copying ARNs through the wizard.

## `POST /api/backups/upsert`

One idempotent call that converges a group's whole config: the config row + a Canopy-generated passphrase Secret + the schedule/retention + auto-provisioning.

- **Mode is implicit** — always from-birth, so there's no passphrase parameter. Creating requires an **empty bucket**: the probe rejects an existing kopia repo (use the interactive wizard to import), other content, an inaccessible bucket, or a bucket/prefix already claimed by another group.
- **`bucket`/`prefix` are the identity and immutable** on re-apply. The role ARNs, region, schedule (`expected_interval`, `null` = manual-only) and retention reconcile to the request each time. Re-applying retries a failed/incomplete provision; a `ready` repo is left untouched.
- **Auth:** `TailscaleAdmin` for now (pulumi has tailnet access). A tagged/ACL machine-auth grant over Tailscale is a later follow-up.

## Delete cleans up the Secret

Deleting a config now also deletes the Canopy-owned passphrase Secret — it must not outlive its config. New idempotent `BackupSecrets::delete_password` (404 = success). Adds `ServerGroupBackupConfig::update_roles_region` for the in-place update path.

Stacked on #236.