### PR TITLE
fix(backups): give kopia static assumed-role creds via AWS_* env [TAM-6877]

### DIFF
--- a/crates/jobs/src/backup/creds_server.rs
+++ b/crates/jobs/src/backup/creds_server.rs
@@ -110,6 +110,40 @@ impl CredsServer {
 			registry: self.registry.clone(),
 		})
 	}
+
+	/// Assume `role_arn` and return its current **static** credentials, for the
+	/// kopia subprocess's `AWS_*` env. kopia's S3 connector requires real keys
+	/// (it can't use the loopback endpoint — its CLI demands `--access-key` at
+	/// parse time), so short kopia ops (init / stats / inspection) take static
+	/// assumed-role creds. These are ~1h-lived; long ops (maintenance) must use a
+	/// refreshing sigv4 proxy instead, not this.
+	pub async fn resolve(&self, role_arn: &str, region: Option<&str>) -> Result<ResolvedCreds> {
+		let mut builder = AssumeRoleProvider::builder(role_arn)
+			.session_name("canopy-kopia")
+			.configure(&self.sdk_config);
+		if let Some(r) = region {
+			builder = builder.region(Region::new(r.to_string()));
+		}
+		let creds = builder
+			.build()
+			.await
+			.provide_credentials()
+			.await
+			.context("assume role for kopia static credentials")?;
+		Ok(ResolvedCreds {
+			access_key_id: creds.access_key_id().to_string(),
+			secret_access_key: creds.secret_access_key().to_string(),
+			session_token: creds.session_token().unwrap_or_default().to_string(),
+		})
+	}
+}
+
+/// Static credentials resolved from an assumed role, for a kopia subprocess's
+/// `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` env.
+pub struct ResolvedCreds {
+	pub access_key_id: String,
+	pub secret_access_key: String,
+	pub session_token: String,
 }
 
 /// An active credentials lease. Deregisters its token on drop, so a leaked token

--- a/crates/jobs/src/backup/inspection.rs
+++ b/crates/jobs/src/backup/inspection.rs
@@ -79,13 +79,14 @@ async fn run_inspect_op(
 	config: &ServerGroupBackupConfig,
 ) -> anyhow::Result<kopia::InspectOutcome> {
 	let password = worker.read_repo_password(&config.repo_password_ref).await?;
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
 	let env = KopiaEnv {
-		creds_uri: lease.uri().to_string(),
-		creds_token: lease.token().to_string(),
+		access_key_id: creds.access_key_id,
+		secret_access_key: creds.secret_access_key,
+		session_token: creds.session_token,
 		region: config.region.clone(),
 		password,
 	};

--- a/crates/jobs/src/backup/kopia.rs
+++ b/crates/jobs/src/backup/kopia.rs
@@ -46,12 +46,13 @@ pub const MAINTENANCE_HOST: &str = "canopy-maintenance";
 /// [`super::creds_server`].
 #[derive(Debug, Clone)]
 pub struct KopiaEnv {
-	/// `AWS_CONTAINER_CREDENTIALS_FULL_URI` — the loopback creds endpoint
-	/// (`CredsLease::uri`).
-	pub creds_uri: String,
-	/// `AWS_CONTAINER_AUTHORIZATION_TOKEN` — the per-op lease token
-	/// (`CredsLease::token`), sent raw as the `Authorization` header.
-	pub creds_token: String,
+	/// `AWS_ACCESS_KEY_ID` — assumed-role static creds (kopia's S3 connector
+	/// requires real keys; it can't use the container-creds endpoint).
+	pub access_key_id: String,
+	/// `AWS_SECRET_ACCESS_KEY`.
+	pub secret_access_key: String,
+	/// `AWS_SESSION_TOKEN` (assumed-role creds are always session creds).
+	pub session_token: String,
 	/// The group's region (`AWS_REGION`), if set.
 	pub region: Option<String>,
 	/// The repo passphrase, read from the group's k8s Secret (`KOPIA_PASSWORD`).
@@ -59,21 +60,22 @@ pub struct KopiaEnv {
 }
 
 impl KopiaEnv {
-	/// Apply the per-op env to a `kopia` Command: point minio-go at the
-	/// container-creds endpoint and **scrub** every credential source that
-	/// precedes it in minio-go's IAM chain — the pod injects
-	/// `AWS_WEB_IDENTITY_TOKEN_FILE` (IRSA) and would otherwise shadow the
-	/// endpoint. (Verified ordering, kopia 0.23.1 + minio-go 7.2.0.)
+	/// Apply the per-op env to a `kopia` Command. kopia 0.23.1's `s3` connector
+	/// requires real credentials (its CLI demands `--access-key`, defaulting from
+	/// `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) — it does
+	/// **not** honor `AWS_CONTAINER_CREDENTIALS_FULL_URI`. So pass the assumed-role
+	/// static creds via those env vars, and **scrub** the IRSA / container-creds
+	/// sources the pod injects so they can't shadow them in minio-go's chain.
 	fn apply(&self, cmd: &mut Command) {
 		cmd.env("KOPIA_PASSWORD", &self.password);
-		cmd.env("AWS_CONTAINER_CREDENTIALS_FULL_URI", &self.creds_uri);
-		cmd.env("AWS_CONTAINER_AUTHORIZATION_TOKEN", &self.creds_token);
+		cmd.env("AWS_ACCESS_KEY_ID", &self.access_key_id);
+		cmd.env("AWS_SECRET_ACCESS_KEY", &self.secret_access_key);
+		cmd.env("AWS_SESSION_TOKEN", &self.session_token);
 		for shadowing in [
 			"AWS_WEB_IDENTITY_TOKEN_FILE",
 			"AWS_ROLE_ARN",
-			"AWS_ACCESS_KEY_ID",
-			"AWS_SECRET_ACCESS_KEY",
-			"AWS_SESSION_TOKEN",
+			"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+			"AWS_CONTAINER_AUTHORIZATION_TOKEN",
 			"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
 			"AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
 		] {

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -10,9 +10,10 @@
 //! concurrency.
 //!
 //! Retention is resolved per-`(group, type)` (schedule override → type default →
-//! org floor) and applied per source by the kopia layer. The kopia subprocess
-//! assumes the group's per-bucket role via web-identity directly (refreshing),
-//! and reads `KOPIA_PASSWORD` from the group's k8s Secret.
+//! org floor) and applied per source by the kopia layer. Canopy assumes the
+//! group's role and passes the resulting (static, ~1h) credentials to the kopia
+//! subprocess via `AWS_*` env (kopia's S3 connector requires real keys); it reads
+//! `KOPIA_PASSWORD` from the group's k8s Secret.
 
 use std::{collections::HashSet, time::Duration};
 

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -34,7 +34,7 @@ use tracing::{debug, error, info};
 
 use super::{
 	complete,
-	creds_server::CredsLease,
+	creds_server::ResolvedCreds,
 	kopia::{self, KopiaEnv, RetentionMap},
 	worker::Worker,
 };
@@ -68,12 +68,17 @@ async fn retention_map_for_group(
 	Ok(map)
 }
 
-/// Build the per-op kopia env from a creds lease, the group's region, and its
-/// repo password. The `lease` must outlive every kopia invocation in the op.
-fn kopia_env(lease: &CredsLease, config: &ServerGroupBackupConfig, password: String) -> KopiaEnv {
+/// Build the per-op kopia env from the assumed-role static creds, the group's
+/// region, and its repo password.
+fn kopia_env(
+	creds: &ResolvedCreds,
+	config: &ServerGroupBackupConfig,
+	password: String,
+) -> KopiaEnv {
 	KopiaEnv {
-		creds_uri: lease.uri().to_string(),
-		creds_token: lease.token().to_string(),
+		access_key_id: creds.access_key_id.clone(),
+		secret_access_key: creds.secret_access_key.clone(),
+		session_token: creds.session_token.clone(),
 		region: config.region.clone(),
 		password,
 	}
@@ -158,11 +163,11 @@ async fn run_init_op(worker: &Worker, config: &ServerGroupBackupConfig) -> anyho
 	let config = &config;
 
 	let password = worker.read_repo_password(&config.repo_password_ref).await?;
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
-	let env = kopia_env(&lease, config, password);
+	let env = kopia_env(&creds, config, password);
 	let retention = {
 		let mut db = worker
 			.pool
@@ -327,11 +332,11 @@ async fn run_maint_op(
 	kind: MaintenanceKind,
 ) -> anyhow::Result<kopia::MaintOutcome> {
 	let password = worker.read_repo_password(&config.repo_password_ref).await?;
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
-	let env = kopia_env(&lease, config, password);
+	let env = kopia_env(&creds, config, password);
 	let retention = {
 		let mut db = worker
 			.pool

--- a/crates/jobs/src/backup/rotation.rs
+++ b/crates/jobs/src/backup/rotation.rs
@@ -26,7 +26,7 @@ use tokio::{
 use tracing::{debug, error, info, warn};
 
 use super::{
-	creds_server::CredsLease,
+	creds_server::ResolvedCreds,
 	kopia::{self, KopiaEnv},
 	worker::Worker,
 };
@@ -36,11 +36,17 @@ const KEY_CURRENT: &str = "password";
 /// In-flight rotation candidate key.
 const KEY_NEXT: &str = "password_next";
 
-/// Build a [`KopiaEnv`] for `password` from a creds lease + the group's config.
-fn kopia_env(lease: &CredsLease, config: &ServerGroupBackupConfig, password: String) -> KopiaEnv {
+/// Build a [`KopiaEnv`] for `password` from the assumed-role static creds + the
+/// group's config.
+fn kopia_env(
+	creds: &ResolvedCreds,
+	config: &ServerGroupBackupConfig,
+	password: String,
+) -> KopiaEnv {
 	KopiaEnv {
-		creds_uri: lease.uri().to_string(),
-		creds_token: lease.token().to_string(),
+		access_key_id: creds.access_key_id.clone(),
+		secret_access_key: creds.secret_access_key.clone(),
+		session_token: creds.session_token.clone(),
 		region: config.region.clone(),
 		password,
 	}
@@ -87,9 +93,9 @@ pub async fn rotate_to(
 	new: &str,
 ) -> Result<()> {
 	let secret_ref = &config.repo_password_ref;
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
 	let region = config.region.as_deref().unwrap_or_default();
 
@@ -102,7 +108,7 @@ pub async fn rotate_to(
 	.await?;
 	// 2. Rotate the repo (change_password verifies by reconnecting with `new`).
 	kopia::change_password(
-		&kopia_env(&lease, config, current.to_string()),
+		&kopia_env(&creds, config, current.to_string()),
 		&config.bucket,
 		&config.prefix,
 		region,
@@ -168,19 +174,19 @@ pub async fn reconcile(worker: &Worker, config: &ServerGroupBackupConfig) -> Res
 		return Ok(());
 	}
 
-	let lease = worker
+	let creds = worker
 		.creds
-		.lease(&config.maintenance_role_arn, config.region.as_deref())
+		.resolve(&config.maintenance_role_arn, config.region.as_deref())
 		.await?;
 	let region = config.region.as_deref().unwrap_or_default();
-	let env_current = kopia_env(&lease, config, current.clone());
+	let env_current = kopia_env(&creds, config, current.clone());
 	let current_ok = kopia::connect(&env_current, &config.bucket, &config.prefix, region)
 		.await
 		.is_ok();
 	let next_ok = if current_ok {
 		false
 	} else {
-		let env_next = kopia_env(&lease, config, next.clone());
+		let env_next = kopia_env(&creds, config, next.clone());
 		kopia::connect(&env_next, &config.bucket, &config.prefix, region)
 			.await
 			.is_ok()


### PR DESCRIPTION
🤖 Unblocks shared-bucket provisioning, which was failing at kopia repo init with:

> kopia: error: required flag(s) '--access-key', '--secret-access-key' not provided

## Root cause

kopia's S3 connector (`repository create/connect s3`) **requires real access keys** at CLI-parse time. It does **not** honour the ECS-style container-credentials endpoint (`AWS_CONTAINER_CREDENTIALS_FULL_URI` + token) for the S3 backend — it bails at flag-parse, before it would ever poll the endpoint. Verified against kopia 0.23.1 in three podman runs: with only the FULL_URI env set, kopia errors on the missing flags; the endpoint is never hit.

So the loopback container-creds server (`creds_server`) never satisfied the S3 ops, and provisioning a fresh shared bucket died at init.

## Fix

`CredsServer::resolve` assumes the group's role in-process and hands the resulting **static** credentials to the kopia subprocess via `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`. `KopiaEnv::apply` sets those (+ region + `KOPIA_PASSWORD`) and scrubs the pod's own web-identity / container-creds env so they can't shadow the assumed-role creds. The four callers — init/maintenance, inspection, rotation — all resolve then build the env.

These creds are ~1h-lived, which is fine for the short ops (init, stats, listing snapshots, rotation, inspection). **Long maintenance is not covered here** — we've seen 40-minute maintenances on mid-size repos, too close to the chained-session ceiling for comfort. That gets a refreshing SigV4 re-signing proxy in a follow-up (shared with bestool's device backup/restore path, which needs the same proxy regardless). The `creds_server` loopback endpoint is kept in place for that follow-up.

## Stacking

Stacked on #253 (shared-config-on-pod). GitHub will retarget this to `main` once #253 merges. If the unblock needs to land ahead of the billing/shared-config PRs, say the word and I'll rebase it standalone onto `main`.