### PR TITLE
feat(backups): recovery vault verification ceremony [TAM-6877]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4477,6 +4477,7 @@ dependencies = [
 name = "private-server"
 version = "6.6.6"
 dependencies = [
+ "age",
  "algae-cli",
  "aws-config",
  "aws-sdk-s3",

--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -235,6 +235,8 @@ where
 				prober: private_server::backup_probe::BucketProber::fake(
 					private_server::backup_probe::ProbeState::Empty,
 				),
+				recovery_recipients: None,
+				recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -1182,3 +1182,53 @@ impl BackupRequest {
 			.map_err(AppError::from)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// backup_recovery_verifications — the recovery vault verification-ceremony log
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::backup_recovery_verifications)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupRecoveryVerification {
+	pub id: i64,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub verified_at: Timestamp,
+	/// The recipient fingerprints (age1… keys) this ceremony covered, as a JSON
+	/// array of strings.
+	pub recipients: JsonValue,
+}
+
+impl BackupRecoveryVerification {
+	/// Record a successful ceremony against the given recipient fingerprints.
+	pub async fn record(db: &mut AsyncPgConnection, recipients: &[String]) -> Result<Self> {
+		use crate::schema::backup_recovery_verifications::dsl;
+
+		let recipients =
+			serde_json::to_value(recipients).unwrap_or_else(|_| JsonValue::Array(vec![]));
+		diesel::insert_into(dsl::backup_recovery_verifications)
+			.values(dsl::recipients.eq(recipients))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// The most recent verification, if any.
+	pub async fn latest(db: &mut AsyncPgConnection) -> Result<Option<Self>> {
+		use crate::schema::backup_recovery_verifications::dsl;
+
+		dsl::backup_recovery_verifications
+			.order(dsl::verified_at.desc())
+			.select(Self::as_select())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
+	/// The recipient fingerprints this verification covered.
+	pub fn recipient_list(&self) -> Vec<String> {
+		serde_json::from_value(self.recipients.clone()).unwrap_or_default()
+	}
+}

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -31,9 +31,9 @@ pub mod versions;
 pub mod views;
 
 pub use backups::{
-	BackupCredentialIssuance, BackupMaintenanceRun, BackupRepoSnapshot, BackupRepoStats,
-	BackupRequest, BackupRun, BackupTypeDefault, NewBackupCredentialIssuance, NewBackupRun,
-	NewBackupTypeDefault, NewServerGroupBackupConfig, NewServerGroupBackupSchedule,
+	BackupCredentialIssuance, BackupMaintenanceRun, BackupRecoveryVerification, BackupRepoSnapshot,
+	BackupRepoStats, BackupRequest, BackupRun, BackupTypeDefault, NewBackupCredentialIssuance,
+	NewBackupRun, NewBackupTypeDefault, NewServerGroupBackupConfig, NewServerGroupBackupSchedule,
 	RetentionPolicy, ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
 };
 pub use bestool_snippets::{BestoolSnippet, NewBestoolSnippet};

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -40,6 +40,14 @@ diesel::table! {
 }
 
 diesel::table! {
+	backup_recovery_verifications (id) {
+		id -> Int8,
+		verified_at -> Timestamptz,
+		recipients -> Jsonb,
+	}
+}
+
+diesel::table! {
 	backup_maintenance_runs (id) {
 		id -> Int8,
 		group_id -> Uuid,
@@ -528,6 +536,7 @@ diesel::allow_tables_to_appear_in_same_query!(
 	admins,
 	artifacts,
 	backup_credential_issuances,
+	backup_recovery_verifications,
 	backup_maintenance_runs,
 	backup_repo_snapshots,
 	backup_repo_stats,

--- a/crates/private-server/Cargo.toml
+++ b/crates/private-server/Cargo.toml
@@ -46,6 +46,7 @@ chbs = "0.1.1"
 algae-cli = "1.1.0"
 
 [dev-dependencies]
+age = { version = "0.11.3", default-features = false }
 commons-tests = { path = "../commons-tests" }
 hex = "0.4.3"
 rcgen = "0.14.8"

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -20,19 +20,26 @@ use commons_types::{
 };
 use database::pg_duration::PgDuration;
 use database::{
-	BackupMaintenanceRun, BackupRepoStats, BackupRequest, BackupRun, NewServerGroupBackupConfig,
-	NewServerGroupBackupSchedule, RetentionPolicy, ServerBackupCapability, ServerGroupBackupConfig,
-	ServerGroupBackupSchedule, server_groups::ServerGroup,
+	BackupMaintenanceRun, BackupRecoveryVerification, BackupRepoStats, BackupRequest, BackupRun,
+	NewServerGroupBackupConfig, NewServerGroupBackupSchedule, RetentionPolicy,
+	ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
+	server_groups::ServerGroup,
 };
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
-use crate::state::AppState;
+use crate::state::{AppState, RecoveryChallenge};
 
 /// Secret key the from-birth init Job writes the generated passphrase under.
 const REPO_PASSWORD_SECRET_KEY: &str = "password";
+
+/// The recovery verification ceremony is due if the last one is older than this.
+const RECOVERY_VERIFICATION_MAX_AGE_SECS: i64 = 365 * 24 * 3600;
+
+/// A challenge older than this is stale (operator must request a fresh one).
+const RECOVERY_CHALLENGE_TTL_SECS: i64 = 3600;
 
 /// Cap on the recent-runs / maintenance lists in the stats panel.
 const RECENT_LIMIT: i64 = 20;
@@ -53,6 +60,9 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(capabilities))
 		.routes(routes!(set_capability))
 		.routes(routes!(delete))
+		.routes(routes!(recovery_status))
+		.routes(routes!(recovery_challenge))
+		.routes(routes!(recovery_verify))
 }
 
 // ── Wire types ──────────────────────────────────────────────────────────────
@@ -883,6 +893,230 @@ pub async fn delete(
 		kube.delete_password(&config.repo_password_ref).await?;
 	}
 	Ok(Json(()))
+}
+
+// ── recovery vault verification ceremony ───────────────────────────────────────────
+
+/// Status of the recovery vault verification ceremony.
+#[derive(Serialize, ToSchema)]
+pub struct RecoveryStatusResponse {
+	/// Whether recovery recipients are configured on this server at all.
+	pub configured: bool,
+	/// The live recipient fingerprints (`age1…`).
+	pub recipients: Vec<String>,
+	pub last_verified_at: Option<Timestamp>,
+	/// The recipient set the last verification covered.
+	pub last_verified_recipients: Vec<String>,
+	/// Whether a (fresh) ceremony is due.
+	pub due: bool,
+	/// Human-readable reason for the `due` value.
+	pub reason: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct RecoveryChallengeResponse {
+	/// The challenge ciphertext (`age` to the recipients), base64-encoded. The
+	/// operator decrypts it offline with a held private key (`bestool crypto
+	/// decrypt` / `age`) and submits the plaintext to `recovery_verify`.
+	pub ciphertext_base64: String,
+	/// The recipients this challenge was encrypted to.
+	pub recipients: Vec<String>,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct RecoveryVerifyArgs {
+	/// The decrypted challenge plaintext.
+	pub answer: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct RecoveryVerifyResponse {
+	pub verified_at: Timestamp,
+}
+
+/// Compute whether the ceremony is due: never run, last run > 1 year ago, or the
+/// recipient set changed since the last verification.
+fn recovery_due(
+	latest: Option<&BackupRecoveryVerification>,
+	current: &[String],
+	now: Timestamp,
+) -> (bool, String) {
+	let Some(latest) = latest else {
+		return (true, "never verified".into());
+	};
+	if now.as_second() - latest.verified_at.as_second() > RECOVERY_VERIFICATION_MAX_AGE_SECS {
+		return (true, "last verification was over a year ago".into());
+	}
+	let mut prev = latest.recipient_list();
+	prev.sort();
+	let mut cur = current.to_vec();
+	cur.sort();
+	if prev != cur {
+		return (
+			true,
+			"the recipient set changed since the last verification".into(),
+		);
+	}
+	(
+		false,
+		"verified within the last year for the current recipients".into(),
+	)
+}
+
+/// Report the recovery vault verification status (recipients, last verification, and
+/// whether a ceremony is due).
+#[utoipa::path(
+	post,
+	path = "/recovery_status",
+	operation_id = "backups_recovery_status",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	responses((status = 200, body = RecoveryStatusResponse)),
+)]
+pub async fn recovery_status(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	_body: Json<serde_json::Value>,
+) -> Result<Json<RecoveryStatusResponse>> {
+	let recipients = state
+		.recovery_recipients
+		.as_ref()
+		.map(|r| r.fingerprints().to_vec())
+		.unwrap_or_default();
+	let mut conn = state.db.get().await?;
+	let latest = BackupRecoveryVerification::latest(&mut conn).await?;
+	let (due, reason) = recovery_due(latest.as_ref(), &recipients, Timestamp::now());
+	Ok(Json(RecoveryStatusResponse {
+		configured: state.recovery_recipients.is_some(),
+		recipients,
+		last_verified_at: latest.as_ref().map(|v| v.verified_at),
+		last_verified_recipients: latest.map(|v| v.recipient_list()).unwrap_or_default(),
+		due,
+		reason,
+	}))
+}
+
+/// Issue a verification challenge: a fresh nonce encrypted to the recovery recipients.
+/// The operator decrypts it offline (proving a private key is genuinely held) and
+/// posts the plaintext back to `recovery_verify`.
+#[utoipa::path(
+	post,
+	path = "/recovery_challenge",
+	operation_id = "backups_recovery_challenge",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	responses(
+		(status = 200, body = RecoveryChallengeResponse),
+		(status = 502, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn recovery_challenge(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	_body: Json<serde_json::Value>,
+) -> Result<Json<RecoveryChallengeResponse>> {
+	use base64::prelude::*;
+
+	let recipients = state.recovery_recipients.as_ref().ok_or_else(|| {
+		AppError::Upstream("recovery recipients are not configured on this server".into())
+	})?;
+
+	let nonce = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+	let ciphertext = recipients.encrypt(nonce.as_bytes())?;
+
+	*state.recovery_challenge.lock().unwrap() = Some(RecoveryChallenge {
+		nonce,
+		issued_at: Timestamp::now(),
+	});
+
+	Ok(Json(RecoveryChallengeResponse {
+		ciphertext_base64: BASE64_STANDARD.encode(ciphertext),
+		recipients: recipients.fingerprints().to_vec(),
+	}))
+}
+
+/// Complete the ceremony: verify the operator's decrypted answer matches the
+/// outstanding challenge, then record the verification against the current
+/// recipient set.
+#[utoipa::path(
+	post,
+	path = "/recovery_verify",
+	operation_id = "backups_recovery_verify",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = RecoveryVerifyArgs,
+	responses(
+		(status = 200, body = RecoveryVerifyResponse),
+		(status = 400, body = ProblemDetailsSchema),
+		(status = 502, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn recovery_verify(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<RecoveryVerifyArgs>,
+) -> Result<Json<RecoveryVerifyResponse>> {
+	let recipients = state.recovery_recipients.as_ref().ok_or_else(|| {
+		AppError::Upstream("recovery recipients are not configured on this server".into())
+	})?;
+
+	// Take (consume) the pending challenge: success or failure, it's single-use.
+	let pending = state.recovery_challenge.lock().unwrap().take();
+	let Some(pending) = pending else {
+		return Err(AppError::BadRequest(
+			"no outstanding challenge; request one first".into(),
+		));
+	};
+	if Timestamp::now().as_second() - pending.issued_at.as_second() > RECOVERY_CHALLENGE_TTL_SECS {
+		return Err(AppError::BadRequest(
+			"challenge expired; request a fresh one".into(),
+		));
+	}
+	if args.answer.trim() != pending.nonce {
+		return Err(AppError::BadRequest(
+			"answer does not match the challenge".into(),
+		));
+	}
+
+	let mut conn = state.db.get().await?;
+	let recorded = BackupRecoveryVerification::record(&mut conn, recipients.fingerprints()).await?;
+	Ok(Json(RecoveryVerifyResponse {
+		verified_at: recorded.verified_at,
+	}))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn verification(verified_at_secs: i64, recipients: &[&str]) -> BackupRecoveryVerification {
+		BackupRecoveryVerification {
+			id: 1,
+			verified_at: Timestamp::from_second(verified_at_secs).unwrap(),
+			recipients: serde_json::json!(recipients),
+		}
+	}
+
+	#[test]
+	fn recovery_due_logic() {
+		let now = Timestamp::from_second(2_000_000_000).unwrap();
+		let recips = ["age1aaa".to_string(), "age1bbb".to_string()];
+
+		// Never verified.
+		assert!(recovery_due(None, &recips, now).0);
+
+		// Fresh + same set (order-insensitive) → not due.
+		let fresh = verification(now.as_second() - 10, &["age1bbb", "age1aaa"]);
+		assert!(!recovery_due(Some(&fresh), &recips, now).0);
+
+		// Over a year old → due.
+		let old = verification(now.as_second() - (366 * 24 * 3600), &["age1aaa", "age1bbb"]);
+		assert!(recovery_due(Some(&old), &recips, now).0);
+
+		// Recent but recipient set changed → due.
+		let changed = verification(now.as_second() - 10, &["age1aaa"]);
+		assert!(recovery_due(Some(&changed), &recips, now).0);
+	}
 }
 
 /// Fetch a group's config or 404 — used by the mutation handlers that require

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -1,11 +1,26 @@
+use std::sync::{Arc, Mutex};
+
 use axum::extract::FromRef;
 use bestool_postgres::pool::PgPool;
 use commons_errors::Result;
+use commons_servers::recovery_vault::Recipients;
 use commons_servers::tailnet_directory::{TailnetDirectory, TailnetDirectoryConfig};
 use database::Db;
 use public_server::state::BackupSecrets;
 
 use crate::backup_probe::BucketProber;
+
+/// A pending recovery vault verification challenge: the random nonce Canopy issued
+/// (encrypted to the recipients) and when, so [`crate::fns::backups::recovery_verify`]
+/// can match the operator's decrypted answer and reject stale ones.
+#[derive(Clone, Debug)]
+pub struct RecoveryChallenge {
+	pub nonce: String,
+	pub issued_at: jiff::Timestamp,
+}
+
+/// At most one in-flight recovery-vault challenge at a time (operator-driven).
+pub type RecoveryChallengeStore = Arc<Mutex<Option<RecoveryChallenge>>>;
 
 #[derive(Clone, Debug, FromRef)]
 pub struct AppState {
@@ -19,6 +34,28 @@ pub struct AppState {
 	/// Bucket prober for the setup wizard (assume role + inspect S3). `Aws` in
 	/// prod; a `Fake` canned result in tests / the e2e binary.
 	pub prober: BucketProber,
+	/// recovery vault recipient public keys (`CANOPY_RECOVERY_VAULT_KEYS`), for the
+	/// verification ceremony. `None` ⇒ the ceremony endpoints 502 (the backups
+	/// pod is what hard-requires them, not this admin server).
+	pub recovery_recipients: Option<Recipients>,
+	/// The single in-flight recovery verification challenge, if any.
+	pub recovery_challenge: RecoveryChallengeStore,
+}
+
+/// Read the recovery recipients from the environment, logging (not failing) a malformed
+/// list — the admin server should still come up; the ceremony endpoints surface
+/// the misconfiguration.
+fn recovery_recipients_from_env() -> Option<Recipients> {
+	match Recipients::from_env() {
+		Ok(r) => r,
+		Err(e) => {
+			tracing::warn!(
+				"ignoring malformed {}: {e}",
+				commons_servers::recovery_vault::RECIPIENTS_ENV
+			);
+			None
+		}
+	}
 }
 
 impl AppState {
@@ -43,6 +80,8 @@ impl AppState {
 			tailnet_directory,
 			kube,
 			prober,
+			recovery_recipients: recovery_recipients_from_env(),
+			recovery_challenge: Arc::new(Mutex::new(None)),
 		})
 	}
 
@@ -62,6 +101,9 @@ impl AppState {
 			// drives each probe state by naming the bucket — `…existing…` → kopia
 			// repo, `…other…` → other content, `…denied…` → inaccessible, else empty.
 			prober: BucketProber::Fake(None),
+			// Read from env so the e2e fixture can exercise the recovery ceremony.
+			recovery_recipients: recovery_recipients_from_env(),
+			recovery_challenge: Arc::new(Mutex::new(None)),
 		})
 	}
 }

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -727,3 +727,115 @@ async fn upsert_rejects_bucket_already_configured_for_another_group() {
 	})
 	.await;
 }
+
+/// Decrypt an `age` ciphertext with the given identity (test-side, proving the
+/// vault format is standard and the ceremony round-trips).
+fn age_decrypt(ciphertext: &[u8], identity: &age::x25519::Identity) -> Vec<u8> {
+	use std::io::Read;
+	let decryptor = age::Decryptor::new_buffered(ciphertext).unwrap();
+	let mut reader = decryptor
+		.decrypt(std::iter::once(identity as &dyn age::Identity))
+		.unwrap();
+	let mut out = Vec::new();
+	reader.read_to_end(&mut out).unwrap();
+	out
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recovery_ceremony_roundtrip() {
+	use base64::prelude::*;
+
+	// Each nextest test runs in its own process, so this env set is isolated.
+	let identity = age::x25519::Identity::generate();
+	unsafe {
+		std::env::set_var(
+			"CANOPY_RECOVERY_VAULT_KEYS",
+			identity.to_public().to_string(),
+		);
+	}
+
+	commons_tests::server::run(async move |_conn, _public, private| {
+		// Status: configured but never verified → due.
+		let resp = private
+			.post("/api/backups/recovery_status")
+			.json(&serde_json::json!({}))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert_eq!(body["configured"], true);
+		assert_eq!(body["due"], true);
+		assert!(body["last_verified_at"].is_null());
+
+		// Challenge → decrypt offline → verify.
+		let resp = private
+			.post("/api/backups/recovery_challenge")
+			.json(&serde_json::json!({}))
+			.await;
+		resp.assert_status_ok();
+		let ct_b64 = resp.json::<serde_json::Value>()["ciphertext_base64"]
+			.as_str()
+			.unwrap()
+			.to_string();
+		let plaintext = age_decrypt(&BASE64_STANDARD.decode(ct_b64).unwrap(), &identity);
+		let answer = String::from_utf8(plaintext).unwrap();
+
+		let resp = private
+			.post("/api/backups/recovery_verify")
+			.json(&serde_json::json!({ "answer": answer }))
+			.await;
+		resp.assert_status_ok();
+
+		// Status now reports verified (not due) for the current recipients.
+		let resp = private
+			.post("/api/backups/recovery_status")
+			.json(&serde_json::json!({}))
+			.await;
+		let body: serde_json::Value = resp.json();
+		assert_eq!(body["due"], false);
+		assert!(!body["last_verified_at"].is_null());
+		assert_eq!(
+			body["last_verified_recipients"][0],
+			identity.to_public().to_string()
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recovery_verify_rejects_wrong_and_missing() {
+	let identity = age::x25519::Identity::generate();
+	unsafe {
+		std::env::set_var(
+			"CANOPY_RECOVERY_VAULT_KEYS",
+			identity.to_public().to_string(),
+		);
+	}
+
+	commons_tests::server::run(async move |_conn, _public, private| {
+		// No outstanding challenge → 400.
+		private
+			.post("/api/backups/recovery_verify")
+			.json(&serde_json::json!({ "answer": "anything" }))
+			.await
+			.assert_status_bad_request();
+
+		// Issue a challenge, then answer wrong → 400 (and the challenge is spent).
+		private
+			.post("/api/backups/recovery_challenge")
+			.json(&serde_json::json!({}))
+			.await
+			.assert_status_ok();
+		private
+			.post("/api/backups/recovery_verify")
+			.json(&serde_json::json!({ "answer": "not-the-nonce" }))
+			.await
+			.assert_status_bad_request();
+		// Spent: a second verify with no fresh challenge → 400.
+		private
+			.post("/api/backups/recovery_verify")
+			.json(&serde_json::json!({ "answer": "not-the-nonce" }))
+			.await
+			.assert_status_bad_request();
+	})
+	.await;
+}

--- a/crates/private-server/tests/device_admin_endpoints.rs
+++ b/crates/private-server/tests/device_admin_endpoints.rs
@@ -40,6 +40,8 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 			prober: private_server::backup_probe::BucketProber::fake(
 				private_server::backup_probe::ProbeState::Empty,
 			),
+			recovery_recipients: None,
+			recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
 		})
 		.unwrap(),
 		ClientIpSource::RightmostForwarded,

--- a/crates/private-server/tests/tailnet_device_auth.rs
+++ b/crates/private-server/tests/tailnet_device_auth.rs
@@ -86,6 +86,8 @@ async fn unknown_tailnet_node_auto_creates_untrusted_then_403s_role_gate() {
 				prober: private_server::backup_probe::BucketProber::fake(
 					private_server::backup_probe::ProbeState::Empty,
 				),
+				recovery_recipients: None,
+				recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/docs/plans/backup-setup-wizard-ops-handoff.md
+++ b/docs/plans/backup-setup-wizard-ops-handoff.md
@@ -168,3 +168,35 @@ action items §1–§3, §5 are the source of truth; treat them as done.
   Read-only `get secrets` no longer covers the rotation path.
 - No other ops change; rotation cadence is a canopy env
   (`CANOPY_BACKUP_ROTATION_DAYS`, default 7).
+
+**2026-06-21 — NEW ops action (recovery vault):**
+- ⚠️ **A new object-locked S3 bucket for the recovery vault, in a SEPARATE account**
+  from both the canopy cluster account and the per-tenant backup accounts.
+  Requirements:
+  - **Object Lock = COMPLIANCE** + **versioning** on (so a Canopy compromise
+    can't delete history; each daily write is a new immutable version of the
+    same key). Pick a retention period (with a lifecycle expiry so it doesn't
+    grow forever). SSE on.
+  - A **writer role** the `canopy-jobs` SA assumes (chained AssumeRole), granted
+    **`s3:PutObject` ONLY** on that bucket — **no delete, no get** (Canopy never
+    reads the vault back; the blob is asymmetrically encrypted so it couldn't
+    read it anyway).
+- ⚠️ **age recipient keypairs (recovery-key custody).** Generate **multiple** age
+  keypairs (e.g. one per recovery officer; `bestool crypto keygen`). The
+  **public** keys go to Canopy via `CANOPY_RECOVERY_VAULT_KEYS` (space/comma-
+  separated `age1…`); the **private** keys are held **offline, out-of-band**
+  (any one can recover). Custody is an ops runbook — Canopy never sees a private
+  key.
+- **Canopy env (backups pod):** `CANOPY_RECOVERY_VAULT_KEYS` (**mandatory** — the
+  pod refuses to start without it), `CANOPY_RECOVERY_VAULT_BUCKET` (**mandatory**),
+  `CANOPY_RECOVERY_VAULT_REGION`, `CANOPY_RECOVERY_VAULT_ROLE_ARN` (the writer role),
+  `CANOPY_RECOVERY_VAULT_SNAPSHOT_HOURS` (default 24). The object key/path within
+  the bucket is not configurable (fixed at `canopy-recovery/state.age`). These
+  must be provisioned **before** the backups pod is deployed with this build, or
+  it will crash-loop on the mandatory check.
+- **Verification ceremony (runbook):** operators run a yearly (and on-key-change)
+  ceremony in the canopy admin UI (recovery vault page): Canopy issues an age-encrypted
+  challenge, the operator decrypts it offline with a held private key
+  (`bestool crypto decrypt`) and pastes it back. The vault blob itself is plain
+  `age` v1 (decryptable with `bestool crypto decrypt` / `age` / `rage`).
+- No k8s RBAC change (the vault is S3, not a Secret).

--- a/migrations/2026-06-20-130659-0000_add_backup_recovery_verifications/down.sql
+++ b/migrations/2026-06-20-130659-0000_add_backup_recovery_verifications/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE backup_recovery_verifications;

--- a/migrations/2026-06-20-130659-0000_add_backup_recovery_verifications/up.sql
+++ b/migrations/2026-06-20-130659-0000_add_backup_recovery_verifications/up.sql
@@ -1,0 +1,13 @@
+-- Records of the recovery vault verification ceremony: each time an operator proves
+-- they can decrypt a Canopy-issued challenge with a held private key, we record
+-- when and against which recipient set. The ceremony is due when there is no
+-- record, the latest is over a year old, or the recipient set has changed.
+CREATE TABLE backup_recovery_verifications (
+    id BIGSERIAL PRIMARY KEY,
+    verified_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- The recipient fingerprints (age1… public keys) this verification covered,
+    -- as a JSON array of strings; compared against the live set to detect a
+    -- changed key set.
+    recipients JSONB NOT NULL,
+    CONSTRAINT recipients_is_array CHECK (jsonb_typeof(recipients) = 'array')
+);

--- a/private-web/e2e/fixture.ts
+++ b/private-web/e2e/fixture.ts
@@ -194,6 +194,12 @@ export async function startStack(opts: StartOptions = {}): Promise<StackHandle> 
 				// the bucket name (…existing… → kopia repo, …other… → other content,
 				// …denied… → inaccessible, else empty).
 				CANOPY_BACKUP_PROBER_FAKE: "1",
+				// A throwaway age recipient (bestool-generated) so the recovery vault
+				// ceremony page reports as configured. The matching private key isn't
+				// needed: the e2e exercises status + challenge + wrong-answer, and the
+				// full decrypt round-trip is covered by the Rust endpoint tests.
+				CANOPY_RECOVERY_VAULT_KEYS:
+					"age1uy3nqmdxf4lc3sc4p32c2cp9dlqwk868gjh002gysullrgvp0cjsdg03dn",
 				// Needed by mint_enrollment to build the ticket's api_url; the
 				// setup-instructions flow auto-mints on an unregistered server.
 				PUBLIC_URL: process.env.PUBLIC_URL ?? "https://api.e2e.invalid",

--- a/private-web/e2e/recovery-vault.spec.ts
+++ b/private-web/e2e/recovery-vault.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "./test-fixtures";
+
+// The fixture configures CANOPY_RECOVERY_VAULT_KEYS with a throwaway age public
+// key, so the recovery vault page reports as configured. The full decrypt round-trip
+// (correct answer → recorded verification) is covered by the Rust endpoint
+// tests; here we exercise the page, the challenge issuance, and the
+// wrong-answer rejection.
+const RECIPIENT =
+	"age1uy3nqmdxf4lc3sc4p32c2cp9dlqwk868gjh002gysullrgvp0cjsdg03dn";
+
+test.describe("Recovery vault ceremony", () => {
+	test("shows status, lists the recipient, and runs a challenge", async ({
+		page,
+	}) => {
+		await page.goto("/backups/recovery");
+
+		await expect(
+			page.getByRole("heading", { name: /recovery vault/i }),
+		).toBeVisible();
+		// Never verified yet → due.
+		await expect(page.getByText("Verification due")).toBeVisible();
+		// The configured recipient is listed.
+		await expect(page.getByText(RECIPIENT)).toBeVisible();
+
+		// Issue a challenge → the ciphertext field appears, non-empty.
+		await page.getByRole("button", { name: /issue challenge/i }).click();
+		const challenge = page.getByLabel("Challenge (base64 age ciphertext)");
+		await expect(challenge).toBeVisible();
+		await expect(challenge).not.toHaveValue("");
+
+		// A wrong answer is rejected.
+		await page.getByLabel("Decrypted answer").fill("not-the-nonce");
+		await page.getByRole("button", { name: /submit answer/i }).click();
+		await expect(page.getByText(/does not match/i)).toBeVisible();
+	});
+});

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -512,6 +512,140 @@
         ]
       }
     },
+    "/api/backups/recovery_challenge": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Issue a verification challenge: a fresh nonce encrypted to the recovery recipients.\nThe operator decrypts it offline (proving a private key is genuinely held) and\nposts the plaintext back to `recovery_verify`.",
+        "operationId": "backups_recovery_challenge",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecoveryChallengeResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/backups/recovery_status": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Report the recovery vault verification status (recipients, last verification, and\nwhether a ceremony is due).",
+        "operationId": "backups_recovery_status",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecoveryStatusResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/backups/recovery_verify": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Complete the ceremony: verify the operator's decrypted answer matches the\noutstanding challenge, then record the verification against the current\nrecipient set.",
+        "operationId": "backups_recovery_verify",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecoveryVerifyArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecoveryVerifyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/backups/request_now": {
       "post": {
         "tags": [
@@ -7456,6 +7590,96 @@
             "format": "uri",
             "description": "A URI reference identifying the problem type.",
             "example": "/errors/resource-not-found"
+          }
+        }
+      },
+      "RecoveryChallengeResponse": {
+        "type": "object",
+        "required": [
+          "ciphertext_base64",
+          "recipients"
+        ],
+        "properties": {
+          "ciphertext_base64": {
+            "type": "string",
+            "description": "The challenge ciphertext (`age` to the recipients), base64-encoded. The\noperator decrypts it offline with a held private key (`bestool crypto\ndecrypt` / `age`) and submits the plaintext to `recovery_verify`."
+          },
+          "recipients": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The recipients this challenge was encrypted to."
+          }
+        }
+      },
+      "RecoveryStatusResponse": {
+        "type": "object",
+        "description": "Status of the recovery vault verification ceremony.",
+        "required": [
+          "configured",
+          "recipients",
+          "last_verified_recipients",
+          "due",
+          "reason"
+        ],
+        "properties": {
+          "configured": {
+            "type": "boolean",
+            "description": "Whether recovery recipients are configured on this server at all."
+          },
+          "due": {
+            "type": "boolean",
+            "description": "Whether a (fresh) ceremony is due."
+          },
+          "last_verified_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "last_verified_recipients": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The recipient set the last verification covered."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Human-readable reason for the `due` value."
+          },
+          "recipients": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The live recipient fingerprints (`age1…`)."
+          }
+        }
+      },
+      "RecoveryVerifyArgs": {
+        "type": "object",
+        "required": [
+          "answer"
+        ],
+        "properties": {
+          "answer": {
+            "type": "string",
+            "description": "The decrypted challenge plaintext."
+          }
+        }
+      },
+      "RecoveryVerifyResponse": {
+        "type": "object",
+        "required": [
+          "verified_at"
+        ],
+        "properties": {
+          "verified_at": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -14,6 +14,7 @@ import { AdminProvider } from "./hooks/useIsAdmin";
 import { useReloadInterval } from "./hooks/useReloadInterval";
 import Admins from "./routes/Admins";
 import BackupConfig from "./routes/BackupConfig";
+import RecoveryVault from "./routes/RecoveryVault";
 import BackupPanel from "./routes/BackupPanel";
 import Bestool from "./routes/Bestool";
 import BestoolSnippetDetail from "./routes/BestoolSnippetDetail";
@@ -53,6 +54,7 @@ const BASE_NAV: NavItem[] = [
 	{ label: "Versions", to: "/versions" },
 	{ label: "Devices", to: "/devices" },
 	{ label: "Bestool", to: "/bestool" },
+	{ label: "Recovery vault", to: "/backups/recovery" },
 	{ label: "Admins", to: "/admins" },
 ];
 
@@ -203,6 +205,7 @@ export default function App() {
 						path="/groups/:id/backups/config"
 						element={<BackupConfig />}
 					/>
+					<Route path="/backups/recovery" element={<RecoveryVault />} />
 					<Route path="/devices" element={<Devices />}>
 						<Route index element={<DevicesSearch />} />
 						<Route

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -209,6 +209,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/backups/recovery_challenge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Issue a verification challenge: a fresh nonce encrypted to the recovery recipients.
+         *     The operator decrypts it offline (proving a private key is genuinely held) and
+         *     posts the plaintext back to `recovery_verify`.
+         */
+        post: operations["backups_recovery_challenge"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/backups/recovery_status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Report the recovery vault verification status (recipients, last verification, and
+         *     whether a ceremony is due).
+         */
+        post: operations["backups_recovery_status"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/backups/recovery_verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Complete the ceremony: verify the operator's decrypted answer matches the
+         *     outstanding challenge, then record the verification against the current
+         *     recipient set.
+         */
+        post: operations["backups_recovery_verify"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/backups/request_now": {
         parameters: {
             query?: never;
@@ -2970,6 +3032,39 @@ export interface components {
              */
             type: string;
         };
+        RecoveryChallengeResponse: {
+            /**
+             * @description The challenge ciphertext (`age` to the recipients), base64-encoded. The
+             *     operator decrypts it offline with a held private key (`bestool crypto
+             *     decrypt` / `age`) and submits the plaintext to `recovery_verify`.
+             */
+            ciphertext_base64: string;
+            /** @description The recipients this challenge was encrypted to. */
+            recipients: string[];
+        };
+        /** @description Status of the recovery vault verification ceremony. */
+        RecoveryStatusResponse: {
+            /** @description Whether recovery recipients are configured on this server at all. */
+            configured: boolean;
+            /** @description Whether a (fresh) ceremony is due. */
+            due: boolean;
+            /** Format: date-time */
+            last_verified_at?: string | null;
+            /** @description The recipient set the last verification covered. */
+            last_verified_recipients: string[];
+            /** @description Human-readable reason for the `due` value. */
+            reason: string;
+            /** @description The live recipient fingerprints (`age1…`). */
+            recipients: string[];
+        };
+        RecoveryVerifyArgs: {
+            /** @description The decrypted challenge plaintext. */
+            answer: string;
+        };
+        RecoveryVerifyResponse: {
+            /** Format: date-time */
+            verified_at: string;
+        };
         RelatedVersionData: {
             changelog: string;
             /** Format: int32 */
@@ -3977,6 +4072,99 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProbeResponse"];
+                };
+            };
+        };
+    };
+    backups_recovery_challenge: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": unknown;
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryChallengeResponse"];
+                };
+            };
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    backups_recovery_status: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": unknown;
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryStatusResponse"];
+                };
+            };
+        };
+    };
+    backups_recovery_verify: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecoveryVerifyArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecoveryVerifyResponse"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
                 };
             };
         };

--- a/private-web/src/routes/RecoveryVault.tsx
+++ b/private-web/src/routes/RecoveryVault.tsx
@@ -1,0 +1,207 @@
+import {
+	Alert,
+	Button,
+	Chip,
+	LinearProgress,
+	Link as MuiLink,
+	List,
+	ListItem,
+	ListItemText,
+	Paper,
+	Snackbar,
+	Stack,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { useState } from "react";
+import { useApi, useApiAction } from "../api";
+import { usePageTitle } from "../hooks/usePageTitle";
+
+/// Server-wide recovery vault status + verification ceremony.
+///
+/// Canopy backs up its recovery-critical state (every repo passphrase + repo
+/// coordinates) age-encrypted to recipient public keys it never holds the
+/// private half of. This page runs the ceremony that proves a private key is
+/// genuinely held and a blob decrypts — due yearly, or whenever the recipient
+/// set changes.
+export default function RecoveryVault() {
+	usePageTitle("Recovery vault");
+	const status = useApi("backups", "recovery_status");
+	const challenge = useApiAction("backups", "recovery_challenge");
+	const verify = useApiAction("backups", "recovery_verify");
+
+	const [ciphertext, setCiphertext] = useState<string | null>(null);
+	const [answer, setAnswer] = useState("");
+	const [toast, setToast] = useState<string | null>(null);
+
+	const startChallenge = async () => {
+		setAnswer("");
+		const res = await challenge.call();
+		setCiphertext(res.ciphertext_base64);
+	};
+
+	const submitAnswer = async () => {
+		await verify.call({ answer });
+		setCiphertext(null);
+		setAnswer("");
+		setToast("Verification recorded");
+		status.reload();
+	};
+
+	if (status.status === "loading" || status.status === "idle") {
+		return <LinearProgress />;
+	}
+	if (status.status === "error") {
+		return <Alert severity="error">{status.error.message}</Alert>;
+	}
+	const s = status.data;
+
+	return (
+		<Stack spacing={3}>
+			<Typography variant="h5" component="h1">
+				Recovery vault
+			</Typography>
+
+			{!s.configured && (
+				<Alert severity="warning">
+					No recovery recipients are configured on this server (
+					<code>CANOPY_RECOVERY_VAULT_KEYS</code>). The backups pod requires them
+					and won't run without them — set them in ops before relying on the
+					vault.
+				</Alert>
+			)}
+
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<Stack spacing={2}>
+					<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+						<Typography variant="subtitle1">Verification status</Typography>
+						<Chip
+							size="small"
+							color={s.due ? "warning" : "success"}
+							label={s.due ? "Verification due" : "Verified"}
+						/>
+					</Stack>
+					<Typography variant="body2" color="text.secondary">
+						{s.reason}.
+					</Typography>
+					<Typography variant="body2">
+						Last verified:{" "}
+						{s.last_verified_at
+							? new Date(s.last_verified_at).toLocaleString()
+							: "never"}
+					</Typography>
+
+					<Typography variant="subtitle2">Recipients</Typography>
+					{s.recipients.length === 0 ? (
+						<Typography variant="body2" color="text.secondary">
+							None configured.
+						</Typography>
+					) : (
+						<List dense disablePadding>
+							{s.recipients.map((r) => (
+								<ListItem key={r} disableGutters>
+									<ListItemText
+										slotProps={{
+											primary: {
+												sx: { fontFamily: "monospace", wordBreak: "break-all" },
+											},
+										}}
+										primary={r}
+									/>
+								</ListItem>
+							))}
+						</List>
+					)}
+				</Stack>
+			</Paper>
+
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<Stack spacing={2}>
+					<Typography variant="subtitle1">
+						Run the verification ceremony
+					</Typography>
+					<Typography variant="body2" color="text.secondary">
+						Canopy issues a challenge encrypted to the recipients above. Decrypt
+						it offline with one of the held private keys — e.g.{" "}
+						<code>base64 -d | bestool crypto decrypt --key-path identity</code>{" "}
+						(or <code>age -d</code>) — and paste the result back to confirm a
+						key is genuinely held and the vault decrypts.
+					</Typography>
+
+					<Stack direction="row" spacing={1}>
+						<Button
+							variant="contained"
+							onClick={startChallenge}
+							disabled={!s.configured || challenge.pending}
+						>
+							{challenge.pending ? "Issuing…" : "Issue challenge"}
+						</Button>
+					</Stack>
+					{challenge.error && (
+						<Alert severity="error">{challenge.error.message}</Alert>
+					)}
+
+					{ciphertext && (
+						<>
+							<TextField
+								label="Challenge (base64 age ciphertext)"
+								value={ciphertext}
+								multiline
+								minRows={3}
+								slotProps={{ htmlInput: { readOnly: true } }}
+								sx={{ "& textarea": { fontFamily: "monospace", fontSize: 12 } }}
+							/>
+							<Button
+								size="small"
+								onClick={() => {
+									navigator.clipboard?.writeText(ciphertext);
+									setToast("Copied");
+								}}
+								sx={{ alignSelf: "flex-start" }}
+							>
+								Copy challenge
+							</Button>
+							<TextField
+								label="Decrypted answer"
+								value={answer}
+								onChange={(e) => setAnswer(e.target.value)}
+								disabled={verify.pending}
+							/>
+							{verify.error && (
+								<Alert severity="error">{verify.error.message}</Alert>
+							)}
+							<Button
+								variant="contained"
+								onClick={submitAnswer}
+								disabled={verify.pending || answer.trim() === ""}
+								sx={{ alignSelf: "flex-start" }}
+							>
+								{verify.pending ? "Verifying…" : "Submit answer"}
+							</Button>
+						</>
+					)}
+				</Stack>
+			</Paper>
+
+			<Typography variant="caption" color="text.secondary">
+				The vault is written by the backups pod to object-locked S3. Recovery
+				decrypts the latest object with a held private key; see the ops runbook.{" "}
+				<MuiLink
+					href="https://github.com/beyondessential/bestool"
+					target="_blank"
+					rel="noreferrer"
+				>
+					bestool crypto
+				</MuiLink>
+				.
+			</Typography>
+
+			<Snackbar
+				open={!!toast}
+				autoHideDuration={2500}
+				onClose={() => setToast(null)}
+				message={toast ?? ""}
+			/>
+		</Stack>
+	);
+}


### PR DESCRIPTION
🤖 The recovery vault, part 2: the verification ceremony. The vault is age-encrypted to recipient keys Canopy never holds, so this is how an operator proves a private key is genuinely held and a blob actually decrypts.

## The ceremony

- `POST /api/backups/recovery_challenge` — Canopy issues a random nonce encrypted to the configured recipients (base64). The operator decrypts it offline with one of the held private keys (`bestool crypto decrypt` / `age`) and posts the plaintext to:
- `POST /api/backups/recovery_verify` — matches the answer against the single-use, hour-TTL challenge and records a verification against the current recipient fingerprints.
- `POST /api/backups/recovery_status` — recipients, last verification, and whether a ceremony is **due**: never run, last one **over a year old**, or the **recipient set changed** since the last verification.

## UI

A server-wide **Recovery vault** admin page (new nav entry): verified/due status + reason, the recipient list, and the run-the-ceremony flow.

## Storage

`backup_recovery_verifications` (verified_at + recipient fingerprints). Recipients come from `CANOPY_RECOVERY_VAULT_KEYS` on `AppState`; the in-flight challenge is held in-memory (single-use).

## Tests

Rust HTTP full round-trip (challenge → age-decrypt → verify → status flips), wrong/missing-answer rejection, the due-logic unit, and a Playwright e2e of the page + challenge + wrong-answer (fixture uses a bestool-generated recipient).

Stacked on #238.