### PR TITLE
feat(backups): deliver "back up now" to devices via the status heartbeat [TAM-6877]

### DIFF
--- a/crates/commons-servers/src/backup_jobs.rs
+++ b/crates/commons-servers/src/backup_jobs.rs
@@ -8,10 +8,13 @@ use std::time::Duration;
 use commons_errors::Result;
 use commons_types::{
 	Uuid,
-	backup::BackupType,
+	backup::{BackupConfigStatus, BackupPurpose, BackupType},
 	server::{rank::ServerRank, tags::TagMap},
 };
-use database::{BackupTypeDefault, ServerBackupCapability, ServerGroupBackupSchedule};
+use database::{
+	BackupRequest, BackupRun, BackupTypeDefault, ServerBackupCapability, ServerGroupBackupConfig,
+	ServerGroupBackupSchedule,
+};
 use diesel_async::AsyncPgConnection;
 use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
@@ -121,6 +124,27 @@ pub async fn effective_retention_for_group(
 	Ok(out)
 }
 
+/// Resolve the effective backup interval for one `(group, type)`: the schedule
+/// `expected_interval` override, else the type's `default_interval`. `None` ⇒
+/// manual-only (no scheduled cadence).
+async fn effective_interval_for_type(
+	db: &mut AsyncPgConnection,
+	group_id: Uuid,
+	ty: &BackupType,
+) -> Result<Option<Duration>> {
+	let interval = match ServerGroupBackupSchedule::get(db, group_id, ty)
+		.await?
+		.and_then(|s| s.expected_interval)
+	{
+		Some(i) => Some(i),
+		None => BackupTypeDefault::get(db, ty)
+			.await?
+			.and_then(|d| d.default_interval),
+	};
+	// PgDuration wraps a jiff SignedDuration; whole seconds → Duration.
+	Ok(interval.map(|pg| Duration::from_secs(pg.0.as_secs().max(0) as u64)))
+}
+
 /// Resolve the effective backup interval for the group: per enabled type, the
 /// schedule `expected_interval` else the type `default_interval`; the group's
 /// effective cadence is the MINIMUM across types (the most-frequent type drives
@@ -132,23 +156,64 @@ pub async fn effective_interval_for_group(
 	let types = ServerBackupCapability::enabled_types_for_group(db, group_id).await?;
 	let mut min: Option<Duration> = None;
 	for ty in types {
-		let schedule_interval = ServerGroupBackupSchedule::get(db, group_id, &ty)
-			.await?
-			.and_then(|s| s.expected_interval);
-		let interval = match schedule_interval {
-			Some(i) => Some(i),
-			None => BackupTypeDefault::get(db, &ty)
-				.await?
-				.and_then(|d| d.default_interval),
-		};
-		if let Some(pg) = interval {
-			// PgDuration wraps a jiff SignedDuration; whole seconds → Duration.
-			let secs = pg.0.as_secs().max(0) as u64;
-			let d = Duration::from_secs(secs);
+		if let Some(d) = effective_interval_for_type(db, group_id, &ty).await? {
 			min = Some(min.map_or(d, |m| m.min(d)));
 		}
 	}
 	Ok(min)
+}
+
+/// The backup types a server should back up *now*: every enabled `(server,
+/// type)` whose effective interval has elapsed since its last successful backup
+/// (schedule-due), unioned with operator one-off [`BackupRequest`]s
+/// (`purpose = backup` only — restore is operator-directed, not delivered over
+/// the heartbeat). Manual-only types (no effective interval) appear only when
+/// explicitly requested. Sorted by type name for a stable wire order.
+///
+/// Emitted idempotently each tick: a due type keeps appearing until a
+/// successful run reports (advancing the staleness anchor), and a one-off until
+/// the run is reported (which clears the request). The device is responsible
+/// for not starting a second run while one is already in flight.
+pub async fn backups_due_now_for_server(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	group_id: Uuid,
+	now: Timestamp,
+) -> Result<Vec<BackupType>> {
+	// Nothing to back up to unless the group's repo is ready — a request or a
+	// due schedule against a still-provisioning config would only bounce off the
+	// device's `/backup-target` (dormant). Gate the whole signal on readiness.
+	match ServerGroupBackupConfig::get(db, group_id).await? {
+		Some(cfg) if cfg.status == BackupConfigStatus::Ready => {}
+		_ => return Ok(Vec::new()),
+	}
+
+	let mut due: std::collections::HashSet<BackupType> = std::collections::HashSet::new();
+
+	for req in BackupRequest::pending_for_server(db, server_id).await? {
+		if req.purpose == BackupPurpose::Backup {
+			due.insert(req.r#type);
+		}
+	}
+
+	for cap in ServerBackupCapability::list_for_server(db, server_id).await? {
+		if !cap.enabled {
+			continue;
+		}
+		let Some(interval) = effective_interval_for_type(db, group_id, &cap.r#type).await? else {
+			continue;
+		};
+		let last = BackupRun::latest_success_for_server(db, server_id, &cap.r#type)
+			.await?
+			.map(|r| r.reported_at);
+		if is_due(interval, last, now) {
+			due.insert(cap.r#type);
+		}
+	}
+
+	let mut out: Vec<BackupType> = due.into_iter().collect();
+	out.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+	Ok(out)
 }
 
 /// The three `billing.*` pod labels spawned Jobs carry for AWS cost allocation.

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -580,7 +580,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Status"
+                  "$ref": "#/components/schemas/StatusResponse"
                 }
               }
             }
@@ -1608,6 +1608,29 @@
           }
         ],
         "description": "Status payload contract — documents the wire shape only. The\nhandler actually receives `serde_json::Value` and runs its own\nvalidation so arbitrary additional fields flow through into\n`statuses.extra` unchanged.\n\nSchema is reproduced here so the openapi spec describes the\n`healthy` and `health` keys explicitly; otherwise consumers have\nto read the prose to know they exist."
+      },
+      "StatusResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Status"
+          },
+          {
+            "type": "object",
+            "required": [
+              "backup_now"
+            ],
+            "properties": {
+              "backup_now": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Backup types due/requested for this server now. Each serializes as a\nplain string (e.g. `\"tamanu-postgres\"`)."
+              }
+            }
+          }
+        ],
+        "description": "The status-push response: the persisted [`Status`] plus `backup_now`, the\nbackup types this server should back up *right now* (operator one-offs +\nschedule-due; see [`backups_due_now_for_server`]). The device runs each; an\nempty list means \"nothing to do\". The `Status` fields are flattened so they\nstay top-level for clients that predate `backup_now` and ignore it."
       },
       "TagMap": {
         "type": "object",

--- a/crates/public-server/src/backup.rs
+++ b/crates/public-server/src/backup.rs
@@ -25,7 +25,8 @@ use database::{
 	Db,
 	backups::BackupTypeDefault,
 	backups::{
-		NewBackupCredentialIssuance, NewBackupRun, ServerBackupCapability, ServerGroupBackupConfig,
+		BackupRequest, NewBackupCredentialIssuance, NewBackupRun, ServerBackupCapability,
+		ServerGroupBackupConfig,
 	},
 	servers::Server,
 };
@@ -456,7 +457,7 @@ async fn report(
 			device_id,
 			group_id,
 			server_id: Some(server.id),
-			r#type: rep.r#type,
+			r#type: rep.r#type.clone(),
 			purpose: rep.purpose,
 			outcome: rep.outcome,
 			error: rep.error,
@@ -465,6 +466,12 @@ async fn report(
 		},
 	)
 	.await?;
+
+	// Clear any matching operator one-off so the heartbeat stops re-emitting
+	// "back up now" for it — regardless of outcome (the operator asked for one
+	// attempt; they can re-request). A scheduled-due signal self-clears once the
+	// successful run advances the staleness anchor, so it needs no clearing here.
+	BackupRequest::clear(&mut conn, server.id, &rep.r#type, rep.purpose).await?;
 
 	Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -5,8 +5,10 @@ use axum::{
 	extract::{Path, State},
 };
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
-use commons_servers::{device_auth::ServerDevice, headers::VersionHeader};
-use commons_types::{device::DeviceRole, issue::Severity, status::CheckResult};
+use commons_servers::{
+	backup_jobs::backups_due_now_for_server, device_auth::ServerDevice, headers::VersionHeader,
+};
+use commons_types::{backup::BackupType, device::DeviceRole, issue::Severity, status::CheckResult};
 use database::{
 	Db,
 	devices::Device,
@@ -16,7 +18,8 @@ use database::{
 	servers::Server,
 	statuses::{NewStatus, Status},
 };
-use serde::Deserialize;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
@@ -111,6 +114,21 @@ const HEALTH_REF: &str = "health";
 /// operators can silence the two independently.
 const BROKEN_REF: &str = "health-broken";
 
+/// The status-push response: the persisted [`Status`] plus `backup_now`, the
+/// backup types this server should back up *right now* (operator one-offs +
+/// schedule-due; see [`backups_due_now_for_server`]). The device runs each; an
+/// empty list means "nothing to do". The `Status` fields are flattened so they
+/// stay top-level for clients that predate `backup_now` and ignore it.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct StatusResponse {
+	#[serde(flatten)]
+	pub status: Status,
+	/// Backup types due/requested for this server now. Each serializes as a
+	/// plain string (e.g. `"tamanu-postgres"`).
+	#[schema(value_type = Vec<String>)]
+	pub backup_now: Vec<BackupType>,
+}
+
 pub fn routes() -> OpenApiRouter<AppState> {
 	OpenApiRouter::new().routes(routes!(create))
 }
@@ -128,7 +146,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		description = "Status push. A `health` array is required (it may be empty); a body without it is rejected with 400, unless the server has `allow_legacy_status` set, in which case the push refreshes reachability only and carries the last known healthchecks forward.",
 	),
 	responses(
-		(status = 200, body = Status),
+		(status = 200, body = StatusResponse),
 		(status = 400, body = ProblemDetailsSchema),
 		(status = 401, body = ProblemDetailsSchema),
 		(status = 403, body = ProblemDetailsSchema),
@@ -140,7 +158,7 @@ async fn create(
 	device: ServerDevice,
 	current_version: VersionHeader,
 	body: Option<Json<serde_json::Value>>,
-) -> Result<Json<Status>> {
+) -> Result<Json<StatusResponse>> {
 	let mut db = db.get().await?;
 	let Device { role, id, .. } = device.0.0;
 
@@ -153,6 +171,16 @@ async fn create(
 		));
 	}
 
+	// Tell the device which backup types to run now (operator one-offs +
+	// schedule-due), riding the heartbeat response. Empty for an ungrouped
+	// server or one whose group has no `ready` backup config.
+	let backup_now = match server.group_id {
+		Some(group_id) => {
+			backups_due_now_for_server(&mut db, server_id, group_id, Timestamp::now()).await?
+		}
+		None => Vec::new(),
+	};
+
 	let raw = body.map(|j| j.0).unwrap_or(serde_json::Value::Null);
 	let (healthy, health, extra) = split_health_from_extra(raw)?;
 
@@ -163,9 +191,8 @@ async fn create(
 		if !server.allow_legacy_status {
 			return Err(AppError::BadRequest("`health` array is required".into()));
 		}
-		return Ok(Json(
-			create_legacy_status(&mut db, server_id, id, extra, current_version.0).await?,
-		));
+		let status = create_legacy_status(&mut db, server_id, id, extra, current_version.0).await?;
+		return Ok(Json(StatusResponse { status, backup_now }));
 	};
 
 	// Resolve the server's effective tag map outside the write transaction.
@@ -199,7 +226,7 @@ async fn create(
 		})
 		.await?;
 
-	Ok(Json(status))
+	Ok(Json(StatusResponse { status, backup_now }))
 }
 
 /// Store a legacy-format push (no `health` array) for a server that's opted

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -2310,3 +2310,199 @@ async fn submit_status_result_all_kinds_upsert_catalog() {
 	)
 	.await
 }
+
+// --- backup_now signal on the status response -------------------------------
+
+async fn seed_server_in_group(
+	conn: &mut diesel_async::AsyncPgConnection,
+	device_id: Uuid,
+) -> (Uuid, Uuid) {
+	let group_id = Uuid::new_v4();
+	sql_query("INSERT INTO server_groups (id, name) VALUES ($1, 'backup-now-test')")
+		.bind::<sql_types::Uuid, _>(group_id)
+		.execute(conn)
+		.await
+		.expect("insert group");
+	let server_id = Uuid::new_v4();
+	sql_query(
+		"INSERT INTO servers (id, host, kind, device_id, group_id) \
+		 VALUES ($1, 'https://srv.example.com', 'central', $2, $3)",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(Some(device_id))
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(Some(group_id))
+	.execute(conn)
+	.await
+	.expect("insert server");
+	(server_id, group_id)
+}
+
+async fn seed_backup_config(
+	conn: &mut diesel_async::AsyncPgConnection,
+	group_id: Uuid,
+	status: &str,
+) {
+	sql_query(
+		"INSERT INTO server_group_backup_config \
+		 (group_id, bucket, prefix, target_role_arn, maintenance_role_arn, region, repo_password_ref, status) \
+		 VALUES ($1, 'grp-bucket', '', 'arn:aws:iam::123456789012:role/grp', 'arn:aws:iam::123456789012:role/grp-maint', 'ap-southeast-2', 'grp-repo-pw', $2)",
+	)
+	.bind::<sql_types::Uuid, _>(group_id)
+	.bind::<sql_types::Text, _>(status)
+	.execute(conn)
+	.await
+	.expect("insert config");
+}
+
+async fn enable_backup_capability(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	r#type: &str,
+) {
+	sql_query(
+		"INSERT INTO server_backup_capabilities (server_id, type, enabled) VALUES ($1, $2, true)",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(r#type)
+	.execute(conn)
+	.await
+	.expect("insert capability");
+}
+
+fn backup_now(body: &serde_json::Value) -> Vec<String> {
+	body["backup_now"]
+		.as_array()
+		.expect("backup_now array")
+		.iter()
+		.map(|v| v.as_str().expect("type string").to_string())
+		.collect()
+}
+
+/// An enabled type with no prior successful run is schedule-due (the seeded
+/// 6h `tamanu-postgres` default applies), so the heartbeat names it.
+#[tokio::test(flavor = "multi_thread")]
+async fn status_signals_backup_now_for_due_schedule() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let (server_id, group_id) = seed_server_in_group(&mut conn, device_id).await;
+			seed_backup_config(&mut conn, group_id, "ready").await;
+			enable_backup_capability(&mut conn, server_id, "tamanu-postgres").await;
+
+			let resp = public
+				.post(&format!("/status/{server_id}"))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "health": [] }))
+				.await;
+			resp.assert_status_ok();
+			assert_eq!(backup_now(&resp.json()), vec!["tamanu-postgres"]);
+		},
+	)
+	.await
+}
+
+/// A recent successful backup is within the interval ⇒ not due ⇒ no signal.
+#[tokio::test(flavor = "multi_thread")]
+async fn status_no_backup_now_when_recent_success() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let (server_id, group_id) = seed_server_in_group(&mut conn, device_id).await;
+			seed_backup_config(&mut conn, group_id, "ready").await;
+			enable_backup_capability(&mut conn, server_id, "tamanu-postgres").await;
+			sql_query(
+				"INSERT INTO backup_runs (id, device_id, group_id, server_id, type, purpose, outcome, reported_at) \
+				 VALUES ($1, $2, $3, $4, 'tamanu-postgres', 'backup', 'success', now())",
+			)
+			.bind::<sql_types::Uuid, _>(Uuid::new_v4())
+			.bind::<sql_types::Uuid, _>(device_id)
+			.bind::<sql_types::Uuid, _>(group_id)
+			.bind::<sql_types::Nullable<sql_types::Uuid>, _>(Some(server_id))
+			.execute(&mut conn)
+			.await
+			.expect("insert run");
+
+			let resp = public
+				.post(&format!("/status/{server_id}"))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "health": [] }))
+				.await;
+			resp.assert_status_ok();
+			assert!(backup_now(&resp.json()).is_empty());
+		},
+	)
+	.await
+}
+
+/// The signal is gated on a `ready` config — a provisioning group emits nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn status_no_backup_now_until_config_ready() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let (server_id, group_id) = seed_server_in_group(&mut conn, device_id).await;
+			seed_backup_config(&mut conn, group_id, "provisioning").await;
+			enable_backup_capability(&mut conn, server_id, "tamanu-postgres").await;
+
+			let resp = public
+				.post(&format!("/status/{server_id}"))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "health": [] }))
+				.await;
+			resp.assert_status_ok();
+			assert!(backup_now(&resp.json()).is_empty());
+		},
+	)
+	.await
+}
+
+/// An operator one-off is surfaced, then cleared by `/backup-report` so the next
+/// heartbeat stops naming it.
+#[tokio::test(flavor = "multi_thread")]
+async fn status_one_off_request_surfaced_then_cleared_by_report() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let (server_id, group_id) = seed_server_in_group(&mut conn, device_id).await;
+			seed_backup_config(&mut conn, group_id, "ready").await;
+			// No enabled capability: the type appears only via the explicit request,
+			// so clearing it (not a due schedule) is what empties the signal.
+			sql_query(
+				"INSERT INTO backup_requests (server_id, type, purpose) VALUES ($1, 'tamanu-postgres', 'backup')",
+			)
+			.bind::<sql_types::Uuid, _>(server_id)
+			.execute(&mut conn)
+			.await
+			.expect("enqueue request");
+
+			let resp = public
+				.post(&format!("/status/{server_id}"))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "health": [] }))
+				.await;
+			resp.assert_status_ok();
+			assert_eq!(backup_now(&resp.json()), vec!["tamanu-postgres"]);
+
+			let report = public
+				.post("/backup-report")
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({
+					"run_id": Uuid::new_v4(),
+					"type": "tamanu-postgres",
+					"purpose": "backup",
+					"outcome": "success",
+				}))
+				.await;
+			report.assert_status(http::StatusCode::NO_CONTENT);
+
+			let resp = public
+				.post(&format!("/status/{server_id}"))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "health": [] }))
+				.await;
+			resp.assert_status_ok();
+			assert!(backup_now(&resp.json()).is_empty());
+		},
+	)
+	.await
+}


### PR DESCRIPTION
🤖 Canopy had no way to tell a device to back up — `backup_requests` (operator one-offs) and the schedule-due helpers existed, but nothing device-facing surfaced them. This adds the canopy→device leg by piggybacking on the existing ~1-minute status-POST healthcheck.

The status response (`POST /status/{server_id}`) gains a `backup_now: [BackupType]` list — the backup types this server should back up right now. The device runs each; empty means nothing to do. It's the union of:

- **operator one-offs** — pending `BackupRequest`s (`purpose = backup`); and
- **schedule-due** — each enabled `(server, type)` whose effective interval (group override ?? type default) has elapsed since its last successful backup. Manual-only types (no interval) are never schedule-due.

The whole signal is gated on the group having a `ready` config. The `Status` fields stay flattened at the top level, so it's additive for clients that don't read `backup_now`.

`POST /backup-report` now clears the matching one-off request (regardless of outcome) so the heartbeat stops re-emitting it; schedule-due self-clears once the successful run advances the staleness anchor. Canopy emits idempotently and stays stateless — the device guards against starting overlapping runs.

`backup_now` is the wire contract the bestool device side consumes.