### PR TITLE
feat(web): group Admins + Recovery vault under a Settings nav item

### DIFF
--- a/private-web/e2e/admins.spec.ts
+++ b/private-web/e2e/admins.spec.ts
@@ -22,7 +22,7 @@ test.describe("admins page", () => {
 		await callApi(request, "admins", "add", { email: seeded });
 
 		try {
-			await page.goto("/admins");
+			await page.goto("/settings/admins");
 			await expect(page.getByText(seeded)).toBeVisible();
 		} finally {
 			await callApi(request, "admins", "delete", { email: seeded });
@@ -33,7 +33,7 @@ test.describe("admins page", () => {
 		const seeded = uniqueEmail("del");
 		await callApi(request, "admins", "add", { email: seeded });
 
-		await page.goto("/admins");
+		await page.goto("/settings/admins");
 		await expect(page.getByText(seeded)).toBeVisible();
 
 		await page.getByRole("button", { name: `delete ${seeded}` }).click();
@@ -43,7 +43,7 @@ test.describe("admins page", () => {
 	test("add form creates an admin", async ({ page, request }) => {
 		const fresh = uniqueEmail("add");
 
-		await page.goto("/admins");
+		await page.goto("/settings/admins");
 		await page.getByLabel("Email").fill(fresh);
 		await page.getByRole("button", { name: "Add admin" }).click();
 
@@ -55,7 +55,7 @@ test.describe("admins page", () => {
 	});
 
 	test("rejects empty email with an inline error", async ({ page }) => {
-		await page.goto("/admins");
+		await page.goto("/settings/admins");
 		// Browser email validation will block submit when empty;
 		// circumvent with a space-only value to hit our own check.
 		await page.getByLabel("Email").fill("   ");

--- a/private-web/e2e/recovery-vault.spec.ts
+++ b/private-web/e2e/recovery-vault.spec.ts
@@ -12,7 +12,7 @@ test.describe("Recovery vault ceremony", () => {
 	test("shows status, lists the recipient, and runs a challenge", async ({
 		page,
 	}) => {
-		await page.goto("/backups/recovery");
+		await page.goto("/settings/recovery");
 
 		await expect(
 			page.getByRole("heading", { name: /recovery vault/i }),

--- a/private-web/e2e/settings.spec.ts
+++ b/private-web/e2e/settings.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "./test-fixtures";
+
+test.describe("Settings", () => {
+	test("groups Admins + Recovery vault under one nav item", async ({ page }) => {
+		await page.goto("/status");
+
+		// The top bar has a single "Settings" item (no standalone Admins /
+		// Recovery vault). Following it lands on Admins (the index).
+		await page.getByRole("link", { name: "Settings" }).click();
+		await expect(page).toHaveURL(/\/settings\/admins$/);
+		await expect(page.getByRole("tab", { name: "Admins" })).toBeVisible();
+
+		// The Recovery vault tab switches to its page.
+		await page.getByRole("tab", { name: "Recovery vault" }).click();
+		await expect(page).toHaveURL(/\/settings\/recovery$/);
+		await expect(
+			page.getByRole("heading", { name: /recovery vault/i }),
+		).toBeVisible();
+	});
+});

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -36,6 +36,7 @@ import ServerDetail from "./routes/ServerDetail";
 import ServerEdit from "./routes/ServerEdit";
 import ArchivedList from "./routes/ArchivedList";
 import Servers from "./routes/Servers";
+import Settings from "./routes/Settings";
 import Sql from "./routes/Sql";
 import UngroupedServersList from "./routes/UngroupedServersList";
 import VersionDetail from "./routes/VersionDetail";
@@ -54,8 +55,7 @@ const BASE_NAV: NavItem[] = [
 	{ label: "Versions", to: "/versions" },
 	{ label: "Devices", to: "/devices" },
 	{ label: "Bestool", to: "/bestool" },
-	{ label: "Recovery vault", to: "/backups/recovery" },
-	{ label: "Admins", to: "/admins" },
+	{ label: "Settings", to: "/settings" },
 ];
 
 export default function App() {
@@ -180,7 +180,6 @@ export default function App() {
 					<Route path="/incidents/:id" element={<IncidentDetail />} />
 					<Route path="/healthchecks" element={<Healthchecks />} />
 					<Route path="/healthchecks/:checkName" element={<HealthcheckDetail />} />
-					<Route path="/admins" element={<Admins />} />
 					<Route path="/versions" element={<Versions />} />
 					<Route path="/versions/:version" element={<VersionDetail />} />
 					<Route path="/servers" element={<Servers />}>
@@ -205,7 +204,14 @@ export default function App() {
 						path="/groups/:id/backups/config"
 						element={<BackupConfig />}
 					/>
-					<Route path="/backups/recovery" element={<RecoveryVault />} />
+					<Route path="/settings" element={<Settings />}>
+						<Route
+							index
+							element={<Navigate to="/settings/admins" replace />}
+						/>
+						<Route path="admins" element={<Admins />} />
+						<Route path="recovery" element={<RecoveryVault />} />
+					</Route>
 					<Route path="/devices" element={<Devices />}>
 						<Route index element={<DevicesSearch />} />
 						<Route

--- a/private-web/src/routes/Settings.tsx
+++ b/private-web/src/routes/Settings.tsx
@@ -1,0 +1,39 @@
+import { Box, Tab, Tabs } from "@mui/material";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+
+/// Settings groups the infrequently-used admin pages (operator admins, recovery
+/// vault) under one top-level nav item so they don't each hold space in the bar.
+const TABS: Array<{ value: string; label: string; to: string }> = [
+	{ value: "admins", label: "Admins", to: "/settings/admins" },
+	{ value: "recovery", label: "Recovery vault", to: "/settings/recovery" },
+];
+
+function valueFromPath(pathname: string): string {
+	if (pathname.startsWith("/settings/recovery")) return "recovery";
+	if (pathname.startsWith("/settings/admins")) return "admins";
+	return "";
+}
+
+export default function Settings() {
+	const location = useLocation();
+	const navigate = useNavigate();
+	const value = valueFromPath(location.pathname);
+
+	return (
+		<Box>
+			<Tabs
+				value={value || false}
+				onChange={(_, v) => {
+					const target = TABS.find((t) => t.value === v);
+					if (target) navigate(target.to);
+				}}
+				sx={{ mb: 2 }}
+			>
+				{TABS.map((t) => (
+					<Tab key={t.value} value={t.value} label={t.label} />
+				))}
+			</Tabs>
+			<Outlet />
+		</Box>
+	);
+}


### PR DESCRIPTION
🤖 The Recovery vault and Admins pages are infrequently used, so as standalone top-level nav items they just hold space in the bar. This adds a single **Settings** top-level item with both as tabbed subpages.

- `/settings/admins` (the index redirects here) and `/settings/recovery`, with a tab bar — mirroring the existing Devices/Servers sub-nav pattern.
- Removes the standalone "Admins" and "Recovery vault" top-level nav items.
- e2e: a Settings spec (nav → Admins index → Recovery vault tab); the existing admins/recovery specs navigate to the new `/settings/*` paths.

Stacked on #239.