### PR TITLE
fix(backups): read repo-password Secrets from the pod's own namespace [TAM-6877]

### DIFF
--- a/crates/commons-servers/src/backup_secrets.rs
+++ b/crates/commons-servers/src/backup_secrets.rs
@@ -61,11 +61,10 @@ impl BackupSecrets {
 	}
 
 	/// Build a secret store from the ambient cluster config (in-cluster the pod's
-	/// service account; locally `~/.kube/config`), reading from the
-	/// `POD_NAMESPACE` namespace (default `canopy`). If `MEMORY_ENV` is set,
-	/// returns the in-memory store instead. Returns `None` (logged) when no
-	/// cluster config is available, so callers degrade to 502 rather than failing
-	/// startup.
+	/// service account; locally `~/.kube/config`), reading from the pod's own
+	/// namespace (see [`pod_namespace`]). If `MEMORY_ENV` is set, returns the
+	/// in-memory store instead. Returns `None` (logged) when no cluster config is
+	/// available, so callers degrade to 502 rather than failing startup.
 	pub async fn try_default() -> Option<Self> {
 		if std::env::var_os(MEMORY_ENV).is_some() {
 			// The in-memory store is debug-only (tests, e2e, local dev). `memory()`
@@ -84,10 +83,10 @@ impl BackupSecrets {
 			);
 		}
 		match kube::Client::try_default().await {
-			Ok(client) => Some(Self::Kube {
-				client,
-				namespace: namespace_from_env(),
-			}),
+			Ok(client) => {
+				let namespace = pod_namespace(&client);
+				Some(Self::Kube { client, namespace })
+			}
 			Err(err) => {
 				tracing::warn!(error = ?err, "kube client unavailable; backup Secret ops will 502");
 				None
@@ -271,10 +270,15 @@ fn secret_object(secret_name: &str, key: &str, value: &str) -> k8s_openapi::api:
 	}
 }
 
-/// Namespace the repo-password Secrets live in: `POD_NAMESPACE` (inject via the
-/// downward API), defaulting to `canopy`.
-fn namespace_from_env() -> String {
-	std::env::var("POD_NAMESPACE").unwrap_or_else(|_| "canopy".to_string())
+/// Namespace the repo-password Secrets live in. `POD_NAMESPACE` (injected via the
+/// downward API) wins if set; otherwise the pod's **own** namespace from the
+/// in-cluster config — i.e. the ServiceAccount's namespace. Never a hardcoded
+/// guess: defaulting to `canopy` meant a pod deployed elsewhere (e.g.
+/// `tamanu-meta-prod`) read/created Secrets in `canopy`, where its SA has no RBAC
+/// (403 Forbidden), so onboarding's Secret and the backups pod's read landed in
+/// different namespaces than the grants.
+fn pod_namespace(client: &kube::Client) -> String {
+	std::env::var("POD_NAMESPACE").unwrap_or_else(|_| client.default_namespace().to_string())
 }
 
 #[cfg(test)]

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -392,8 +392,16 @@ pub async fn create(
 		},
 	)
 	.await?;
-	kube.create_password(&repo_password_ref, REPO_PASSWORD_SECRET_KEY, &passphrase)
-		.await?;
+	// Roll back the config row if the Secret can't be created, so onboarding is
+	// all-or-nothing — a failed Secret create must not leave a half-created config
+	// stuck in `provisioning` with no passphrase.
+	if let Err(e) = kube
+		.create_password(&repo_password_ref, REPO_PASSWORD_SECRET_KEY, &passphrase)
+		.await
+	{
+		let _ = ServerGroupBackupConfig::delete(&mut conn, args.server_group_id).await;
+		return Err(e);
+	}
 
 	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
 }

--- a/docs/plans/backup-setup-wizard-ops-handoff.md
+++ b/docs/plans/backup-setup-wizard-ops-handoff.md
@@ -209,3 +209,16 @@ action items §1–§3, §5 are the source of truth; treat them as done.
   ceremony as unavailable. private-server does **not** hard-require them (it
   starts fine without; only the ceremony page is degraded) — unlike the backups
   pod, which won't start without them. Nothing else on private-server needs it.
+
+**2026-06-22 — fix (repo-password Secret namespace):**
+- Canopy now reads/creates the repo-password Secrets in the **pod's own
+  namespace** (the ServiceAccount's namespace from the in-cluster config), not a
+  hardcoded `canopy`. So in `tamanu-meta-prod` the Secrets live in
+  `tamanu-meta-prod`. **No `POD_NAMESPACE` env needed** (it's still honored as an
+  override if set). Earlier the default `canopy` caused `canopy-jobs` (in
+  `tamanu-meta-prod`) to hit `403 Forbidden` reading `backup-repo-*` in `canopy`.
+- ⚠️ **Ensure both SAs have secret RBAC in the deployment namespace:**
+  `canopy-private` (`get`+`create` secrets) and `canopy-jobs` (`get`+`create`/
+  `update`/`patch` secrets, for rotation) — in whatever namespace the pods run
+  (e.g. `tamanu-meta-prod`), which is the standard same-namespace grant. If those
+  Role/RoleBindings were created in `canopy`, move them to the pods' namespace.


### PR DESCRIPTION
🤖 Repo creation failed in prod with `canopy-jobs` (in `tamanu-meta-prod`) getting `403 Forbidden` reading `backup-repo-…` in namespace `canopy`.

## Fix 1 — Secret namespace

`BackupSecrets` defaulted its namespace to a hardcoded `"canopy"` when `POD_NAMESPACE` was unset, so a pod in `tamanu-meta-prod` read/created Secrets in `canopy` where its SA has no RBAC. Now defaults to the **kube client's own namespace** (the SA's namespace from the in-cluster config); `POD_NAMESPACE` still overrides. Ops handoff updated (ensure `canopy-private`/`canopy-jobs` have secret RBAC in the deployment namespace).

## Fix 2 — atomic create (rollback)

Onboarding's `create` inserted the config row *then* created the Secret with no rollback, so a Secret-create failure (exactly fix 1's symptom) left a **half-created config** stuck in `provisioning` with no passphrase. Now `create` rolls back the config row if the Secret can't be created — onboarding is all-or-nothing.

Compiles + commons-servers/private-server tests pass; e2e in CI. Rebased onto main (post #244/#245 merge). The rollback's failure path can't be exercised with the in-memory test store (its `create_password` never fails).