### PR TITLE
feat(backups): recovery vault writer — age-encrypted state snapshot to object-locked S3 [TAM-6877]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
 name = "commons-servers"
 version = "6.6.6"
 dependencies = [
+ "age",
  "axum",
  "axum-client-ip",
  "axum-server-timing",

--- a/crates/commons-servers/Cargo.toml
+++ b/crates/commons-servers/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 
 [dependencies]
+age = { version = "0.11.3", default-features = false }
 axum = { workspace = true, features = ["json", "macros"] }
 axum-client-ip = { version = "1.3.1", features = ["forwarded-header"] }
 axum-server-timing = "3.0.1"

--- a/crates/commons-servers/src/lib.rs
+++ b/crates/commons-servers/src/lib.rs
@@ -17,6 +17,7 @@ pub mod backup_secrets;
 pub mod device_auth;
 pub mod headers;
 pub mod health;
+pub mod recovery_vault;
 pub mod tailnet_directory;
 pub mod tailnet_guard;
 pub mod tailnet_sweeps;

--- a/crates/commons-servers/src/recovery_vault.rs
+++ b/crates/commons-servers/src/recovery_vault.rs
@@ -1,0 +1,160 @@
+//! Shared `age` helper for the recovery secret vault.
+//!
+//! Canopy owns every repo passphrase with no human copy, so it backs up its
+//! recovery-critical state to an object-locked S3 bucket — but encrypted with **`age`
+//! asymmetric** crypto to one or more recipient public keys whose private keys
+//! Canopy never holds. Canopy can *write* the vault but cannot *read* it back, so
+//! a full Canopy compromise can't disclose the historical secrets.
+//!
+//! This module is the recipient/encryption half, shared by the jobs writer
+//! ([`crate::backup_secrets`]-adjacent) and the private-server verification
+//! ceremony. The S3 write + the operator-facing challenge/verify live in their
+//! respective crates.
+//!
+//! Recipients come from `CANOPY_RECOVERY_VAULT_KEYS` (whitespace/comma-separated
+//! `age1…` public keys). The "fingerprint" of a recipient is simply its public
+//! `age1…` string — it's public and uniquely identifying, and lets the ceremony
+//! detect when the recipient set has changed.
+//!
+//! ## bestool compatibility
+//!
+//! Output is **standard `age` v1** to `x25519` recipients — the exact same crate
+//! (`age` 0.11.3) and format BES's `algae-cli` uses. So a vault object is
+//! decryptable by **`bestool crypto decrypt`** (algae) and by plain `age`/`rage`,
+//! and the recipient keys are whatever `bestool crypto keygen` emits. Recovery
+//! uses one of the recipients' (offline) private keys with `bestool crypto
+//! decrypt`. We don't depend on `algae-cli` directly: it's CLI/async-stream
+//! shaped and single-recipient, whereas this is a small sync multi-recipient
+//! helper — but the on-the-wire format is identical (asserted in the tests).
+
+use std::str::FromStr;
+
+use commons_errors::{AppError, Result};
+
+/// Env var holding the whitespace/comma-separated `age1…` recipient public keys.
+pub const RECIPIENTS_ENV: &str = "CANOPY_RECOVERY_VAULT_KEYS";
+
+/// One or more `age` recipients Canopy encrypts the recovery vault to. Holds the parsed
+/// keys plus their canonical `age1…` strings (used as stable fingerprints).
+#[derive(Clone)]
+pub struct Recipients {
+	keys: Vec<age::x25519::Recipient>,
+	fingerprints: Vec<String>,
+}
+
+impl std::fmt::Debug for Recipients {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Recipients")
+			.field("fingerprints", &self.fingerprints)
+			.finish()
+	}
+}
+
+impl Recipients {
+	/// Parse from a whitespace/comma-separated list of `age1…` keys. Errors if any
+	/// token fails to parse or the list is empty.
+	pub fn parse(list: &str) -> Result<Self> {
+		let mut keys = Vec::new();
+		let mut fingerprints = Vec::new();
+		for tok in list.split([',', ' ', '\t', '\n', '\r']) {
+			let tok = tok.trim();
+			if tok.is_empty() {
+				continue;
+			}
+			let key = age::x25519::Recipient::from_str(tok)
+				.map_err(|e| AppError::BadRequest(format!("invalid age recipient {tok:?}: {e}")))?;
+			fingerprints.push(tok.to_string());
+			keys.push(key);
+		}
+		if keys.is_empty() {
+			return Err(AppError::BadRequest("no age recipients configured".into()));
+		}
+		Ok(Self { keys, fingerprints })
+	}
+
+	/// Parse from `CANOPY_RECOVERY_VAULT_KEYS`. `Ok(None)` if unset/blank;
+	/// `Err` if set but unparseable.
+	pub fn from_env() -> Result<Option<Self>> {
+		match std::env::var(RECIPIENTS_ENV) {
+			Err(_) => Ok(None),
+			Ok(v) if v.trim().is_empty() => Ok(None),
+			Ok(v) => Self::parse(&v).map(Some),
+		}
+	}
+
+	/// The recipients' `age1…` strings — stable, public identifiers the ceremony
+	/// compares to detect a changed recipient set.
+	pub fn fingerprints(&self) -> &[String] {
+		&self.fingerprints
+	}
+
+	pub fn len(&self) -> usize {
+		self.keys.len()
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.keys.is_empty()
+	}
+
+	/// Encrypt `plaintext` to all recipients (binary `age` format). Any one of the
+	/// recipients' private keys can later decrypt it.
+	pub fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
+		use std::io::Write;
+
+		let encryptor =
+			age::Encryptor::with_recipients(self.keys.iter().map(|r| r as &dyn age::Recipient))
+				.map_err(|e| AppError::Upstream(format!("age encryptor: {e}")))?;
+		let mut out = Vec::new();
+		let mut writer = encryptor
+			.wrap_output(&mut out)
+			.map_err(|e| AppError::Upstream(format!("age wrap_output: {e}")))?;
+		writer
+			.write_all(plaintext)
+			.map_err(|e| AppError::Upstream(format!("age write: {e}")))?;
+		writer
+			.finish()
+			.map_err(|e| AppError::Upstream(format!("age finish: {e}")))?;
+		Ok(out)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::io::Read;
+
+	#[test]
+	fn parse_rejects_garbage_and_empty() {
+		assert!(Recipients::parse("not-an-age-key").is_err());
+		assert!(Recipients::parse("   ").is_err());
+	}
+
+	#[test]
+	fn encrypt_roundtrips_with_any_recipient_key() {
+		// Two recipients; either private key must decrypt the same ciphertext.
+		let id_a = age::x25519::Identity::generate();
+		let id_b = age::x25519::Identity::generate();
+		let list = format!("{} {}", id_a.to_public(), id_b.to_public());
+
+		let recipients = Recipients::parse(&list).unwrap();
+		assert_eq!(recipients.len(), 2);
+		assert_eq!(recipients.fingerprints().len(), 2);
+
+		let plaintext = br#"{"hello":"recovery-vault"}"#;
+		let ciphertext = recipients.encrypt(plaintext).unwrap();
+		assert_ne!(&ciphertext[..], &plaintext[..]);
+		// Standard age v1 framing → decryptable by `bestool crypto decrypt`
+		// (algae-cli) and `age`/`rage`, not a bespoke envelope.
+		assert!(ciphertext.starts_with(b"age-encryption.org/v1\n"));
+
+		for id in [&id_a, &id_b] {
+			let decryptor = age::Decryptor::new_buffered(&ciphertext[..]).unwrap();
+			let mut reader = decryptor
+				.decrypt(std::iter::once(id as &dyn age::Identity))
+				.unwrap();
+			let mut got = Vec::new();
+			reader.read_to_end(&mut got).unwrap();
+			assert_eq!(got, plaintext);
+		}
+	}
+}

--- a/crates/jobs/src/backup.rs
+++ b/crates/jobs/src/backup.rs
@@ -16,6 +16,7 @@
 pub mod complete;
 pub mod creds_server;
 pub mod kopia;
+pub mod recovery_snapshot;
 pub mod worker;
 
 pub mod inspection;

--- a/crates/jobs/src/backup/recovery_snapshot.rs
+++ b/crates/jobs/src/backup/recovery_snapshot.rs
@@ -1,0 +1,296 @@
+//! Recovery vault writer.
+//!
+//! Canopy owns every repo passphrase with no human copy, so it periodically
+//! snapshots its recovery-critical state — server groups, backup configs with their
+//! per-group passphrase keysets + repo coordinates, schedules, capabilities, and
+//! the server list — and writes it, **`age`-encrypted to recipient public keys
+//! Canopy never holds the private half of** ([`commons_servers::recovery_vault`]), to a
+//! **versioned, object-locked** S3 bucket. Canopy can write the vault but cannot
+//! read it back: a full Canopy compromise can't disclose the historical secrets,
+//! and object-lock means even root can't delete a version before it expires.
+//!
+//! Recipients are **mandatory** (`CANOPY_RECOVERY_VAULT_KEYS`) — the backups pod
+//! refuses to start without them (see the `backups` bin). The blob is written to
+//! the same key each tick; bucket versioning keeps the history.
+
+use std::{collections::BTreeMap, time::Duration};
+
+use anyhow::{Context, Result};
+use commons_servers::{backup_secrets::BackupSecrets, recovery_vault::Recipients};
+use database::{
+	ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
+	server_groups::ServerGroup, servers::Server,
+};
+use jiff::Timestamp;
+use serde::Serialize;
+use tokio::{
+	task::{self, JoinHandle},
+	time::sleep,
+};
+use tracing::{error, info, warn};
+
+use super::worker::Worker;
+
+/// The vault object key (path within the bucket). Not configurable — there's only
+/// ever one recovery-state object per bucket; bucket versioning keeps the history.
+const VAULT_OBJECT_KEY: &str = "canopy-recovery/state.age";
+const DEFAULT_SNAPSHOT_HOURS: u64 = 24;
+const SCHEMA_VERSION: u32 = 1;
+
+/// Where + how the recovery vault is written. Recipients are mandatory; the rest
+/// comes from `CANOPY_RECOVERY_VAULT_*`.
+#[derive(Clone, Debug)]
+pub struct RecoveryVaultConfig {
+	pub recipients: Recipients,
+	pub bucket: String,
+	pub region: Option<String>,
+	/// Role to assume for the PutObject (the vault bucket lives in a separate
+	/// account). `None` → use the pod's default credential chain directly.
+	pub role_arn: Option<String>,
+	pub period: Duration,
+}
+
+impl RecoveryVaultConfig {
+	/// Build from the environment. `Err` (not `None`) if the mandatory recipients
+	/// or bucket are missing — the backups pod must not run a silent recovery gap.
+	pub fn from_env() -> std::result::Result<Self, String> {
+		let recipients = Recipients::from_env()
+			.map_err(|e| e.to_string())?
+			.ok_or_else(|| {
+				format!(
+					"{} must be set — the recovery vault recipients are mandatory",
+					commons_servers::recovery_vault::RECIPIENTS_ENV
+				)
+			})?;
+		let bucket = std::env::var("CANOPY_RECOVERY_VAULT_BUCKET").map_err(|_| {
+			"CANOPY_RECOVERY_VAULT_BUCKET must be set for the recovery vault".to_string()
+		})?;
+		let region = std::env::var("CANOPY_RECOVERY_VAULT_REGION").ok();
+		let role_arn = std::env::var("CANOPY_RECOVERY_VAULT_ROLE_ARN").ok();
+		let hours = std::env::var("CANOPY_RECOVERY_VAULT_SNAPSHOT_HOURS")
+			.ok()
+			.and_then(|s| s.parse::<u64>().ok())
+			.filter(|h| *h > 0)
+			.unwrap_or(DEFAULT_SNAPSHOT_HOURS);
+		Ok(Self {
+			recipients,
+			bucket,
+			region,
+			role_arn,
+			period: Duration::from_secs(hours * 3600),
+		})
+	}
+}
+
+// ── Snapshot shape ─────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct RecoverySnapshot {
+	schema_version: u32,
+	taken_at: String,
+	groups: Vec<RecoveryGroup>,
+	servers: Vec<Server>,
+	enabled_capabilities: Vec<ServerBackupCapability>,
+}
+
+#[derive(Serialize)]
+struct RecoveryGroup {
+	#[serde(flatten)]
+	group: ServerGroup,
+	config: Option<RecoveryConfig>,
+}
+
+#[derive(Serialize)]
+struct RecoveryConfig {
+	#[serde(flatten)]
+	config: ServerGroupBackupConfig,
+	/// The Secret's keyset (`password`, and `password_next` mid-rotation) — the
+	/// whole point of the vault. Empty (logged) if the Secret can't be read.
+	keys: BTreeMap<String, String>,
+	schedules: Vec<ServerGroupBackupSchedule>,
+}
+
+/// Gather the recovery-critical state and serialise it to JSON bytes (plaintext, before
+/// encryption). Reads the passphrase keyset per group; a missing/unreadable
+/// Secret is logged and left empty rather than failing the whole snapshot.
+pub async fn build_snapshot_json(
+	db: &mut database::diesel_async::AsyncPgConnection,
+	secrets: &BackupSecrets,
+	now: Timestamp,
+) -> Result<Vec<u8>> {
+	let groups = ServerGroup::list_all(db).await.context("list groups")?;
+	let configs: BTreeMap<_, _> = ServerGroupBackupConfig::list(db)
+		.await
+		.context("list configs")?
+		.into_iter()
+		.map(|c| (c.group_id, c))
+		.collect();
+
+	let mut recovery_groups = Vec::with_capacity(groups.len());
+	let mut servers: Vec<Server> = Vec::new();
+	for group in groups {
+		servers.extend(group.list_servers(db).await.context("list group servers")?);
+
+		let config = match configs.get(&group.id) {
+			Some(config) => {
+				let keys = match secrets.read_keys(&config.repo_password_ref).await {
+					Ok(keys) => keys,
+					Err(e) => {
+						warn!(group = %group.id, "recovery-snapshot: keyset unreadable ({e}); storing empty");
+						BTreeMap::new()
+					}
+				};
+				let schedules = ServerGroupBackupSchedule::list_for_group(db, group.id)
+					.await
+					.context("list schedules")?;
+				Some(RecoveryConfig {
+					config: config.clone(),
+					keys,
+					schedules,
+				})
+			}
+			None => None,
+		};
+		recovery_groups.push(RecoveryGroup { group, config });
+	}
+	servers.extend(
+		Server::list_ungrouped(db)
+			.await
+			.context("list ungrouped servers")?,
+	);
+
+	let snapshot = RecoverySnapshot {
+		schema_version: SCHEMA_VERSION,
+		taken_at: now.to_string(),
+		groups: recovery_groups,
+		servers,
+		enabled_capabilities: ServerBackupCapability::list_enabled(db)
+			.await
+			.context("list capabilities")?,
+	};
+	serde_json::to_vec(&snapshot).context("serialise snapshot")
+}
+
+/// Encrypt the ciphertext and PUT it to the (versioned, object-locked) vault.
+async fn write_vault(config: &RecoveryVaultConfig, ciphertext: Vec<u8>) -> Result<()> {
+	let sdk = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+	let mut builder = aws_sdk_s3::config::Builder::from(&sdk);
+	if let Some(role_arn) = &config.role_arn {
+		let sts = aws_sdk_sts::Client::new(&sdk);
+		let assumed = sts
+			.assume_role()
+			.role_arn(role_arn)
+			.role_session_name("canopy-recovery-vault")
+			.send()
+			.await
+			.context("assume recovery vault role")?;
+		let c = assumed
+			.credentials()
+			.context("AssumeRole returned no credentials")?;
+		builder = builder.credentials_provider(aws_sdk_s3::config::Credentials::new(
+			c.access_key_id(),
+			c.secret_access_key(),
+			Some(c.session_token().to_string()),
+			None,
+			"canopy-recovery-vault",
+		));
+	}
+	if let Some(region) = &config.region {
+		builder = builder.region(aws_sdk_s3::config::Region::new(region.clone()));
+	}
+	let s3 = aws_sdk_s3::Client::from_conf(builder.build());
+
+	s3.put_object()
+		.bucket(&config.bucket)
+		.key(VAULT_OBJECT_KEY)
+		.body(ciphertext.into())
+		.content_type("application/age")
+		.send()
+		.await
+		.context("put recovery vault object")?;
+	Ok(())
+}
+
+async fn tick(worker: &Worker, config: &RecoveryVaultConfig) -> Result<()> {
+	let mut db = worker
+		.pool
+		.get()
+		.await
+		.map_err(|e| anyhow::anyhow!("db: {e}"))?;
+	let plaintext = build_snapshot_json(&mut db, &worker.secrets, Timestamp::now()).await?;
+	let ciphertext = config
+		.recipients
+		.encrypt(&plaintext)
+		.map_err(|e| anyhow::anyhow!("encrypt: {e}"))?;
+	let bytes = ciphertext.len();
+	write_vault(config, ciphertext).await?;
+	info!(
+		bucket = %config.bucket,
+		key = VAULT_OBJECT_KEY,
+		recipients = config.recipients.len(),
+		bytes,
+		"recovery-snapshot: wrote encrypted vault object"
+	);
+	Ok(())
+}
+
+pub fn spawn(worker: Worker, config: RecoveryVaultConfig) -> JoinHandle<()> {
+	task::spawn(async move {
+		info!(
+			period_secs = config.period.as_secs(),
+			recipients = config.recipients.len(),
+			"recovery-snapshot writer started"
+		);
+		loop {
+			if let Err(e) = tick(&worker, &config).await {
+				error!("recovery-snapshot tick failed: {e:#}");
+			}
+			sleep(config.period).await;
+		}
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use commons_tests::db::TestDb;
+	use database::diesel_async::SimpleAsyncConnection;
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn snapshot_includes_group_config_and_keyset() {
+		TestDb::run(|mut conn, _url| async move {
+			let group_id = uuid::Uuid::new_v4();
+			conn.batch_execute(&format!(
+				"INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g');
+				 INSERT INTO server_group_backup_config
+				   (group_id, bucket, prefix, target_role_arn, maintenance_role_arn,
+				    repo_password_ref, status, mode)
+				 VALUES ('{group_id}', 'bkt', 'p/', 'arn:dev', 'arn:maint',
+				    'backup-repo-{group_id}', 'ready', 'from_birth');"
+			))
+			.await
+			.unwrap();
+
+			// Seed the passphrase keyset in the in-memory secret store.
+			let secrets = BackupSecrets::memory();
+			secrets
+				.create_password(&format!("backup-repo-{group_id}"), "password", "sekret")
+				.await
+				.unwrap();
+
+			let json = build_snapshot_json(&mut conn, &secrets, Timestamp::now())
+				.await
+				.unwrap();
+			let value: serde_json::Value = serde_json::from_slice(&json).unwrap();
+
+			assert_eq!(value["schema_version"], SCHEMA_VERSION);
+			let group = &value["groups"][0];
+			assert_eq!(group["id"], group_id.to_string());
+			assert_eq!(group["config"]["bucket"], "bkt");
+			assert_eq!(group["config"]["maintenance_role_arn"], "arn:maint");
+			// The passphrase keyset is the whole point — it must be present.
+			assert_eq!(group["config"]["keys"]["password"], "sekret");
+		})
+		.await;
+	}
+}

--- a/crates/jobs/src/bin/backups.rs
+++ b/crates/jobs/src/bin/backups.rs
@@ -5,7 +5,11 @@
 //! - upstream preflight ([`jobs::backup::preflight`]),
 //! - kopia maintenance scheduler ([`jobs::backup::maintenance`]),
 //! - read-only inspection scheduler ([`jobs::backup::inspection`]),
-//! - S3 CloudWatch metrics task ([`jobs::backup::s3_metrics`]).
+//! - passphrase rotation loop ([`jobs::backup::rotation`]),
+//! - S3 CloudWatch metrics task ([`jobs::backup::s3_metrics`]),
+//! - recovery vault writer ([`jobs::backup::recovery_snapshot`]) — encrypts a state snapshot
+//!   to `age` recipients and writes it to object-locked S3. Its recipients are
+//!   mandatory, so the pod refuses to start if they're unset.
 //!
 //! The maintenance + inspection loops run kopia **in-process** (subprocesses)
 //! rather than spawning Kubernetes Jobs; they share a [`jobs::backup::worker::Worker`]
@@ -56,11 +60,25 @@ async fn main() -> miette::Result<()> {
 		.map_err(|e| miette!("container-creds endpoint init failed: {e}"))?;
 	let worker = Worker::new(pool, secrets, Cfg::from_env(), creds);
 
+	// recovery vault recipients are MANDATORY — refuse to start without them so there's
+	// never a silent recovery gap (Canopy owns every passphrase).
+	let recovery_config = jobs::backup::recovery_snapshot::RecoveryVaultConfig::from_env()
+		.map_err(|e| miette!("recovery vault misconfigured: {e}"))?;
+
 	let preflight = jobs::backup::preflight::spawn();
 	let maintenance = jobs::backup::maintenance::spawn(worker.clone());
 	let inspection = jobs::backup::inspection::spawn(worker.clone());
-	let rotation = jobs::backup::rotation::spawn(worker);
+	let rotation = jobs::backup::rotation::spawn(worker.clone());
 	let s3_metrics = jobs::backup::s3_metrics::spawn();
-	tokio::try_join!(preflight, maintenance, inspection, rotation, s3_metrics).into_diagnostic()?;
+	let recovery_snapshot = jobs::backup::recovery_snapshot::spawn(worker, recovery_config);
+	tokio::try_join!(
+		preflight,
+		maintenance,
+		inspection,
+		rotation,
+		s3_metrics,
+		recovery_snapshot
+	)
+	.into_diagnostic()?;
 	Ok(())
 }


### PR DESCRIPTION
🤖 The recovery vault, part 1: the writer. Canopy owns every repo passphrase with no human copy, so the backups pod backs up its recovery-critical state where a cluster loss can't take it down with it — and where a Canopy compromise can't read it.

## What it writes

A periodic snapshot of the recovery-critical state — server groups, backup configs with their **per-group passphrase keysets** + repo coordinates, schedules, enabled capabilities, and the server list — serialised to JSON and written to a **versioned, object-locked** S3 bucket.

## How it's protected

- **age asymmetric encryption** to one or more recipient public keys whose private halves Canopy never holds. Canopy can *write* the vault but **cannot read it back**.
- **Object Lock (COMPLIANCE) + versioning** — even root can't delete a version before it expires; each tick writes a new version of a single fixed object key (`canopy-recovery/state.age`).
- **bestool-compatible:** standard age v1 / x25519 — the same crate and format as BES `algae-cli`, so a vault object decrypts with `bestool crypto decrypt` (and `age`/`rage`). No `algae-cli` dependency; format compatibility is asserted in tests.

## Mandatory by design

Recipients are **required**: the backups pod refuses to start without `CANOPY_RECOVERY_VAULT_KEYS` (and `CANOPY_RECOVERY_VAULT_BUCKET`).

Config (ops/TAM-6878 provides): `CANOPY_RECOVERY_VAULT_KEYS` (space/comma-separated `age1…`), `CANOPY_RECOVERY_VAULT_BUCKET`/`_REGION`/`_ROLE_ARN`, `CANOPY_RECOVERY_VAULT_SNAPSHOT_HOURS` (default 24). The object key/path is fixed, not configurable. Soft rotation is possible via using multiple keys.

The verification ceremony follows in the next PR. Stacked on #237.