### PR TITLE
feat(ui): per-type "backup now" with declared-type gating [TAM-6877]

### DIFF
--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -247,6 +247,10 @@ pub struct BackupStatsView {
 	pub recent_runs: Vec<BackupRun>,
 	pub recent_maintenance: Vec<BackupMaintenanceRun>,
 	pub pending_requests: Vec<PendingRequestRow>,
+	/// Backup types each member server has advertised it can run (with their
+	/// enabled state), so the "back up now" panel can offer the right types per
+	/// server and grey out servers that have declared none.
+	pub capabilities: Vec<ServerBackupCapabilityView>,
 }
 
 /// One `(server, type)` backup capability and whether the operator has it
@@ -1079,9 +1083,10 @@ pub async fn stats(
 	let recent_maintenance =
 		BackupMaintenanceRun::list_for_group(&mut conn, args.server_group_id, RECENT_LIMIT).await?;
 
-	// Pending requests across the group's member servers.
+	// Pending requests + declared capabilities across the group's member servers.
 	let members = group.list_servers(&mut conn).await?;
 	let mut pending_requests = Vec::new();
+	let mut capabilities = Vec::new();
 	for server in &members {
 		for req in BackupRequest::pending_for_server(&mut conn, server.id).await? {
 			pending_requests.push(PendingRequestRow {
@@ -1092,6 +1097,13 @@ pub async fn stats(
 				requested_by: req.requested_by,
 			});
 		}
+		for cap in ServerBackupCapability::list_for_server(&mut conn, server.id).await? {
+			capabilities.push(ServerBackupCapabilityView {
+				server_id: cap.server_id,
+				r#type: cap.r#type,
+				enabled: cap.enabled,
+			});
+		}
 	}
 
 	Ok(Json(BackupStatsView {
@@ -1099,6 +1111,7 @@ pub async fn stats(
 		recent_runs,
 		recent_maintenance,
 		pending_requests,
+		capabilities,
 	}))
 }
 

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -432,7 +432,9 @@ async fn stats_includes_runs_and_pending_requests() {
 			 INSERT INTO backup_runs (id, device_id, group_id, server_id, type, purpose, outcome, bytes_uploaded) \
 				VALUES ('{run_id}', '{device_id}', '{group_id}', '{server_id}', 'tamanu-postgres', 'backup', 'success', 500);
 			 INSERT INTO backup_requests (server_id, type, purpose) VALUES \
-				('{server_id}', 'tamanu-postgres', 'backup');"
+				('{server_id}', 'tamanu-postgres', 'backup');
+			 INSERT INTO server_backup_capabilities (server_id, type, enabled) VALUES \
+				('{server_id}', 'tamanu-postgres', true);"
 		))
 		.await
 		.expect("seed stats");
@@ -448,6 +450,12 @@ async fn stats_includes_runs_and_pending_requests() {
 		assert_eq!(body["recent_runs"][0]["outcome"], "success");
 		assert_eq!(body["pending_requests"].as_array().unwrap().len(), 1);
 		assert_eq!(body["pending_requests"][0]["purpose"], "backup");
+		// The member's declared capabilities ride along so the "back up now"
+		// panel knows which types to offer per server.
+		assert_eq!(body["capabilities"].as_array().unwrap().len(), 1);
+		assert_eq!(body["capabilities"][0]["server_id"], server_id.to_string());
+		assert_eq!(body["capabilities"][0]["type"], "tamanu-postgres");
+		assert_eq!(body["capabilities"][0]["enabled"], true);
 	})
 	.await;
 }

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -186,9 +186,15 @@ test.describe("backups ready: stats + backup-now", () => {
 
 		await page.goto(`/groups/${group.id}/backups`);
 
+		// Scope to the schedule panel: the type now also appears in the "Back up
+		// now" panel (as a declared-type label), so a page-wide text match is
+		// ambiguous.
+		const schedules = page
+			.getByRole("heading", { name: /schedule & retention/i })
+			.locator("..");
 		// No override yet → inherits the seeded canopy-wide default.
-		await expect(page.getByText("tamanu-postgres")).toBeVisible();
-		await expect(page.getByText("Inherited default")).toBeVisible();
+		await expect(schedules.getByText("tamanu-postgres")).toBeVisible();
+		await expect(schedules.getByText("Inherited default")).toBeVisible();
 
 		// Override the interval to 12h.
 		await page.getByRole("button", { name: /^override$/i }).click();

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -263,16 +263,22 @@ test.describe("backups ready: stats + backup-now", () => {
 			status: "ready",
 			intervalSeconds: 3600,
 		});
+		// A declared type is what enables the button (and names which type runs).
+		await seedServerBackupCapability(sql, {
+			serverId: server.id,
+			type: "tamanu-postgres",
+		});
 
 		await page.goto(`/groups/${group.id}/backups`);
 		await page.getByRole("button", { name: /backup now/i }).click();
 
 		await expect(async () => {
-			const rows = await sql.query(
-				`SELECT 1 FROM backup_requests WHERE server_id = $1 AND purpose = 'backup'`,
+			const rows = await sql.query<{ type: string }>(
+				`SELECT type FROM backup_requests WHERE server_id = $1 AND purpose = 'backup'`,
 				[server.id],
 			);
 			expect(rows).toHaveLength(1);
+			expect(rows[0]!.type).toBe("tamanu-postgres");
 		}).toPass();
 
 		await expect(page.getByText(/requested/i)).toBeVisible();
@@ -284,6 +290,78 @@ test.describe("backups ready: stats + backup-now", () => {
 				[server.id],
 			);
 			expect(rows).toHaveLength(0);
+		}).toPass();
+	});
+
+	test("a server with no declared types has a disabled backup-now button", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "no-types-group" });
+		await seedServer(sql, { name: "no-types-srv", groupId: group.id });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		// The server appears in the "Back up now" panel, but its button is greyed
+		// out because it has registered no backup types.
+		await expect(page.getByText("no-types-srv")).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: /backup now/i }),
+		).toBeDisabled();
+	});
+
+	test("a server declaring multiple types offers a backup-now per type", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "multi-type-group" });
+		const server = await seedServer(sql, {
+			name: "multi-srv",
+			groupId: group.id,
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+		await seedServerBackupCapability(sql, {
+			serverId: server.id,
+			type: "tamanu-postgres",
+		});
+		await seedServerBackupCapability(sql, {
+			serverId: server.id,
+			type: "files",
+			enabled: false,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+
+		// Both declared types are listed (the disabled-for-schedule one too, since
+		// a one-off backup-now overrides the enabled gate), each with its own button.
+		const panel = page
+			.getByRole("heading", { name: /back up now/i })
+			.locator("..");
+		await expect(panel.getByText("tamanu-postgres")).toBeVisible();
+		await expect(panel.getByText("files")).toBeVisible();
+		await expect(
+			panel.getByRole("button", { name: /backup now/i }),
+		).toHaveCount(2);
+
+		// Backing up the non-default type writes a request for exactly that type.
+		await panel
+			.getByText("files")
+			.locator("..")
+			.getByRole("button", { name: /backup now/i })
+			.click();
+		await expect(async () => {
+			const rows = await sql.query<{ type: string }>(
+				`SELECT type FROM backup_requests WHERE server_id = $1 AND purpose = 'backup'`,
+				[server.id],
+			);
+			expect(rows).toHaveLength(1);
+			expect(rows[0]!.type).toBe("files");
 		}).toPass();
 	});
 

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -5531,9 +5531,17 @@
         "required": [
           "recent_runs",
           "recent_maintenance",
-          "pending_requests"
+          "pending_requests",
+          "capabilities"
         ],
         "properties": {
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServerBackupCapabilityView"
+            },
+            "description": "Backup types each member server has advertised it can run (with their\nenabled state), so the \"back up now\" panel can offer the right types per\nserver and grey out servers that have declared none."
+          },
           "pending_requests": {
             "type": "array",
             "items": {

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2282,6 +2282,12 @@ export interface components {
             type: string;
         };
         BackupStatsView: {
+            /**
+             * @description Backup types each member server has advertised it can run (with their
+             *     enabled state), so the "back up now" panel can offer the right types per
+             *     server and grey out servers that have declared none.
+             */
+            capabilities: components["schemas"]["ServerBackupCapabilityView"][];
             pending_requests: components["schemas"]["PendingRequestRow"][];
             recent_maintenance: components["schemas"]["BackupMaintenanceRun"][];
             recent_runs: components["schemas"]["BackupRun"][];

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -21,6 +21,7 @@ import {
 	TableHead,
 	TableRow,
 	TextField,
+	Tooltip,
 	Typography,
 } from "@mui/material";
 import { useState } from "react";
@@ -43,8 +44,6 @@ import {
 	type BackupConfigView,
 	type ServerInfo,
 } from "../types";
-
-const WELL_KNOWN_TYPE = "tamanu-postgres";
 
 export default function BackupPanel() {
 	const { id = "" } = useParams<{ id: string }>();
@@ -661,17 +660,37 @@ function RunsAndRequests({
 
 	const pending =
 		stats.status === "ok" ? stats.data.pending_requests : [];
+	const capabilities =
+		stats.status === "ok" ? stats.data.capabilities : [];
 
-	const isPending = (serverId: string) =>
+	// The backup types to offer per server: the ones it has declared it can run
+	// (bestool fails fast on a type it has no definition for), unioned with any
+	// type that already has a pending backup request — so a request can always be
+	// cancelled even if the server later stops declaring that type.
+	const typesForServer = (serverId: string): string[] => {
+		const set = new Set<string>();
+		for (const c of capabilities) {
+			if (c.server_id === serverId) set.add(c.type);
+		}
+		for (const p of pending) {
+			if (p.server_id === serverId && p.purpose === "backup") set.add(p.type);
+		}
+		return [...set].sort();
+	};
+
+	const pendingFor = (serverId: string, type: string) =>
 		pending.find(
-			(p) => p.server_id === serverId && p.purpose === "backup",
+			(p) =>
+				p.server_id === serverId &&
+				p.type === type &&
+				p.purpose === "backup",
 		);
 
-	const onRequest = async (serverId: string) => {
+	const onRequest = async (serverId: string, type: string) => {
 		try {
 			await requestNow.call({
 				server_id: serverId,
-				type: WELL_KNOWN_TYPE,
+				type,
 				purpose: "backup",
 			});
 			stats.reload();
@@ -679,11 +698,11 @@ function RunsAndRequests({
 			/* surfaced via requestNow.error */
 		}
 	};
-	const onCancel = async (serverId: string) => {
+	const onCancel = async (serverId: string, type: string) => {
 		try {
 			await cancel.call({
 				server_id: serverId,
-				type: WELL_KNOWN_TYPE,
+				type,
 				purpose: "backup",
 			});
 			stats.reload();
@@ -704,55 +723,91 @@ function RunsAndRequests({
 			) : (
 				<Stack spacing={1} divider={<Divider />}>
 					{members.map((m) => {
-						const req = isPending(m.id);
+						const types = typesForServer(m.id);
 						return (
 							<Stack
 								key={m.id}
 								direction="row"
 								spacing={2}
-								sx={{ alignItems: "center", justifyContent: "space-between" }}
+								sx={{
+									alignItems: "flex-start",
+									justifyContent: "space-between",
+								}}
 							>
-								<Typography variant="body2">
+								<Typography variant="body2" sx={{ pt: 0.75 }}>
 									{m.name ?? m.id.slice(0, 8)}
 								</Typography>
-								{req ? (
-									<Stack
-										direction="row"
-										spacing={1}
-										sx={{ alignItems: "center" }}
-									>
-										<Chip
-											size="small"
-											color="info"
-											label={
-												<>
-													requested <TimeAgo timestamp={req.requested_at} />
-												</>
-											}
-										/>
-										{isAdmin && (
+								{types.length === 0 ? (
+									<Tooltip title="This server hasn't registered any backup types yet.">
+										{/* span so the tooltip works on the disabled button */}
+										<span>
 											<Button
 												size="small"
-												color="error"
-												onClick={() => onCancel(m.id)}
-												disabled={cancel.pending}
+												variant="outlined"
+												startIcon={<BackupIcon />}
+												disabled
 											>
-												Cancel
+												Backup now
 											</Button>
-										)}
-									</Stack>
+										</span>
+									</Tooltip>
 								) : (
-									isAdmin && (
-										<Button
-											size="small"
-											variant="outlined"
-											startIcon={<BackupIcon />}
-											onClick={() => onRequest(m.id)}
-											disabled={requestNow.pending}
-										>
-											Backup now
-										</Button>
-									)
+									<Stack spacing={0.5} sx={{ alignItems: "flex-end" }}>
+										{types.map((t) => {
+											const req = pendingFor(m.id, t);
+											return (
+												<Stack
+													key={t}
+													direction="row"
+													spacing={1}
+													sx={{ alignItems: "center" }}
+												>
+													<Typography
+														variant="body2"
+														sx={{ fontFamily: "monospace" }}
+													>
+														{t}
+													</Typography>
+													{req ? (
+														<>
+															<Chip
+																size="small"
+																color="info"
+																label={
+																	<>
+																		requested{" "}
+																		<TimeAgo timestamp={req.requested_at} />
+																	</>
+																}
+															/>
+															{isAdmin && (
+																<Button
+																	size="small"
+																	color="error"
+																	onClick={() => onCancel(m.id, t)}
+																	disabled={cancel.pending}
+																>
+																	Cancel
+																</Button>
+															)}
+														</>
+													) : (
+														isAdmin && (
+															<Button
+																size="small"
+																variant="outlined"
+																startIcon={<BackupIcon />}
+																onClick={() => onRequest(m.id, t)}
+																disabled={requestNow.pending}
+															>
+																Backup now
+															</Button>
+														)
+													)}
+												</Stack>
+											);
+										})}
+									</Stack>
 								)}
 							</Stack>
 						);


### PR DESCRIPTION
🤖 Three related tweaks to the group backups panel's "Back up now" section.

Before, each member server got a single "Backup now" button hardcoded to the `tamanu-postgres` type. This:

1. **Lets the operator pick what to back up** — renders a "Backup now" button per backup type the server has declared it can run, passing the chosen type to `request_now`. A pending request and its Cancel are now matched per `(server, type)` instead of per server.
2. **Greys out servers with no declared types** — a server that has registered no backup types gets a disabled button with a tooltip explaining why, since bestool fails fast on a type it has no definition for.
3. **Shows which server declares which types** — each declared type is listed next to its button, right where the action is (complementing the per-server toggle list already on each server's detail page).

All declared types are offered regardless of the capability's `enabled` flag, because a one-off backup-now overrides the schedule gate (`backups_due_now_for_server` unions one-offs in without the enabled check).

## Plumbing

Declared capabilities now ride along on the existing `/api/backups/stats` response (`BackupStatsView.capabilities`), populated in the handler's existing member loop — no new endpoint and no per-server round-trip from the UI. Regenerated `openapi.json` + `api-types.ts`.

Coverage: extended the Rust `stats` endpoint test to assert capabilities surface; added Playwright specs for the greyed-out empty state and per-type backup-now (and fixed the existing backup-now spec to seed a capability, since that's now what enables the button).