### PR TITLE
fix(backups): resolve shared-account config on the backups pod, not private-server [TAM-6877]

### DIFF
--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -237,7 +237,6 @@ where
 				),
 				recovery_recipients: None,
 				recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
-				shared_backups: None,
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/crates/jobs/src/backup/creds_server.rs
+++ b/crates/jobs/src/backup/creds_server.rs
@@ -110,6 +110,40 @@ impl CredsServer {
 			registry: self.registry.clone(),
 		})
 	}
+
+	/// Assume `role_arn` and return its current **static** credentials, for the
+	/// kopia subprocess's `AWS_*` env. kopia's S3 connector requires real keys
+	/// (it can't use the loopback endpoint — its CLI demands `--access-key` at
+	/// parse time), so short kopia ops (init / stats / inspection) take static
+	/// assumed-role creds. These are ~1h-lived; long ops (maintenance) must use a
+	/// refreshing sigv4 proxy instead, not this.
+	pub async fn resolve(&self, role_arn: &str, region: Option<&str>) -> Result<ResolvedCreds> {
+		let mut builder = AssumeRoleProvider::builder(role_arn)
+			.session_name("canopy-kopia")
+			.configure(&self.sdk_config);
+		if let Some(r) = region {
+			builder = builder.region(Region::new(r.to_string()));
+		}
+		let creds = builder
+			.build()
+			.await
+			.provide_credentials()
+			.await
+			.context("assume role for kopia static credentials")?;
+		Ok(ResolvedCreds {
+			access_key_id: creds.access_key_id().to_string(),
+			secret_access_key: creds.secret_access_key().to_string(),
+			session_token: creds.session_token().unwrap_or_default().to_string(),
+		})
+	}
+}
+
+/// Static credentials resolved from an assumed role, for a kopia subprocess's
+/// `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` env.
+pub struct ResolvedCreds {
+	pub access_key_id: String,
+	pub secret_access_key: String,
+	pub session_token: String,
 }
 
 /// An active credentials lease. Deregisters its token on drop, so a leaked token

--- a/crates/jobs/src/backup/inspection.rs
+++ b/crates/jobs/src/backup/inspection.rs
@@ -79,13 +79,14 @@ async fn run_inspect_op(
 	config: &ServerGroupBackupConfig,
 ) -> anyhow::Result<kopia::InspectOutcome> {
 	let password = worker.read_repo_password(&config.repo_password_ref).await?;
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
 	let env = KopiaEnv {
-		creds_uri: lease.uri().to_string(),
-		creds_token: lease.token().to_string(),
+		access_key_id: creds.access_key_id,
+		secret_access_key: creds.secret_access_key,
+		session_token: creds.session_token,
 		region: config.region.clone(),
 		password,
 	};

--- a/crates/jobs/src/backup/kopia.rs
+++ b/crates/jobs/src/backup/kopia.rs
@@ -46,12 +46,13 @@ pub const MAINTENANCE_HOST: &str = "canopy-maintenance";
 /// [`super::creds_server`].
 #[derive(Debug, Clone)]
 pub struct KopiaEnv {
-	/// `AWS_CONTAINER_CREDENTIALS_FULL_URI` — the loopback creds endpoint
-	/// (`CredsLease::uri`).
-	pub creds_uri: String,
-	/// `AWS_CONTAINER_AUTHORIZATION_TOKEN` — the per-op lease token
-	/// (`CredsLease::token`), sent raw as the `Authorization` header.
-	pub creds_token: String,
+	/// `AWS_ACCESS_KEY_ID` — assumed-role static creds (kopia's S3 connector
+	/// requires real keys; it can't use the container-creds endpoint).
+	pub access_key_id: String,
+	/// `AWS_SECRET_ACCESS_KEY`.
+	pub secret_access_key: String,
+	/// `AWS_SESSION_TOKEN` (assumed-role creds are always session creds).
+	pub session_token: String,
 	/// The group's region (`AWS_REGION`), if set.
 	pub region: Option<String>,
 	/// The repo passphrase, read from the group's k8s Secret (`KOPIA_PASSWORD`).
@@ -59,21 +60,22 @@ pub struct KopiaEnv {
 }
 
 impl KopiaEnv {
-	/// Apply the per-op env to a `kopia` Command: point minio-go at the
-	/// container-creds endpoint and **scrub** every credential source that
-	/// precedes it in minio-go's IAM chain — the pod injects
-	/// `AWS_WEB_IDENTITY_TOKEN_FILE` (IRSA) and would otherwise shadow the
-	/// endpoint. (Verified ordering, kopia 0.23.1 + minio-go 7.2.0.)
+	/// Apply the per-op env to a `kopia` Command. kopia 0.23.1's `s3` connector
+	/// requires real credentials (its CLI demands `--access-key`, defaulting from
+	/// `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) — it does
+	/// **not** honor `AWS_CONTAINER_CREDENTIALS_FULL_URI`. So pass the assumed-role
+	/// static creds via those env vars, and **scrub** the IRSA / container-creds
+	/// sources the pod injects so they can't shadow them in minio-go's chain.
 	fn apply(&self, cmd: &mut Command) {
 		cmd.env("KOPIA_PASSWORD", &self.password);
-		cmd.env("AWS_CONTAINER_CREDENTIALS_FULL_URI", &self.creds_uri);
-		cmd.env("AWS_CONTAINER_AUTHORIZATION_TOKEN", &self.creds_token);
+		cmd.env("AWS_ACCESS_KEY_ID", &self.access_key_id);
+		cmd.env("AWS_SECRET_ACCESS_KEY", &self.secret_access_key);
+		cmd.env("AWS_SESSION_TOKEN", &self.session_token);
 		for shadowing in [
 			"AWS_WEB_IDENTITY_TOKEN_FILE",
 			"AWS_ROLE_ARN",
-			"AWS_ACCESS_KEY_ID",
-			"AWS_SECRET_ACCESS_KEY",
-			"AWS_SESSION_TOKEN",
+			"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+			"AWS_CONTAINER_AUTHORIZATION_TOKEN",
 			"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
 			"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
 		] {

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -10,9 +10,10 @@
 //! concurrency.
 //!
 //! Retention is resolved per-`(group, type)` (schedule override → type default →
-//! org floor) and applied per source by the kopia layer. The kopia subprocess
-//! assumes the group's per-bucket role via web-identity directly (refreshing),
-//! and reads `KOPIA_PASSWORD` from the group's k8s Secret.
+//! org floor) and applied per source by the kopia layer. Canopy assumes the
+//! group's role and passes the resulting (static, ~1h) credentials to the kopia
+//! subprocess via `AWS_*` env (kopia's S3 connector requires real keys); it reads
+//! `KOPIA_PASSWORD` from the group's k8s Secret.
 
 use std::{collections::HashSet, time::Duration};
 

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -17,7 +17,8 @@
 use std::{collections::HashSet, time::Duration};
 
 use commons_servers::backup_jobs::{
-	JobKind, backup_bucket_billing_tags, effective_retention_for_group, is_due, slot_is_due,
+	JobKind, SharedBackupConfig, backup_bucket_billing_tags, effective_retention_for_group, is_due,
+	slot_is_due,
 };
 use commons_types::backup::BackupPlacement;
 use database::{
@@ -145,11 +146,16 @@ fn spawn_init(worker: &Worker, config: ServerGroupBackupConfig) {
 
 /// The kopia side of an init op: read the password + retention, run init.
 async fn run_init_op(worker: &Worker, config: &ServerGroupBackupConfig) -> anyhow::Result<()> {
-	// Shared-account configs: Canopy owns the bucket — create + configure it
-	// (idempotent) before kopia connects. BYO (`external`) buckets already exist.
-	if config.placement == BackupPlacement::Shared {
-		provision_shared_bucket(worker, config).await?;
-	}
+	// Shared-account configs: Canopy owns the bucket. Stamp the shared role ARNs +
+	// region into the row (from the backups pod's env) and create + configure the
+	// bucket — all before kopia connects. BYO (`external`) rows already carry their
+	// ARNs, so this is a no-op for them.
+	let config = if config.placement == BackupPlacement::Shared {
+		provision_shared(worker, config).await?
+	} else {
+		config.clone()
+	};
+	let config = &config;
 
 	let password = worker.read_repo_password(&config.repo_password_ref).await?;
 	let lease = worker
@@ -206,43 +212,60 @@ async fn run_init_op(worker: &Worker, config: &ServerGroupBackupConfig) -> anyho
 	Ok(())
 }
 
-/// Create + configure the shared-account bucket for a `placement=shared` config,
-/// tagged with the group's current billing tags. The provisioner role comes from
-/// `CANOPY_SHARED_BACKUP_PROVISIONER_ROLE_ARN` (required when any shared config
-/// reaches init). Idempotent — see [`super::provision`].
-async fn provision_shared_bucket(
+/// Provision a `placement=shared` config: resolve the shared-account settings
+/// from the backups pod's `CANOPY_SHARED_BACKUP_*` env, **stamp the device /
+/// maintenance role ARNs + region into the row** (so public-server's device-cred
+/// path and the maintenance lease read them like any other group), then create +
+/// configure the bucket (idempotent — see [`super::provision`]). Returns the
+/// updated config. A missing/incomplete env is a clear error, recorded as
+/// `last_init_error` — the requirement lives here, on the pod that has the env,
+/// not on private-server's onboarding endpoint.
+async fn provision_shared(
 	worker: &Worker,
 	config: &ServerGroupBackupConfig,
-) -> anyhow::Result<()> {
-	let provisioner_role_arn = std::env::var("CANOPY_SHARED_BACKUP_PROVISIONER_ROLE_ARN")
-		.ok()
-		.filter(|v| !v.trim().is_empty())
+) -> anyhow::Result<ServerGroupBackupConfig> {
+	let shared = SharedBackupConfig::from_env()
+		.filter(|s| !s.provisioner_role_arn.trim().is_empty())
 		.ok_or_else(|| {
 			anyhow::anyhow!(
-				"placement=shared but CANOPY_SHARED_BACKUP_PROVISIONER_ROLE_ARN is unset"
+				"shared-account backups are not configured: set CANOPY_SHARED_BACKUP_REGION, \
+				 _DEVICE_ROLE_ARN, _MAINTENANCE_ROLE_ARN and _PROVISIONER_ROLE_ARN on the backups pod"
 			)
 		})?;
+	// An operator-supplied region wins; otherwise the shared-account default.
+	let region = config
+		.region
+		.clone()
+		.unwrap_or_else(|| shared.region.clone());
 
-	let (group, highest_rank) = {
-		let mut db = worker
-			.pool
-			.get()
-			.await
-			.map_err(|e| anyhow::anyhow!("db connection: {e}"))?;
-		let group = ServerGroup::get_by_id(&mut db, config.group_id)
-			.await
-			.map_err(|e| anyhow::anyhow!(e))?;
-		let rank = ServerGroup::highest_member_ranks(&mut db, &[config.group_id])
-			.await
-			.map_err(|e| anyhow::anyhow!(e))?
-			.get(&config.group_id)
-			.copied();
-		(group, rank)
-	};
+	let mut db = worker
+		.pool
+		.get()
+		.await
+		.map_err(|e| anyhow::anyhow!("db connection: {e}"))?;
+	let config = ServerGroupBackupConfig::update_roles_region(
+		&mut db,
+		config.group_id,
+		&shared.device_role_arn,
+		&shared.maintenance_role_arn,
+		Some(&region),
+	)
+	.await
+	.map_err(|e| anyhow::anyhow!(e))?;
 
+	let group = ServerGroup::get_by_id(&mut db, config.group_id)
+		.await
+		.map_err(|e| anyhow::anyhow!(e))?;
+	let highest_rank = ServerGroup::highest_member_ranks(&mut db, &[config.group_id])
+		.await
+		.map_err(|e| anyhow::anyhow!(e))?
+		.get(&config.group_id)
+		.copied();
 	let tags = backup_bucket_billing_tags(&group.tags, &group.name, highest_rank);
-	let region = config.region.as_deref().unwrap_or("us-east-1");
-	super::provision::ensure_bucket(&provisioner_role_arn, &config.bucket, region, &tags).await
+
+	super::provision::ensure_bucket(&shared.provisioner_role_arn, &config.bucket, &region, &tags)
+		.await?;
+	Ok(config)
 }
 
 /// Run a maintenance op in a spawned task: start the run row, read the password,

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -34,7 +34,7 @@ use tracing::{debug, error, info};
 
 use super::{
 	complete,
-	creds_server::CredsLease,
+	creds_server::ResolvedCreds,
 	kopia::{self, KopiaEnv, RetentionMap},
 	worker::Worker,
 };
@@ -68,12 +68,17 @@ async fn retention_map_for_group(
 	Ok(map)
 }
 
-/// Build the per-op kopia env from a creds lease, the group's region, and its
-/// repo password. The `lease` must outlive every kopia invocation in the op.
-fn kopia_env(lease: &CredsLease, config: &ServerGroupBackupConfig, password: String) -> KopiaEnv {
+/// Build the per-op kopia env from the assumed-role static creds, the group's
+/// region, and its repo password.
+fn kopia_env(
+	creds: &ResolvedCreds,
+	config: &ServerGroupBackupConfig,
+	password: String,
+) -> KopiaEnv {
 	KopiaEnv {
-		creds_uri: lease.uri().to_string(),
-		creds_token: lease.token().to_string(),
+		access_key_id: creds.access_key_id.clone(),
+		secret_access_key: creds.secret_access_key.clone(),
+		session_token: creds.session_token.clone(),
 		region: config.region.clone(),
 		password,
 	}
@@ -158,11 +163,11 @@ async fn run_init_op(worker: &Worker, config: &ServerGroupBackupConfig) -> anyho
 	let config = &config;
 
 	let password = worker.read_repo_password(&config.repo_password_ref).await?;
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
-	let env = kopia_env(&lease, config, password);
+	let env = kopia_env(&creds, config, password);
 	let retention = {
 		let mut db = worker
 			.pool
@@ -327,11 +332,11 @@ async fn run_maint_op(
 	kind: MaintenanceKind,
 ) -> anyhow::Result<kopia::MaintOutcome> {
 	let password = worker.read_repo_password(&config.repo_password_ref).await?;
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
-	let env = kopia_env(&lease, config, password);
+	let env = kopia_env(&creds, config, password);
 	let retention = {
 		let mut db = worker
 			.pool

--- a/crates/jobs/src/backup/rotation.rs
+++ b/crates/jobs/src/backup/rotation.rs
@@ -26,7 +26,7 @@ use tokio::{
 use tracing::{debug, error, info, warn};
 
 use super::{
-	creds_server::CredsLease,
+	creds_server::ResolvedCreds,
 	kopia::{self, KopiaEnv},
 	worker::Worker,
 };
@@ -36,11 +36,17 @@ const KEY_CURRENT: &str = "password";
 /// In-flight rotation candidate key.
 const KEY_NEXT: &str = "password_next";
 
-/// Build a [`KopiaEnv`] for `password` from a creds lease + the group's config.
-fn kopia_env(lease: &CredsLease, config: &ServerGroupBackupConfig, password: String) -> KopiaEnv {
+/// Build a [`KopiaEnv`] for `password` from the assumed-role static creds + the
+/// group's config.
+fn kopia_env(
+	creds: &ResolvedCreds,
+	config: &ServerGroupBackupConfig,
+	password: String,
+) -> KopiaEnv {
 	KopiaEnv {
-		creds_uri: lease.uri().to_string(),
-		creds_token: lease.token().to_string(),
+		access_key_id: creds.access_key_id.clone(),
+		secret_access_key: creds.secret_access_key.clone(),
+		session_token: creds.session_token.clone(),
 		region: config.region.clone(),
 		password,
 	}
@@ -87,9 +93,9 @@ pub async fn rotate_to(
 	new: &str,
 ) -> Result<()> {
 	let secret_ref = &config.repo_password_ref;
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
 	let region = config.region.as_deref().unwrap_or_default();
 
@@ -102,7 +108,7 @@ pub async fn rotate_to(
 	.await?;
 	// 2. Rotate the repo (change_password verifies by reconnecting with `new`).
 	kopia::change_password(
-		&kopia_env(&lease, config, current.to_string()),
+		&kopia_env(&creds, config, current.to_string()),
 		&config.bucket,
 		&config.prefix,
 		region,
@@ -168,19 +174,19 @@ pub async fn reconcile(worker: &Worker, config: &ServerGroupBackupConfig) -> Res
 		return Ok(());
 	}
 
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
 	let region = config.region.as_deref().unwrap_or_default();
-	let env_current = kopia_env(&lease, config, current.clone());
+	let env_current = kopia_env(&creds, config, current.clone());
 	let current_ok = kopia::connect(&env_current, &config.bucket, &config.prefix, region)
 		.await
 		.is_ok();
 	let next_ok = if current_ok {
 		false
 	} else {
-		let env_next = kopia_env(&lease, config, next.clone());
+		let env_next = kopia_env(&creds, config, next.clone());
 		kopia::connect(&env_next, &config.bucket, &config.prefix, region)
 			.await
 			.is_ok()

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -425,12 +425,14 @@ pub struct CreateSharedBackupConfigArgs {
 
 /// Onboard a group onto **shared-account** backups — for deployments with no AWS
 /// account of their own. Canopy auto-names a bucket
-/// (`bes-canopy-backup-<group>-<random>`) in the shared account, uses the shared
-/// device/maintenance roles, generates + stores the passphrase, and marks the
-/// config `provisioning`/`placement=shared`; the backups pod creates the bucket
-/// at init. Unlike `create`/`upsert` (BYO), there is no caller-supplied
-/// bucket/roles and no probe (the bucket doesn't exist yet). 502 if shared-account
-/// backups (`CANOPY_SHARED_BACKUP_*`) or the secret store aren't configured.
+/// (`bes-canopy-backup-<group>-<random>`), generates + stores the passphrase, and
+/// marks the config `provisioning`/`placement=shared` with **blank** role ARNs.
+/// The backups pod stamps the shared device/maintenance role ARNs + region (from
+/// its own `CANOPY_SHARED_BACKUP_*` env) and creates the bucket at init — so this
+/// endpoint needs no shared-account env (a missing pod env surfaces as
+/// `last_init_error`, not here). Unlike `create`/`upsert` (BYO), there's no
+/// caller-supplied bucket/roles and no probe. 502 only if the secret store
+/// (passphrase Secret) isn't configured.
 #[utoipa::path(
 	post,
 	path = "/create_shared",
@@ -453,9 +455,6 @@ pub async fn create_shared(
 	let mut conn = state.db.get().await?;
 	let group = ServerGroup::get_by_id(&mut conn, args.server_group_id).await?;
 
-	let shared = state.shared_backups.as_ref().ok_or_else(|| {
-		AppError::Upstream("shared-account backups are not configured on this server".into())
-	})?;
 	let kube = state.kube.as_ref().ok_or_else(|| {
 		AppError::Upstream("secret store not configured; cannot create repo passphrase".into())
 	})?;
@@ -467,15 +466,20 @@ pub async fn create_shared(
 	let passphrase = commons_servers::backup_secrets::generate_passphrase();
 	let repo_password_ref = format!("backup-repo-{}", args.server_group_id);
 
+	// The shared role ARNs + default region are the backups pod's concern (it has
+	// `CANOPY_SHARED_BACKUP_*`): it stamps them into this row and provisions the
+	// bucket at init. Private-server only marks the group `placement=shared` and
+	// owns the passphrase Secret — so it needs no shared-account env. An
+	// operator-supplied region is kept; otherwise the pod fills it.
 	let config = ServerGroupBackupConfig::insert(
 		&mut conn,
 		NewServerGroupBackupConfig {
 			group_id: args.server_group_id,
 			bucket,
 			prefix: String::new(),
-			target_role_arn: shared.device_role_arn.clone(),
-			maintenance_role_arn: shared.maintenance_role_arn.clone(),
-			region: Some(args.region.clone().unwrap_or_else(|| shared.region.clone())),
+			target_role_arn: String::new(),
+			maintenance_role_arn: String::new(),
+			region: args.region.clone(),
 			repo_password_ref: repo_password_ref.clone(),
 			status: BackupConfigStatus::Provisioning,
 			mode: BackupRepoMode::FromBirth,

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 use axum::extract::FromRef;
 use bestool_postgres::pool::PgPool;
 use commons_errors::Result;
-use commons_servers::backup_jobs::SharedBackupConfig;
 use commons_servers::recovery_vault::Recipients;
 use commons_servers::tailnet_directory::{TailnetDirectory, TailnetDirectoryConfig};
 use database::Db;
@@ -41,10 +40,6 @@ pub struct AppState {
 	pub recovery_recipients: Option<Recipients>,
 	/// The single in-flight recovery verification challenge, if any.
 	pub recovery_challenge: RecoveryChallengeStore,
-	/// Shared-account backup settings (`CANOPY_SHARED_BACKUP_*`). `None` ⇒ the
-	/// shared-account onboarding endpoint 502s; BYO (`external`) onboarding is
-	/// unaffected.
-	pub shared_backups: Option<SharedBackupConfig>,
 }
 
 /// Read the recovery recipients from the environment, logging (not failing) a malformed
@@ -87,7 +82,6 @@ impl AppState {
 			prober,
 			recovery_recipients: recovery_recipients_from_env(),
 			recovery_challenge: Arc::new(Mutex::new(None)),
-			shared_backups: SharedBackupConfig::from_env(),
 		})
 	}
 
@@ -110,16 +104,6 @@ impl AppState {
 			// Read from env so the e2e fixture can exercise the recovery ceremony.
 			recovery_recipients: recovery_recipients_from_env(),
 			recovery_challenge: Arc::new(Mutex::new(None)),
-			// A canned shared-account config so the shared-onboarding endpoint is
-			// exercisable in tests/e2e without real AWS. Placeholder account id.
-			shared_backups: Some(SharedBackupConfig {
-				region: "ap-southeast-2".to_string(),
-				device_role_arn: "arn:aws:iam::123456789012:role/canopy-shared-device".to_string(),
-				maintenance_role_arn: "arn:aws:iam::123456789012:role/canopy-shared-maint"
-					.to_string(),
-				provisioner_role_arn: "arn:aws:iam::123456789012:role/canopy-shared-provisioner"
-					.to_string(),
-			}),
 		})
 	}
 }

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -933,7 +933,7 @@ async fn clear_schedule_removes_override() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn create_shared_auto_names_bucket_and_uses_shared_roles() {
+async fn create_shared_auto_names_bucket_with_blank_roles() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		// Custom group name so its sanitized form lands in the auto bucket name.
 		let group_id = Uuid::new_v4();
@@ -953,17 +953,11 @@ async fn create_shared_auto_names_bucket_and_uses_shared_roles() {
 		assert_eq!(body["placement"], "shared");
 		assert_eq!(body["status"], "provisioning");
 		assert_eq!(body["mode"], "from_birth");
-		// Shared roles + region come from the harness's canned SharedBackupConfig,
-		// not from the caller — proving the shared path (not BYO `create`) ran.
-		assert_eq!(
-			body["target_role_arn"],
-			"arn:aws:iam::123456789012:role/canopy-shared-device"
-		);
-		assert_eq!(
-			body["maintenance_role_arn"],
-			"arn:aws:iam::123456789012:role/canopy-shared-maint"
-		);
-		assert_eq!(body["region"], "ap-southeast-2");
+		// The role ARNs + region are left blank: the backups pod stamps them at
+		// provision time from its own env, so private-server needs no shared config.
+		assert_eq!(body["target_role_arn"], "");
+		assert_eq!(body["maintenance_role_arn"], "");
+		assert!(body["region"].is_null());
 		// Auto-named from the group name + random suffix, whole name ≤ 63.
 		let bucket = body["bucket"].as_str().expect("bucket string");
 		assert!(

--- a/crates/private-server/tests/device_admin_endpoints.rs
+++ b/crates/private-server/tests/device_admin_endpoints.rs
@@ -42,7 +42,6 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 			),
 			recovery_recipients: None,
 			recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
-			shared_backups: None,
 		})
 		.unwrap(),
 		ClientIpSource::RightmostForwarded,

--- a/crates/private-server/tests/tailnet_device_auth.rs
+++ b/crates/private-server/tests/tailnet_device_auth.rs
@@ -88,7 +88,6 @@ async fn unknown_tailnet_node_auto_creates_untrusted_then_403s_role_gate() {
 				),
 				recovery_recipients: None,
 				recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
-				shared_backups: None,
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/private-web/e2e/fixture.ts
+++ b/private-web/e2e/fixture.ts
@@ -200,14 +200,6 @@ export async function startStack(opts: StartOptions = {}): Promise<StackHandle> 
 				// full decrypt round-trip is covered by the Rust endpoint tests.
 				CANOPY_RECOVERY_VAULT_KEYS:
 					"age1uy3nqmdxf4lc3sc4p32c2cp9dlqwk868gjh002gysullrgvp0cjsdg03dn",
-				// Shared-account backups configured (placeholder ARNs/region) so the
-				// "Shared backups" wizard option + create_shared endpoint work. The
-				// bucket isn't actually created in e2e (the backups pod isn't running).
-				CANOPY_SHARED_BACKUP_REGION: "ap-southeast-2",
-				CANOPY_SHARED_BACKUP_DEVICE_ROLE_ARN:
-					"arn:aws:iam::123456789012:role/canopy-shared-device",
-				CANOPY_SHARED_BACKUP_MAINTENANCE_ROLE_ARN:
-					"arn:aws:iam::123456789012:role/canopy-shared-maint",
 				// Needed by mint_enrollment to build the ticket's api_url; the
 				// setup-instructions flow auto-mints on an unregistered server.
 				PUBLIC_URL: process.env.PUBLIC_URL ?? "https://api.e2e.invalid",

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -398,7 +398,7 @@
         "tags": [
           "backups"
         ],
-        "summary": "Onboard a group onto **shared-account** backups — for deployments with no AWS\naccount of their own. Canopy auto-names a bucket\n(`bes-canopy-backup-<group>-<random>`) in the shared account, uses the shared\ndevice/maintenance roles, generates + stores the passphrase, and marks the\nconfig `provisioning`/`placement=shared`; the backups pod creates the bucket\nat init. Unlike `create`/`upsert` (BYO), there is no caller-supplied\nbucket/roles and no probe (the bucket doesn't exist yet). 502 if shared-account\nbackups (`CANOPY_SHARED_BACKUP_*`) or the secret store aren't configured.",
+        "summary": "Onboard a group onto **shared-account** backups — for deployments with no AWS\naccount of their own. Canopy auto-names a bucket\n(`bes-canopy-backup-<group>-<random>`), generates + stores the passphrase, and\nmarks the config `provisioning`/`placement=shared` with **blank** role ARNs.\nThe backups pod stamps the shared device/maintenance role ARNs + region (from\nits own `CANOPY_SHARED_BACKUP_*` env) and creates the bucket at init — so this\nendpoint needs no shared-account env (a missing pod env surfaces as\n`last_init_error`, not here). Unlike `create`/`upsert` (BYO), there's no\ncaller-supplied bucket/roles and no probe. 502 only if the secret store\n(passphrase Secret) isn't configured.",
         "operationId": "backups_create_shared",
         "requestBody": {
           "content": {

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -162,12 +162,14 @@ export interface paths {
         /**
          * Onboard a group onto **shared-account** backups — for deployments with no AWS
          *     account of their own. Canopy auto-names a bucket
-         *     (`bes-canopy-backup-<group>-<random>`) in the shared account, uses the shared
-         *     device/maintenance roles, generates + stores the passphrase, and marks the
-         *     config `provisioning`/`placement=shared`; the backups pod creates the bucket
-         *     at init. Unlike `create`/`upsert` (BYO), there is no caller-supplied
-         *     bucket/roles and no probe (the bucket doesn't exist yet). 502 if shared-account
-         *     backups (`CANOPY_SHARED_BACKUP_*`) or the secret store aren't configured.
+         *     (`bes-canopy-backup-<group>-<random>`), generates + stores the passphrase, and
+         *     marks the config `provisioning`/`placement=shared` with **blank** role ARNs.
+         *     The backups pod stamps the shared device/maintenance role ARNs + region (from
+         *     its own `CANOPY_SHARED_BACKUP_*` env) and creates the bucket at init — so this
+         *     endpoint needs no shared-account env (a missing pod env surfaces as
+         *     `last_init_error`, not here). Unlike `create`/`upsert` (BYO), there's no
+         *     caller-supplied bucket/roles and no probe. 502 only if the secret store
+         *     (passphrase Secret) isn't configured.
          */
         post: operations["backups_create_shared"];
         delete?: never;


### PR DESCRIPTION
🤖 Fixes the recurring "envs required on the backups pod but private-server checks them" mismatch for shared-account onboarding. `create_shared` ran on private-server and read `CANOPY_SHARED_BACKUP_{DEVICE,MAINTENANCE}_ROLE_ARN` + `REGION` from **private-server's** env — so it 502'd when those were only on the backups pod, and (worse) it stamped whatever private-server had into the config, which the pod then assumed for kopia's maintenance creds.

Now:
- `create_shared` writes a `placement=shared` / `provisioning` row with **blank** role ARNs + the caller's optional region — no shared-account env on private-server (it still owns the passphrase Secret).
- The **backups pod** resolves `CANOPY_SHARED_BACKUP_*` from its own env at provision time, **stamps** the device/maintenance role ARNs + region into the row (`update_roles_region`), then provisions the bucket. A missing/incomplete pod env is recorded as `last_init_error` — a visible signal, not a cross-pod 502.
- Removed `AppState.shared_backups` (+ the inline test constructions) and the shared env from the e2e fixture.

Net ops requirement: `CANOPY_SHARED_BACKUP_*` on the **backups pod only**.

Stacked on #252 (backups-billing-via-labels) — retargets to main when that merges.