### PR TITLE
feat(backups): per-type schedule/retention — canopy-wide defaults + per-group overrides [TAM-6877]

### DIFF
--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -605,6 +605,26 @@ impl ServerGroupBackupSchedule {
 			.await
 			.map_err(AppError::from)
 	}
+
+	/// Remove a group's per-`(group,type)` schedule override so the type reverts
+	/// to inheriting the canopy-wide default. No-op if there was no override.
+	pub async fn delete(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		r#type: &BackupType,
+	) -> Result<()> {
+		use crate::schema::server_group_backup_schedule::dsl;
+
+		diesel::delete(
+			dsl::server_group_backup_schedule
+				.filter(dsl::group_id.eq(group_id))
+				.filter(dsl::type_.eq(r#type.as_str())),
+		)
+		.execute(db)
+		.await
+		.map_err(AppError::from)?;
+		Ok(())
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -21,9 +21,9 @@ use commons_types::{
 use database::pg_duration::PgDuration;
 use database::{
 	BackupMaintenanceRun, BackupRecoveryVerification, BackupRepoStats, BackupRequest, BackupRun,
-	NewServerGroupBackupConfig, NewServerGroupBackupSchedule, RetentionPolicy,
-	ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
-	server_groups::ServerGroup,
+	BackupTypeDefault, NewBackupTypeDefault, NewServerGroupBackupConfig,
+	NewServerGroupBackupSchedule, RetentionPolicy, ServerBackupCapability, ServerGroupBackupConfig,
+	ServerGroupBackupSchedule, server_groups::ServerGroup,
 };
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -53,6 +53,10 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(probe))
 		.routes(routes!(update))
 		.routes(routes!(set_schedule))
+		.routes(routes!(clear_schedule))
+		.routes(routes!(group_schedules))
+		.routes(routes!(type_defaults))
+		.routes(routes!(set_type_default))
 		.routes(routes!(create_repo))
 		.routes(routes!(request_now))
 		.routes(routes!(cancel_request))
@@ -169,8 +173,10 @@ pub struct CreateBackupConfigArgs {
 /// Machine-facing config-as-a-resource upsert (ops/pulumi). `mode` is implicit
 /// — always from-birth — so the bucket must be empty and no passphrase is
 /// supplied (importing an existing repo stays an interactive operator action).
-/// `bucket`/`prefix` are the identity and immutable on re-apply; role ARNs,
-/// region, schedule and retention are reconciled to the request each time.
+/// `bucket`/`prefix` are the identity and immutable on re-apply; the role ARNs
+/// and region are reconciled to the request each time. **Schedule and retention
+/// are intentionally NOT part of this API** — they're per-`(group, type)` and
+/// managed through the operator UI (inheriting the canopy-wide type defaults).
 #[derive(Deserialize, ToSchema)]
 pub struct UpsertBackupConfigArgs {
 	pub server_group_id: Uuid,
@@ -183,19 +189,6 @@ pub struct UpsertBackupConfigArgs {
 	/// s3-metrics (s3:* + delete + CloudWatch).
 	pub maintenance_role_arn: String,
 	pub region: Option<String>,
-	/// Schedule type to reconcile (defaults to `tamanu-postgres`).
-	#[serde(rename = "type", default = "default_backup_type")]
-	#[schema(value_type = String)]
-	pub r#type: BackupType,
-	/// Seconds between scheduled runs; None = manual-only (no schedule).
-	#[schema(value_type = Option<i64>, format = "int64")]
-	pub expected_interval: Option<PgDuration>,
-	/// None = inherit the type default. A present policy is floor-validated.
-	pub retention: Option<RetentionPolicy>,
-}
-
-fn default_backup_type() -> BackupType {
-	BackupType::TamanuPostgres
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -436,10 +429,6 @@ pub async fn upsert(
 	let mut conn = state.db.get().await?;
 	ServerGroup::get_by_id(&mut conn, args.server_group_id).await?;
 
-	if let Some(policy) = &args.retention {
-		policy.validate_floor()?;
-	}
-
 	match ServerGroupBackupConfig::get(&mut conn, args.server_group_id).await? {
 		// Update path: reconcile the mutable fields; bucket/prefix are immutable.
 		Some(existing) => {
@@ -536,18 +525,6 @@ pub async fn upsert(
 			.await?;
 		}
 	}
-
-	// Reconcile the schedule/retention in both paths.
-	ServerGroupBackupSchedule::upsert(
-		&mut conn,
-		NewServerGroupBackupSchedule {
-			group_id: args.server_group_id,
-			r#type: args.r#type,
-			expected_interval: args.expected_interval,
-			retention: args.retention.map(|r| r.to_json()),
-		},
-	)
-	.await?;
 
 	let config = require_config(&mut conn, args.server_group_id).await?;
 	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
@@ -687,6 +664,196 @@ pub async fn set_schedule(
 	.await?;
 	let config = require_config(&mut conn, args.server_group_id).await?;
 	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
+}
+
+// ── Per-type schedule/retention: canopy-wide defaults + per-group overrides ───
+
+/// Org-floor baseline retention, used when a type has neither an override nor a
+/// canopy-wide default (writes are floor-validated, so this only fills display).
+const FLOOR_RETENTION: RetentionPolicy = RetentionPolicy {
+	keep_latest: 1,
+	keep_daily: RetentionPolicy::FLOOR_DAILY,
+	keep_weekly: RetentionPolicy::FLOOR_WEEKLY,
+	keep_monthly: RetentionPolicy::FLOOR_MONTHLY,
+	keep_annual: 0,
+};
+
+#[derive(Deserialize, ToSchema)]
+pub struct ClearScheduleArgs {
+	pub server_group_id: Uuid,
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+}
+
+/// Remove a per-`(group,type)` schedule override → revert that type to inheriting
+/// the canopy-wide default.
+#[utoipa::path(
+	post,
+	path = "/clear_schedule",
+	operation_id = "backups_clear_schedule",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = ClearScheduleArgs,
+	responses(
+		(status = 200, body = BackupConfigView),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn clear_schedule(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<ClearScheduleArgs>,
+) -> Result<Json<BackupConfigView>> {
+	let mut conn = state.db.get().await?;
+	require_config(&mut conn, args.server_group_id).await?;
+	ServerGroupBackupSchedule::delete(&mut conn, args.server_group_id, &args.r#type).await?;
+	let config = require_config(&mut conn, args.server_group_id).await?;
+	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
+}
+
+/// Effective schedule/retention for one enabled backup type of a group: the
+/// per-`(group,type)` override if present, else the canopy-wide default.
+/// `has_override` tells the UI whether it's inheriting or overriding.
+#[derive(Serialize, ToSchema)]
+pub struct GroupTypeScheduleView {
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	/// Seconds between scheduled runs; null = manual-only (no scheduled interval).
+	pub effective_interval: Option<i64>,
+	pub effective_retention: RetentionPolicy,
+	pub has_override: bool,
+}
+
+/// Per enabled backup type, the group's effective schedule/retention (override
+/// or inherited default) — drives the per-type editor in the group panel.
+#[utoipa::path(
+	post,
+	path = "/group_schedules",
+	operation_id = "backups_group_schedules",
+	tag = "backups",
+	security(("tailscale-user" = [])),
+	request_body = GroupArgs,
+	responses((status = 200, body = Vec<GroupTypeScheduleView>)),
+)]
+pub async fn group_schedules(
+	State(state): State<AppState>,
+	Json(args): Json<GroupArgs>,
+) -> Result<Json<Vec<GroupTypeScheduleView>>> {
+	let mut conn = state.db.get().await?;
+	let types =
+		ServerBackupCapability::enabled_types_for_group(&mut conn, args.server_group_id).await?;
+	let mut out = Vec::with_capacity(types.len());
+	for ty in types {
+		let over = ServerGroupBackupSchedule::get(&mut conn, args.server_group_id, &ty).await?;
+		let def = BackupTypeDefault::get(&mut conn, &ty).await?;
+		let effective_interval = over
+			.as_ref()
+			.and_then(|s| s.expected_interval)
+			.or_else(|| def.as_ref().and_then(|d| d.default_interval))
+			.map(|pg| pg.0.as_secs());
+		let effective_retention = over
+			.as_ref()
+			.and_then(|s| s.retention.as_ref())
+			.and_then(RetentionPolicy::from_json)
+			.or_else(|| {
+				def.as_ref()
+					.and_then(|d| RetentionPolicy::from_json(&d.default_retention))
+			})
+			.unwrap_or(FLOOR_RETENTION);
+		out.push(GroupTypeScheduleView {
+			r#type: ty,
+			effective_interval,
+			effective_retention,
+			has_override: over.is_some(),
+		});
+	}
+	Ok(Json(out))
+}
+
+/// Canopy-wide default schedule/retention for a backup type.
+#[derive(Serialize, ToSchema)]
+pub struct TypeDefaultView {
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	/// Seconds between scheduled runs; null = manual-only.
+	pub default_interval: Option<i64>,
+	pub default_retention: Option<RetentionPolicy>,
+	pub auto_enable: bool,
+}
+
+/// List the canopy-wide per-type defaults (the "global" schedule/retention each
+/// group inherits unless it overrides a type).
+#[utoipa::path(
+	post,
+	path = "/type_defaults",
+	operation_id = "backups_type_defaults",
+	tag = "backups",
+	security(("tailscale-user" = [])),
+	responses((status = 200, body = Vec<TypeDefaultView>)),
+)]
+pub async fn type_defaults(
+	State(state): State<AppState>,
+	_body: Json<serde_json::Value>,
+) -> Result<Json<Vec<TypeDefaultView>>> {
+	let mut conn = state.db.get().await?;
+	let rows = BackupTypeDefault::list(&mut conn).await?;
+	Ok(Json(
+		rows.into_iter()
+			.map(|d| TypeDefaultView {
+				r#type: d.r#type,
+				default_interval: d.default_interval.map(|pg| pg.0.as_secs()),
+				default_retention: RetentionPolicy::from_json(&d.default_retention),
+				auto_enable: d.auto_enable,
+			})
+			.collect(),
+	))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct SetTypeDefaultArgs {
+	#[serde(rename = "type")]
+	#[schema(value_type = String)]
+	pub r#type: BackupType,
+	/// Seconds between scheduled runs; null = manual-only.
+	#[schema(value_type = Option<i64>, format = "int64")]
+	pub default_interval: Option<PgDuration>,
+	pub default_retention: RetentionPolicy,
+	#[serde(default)]
+	pub auto_enable: bool,
+}
+
+/// Set the canopy-wide default schedule/retention for a backup type
+/// (floor-validated). Operators tune these in Settings → Backup defaults.
+#[utoipa::path(
+	post,
+	path = "/set_type_default",
+	operation_id = "backups_set_type_default",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = SetTypeDefaultArgs,
+	responses((status = 200), (status = 400, body = ProblemDetailsSchema)),
+)]
+pub async fn set_type_default(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<SetTypeDefaultArgs>,
+) -> Result<Json<()>> {
+	args.default_retention.validate_floor()?;
+	let mut conn = state.db.get().await?;
+	BackupTypeDefault::upsert(
+		&mut conn,
+		NewBackupTypeDefault {
+			r#type: args.r#type,
+			default_interval: args.default_interval,
+			default_retention: args.default_retention.to_json(),
+			auto_enable: args.auto_enable,
+		},
+	)
+	.await?;
+	Ok(Json(()))
 }
 
 /// Record intent for the init Job: set/keep `provisioning`, clear

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -825,7 +825,7 @@ async fn type_defaults_list_and_set_roundtrip() {
 			.find(|d| d["type"] == "tamanu-postgres")
 			.expect("seeded default present");
 		assert_eq!(td["default_interval"], 21600); // 6h
-		assert_eq!(td["auto_enable"], true);
+		assert_eq!(td["auto_enable"], false); // capabilities stay opt-in
 
 		// Update it.
 		private

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -501,8 +501,9 @@ async fn upsert_creates_then_reapplies_idempotently() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;
 
-		// First apply → creates from-birth (the fake prober reports empty),
-		// provisions, and sets the schedule.
+		// First apply → creates from-birth (the fake prober reports empty) and
+		// provisions. Schedule/retention are NOT part of this API — they inherit
+		// the canopy-wide type defaults and are UI-managed.
 		let resp = private
 			.post("/api/backups/upsert")
 			.json(&serde_json::json!({
@@ -512,8 +513,6 @@ async fn upsert_creates_then_reapplies_idempotently() {
 				"target_role_arn": "arn:aws:iam::123:role/dev",
 				"maintenance_role_arn": "arn:aws:iam::123:role/maint",
 				"region": "ap-southeast-2",
-				"expected_interval": 3600,
-				"retention": retention_json(),
 			}))
 			.await;
 		resp.assert_status_ok();
@@ -521,9 +520,8 @@ async fn upsert_creates_then_reapplies_idempotently() {
 		assert_eq!(body["status"], "provisioning");
 		assert_eq!(body["mode"], "from_birth");
 		assert_eq!(body["maintenance_role_arn"], "arn:aws:iam::123:role/maint");
-		let schedule = &body["schedules"][0];
-		assert_eq!(schedule["type"], "tamanu-postgres");
-		assert_eq!(schedule["expected_interval"], 3600);
+		// No per-(group,type) schedule override is written by upsert.
+		assert_eq!(body["schedules"].as_array().unwrap().len(), 0);
 
 		// Re-apply with changed mutable fields → updates in place, no duplicate.
 		let resp = private
@@ -535,8 +533,6 @@ async fn upsert_creates_then_reapplies_idempotently() {
 				"target_role_arn": "arn:aws:iam::123:role/dev2",
 				"maintenance_role_arn": "arn:aws:iam::123:role/maint2",
 				"region": "us-east-1",
-				"expected_interval": null,
-				"retention": retention_json(),
 			}))
 			.await;
 		resp.assert_status_ok();
@@ -544,10 +540,6 @@ async fn upsert_creates_then_reapplies_idempotently() {
 		assert_eq!(body["maintenance_role_arn"], "arn:aws:iam::123:role/maint2");
 		assert_eq!(body["target_role_arn"], "arn:aws:iam::123:role/dev2");
 		assert_eq!(body["region"], "us-east-1");
-		// Manual-only now. (That this second apply returns 200 with updated
-		// fields — rather than the 409 a duplicate create would — is what proves
-		// it took the in-place update path, i.e. no duplicate row.)
-		assert!(body["schedules"][0]["expected_interval"].is_null());
 
 		// Changing the bucket (identity) is rejected.
 		let resp = private
@@ -578,30 +570,6 @@ async fn upsert_missing_group_is_404() {
 			}))
 			.await;
 		resp.assert_status_not_found();
-	})
-	.await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn upsert_rejects_below_floor_retention() {
-	commons_tests::server::run(async |mut conn, _public, private| {
-		let group_id = seed_group(&mut conn).await;
-		let resp = private
-			.post("/api/backups/upsert")
-			.json(&serde_json::json!({
-				"server_group_id": group_id,
-				"bucket": "bes-iac",
-				"target_role_arn": "arn",
-				"maintenance_role_arn": "maint",
-				"retention": {
-					"keep_latest": 1, "keep_daily": 1, "keep_weekly": 1,
-					"keep_monthly": 1, "keep_annual": 0
-				},
-			}))
-			.await;
-		resp.assert_status_bad_request();
-		// Floor is checked before anything is written.
-		assert_no_config!(private, group_id);
 	})
 	.await;
 }
@@ -836,6 +804,130 @@ async fn recovery_verify_rejects_wrong_and_missing() {
 			.json(&serde_json::json!({ "answer": "not-the-nonce" }))
 			.await
 			.assert_status_bad_request();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn type_defaults_list_and_set_roundtrip() {
+	commons_tests::server::run(async |_conn, _public, private| {
+		// The migration seeds the tamanu-postgres default at 6h.
+		let resp = private
+			.post("/api/backups/type_defaults")
+			.json(&serde_json::json!({}))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		let td = body
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|d| d["type"] == "tamanu-postgres")
+			.expect("seeded default present");
+		assert_eq!(td["default_interval"], 21600); // 6h
+		assert_eq!(td["auto_enable"], true);
+
+		// Update it.
+		private
+			.post("/api/backups/set_type_default")
+			.json(&serde_json::json!({
+				"type": "tamanu-postgres",
+				"default_interval": 7200,
+				"default_retention": retention_json(),
+				"auto_enable": false,
+			}))
+			.await
+			.assert_status_ok();
+		let resp = private
+			.post("/api/backups/type_defaults")
+			.json(&serde_json::json!({}))
+			.await;
+		let body: serde_json::Value = resp.json();
+		let td = body
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|d| d["type"] == "tamanu-postgres")
+			.unwrap();
+		assert_eq!(td["default_interval"], 7200);
+		assert_eq!(td["auto_enable"], false);
+
+		// Below-floor retention → 400.
+		private
+			.post("/api/backups/set_type_default")
+			.json(&serde_json::json!({
+				"type": "tamanu-postgres",
+				"default_interval": null,
+				"default_retention": {
+					"keep_latest": 1, "keep_daily": 1, "keep_weekly": 1,
+					"keep_monthly": 1, "keep_annual": 0
+				},
+			}))
+			.await
+			.assert_status_bad_request();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn clear_schedule_removes_override() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		private
+			.post("/api/backups/create")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "b",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint",
+				"mode": "from_birth",
+			}))
+			.await
+			.assert_status_ok();
+
+		// Set a per-(group,type) override → appears in the config view.
+		private
+			.post("/api/backups/set_schedule")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"type": "tamanu-postgres",
+				"expected_interval": 3600,
+				"retention": retention_json(),
+			}))
+			.await
+			.assert_status_ok();
+		let resp = private
+			.post("/api/backups/get")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		assert_eq!(
+			resp.json::<serde_json::Value>()["schedules"]
+				.as_array()
+				.unwrap()
+				.len(),
+			1
+		);
+
+		// Clear it → back to inheriting the default (no override row).
+		private
+			.post("/api/backups/clear_schedule")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"type": "tamanu-postgres",
+			}))
+			.await
+			.assert_status_ok();
+		let resp = private
+			.post("/api/backups/get")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		assert_eq!(
+			resp.json::<serde_json::Value>()["schedules"]
+				.as_array()
+				.unwrap()
+				.len(),
+			0
+		);
 	})
 	.await;
 }

--- a/migrations/2026-06-21-151343-0000_seed_tamanu_postgres_backup_default/down.sql
+++ b/migrations/2026-06-21-151343-0000_seed_tamanu_postgres_backup_default/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM backup_type_defaults WHERE type = 'tamanu-postgres';

--- a/migrations/2026-06-21-151343-0000_seed_tamanu_postgres_backup_default/up.sql
+++ b/migrations/2026-06-21-151343-0000_seed_tamanu_postgres_backup_default/up.sql
@@ -3,11 +3,13 @@
 -- box (the scheduler resolves per-(group,type) override → this default → floor).
 -- Operators tune the canopy-wide default (here) and per-group overrides via the
 -- UI. ON CONFLICT DO NOTHING so a hand-edited default isn't clobbered on replay.
+-- auto_enable stays FALSE: capabilities remain opt-in (the operator enables a
+-- type per server); this row only provides the inherited schedule/retention.
 INSERT INTO backup_type_defaults (type, default_interval, default_retention, auto_enable)
 VALUES (
     'tamanu-postgres',
     INTERVAL '6 hours',
     '{"keep_latest": 1, "keep_daily": 7, "keep_weekly": 4, "keep_monthly": 6, "keep_annual": 0}'::jsonb,
-    true
+    false
 )
 ON CONFLICT (type) DO NOTHING;

--- a/migrations/2026-06-21-151343-0000_seed_tamanu_postgres_backup_default/up.sql
+++ b/migrations/2026-06-21-151343-0000_seed_tamanu_postgres_backup_default/up.sql
@@ -1,0 +1,13 @@
+-- Seed the canopy-wide default schedule + retention for the well-known
+-- `tamanu-postgres` backup type, so groups inherit a sane schedule out of the
+-- box (the scheduler resolves per-(group,type) override → this default → floor).
+-- Operators tune the canopy-wide default (here) and per-group overrides via the
+-- UI. ON CONFLICT DO NOTHING so a hand-edited default isn't clobbered on replay.
+INSERT INTO backup_type_defaults (type, default_interval, default_retention, auto_enable)
+VALUES (
+    'tamanu-postgres',
+    INTERVAL '6 hours',
+    '{"keep_latest": 1, "keep_daily": 7, "keep_weekly": 4, "keep_monthly": 6, "keep_annual": 0}'::jsonb,
+    true
+)
+ON CONFLICT (type) DO NOTHING;

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -36,21 +36,6 @@ test.describe("backups zero-state + config", () => {
 		await expect(page.getByText(/backups not set up/i)).toBeVisible();
 	});
 
-	// Walk the wizard's step 0 (target) → step 2 (schedule) for an empty bucket
-	// (the fake prober reports `empty` for buckets without a marker). Leaves the
-	// page on the schedule/retention step.
-	async function emptyBucketToSchedule(
-		page: import("@playwright/test").Page,
-		bucket = "bes-empty",
-	) {
-		await page.getByLabel("Bucket").fill(bucket);
-		await page.getByLabel("Target role ARN").fill("arn");
-		await page.getByLabel("Maintenance role ARN").fill("maint-arn");
-		await page.getByRole("button", { name: /check bucket/i }).click();
-		await expect(page.getByText(/empty bucket/i)).toBeVisible();
-		await page.getByRole("button", { name: /^continue$/i }).click();
-	}
-
 	test("wizard create (empty bucket) writes a from-birth config row", async ({
 		page,
 		sql,
@@ -67,26 +52,18 @@ test.describe("backups zero-state + config", () => {
 			.fill("arn:aws:iam::999:role/created-maint");
 		await page.getByRole("button", { name: /check bucket/i }).click();
 		await expect(page.getByText(/empty bucket/i)).toBeVisible();
-		await page.getByRole("button", { name: /^continue$/i }).click();
-		// Step 2: defaults (schedule on at 60m, retention meets floors).
+		// No schedule step — schedule/retention inherit the per-type defaults.
 		await page.getByRole("button", { name: /create & provision/i }).click();
 
 		await expect(page).toHaveURL(new RegExp(`/groups/${group.id}/backups$`));
 
 		const rows = await sql.query<{
 			status: string;
-			bucket: string;
 			mode: string;
 			maintenance_role_arn: string;
-			secs: string | null;
-			retention: { keep_daily: number };
 		}>(
-			`SELECT c.status, c.bucket, c.mode, c.maintenance_role_arn,
-			        EXTRACT(EPOCH FROM s.expected_interval)::text AS secs,
-			        s.retention
-			 FROM server_group_backup_config c
-			 LEFT JOIN server_group_backup_schedule s ON s.group_id = c.group_id
-			 WHERE c.group_id = $1`,
+			`SELECT status, mode, maintenance_role_arn
+			 FROM server_group_backup_config WHERE group_id = $1`,
 			[group.id],
 		);
 		expect(rows).toHaveLength(1);
@@ -95,8 +72,12 @@ test.describe("backups zero-state + config", () => {
 		expect(rows[0]!.maintenance_role_arn).toBe(
 			"arn:aws:iam::999:role/created-maint",
 		);
-		expect(Number(rows[0]!.secs)).toBe(3600);
-		expect(rows[0]!.retention.keep_daily).toBe(7);
+		// The wizard writes no per-(group,type) schedule override.
+		const sched = await sql.query(
+			`SELECT 1 FROM server_group_backup_schedule WHERE group_id = $1`,
+			[group.id],
+		);
+		expect(sched).toHaveLength(0);
 	});
 
 	test("wizard create (existing repo) requires a passphrase and persists passphrase mode", async ({
@@ -114,14 +95,13 @@ test.describe("backups zero-state + config", () => {
 		await page.getByRole("button", { name: /check bucket/i }).click();
 
 		await expect(page.getByText(/existing kopia repository/i)).toBeVisible();
-		// Continue is gated on the passphrase.
+		// Provisioning is gated on the passphrase.
 		await expect(
-			page.getByRole("button", { name: /^continue$/i }),
+			page.getByRole("button", { name: /create & provision/i }),
 		).toBeDisabled();
 		await page
 			.getByLabel("Existing repository passphrase")
 			.fill("an-existing-repo-passphrase");
-		await page.getByRole("button", { name: /^continue$/i }).click();
 		await page.getByRole("button", { name: /create & provision/i }).click();
 
 		await expect(page).toHaveURL(new RegExp(`/groups/${group.id}/backups$`));
@@ -142,66 +122,52 @@ test.describe("backups zero-state + config", () => {
 		await page.getByRole("button", { name: /check bucket/i }).click();
 
 		await expect(page.getByText(/other \(non-kopia\) content/i)).toBeVisible();
-		// No proceeding: Continue is disabled, Re-check is offered.
+		// No proceeding: Create & provision disabled, Re-check offered.
 		await expect(
-			page.getByRole("button", { name: /^continue$/i }),
+			page.getByRole("button", { name: /create & provision/i }),
 		).toBeDisabled();
 		await expect(page.getByRole("button", { name: /re-check/i })).toBeVisible();
-	});
-
-	test("retention floor violation blocks submit", async ({ page, sql }) => {
-		const group = await seedServerGroup(sql, { name: "floor-group" });
-		await page.goto(`/groups/${group.id}/backups/config`);
-		await emptyBucketToSchedule(page);
-		await page.getByLabel("Daily").fill("2"); // below floor of 7
-
-		const submit = page.getByRole("button", { name: /create & provision/i });
-		await expect(submit).toBeDisabled();
-		await expect(page.getByText(/keep_daily must be ≥ 7/i)).toBeVisible();
-
-		// No row was written.
-		const rows = await sql.query(
-			`SELECT 1 FROM server_group_backup_config WHERE group_id = $1`,
-			[group.id],
-		);
-		expect(rows).toHaveLength(0);
-	});
-
-	test("retention inputs carry the org minimum as a native min", async ({
-		page,
-		sql,
-	}) => {
-		const group = await seedServerGroup(sql, { name: "min-attr-group" });
-		await page.goto(`/groups/${group.id}/backups/config`);
-		await emptyBucketToSchedule(page);
-		// The daily/weekly/monthly inputs set min= to the org floor.
-		await expect(page.getByLabel("Daily")).toHaveAttribute("min", "7");
-		await expect(page.getByLabel("Weekly")).toHaveAttribute("min", "4");
-		await expect(page.getByLabel("Monthly")).toHaveAttribute("min", "6");
-	});
-
-	test("manual-only toggle persists a NULL interval", async ({ page, sql }) => {
-		const group = await seedServerGroup(sql, { name: "manual-group" });
-		await page.goto(`/groups/${group.id}/backups/config`);
-		await emptyBucketToSchedule(page);
-		// Toggle the schedule switch off → manual only.
-		await page.getByText("Scheduled", { exact: true }).click();
-		await page.getByRole("button", { name: /create & provision/i }).click();
-
-		await expect(page).toHaveURL(new RegExp(`/groups/${group.id}/backups$`));
-
-		const rows = await sql.query<{ expected_interval: string | null }>(
-			`SELECT expected_interval FROM server_group_backup_schedule WHERE group_id = $1`,
-			[group.id],
-		);
-		expect(rows).toHaveLength(1);
-		expect(rows[0]!.expected_interval).toBeNull();
 	});
 });
 
 test.describe("backups ready: stats + backup-now", () => {
 	test.beforeEach(async ({ sql }) => {
 		await resetSeededTables(sql);
+	});
+
+	test("per-type schedule inherits the default and saves an override", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "sched-group" });
+		const server = await seedServer(sql, { groupId: group.id });
+		// An enabled tamanu-postgres capability makes the type appear in the panel.
+		await seedServerBackupCapability(sql, { serverId: server.id });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+
+		// No override yet → inherits the seeded canopy-wide default.
+		await expect(page.getByText("tamanu-postgres")).toBeVisible();
+		await expect(page.getByText("Inherited default")).toBeVisible();
+
+		// Override the interval to 12h.
+		await page.getByRole("button", { name: /^override$/i }).click();
+		await page.getByLabel("Back up every (hours)").fill("12");
+		await page.getByRole("button", { name: /save override/i }).click();
+
+		await expect(page.getByText("Override", { exact: true })).toBeVisible();
+		const rows = await sql.query<{ secs: string }>(
+			`SELECT EXTRACT(EPOCH FROM expected_interval)::text AS secs
+			 FROM server_group_backup_schedule
+			 WHERE group_id = $1 AND type = 'tamanu-postgres'`,
+			[group.id],
+		);
+		expect(rows).toHaveLength(1);
+		expect(Number(rows[0]!.secs)).toBe(43200);
 	});
 
 	test("stats render with unknown bucket bytes and recent runs", async ({

--- a/private-web/e2e/settings.spec.ts
+++ b/private-web/e2e/settings.spec.ts
@@ -17,4 +17,26 @@ test.describe("Settings", () => {
 			page.getByRole("heading", { name: /recovery vault/i }),
 		).toBeVisible();
 	});
+
+	test("backup defaults editor edits the canopy-wide per-type default", async ({
+		page,
+		sql,
+	}) => {
+		await page.goto("/settings/backup-defaults");
+		// The seeded tamanu-postgres default is shown.
+		await expect(page.getByText("tamanu-postgres")).toBeVisible();
+
+		await page.getByLabel("Back up every (hours)").fill("8");
+		await page.getByRole("button", { name: /^save$/i }).click();
+
+		await expect
+			.poll(async () => {
+				const rows = await sql.query<{ secs: string }>(
+					`SELECT EXTRACT(EPOCH FROM default_interval)::text AS secs
+					 FROM backup_type_defaults WHERE type = 'tamanu-postgres'`,
+				);
+				return rows[0] ? Number(rows[0].secs) : null;
+			})
+			.toBe(28800);
+	});
 });

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -225,6 +225,52 @@
         ]
       }
     },
+    "/api/backups/clear_schedule": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Remove a per-`(group,type)` schedule override → revert that type to inheriting\nthe canopy-wide default.",
+        "operationId": "backups_clear_schedule",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClearScheduleArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupConfigView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/backups/create": {
       "post": {
         "tags": [
@@ -427,6 +473,45 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
+    "/api/backups/group_schedules": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Per enabled backup type, the group's effective schedule/retention (override\nor inherited default) — drives the per-type editor in the group panel.",
+        "operationId": "backups_group_schedules",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GroupTypeScheduleView"
+                  }
                 }
               }
             }
@@ -780,6 +865,45 @@
         ]
       }
     },
+    "/api/backups/set_type_default": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Set the canopy-wide default schedule/retention for a backup type\n(floor-validated). Operators tune these in Settings → Backup defaults.",
+        "operationId": "backups_set_type_default",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetTypeDefaultArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/backups/stats": {
       "post": {
         "tags": [
@@ -814,6 +938,43 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
+    "/api/backups/type_defaults": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "List the canopy-wide per-type defaults (the \"global\" schedule/retention each\ngroup inherits unless it overrides a type).",
+        "operationId": "backups_type_defaults",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TypeDefaultView"
+                  }
                 }
               }
             }
@@ -5384,6 +5545,22 @@
           }
         }
       },
+      "ClearScheduleArgs": {
+        "type": "object",
+        "required": [
+          "server_group_id",
+          "type"
+        ],
+        "properties": {
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
       "ConnectionHistoryArgs": {
         "type": "object",
         "required": [
@@ -6087,6 +6264,34 @@
           "server_group_id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "GroupTypeScheduleView": {
+        "type": "object",
+        "description": "Effective schedule/retention for one enabled backup type of a group: the\nper-`(group,type)` override if present, else the canopy-wide default.\n`has_override` tells the UI whether it's inheriting or overriding.",
+        "required": [
+          "type",
+          "effective_retention",
+          "has_override"
+        ],
+        "properties": {
+          "effective_interval": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Seconds between scheduled runs; null = manual-only (no scheduled interval)."
+          },
+          "effective_retention": {
+            "$ref": "#/components/schemas/RetentionPolicy"
+          },
+          "has_override": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
           }
         }
       },
@@ -8655,6 +8860,32 @@
           }
         }
       },
+      "SetTypeDefaultArgs": {
+        "type": "object",
+        "required": [
+          "type",
+          "default_retention"
+        ],
+        "properties": {
+          "auto_enable": {
+            "type": "boolean"
+          },
+          "default_interval": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Seconds between scheduled runs; null = manual-only."
+          },
+          "default_retention": {
+            "$ref": "#/components/schemas/RetentionPolicy"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
       "Severity": {
         "type": "string",
         "description": "Canopy's severity vocabulary, narrowed from RFC 5424 to a five-level\nset with operator semantics:\n\n- `Debug`: never participates in incidents (filed for the audit\n  trail / per-server view only).\n- `Info`, `Warning`: join an open incident for context but don't\n  open one or keep one open on their own.\n- `Error`: opens an incident; sits in the per-group `slack_open_delay`\n  holding window before the Slack notification ships.\n- `Critical`: opens an incident and bypasses the holding window —\n  the Slack notification is enqueued for immediate delivery.\n\nStored as text in Postgres; validated as this enum at the API layer.\nDefault is `Error` (the most common severity for a deliberately\nfiled event). The legacy syslog severities `emergency` / `alert` /\n`notice` have been retired — see the\n`2026-05-29-000000-0000_restrict_severities` migration; the\n`FromStr` impl still accepts them as aliases for forward-compat with\nany device that hasn't been updated.",
@@ -9090,6 +9321,40 @@
           }
         }
       },
+      "TypeDefaultView": {
+        "type": "object",
+        "description": "Canopy-wide default schedule/retention for a backup type.",
+        "required": [
+          "type",
+          "auto_enable"
+        ],
+        "properties": {
+          "auto_enable": {
+            "type": "boolean"
+          },
+          "default_interval": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Seconds between scheduled runs; null = manual-only."
+          },
+          "default_retention": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RetentionPolicy"
+              }
+            ]
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
       "UpdateArgs": {
         "type": "object",
         "required": [
@@ -9219,7 +9484,7 @@
       },
       "UpsertBackupConfigArgs": {
         "type": "object",
-        "description": "Machine-facing config-as-a-resource upsert (ops/pulumi). `mode` is implicit\n— always from-birth — so the bucket must be empty and no passphrase is\nsupplied (importing an existing repo stays an interactive operator action).\n`bucket`/`prefix` are the identity and immutable on re-apply; role ARNs,\nregion, schedule and retention are reconciled to the request each time.",
+        "description": "Machine-facing config-as-a-resource upsert (ops/pulumi). `mode` is implicit\n— always from-birth — so the bucket must be empty and no passphrase is\nsupplied (importing an existing repo stays an interactive operator action).\n`bucket`/`prefix` are the identity and immutable on re-apply; the role ARNs\nand region are reconciled to the request each time. **Schedule and retention\nare intentionally NOT part of this API** — they're per-`(group, type)` and\nmanaged through the operator UI (inheriting the canopy-wide type defaults).",
         "required": [
           "server_group_id",
           "bucket",
@@ -9229,14 +9494,6 @@
         "properties": {
           "bucket": {
             "type": "string"
-          },
-          "expected_interval": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int64",
-            "description": "Seconds between scheduled runs; None = manual-only (no schedule)."
           },
           "maintenance_role_arn": {
             "type": "string",
@@ -9251,17 +9508,6 @@
               "null"
             ]
           },
-          "retention": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/RetentionPolicy",
-                "description": "None = inherit the type default. A present policy is floor-validated."
-              }
-            ]
-          },
           "server_group_id": {
             "type": "string",
             "format": "uuid"
@@ -9269,10 +9515,6 @@
           "target_role_arn": {
             "type": "string",
             "description": "Device role: public-server assumes this to mint device creds (no delete)."
-          },
-          "type": {
-            "type": "string",
-            "description": "Schedule type to reconcile (defaults to `tamanu-postgres`)."
           }
         }
       },

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -14,6 +14,7 @@ import { AdminProvider } from "./hooks/useIsAdmin";
 import { useReloadInterval } from "./hooks/useReloadInterval";
 import Admins from "./routes/Admins";
 import BackupConfig from "./routes/BackupConfig";
+import BackupDefaults from "./routes/BackupDefaults";
 import RecoveryVault from "./routes/RecoveryVault";
 import BackupPanel from "./routes/BackupPanel";
 import Bestool from "./routes/Bestool";
@@ -210,6 +211,7 @@ export default function App() {
 							element={<Navigate to="/settings/admins" replace />}
 						/>
 						<Route path="admins" element={<Admins />} />
+						<Route path="backup-defaults" element={<BackupDefaults />} />
 						<Route path="recovery" element={<RecoveryVault />} />
 					</Route>
 					<Route path="/devices" element={<Devices />}>

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -89,6 +89,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/backups/clear_schedule": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Remove a per-`(group,type)` schedule override → revert that type to inheriting
+         *     the canopy-wide default.
+         */
+        post: operations["backups_clear_schedule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/backups/create": {
         parameters: {
             query?: never;
@@ -165,6 +185,26 @@ export interface paths {
          *     config (the zero-state); 404 only when the group itself doesn't exist.
          */
         post: operations["backups_get"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/backups/group_schedules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Per enabled backup type, the group's effective schedule/retention (override
+         *     or inherited default) — drives the per-type editor in the group panel.
+         */
+        post: operations["backups_group_schedules"];
         delete?: never;
         options?: never;
         head?: never;
@@ -328,6 +368,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/backups/set_type_default": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set the canopy-wide default schedule/retention for a backup type
+         *     (floor-validated). Operators tune these in Settings → Backup defaults.
+         */
+        post: operations["backups_set_type_default"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/backups/stats": {
         parameters: {
             query?: never;
@@ -342,6 +402,26 @@ export interface paths {
          *     one-off requests (across the group's member servers).
          */
         post: operations["backups_stats"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/backups/type_defaults": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * List the canopy-wide per-type defaults (the "global" schedule/retention each
+         *     group inherits unless it overrides a type).
+         */
+        post: operations["backups_type_defaults"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2188,6 +2268,11 @@ export interface components {
             id: string;
             name: string;
         };
+        ClearScheduleArgs: {
+            /** Format: uuid */
+            server_group_id: string;
+            type: string;
+        };
         ConnectionHistoryArgs: {
             before?: null | components["schemas"]["HistoryCursor"];
             /** Format: uuid */
@@ -2425,6 +2510,21 @@ export interface components {
             server_count: number;
             /** Format: uuid */
             server_group_id: string;
+        };
+        /**
+         * @description Effective schedule/retention for one enabled backup type of a group: the
+         *     per-`(group,type)` override if present, else the canopy-wide default.
+         *     `has_override` tells the UI whether it's inheriting or overriding.
+         */
+        GroupTypeScheduleView: {
+            /**
+             * Format: int64
+             * @description Seconds between scheduled runs; null = manual-only (no scheduled interval).
+             */
+            effective_interval?: number | null;
+            effective_retention: components["schemas"]["RetentionPolicy"];
+            has_override: boolean;
+            type: string;
         };
         /**
          * @description Server's self-reported health state, derived from the most
@@ -3412,6 +3512,16 @@ export interface components {
             server_group_id: string;
             type: string;
         };
+        SetTypeDefaultArgs: {
+            auto_enable?: boolean;
+            /**
+             * Format: int64
+             * @description Seconds between scheduled runs; null = manual-only.
+             */
+            default_interval?: number | null;
+            default_retention: components["schemas"]["RetentionPolicy"];
+            type: string;
+        };
         /**
          * @description Canopy's severity vocabulary, narrowed from RFC 5424 to a five-level
          *     set with operator semantics:
@@ -3589,6 +3699,17 @@ export interface components {
             device_id: string;
             role: components["schemas"]["DeviceRole"];
         };
+        /** @description Canopy-wide default schedule/retention for a backup type. */
+        TypeDefaultView: {
+            auto_enable: boolean;
+            /**
+             * Format: int64
+             * @description Seconds between scheduled runs; null = manual-only.
+             */
+            default_interval?: number | null;
+            default_retention?: null | components["schemas"]["RetentionPolicy"];
+            type: string;
+        };
         UpdateArgs: {
             check_name: string;
             /**
@@ -3642,16 +3763,13 @@ export interface components {
          * @description Machine-facing config-as-a-resource upsert (ops/pulumi). `mode` is implicit
          *     — always from-birth — so the bucket must be empty and no passphrase is
          *     supplied (importing an existing repo stays an interactive operator action).
-         *     `bucket`/`prefix` are the identity and immutable on re-apply; role ARNs,
-         *     region, schedule and retention are reconciled to the request each time.
+         *     `bucket`/`prefix` are the identity and immutable on re-apply; the role ARNs
+         *     and region are reconciled to the request each time. **Schedule and retention
+         *     are intentionally NOT part of this API** — they're per-`(group, type)` and
+         *     managed through the operator UI (inheriting the canopy-wide type defaults).
          */
         UpsertBackupConfigArgs: {
             bucket: string;
-            /**
-             * Format: int64
-             * @description Seconds between scheduled runs; None = manual-only (no schedule).
-             */
-            expected_interval?: number | null;
             /**
              * @description Maintenance role: the backups pod assumes this for maintenance/inspection/
              *     s3-metrics (s3:* + delete + CloudWatch).
@@ -3659,13 +3777,10 @@ export interface components {
             maintenance_role_arn: string;
             prefix?: string;
             region?: string | null;
-            retention?: null | components["schemas"]["RetentionPolicy"];
             /** Format: uuid */
             server_group_id: string;
             /** @description Device role: public-server assumes this to mint device creds (no delete). */
             target_role_arn: string;
-            /** @description Schedule type to reconcile (defaults to `tamanu-postgres`). */
-            type?: string;
         };
         Value: unknown;
         VersionData: {
@@ -3884,6 +3999,37 @@ export interface operations {
             };
         };
     };
+    backups_clear_schedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ClearScheduleArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupConfigView"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
     backups_create: {
         parameters: {
             query?: never;
@@ -4026,6 +4172,29 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    backups_group_schedules: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupTypeScheduleView"][];
                 };
             };
         };
@@ -4266,6 +4435,35 @@ export interface operations {
             };
         };
     };
+    backups_set_type_default: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetTypeDefaultArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
     backups_stats: {
         parameters: {
             query?: never;
@@ -4293,6 +4491,29 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    backups_type_defaults: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": unknown;
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TypeDefaultView"][];
                 };
             };
         };

--- a/private-web/src/routes/BackupConfig.tsx
+++ b/private-web/src/routes/BackupConfig.tsx
@@ -1,8 +1,6 @@
 import {
 	Alert,
 	Button,
-	Divider,
-	FormControlLabel,
 	LinearProgress,
 	Link as MuiLink,
 	Paper,
@@ -10,7 +8,6 @@ import {
 	Step,
 	StepLabel,
 	Stepper,
-	Switch,
 	TextField,
 	Typography,
 } from "@mui/material";
@@ -18,24 +15,10 @@ import { useState } from "react";
 import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
-import {
-	RETENTION_FLOORS,
-	type BackupConfigView,
-	type BackupRepoMode,
-	type RetentionPolicy,
-} from "../types";
-
-const DEFAULT_RETENTION: RetentionPolicy = {
-	keep_latest: 1,
-	keep_daily: 7,
-	keep_weekly: 4,
-	keep_monthly: 6,
-	keep_annual: 0,
-};
+import { type BackupConfigView, type BackupRepoMode } from "../types";
 
 /// Most buckets live here, so default the region to it.
 const DEFAULT_REGION = "ap-southeast-2";
-const WELL_KNOWN_TYPE = "tamanu-postgres";
 
 /// Probe response shape (wire type is generated; this is the UI-facing subset).
 type ProbeResult = {
@@ -49,7 +32,9 @@ type ProbeResult = {
 /// probe-driven wizard: enter the bucket + roles, Canopy inspects it, and the
 /// repo mode is derived from what's there (empty → from-birth; existing kopia
 /// repo → import by passphrase; other content / inaccessible → blocked). Edit is
-/// a flat form (structural fields are create-only).
+/// a flat form (structural fields are create-only). Schedule + retention are NOT
+/// set here — they're per-`(group, type)`, inherit the canopy-wide type defaults,
+/// and are tuned per type on the group's backup page.
 export default function BackupConfig() {
 	const { id = "" } = useParams<{ id: string }>();
 	const existing = useApi("backups", "get", { server_group_id: id }, [id]);
@@ -75,11 +60,8 @@ function ConfigForm({
 	const isCreate = existing == null;
 	const create = useApiAction("backups", "create");
 	const update = useApiAction("backups", "update");
-	const setSchedule = useApiAction("backups", "set_schedule");
 	const createRepo = useApiAction("backups", "create_repo");
 	const probeAction = useApiAction("backups", "probe");
-
-	const wellKnown = existing?.schedules.find((s) => s.type === WELL_KNOWN_TYPE);
 
 	const [bucket, setBucket] = useState(existing?.bucket ?? "");
 	const [prefix, setPrefix] = useState(existing?.prefix ?? "");
@@ -89,23 +71,10 @@ function ConfigForm({
 	);
 	const [region, setRegion] = useState(existing?.region ?? DEFAULT_REGION);
 	const [passphrase, setPassphrase] = useState("");
-	const [scheduled, setScheduled] = useState(
-		wellKnown ? wellKnown.expected_interval != null : true,
-	);
-	const [intervalMinutes, setIntervalMinutes] = useState<string>(
-		wellKnown?.expected_interval != null
-			? Math.max(1, Math.round(wellKnown.expected_interval / 60)).toString()
-			: "60",
-	);
-	const initialRetention = wellKnown?.retention ?? DEFAULT_RETENTION;
-	const [retention, setRetention] = useState<RetentionPolicy>(initialRetention);
 
 	// Wizard state (create only).
 	const [step, setStep] = useState(0);
 	const [probe, setProbe] = useState<ProbeResult | null>(null);
-
-	const floorErrors = retentionFloorErrors(retention);
-	const hasFloorError = floorErrors.length > 0;
 
 	// Probe-derived repo mode: an existing kopia repo is imported by passphrase;
 	// an empty bucket is created from-birth. (Canopy never lets the operator pick
@@ -113,13 +82,8 @@ function ConfigForm({
 	const mode: BackupRepoMode =
 		probe?.state === "kopia_repo" ? "passphrase" : "from_birth";
 
-	const pending =
-		create.pending ||
-		update.pending ||
-		setSchedule.pending ||
-		createRepo.pending;
-	const error =
-		create.error || update.error || setSchedule.error || createRepo.error;
+	const pending = create.pending || update.pending || createRepo.pending;
+	const error = create.error || update.error || createRepo.error;
 
 	const runProbe = async () => {
 		try {
@@ -149,103 +113,18 @@ function ConfigForm({
 					mode,
 					passphrase: mode === "passphrase" ? passphrase : null,
 				});
+				await createRepo.call({ server_group_id: groupId });
 			} else {
 				await update.call({
 					server_group_id: groupId,
 					region: region.trim() === "" ? null : region,
 				});
 			}
-			await setSchedule.call({
-				server_group_id: groupId,
-				type: WELL_KNOWN_TYPE,
-				expected_interval: scheduled
-					? Math.max(60, Math.round(Number(intervalMinutes) * 60))
-					: null,
-				retention,
-			});
-			if (isCreate) {
-				await createRepo.call({ server_group_id: groupId });
-			}
 			navigate(`/groups/${groupId}/backups`);
 		} catch {
 			/* surfaced via the action errors */
 		}
 	};
-
-	const scheduleAndRetention = (
-		<>
-			<Typography variant="subtitle1">Schedule</Typography>
-			<FormControlLabel
-				control={
-					<Switch
-						checked={scheduled}
-						onChange={(e) => setScheduled(e.target.checked)}
-						disabled={pending}
-					/>
-				}
-				label={scheduled ? "Scheduled" : "Manual only (no schedule)"}
-			/>
-			{scheduled && (
-				<TextField
-					label="Back up every (minutes)"
-					type="number"
-					value={intervalMinutes}
-					onChange={(e) => setIntervalMinutes(e.target.value)}
-					disabled={pending}
-					slotProps={{ htmlInput: { min: 1, step: 1 } }}
-					sx={{ width: 220 }}
-				/>
-			)}
-
-			<Divider />
-
-			<Typography variant="subtitle1">Retention</Typography>
-			<Typography variant="caption" color="text.secondary">
-				kopia keep-* policy. Org minimums: keep_daily ≥{" "}
-				{RETENTION_FLOORS.keep_daily}, keep_weekly ≥{" "}
-				{RETENTION_FLOORS.keep_weekly}, keep_monthly ≥{" "}
-				{RETENTION_FLOORS.keep_monthly}.
-			</Typography>
-			<Stack direction={{ xs: "column", md: "row" }} spacing={2}>
-				<RetentionField
-					label="Latest"
-					value={retention.keep_latest}
-					onChange={(v) => setRetention({ ...retention, keep_latest: v })}
-					disabled={pending}
-				/>
-				<RetentionField
-					label="Daily"
-					value={retention.keep_daily}
-					onChange={(v) => setRetention({ ...retention, keep_daily: v })}
-					disabled={pending}
-					floor={RETENTION_FLOORS.keep_daily}
-				/>
-				<RetentionField
-					label="Weekly"
-					value={retention.keep_weekly}
-					onChange={(v) => setRetention({ ...retention, keep_weekly: v })}
-					disabled={pending}
-					floor={RETENTION_FLOORS.keep_weekly}
-				/>
-				<RetentionField
-					label="Monthly"
-					value={retention.keep_monthly}
-					onChange={(v) => setRetention({ ...retention, keep_monthly: v })}
-					disabled={pending}
-					floor={RETENTION_FLOORS.keep_monthly}
-				/>
-				<RetentionField
-					label="Annual"
-					value={retention.keep_annual}
-					onChange={(v) => setRetention({ ...retention, keep_annual: v })}
-					disabled={pending}
-				/>
-			</Stack>
-			{hasFloorError && (
-				<Alert severity="warning">{floorErrors.join("; ")}</Alert>
-			)}
-		</>
-	);
 
 	// ── Edit mode: flat form (structural fields are create-only) ───────────────
 	if (!isCreate) {
@@ -269,15 +148,13 @@ function ConfigForm({
 						disabled={pending}
 						helperText="Changing region typically implies a different bucket — change with care."
 					/>
-					<Divider />
-					{scheduleAndRetention}
+					<Typography variant="caption" color="text.secondary">
+						Schedule and retention are managed per backup type on the group's
+						backup page.
+					</Typography>
 					{error && <Alert severity="error">{error.message}</Alert>}
 					<Stack direction="row" spacing={1}>
-						<Button
-							variant="contained"
-							onClick={persist}
-							disabled={pending || hasFloorError}
-						>
+						<Button variant="contained" onClick={persist} disabled={pending}>
 							{pending ? "Saving…" : "Save"}
 						</Button>
 						<Button
@@ -299,7 +176,7 @@ function ConfigForm({
 		bucket.trim() !== "" &&
 		roleArn.trim() !== "" &&
 		maintenanceRoleArn.trim() !== "";
-	const canContinueReview =
+	const canProvision =
 		probe != null &&
 		probe.already_configured == null &&
 		(probe.state === "empty" ||
@@ -316,10 +193,7 @@ function ConfigForm({
 						<StepLabel>Target bucket</StepLabel>
 					</Step>
 					<Step>
-						<StepLabel>Review</StepLabel>
-					</Step>
-					<Step>
-						<StepLabel>Schedule &amp; retention</StepLabel>
+						<StepLabel>Review &amp; create</StepLabel>
 					</Step>
 				</Stepper>
 
@@ -394,6 +268,14 @@ function ConfigForm({
 							passphrase={passphrase}
 							setPassphrase={setPassphrase}
 						/>
+						{canProvision && (
+							<Typography variant="caption" color="text.secondary">
+								Schedule &amp; retention inherit the canopy-wide per-type
+								defaults — tune them per type on the group's backup page after
+								setup.
+							</Typography>
+						)}
+						{error && <Alert severity="error">{error.message}</Alert>}
 						<Stack direction="row" spacing={1}>
 							<Button variant="outlined" onClick={() => setStep(0)}>
 								Back
@@ -406,33 +288,10 @@ function ConfigForm({
 							)}
 							<Button
 								variant="contained"
-								onClick={() => setStep(2)}
-								disabled={!canContinueReview}
-							>
-								Continue
-							</Button>
-						</Stack>
-					</Stack>
-				)}
-
-				{step === 2 && (
-					<Stack spacing={2}>
-						{scheduleAndRetention}
-						{error && <Alert severity="error">{error.message}</Alert>}
-						<Stack direction="row" spacing={1}>
-							<Button
-								variant="outlined"
-								onClick={() => setStep(1)}
-								disabled={pending}
-							>
-								Back
-							</Button>
-							<Button
-								variant="contained"
 								onClick={persist}
-								disabled={pending || hasFloorError}
+								disabled={!canProvision || pending}
 							>
-								{pending ? "Saving…" : "Create & provision"}
+								{pending ? "Creating…" : "Create & provision"}
 							</Button>
 						</Stack>
 					</Stack>
@@ -442,7 +301,7 @@ function ConfigForm({
 	);
 }
 
-/// Step-2 review: explain what the probe found and gate the next action.
+/// Review step: explain what the probe found and gate provisioning.
 function ProbeReview({
 	probe,
 	groupId,
@@ -515,44 +374,4 @@ function ProbeReview({
 				</Stack>
 			);
 	}
-}
-
-function RetentionField({
-	label,
-	value,
-	onChange,
-	disabled,
-	floor,
-}: {
-	label: string;
-	value: number;
-	onChange: (v: number) => void;
-	disabled: boolean;
-	floor?: number;
-}) {
-	const below = floor != null && value < floor;
-	return (
-		<TextField
-			label={label}
-			type="number"
-			value={value}
-			onChange={(e) => onChange(Number(e.target.value))}
-			disabled={disabled}
-			error={below}
-			helperText={floor != null ? `≥ ${floor}` : undefined}
-			slotProps={{ htmlInput: { min: floor ?? 0, step: 1 } }}
-			sx={{ width: 110 }}
-		/>
-	);
-}
-
-function retentionFloorErrors(r: RetentionPolicy): string[] {
-	const errs: string[] = [];
-	if (r.keep_daily < RETENTION_FLOORS.keep_daily)
-		errs.push(`keep_daily must be ≥ ${RETENTION_FLOORS.keep_daily}`);
-	if (r.keep_weekly < RETENTION_FLOORS.keep_weekly)
-		errs.push(`keep_weekly must be ≥ ${RETENTION_FLOORS.keep_weekly}`);
-	if (r.keep_monthly < RETENTION_FLOORS.keep_monthly)
-		errs.push(`keep_monthly must be ≥ ${RETENTION_FLOORS.keep_monthly}`);
-	return errs;
 }

--- a/private-web/src/routes/BackupDefaults.tsx
+++ b/private-web/src/routes/BackupDefaults.tsx
@@ -1,0 +1,187 @@
+import {
+	Alert,
+	Box,
+	Button,
+	FormControlLabel,
+	LinearProgress,
+	Paper,
+	Stack,
+	Switch,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { useState } from "react";
+import { useApi, useApiAction } from "../api";
+import { usePageTitle } from "../hooks/usePageTitle";
+
+type Retention = {
+	keep_latest: number;
+	keep_daily: number;
+	keep_weekly: number;
+	keep_monthly: number;
+	keep_annual: number;
+};
+
+type TypeDefault = {
+	type: string;
+	default_interval: number | null;
+	default_retention: Retention | null;
+	auto_enable: boolean;
+};
+
+const FLOOR_RETENTION: Retention = {
+	keep_latest: 1,
+	keep_daily: 7,
+	keep_weekly: 4,
+	keep_monthly: 6,
+	keep_annual: 0,
+};
+
+const RETENTION_FIELDS: Array<{ key: keyof Retention; label: string; floor?: number }> = [
+	{ key: "keep_latest", label: "Latest" },
+	{ key: "keep_daily", label: "Daily", floor: 7 },
+	{ key: "keep_weekly", label: "Weekly", floor: 4 },
+	{ key: "keep_monthly", label: "Monthly", floor: 6 },
+	{ key: "keep_annual", label: "Annual" },
+];
+
+/// Canopy-wide per-type backup defaults (`backup_type_defaults`): the schedule +
+/// retention each group inherits for a type unless it sets a per-group override.
+export default function BackupDefaults() {
+	usePageTitle("Backup defaults");
+	const defaults = useApi("backups", "type_defaults");
+
+	if (defaults.status === "loading" || defaults.status === "idle") {
+		return <LinearProgress />;
+	}
+	if (defaults.status === "error") {
+		return <Alert severity="error">{defaults.error.message}</Alert>;
+	}
+
+	return (
+		<Stack spacing={3}>
+			<Typography variant="body2" color="text.secondary">
+				The canopy-wide default schedule and retention for each backup type.
+				Groups inherit these; per-group overrides are set on a group's backup
+				page.
+			</Typography>
+			{defaults.data.length === 0 ? (
+				<Alert severity="info">No backup type defaults configured.</Alert>
+			) : (
+				defaults.data.map((d) => (
+					<TypeDefaultEditor
+						key={d.type}
+						value={d as TypeDefault}
+						onSaved={defaults.reload}
+					/>
+				))
+			)}
+		</Stack>
+	);
+}
+
+function TypeDefaultEditor({
+	value,
+	onSaved,
+}: {
+	value: TypeDefault;
+	onSaved: () => void;
+}) {
+	const save = useApiAction("backups", "set_type_default");
+	const [scheduled, setScheduled] = useState(value.default_interval != null);
+	const [hours, setHours] = useState(
+		value.default_interval != null
+			? String(Math.max(1, Math.round(value.default_interval / 3600)))
+			: "6",
+	);
+	const [autoEnable, setAutoEnable] = useState(value.auto_enable);
+	const [retention, setRetention] = useState<Retention>(
+		value.default_retention ?? FLOOR_RETENTION,
+	);
+
+	const floorError = RETENTION_FIELDS.filter(
+		(f) => f.floor != null && retention[f.key] < f.floor,
+	).map((f) => `${f.label} must be ≥ ${f.floor}`);
+
+	const onSave = async () => {
+		await save.call({
+			type: value.type,
+			default_interval: scheduled ? Math.max(1, Number(hours)) * 3600 : null,
+			default_retention: retention,
+			auto_enable: autoEnable,
+		});
+		onSaved();
+	};
+
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }}>
+			<Stack spacing={1.5}>
+				<Typography sx={{ fontFamily: "monospace" }}>{value.type}</Typography>
+				<FormControlLabel
+					control={
+						<Switch
+							checked={scheduled}
+							onChange={(e) => setScheduled(e.target.checked)}
+							disabled={save.pending}
+						/>
+					}
+					label={scheduled ? "Scheduled" : "Manual only"}
+				/>
+				{scheduled && (
+					<TextField
+						label="Back up every (hours)"
+						type="number"
+						size="small"
+						value={hours}
+						onChange={(e) => setHours(e.target.value)}
+						disabled={save.pending}
+						slotProps={{ htmlInput: { min: 1, step: 1 } }}
+						sx={{ width: 200 }}
+					/>
+				)}
+				<Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+					{RETENTION_FIELDS.map((f) => (
+						<TextField
+							key={f.key}
+							label={f.label}
+							type="number"
+							size="small"
+							value={retention[f.key]}
+							onChange={(e) =>
+								setRetention({ ...retention, [f.key]: Number(e.target.value) })
+							}
+							disabled={save.pending}
+							error={f.floor != null && retention[f.key] < f.floor}
+							helperText={f.floor != null ? `≥ ${f.floor}` : undefined}
+							slotProps={{ htmlInput: { min: f.floor ?? 0, step: 1 } }}
+							sx={{ width: 100 }}
+						/>
+					))}
+				</Stack>
+				<FormControlLabel
+					control={
+						<Switch
+							checked={autoEnable}
+							onChange={(e) => setAutoEnable(e.target.checked)}
+							disabled={save.pending}
+						/>
+					}
+					label="Auto-enable this type when a server advertises it"
+				/>
+				{floorError.length > 0 && (
+					<Alert severity="warning">{floorError.join("; ")}</Alert>
+				)}
+				{save.error && <Alert severity="error">{save.error.message}</Alert>}
+				<Box>
+					<Button
+						variant="contained"
+						onClick={onSave}
+						disabled={save.pending || floorError.length > 0}
+					>
+						{save.pending ? "Saving…" : "Save"}
+					</Button>
+				</Box>
+			</Stack>
+		</Paper>
+	);
+}

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -5,16 +5,20 @@ import {
 	Chip,
 	CircularProgress,
 	Divider,
+	FormControlLabel,
 	LinearProgress,
 	Paper,
 	Stack,
+	Switch,
 	Table,
 	TableBody,
 	TableCell,
 	TableHead,
 	TableRow,
+	TextField,
 	Typography,
 } from "@mui/material";
+import { useState } from "react";
 import BackupIcon from "@mui/icons-material/Backup";
 import EditIcon from "@mui/icons-material/Edit";
 import RefreshIcon from "@mui/icons-material/Refresh";
@@ -149,6 +153,7 @@ export default function BackupPanel() {
 
 			{status === "ready" && (
 				<>
+					<SchedulesPanel groupId={id} isAdmin={isAdmin} />
 					<StatsPanel groupId={id} />
 					<RunsAndRequests
 						groupId={id}
@@ -162,8 +167,6 @@ export default function BackupPanel() {
 }
 
 function ConfigSummary({ config }: { config: BackupConfigView }) {
-	const sched = config.schedules.find((s) => s.type === WELL_KNOWN_TYPE);
-	const interval = sched?.expected_interval;
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
 			<Stack spacing={0.5}>
@@ -174,23 +177,256 @@ function ConfigSummary({ config }: { config: BackupConfigView }) {
 				<Typography variant="body2">
 					<strong>Region:</strong> {config.region ?? "default"}
 				</Typography>
-				<Typography variant="body2">
-					<strong>Schedule:</strong>{" "}
-					{interval != null
-						? `every ${humanSeconds(interval)}`
-						: "Manual only"}
-				</Typography>
-				{sched?.retention && (
-					<Typography variant="body2">
-						<strong>Retention:</strong> latest {sched.retention.keep_latest},
-						daily {sched.retention.keep_daily}, weekly{" "}
-						{sched.retention.keep_weekly}, monthly{" "}
-						{sched.retention.keep_monthly}, annual{" "}
-						{sched.retention.keep_annual}
-					</Typography>
-				)}
 			</Stack>
 		</Paper>
+	);
+}
+
+/// Per backup type, the group's effective schedule + retention (inherited from
+/// the canopy-wide default, or a per-group override). Admins can override a type
+/// or reset it back to the default.
+function SchedulesPanel({
+	groupId,
+	isAdmin,
+}: {
+	groupId: string;
+	isAdmin: boolean;
+}) {
+	const schedules = useApi(
+		"backups",
+		"group_schedules",
+		{ server_group_id: groupId },
+		[groupId],
+	);
+
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }}>
+			<Typography variant="h6" component="h2" gutterBottom>
+				Schedule &amp; retention
+			</Typography>
+			{schedules.status === "loading" || schedules.status === "idle" ? (
+				<LinearProgress />
+			) : schedules.status === "error" ? (
+				<Alert severity="error">{schedules.error.message}</Alert>
+			) : schedules.data.length === 0 ? (
+				<Alert severity="info">
+					No backup types are enabled for this group's servers yet. Each type
+					inherits the canopy-wide default until a server advertises it.
+				</Alert>
+			) : (
+				<Stack spacing={2}>
+					{schedules.data.map((s) => (
+						<TypeSchedule
+							key={s.type}
+							groupId={groupId}
+							schedule={s}
+							isAdmin={isAdmin}
+							onChanged={schedules.reload}
+						/>
+					))}
+				</Stack>
+			)}
+		</Paper>
+	);
+}
+
+type GroupTypeSchedule = {
+	type: string;
+	effective_interval: number | null;
+	effective_retention: {
+		keep_latest: number;
+		keep_daily: number;
+		keep_weekly: number;
+		keep_monthly: number;
+		keep_annual: number;
+	};
+	has_override: boolean;
+};
+
+function TypeSchedule({
+	groupId,
+	schedule,
+	isAdmin,
+	onChanged,
+}: {
+	groupId: string;
+	schedule: GroupTypeSchedule;
+	isAdmin: boolean;
+	onChanged: () => void;
+}) {
+	const [editing, setEditing] = useState(false);
+	const r = schedule.effective_retention;
+
+	return (
+		<Box sx={{ borderTop: 1, borderColor: "divider", pt: 1.5 }}>
+			<Stack
+				direction="row"
+				spacing={1}
+				sx={{ alignItems: "center", flexWrap: "wrap" }}
+			>
+				<Typography sx={{ fontFamily: "monospace" }}>{schedule.type}</Typography>
+				<Chip
+					size="small"
+					label={schedule.has_override ? "Override" : "Inherited default"}
+					color={schedule.has_override ? "secondary" : "default"}
+					variant={schedule.has_override ? "filled" : "outlined"}
+				/>
+				<Box sx={{ flex: 1 }} />
+				{isAdmin && !editing && (
+					<Button size="small" onClick={() => setEditing(true)}>
+						{schedule.has_override ? "Edit override" : "Override"}
+					</Button>
+				)}
+			</Stack>
+			<Typography variant="body2" color="text.secondary">
+				{schedule.effective_interval != null
+					? `Every ${humanSeconds(schedule.effective_interval)}`
+					: "Manual only (no scheduled interval)"}{" "}
+				· retention latest {r.keep_latest}, daily {r.keep_daily}, weekly{" "}
+				{r.keep_weekly}, monthly {r.keep_monthly}, annual {r.keep_annual}
+			</Typography>
+			{editing && (
+				<OverrideEditor
+					groupId={groupId}
+					schedule={schedule}
+					onDone={() => {
+						setEditing(false);
+						onChanged();
+					}}
+					onCancel={() => setEditing(false)}
+				/>
+			)}
+		</Box>
+	);
+}
+
+const RETENTION_FIELDS: Array<{
+	key: keyof GroupTypeSchedule["effective_retention"];
+	label: string;
+	floor?: number;
+}> = [
+	{ key: "keep_latest", label: "Latest" },
+	{ key: "keep_daily", label: "Daily", floor: 7 },
+	{ key: "keep_weekly", label: "Weekly", floor: 4 },
+	{ key: "keep_monthly", label: "Monthly", floor: 6 },
+	{ key: "keep_annual", label: "Annual" },
+];
+
+function OverrideEditor({
+	groupId,
+	schedule,
+	onDone,
+	onCancel,
+}: {
+	groupId: string;
+	schedule: GroupTypeSchedule;
+	onDone: () => void;
+	onCancel: () => void;
+}) {
+	const setSchedule = useApiAction("backups", "set_schedule");
+	const clearSchedule = useApiAction("backups", "clear_schedule");
+	const [scheduled, setScheduled] = useState(
+		schedule.effective_interval != null,
+	);
+	const [hours, setHours] = useState(
+		schedule.effective_interval != null
+			? String(Math.max(1, Math.round(schedule.effective_interval / 3600)))
+			: "6",
+	);
+	const [retention, setRetention] = useState(schedule.effective_retention);
+
+	const floorError = RETENTION_FIELDS.filter(
+		(f) => f.floor != null && retention[f.key] < f.floor,
+	).map((f) => `${f.label} must be ≥ ${f.floor}`);
+
+	const save = async () => {
+		await setSchedule.call({
+			server_group_id: groupId,
+			type: schedule.type,
+			expected_interval: scheduled ? Math.max(1, Number(hours)) * 3600 : null,
+			retention,
+		});
+		onDone();
+	};
+	const reset = async () => {
+		await clearSchedule.call({ server_group_id: groupId, type: schedule.type });
+		onDone();
+	};
+
+	const pending = setSchedule.pending || clearSchedule.pending;
+	const error = setSchedule.error || clearSchedule.error;
+
+	return (
+		<Stack spacing={1.5} sx={{ mt: 1.5 }}>
+			<FormControlLabel
+				control={
+					<Switch
+						checked={scheduled}
+						onChange={(e) => setScheduled(e.target.checked)}
+						disabled={pending}
+					/>
+				}
+				label={scheduled ? "Scheduled" : "Manual only"}
+			/>
+			{scheduled && (
+				<TextField
+					label="Back up every (hours)"
+					type="number"
+					size="small"
+					value={hours}
+					onChange={(e) => setHours(e.target.value)}
+					disabled={pending}
+					slotProps={{ htmlInput: { min: 1, step: 1 } }}
+					sx={{ width: 200 }}
+				/>
+			)}
+			<Stack direction={{ xs: "column", md: "row" }} spacing={1}>
+				{RETENTION_FIELDS.map((f) => (
+					<TextField
+						key={f.key}
+						label={f.label}
+						type="number"
+						size="small"
+						value={retention[f.key]}
+						onChange={(e) =>
+							setRetention({ ...retention, [f.key]: Number(e.target.value) })
+						}
+						disabled={pending}
+						error={f.floor != null && retention[f.key] < f.floor}
+						helperText={f.floor != null ? `≥ ${f.floor}` : undefined}
+						slotProps={{ htmlInput: { min: f.floor ?? 0, step: 1 } }}
+						sx={{ width: 100 }}
+					/>
+				))}
+			</Stack>
+			{floorError.length > 0 && (
+				<Alert severity="warning">{floorError.join("; ")}</Alert>
+			)}
+			{error && <Alert severity="error">{error.message}</Alert>}
+			<Stack direction="row" spacing={1}>
+				<Button
+					variant="contained"
+					size="small"
+					onClick={save}
+					disabled={pending || floorError.length > 0}
+				>
+					{pending ? "Saving…" : "Save override"}
+				</Button>
+				{schedule.has_override && (
+					<Button
+						size="small"
+						color="warning"
+						onClick={reset}
+						disabled={pending}
+					>
+						Reset to default
+					</Button>
+				)}
+				<Button size="small" onClick={onCancel} disabled={pending}>
+					Cancel
+				</Button>
+			</Stack>
+		</Stack>
 	);
 }
 

--- a/private-web/src/routes/Settings.tsx
+++ b/private-web/src/routes/Settings.tsx
@@ -5,11 +5,17 @@ import { Outlet, useLocation, useNavigate } from "react-router-dom";
 /// vault) under one top-level nav item so they don't each hold space in the bar.
 const TABS: Array<{ value: string; label: string; to: string }> = [
 	{ value: "admins", label: "Admins", to: "/settings/admins" },
+	{
+		value: "backup-defaults",
+		label: "Backup defaults",
+		to: "/settings/backup-defaults",
+	},
 	{ value: "recovery", label: "Recovery vault", to: "/settings/recovery" },
 ];
 
 function valueFromPath(pathname: string): string {
 	if (pathname.startsWith("/settings/recovery")) return "recovery";
+	if (pathname.startsWith("/settings/backup-defaults")) return "backup-defaults";
 	if (pathname.startsWith("/settings/admins")) return "admins";
 	return "";
 }


### PR DESCRIPTION
🤖 Backups are keyed per-`(group, type)`, but schedule + retention were still configured as a single "global" setting (the wizard hardcoded `tamanu-postgres`, and `backup_type_defaults` existed but was never seeded or exposed). This reconciles the UI/API with the model.

## Model

- **Canopy-wide per-type defaults** (`backup_type_defaults`) are the baseline every group inherits. Seeds `tamanu-postgres` (6h interval, floor-meeting retention, auto-enable). Editable in **Settings → Backup defaults**.
- **Per-`(group, type)` overrides** are managed on the group's backup page — a *Schedule & retention* panel lists each enabled type with its effective schedule (inherited or overridden) and an override / reset-to-default editor. Intervals are entered in **hours**.

## Changes

- **Wizard** drops its schedule/retention step — a new repo just inherits the defaults (2-step: target → review & create).
- **Machine `upsert` API** loses `type`/`expected_interval`/`retention` — it's repo config only (bucket/prefix/roles/region); schedule is UI-managed.
- New endpoints: `group_schedules` (effective per-type), `type_defaults` / `set_type_default` (canopy-wide), `clear_schedule` (drop an override). New `ServerGroupBackupSchedule::delete`. Seed migration.

## Tests

Rust: type-default list/set + floor rejection, clear-override. e2e: per-type override editor saves an override, the Backup defaults editor persists, the simplified 2-step wizard (no schedule step). Rust suite + typecheck pass locally; e2e runs in CI (local parallel e2e starves under the core cap).