### PR TITLE
feat(backups): route long maintenance through the bestool-kopia SigV4 proxy [TAM-6877]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1064,7 +1064,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 [[package]]
 name = "bestool-kopia"
 version = "0.1.4"
-source = "git+https://github.com/beyondessential/bestool?branch=s3-proxy#59a9d46af26baf547f868dc78ded74703ed2c139"
+source = "git+https://github.com/beyondessential/bestool?rev=ebd4663cfe48743404b3117cca4db3ff71a0a053#ebd4663cfe48743404b3117cca4db3ff71a0a053"
 dependencies = [
  "bytes",
  "hex",
@@ -2206,7 +2206,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2357,7 +2357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3086,7 +3086,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3980,7 +3980,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4689,7 +4689,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4727,7 +4727,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5127,7 +5127,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5151,7 +5151,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -5198,7 +5197,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5628,7 +5627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5663,7 +5662,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5793,7 +5792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6761,7 +6760,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bestool-kopia"
+version = "0.1.4"
+source = "git+https://github.com/beyondessential/bestool?branch=s3-proxy#59a9d46af26baf547f868dc78ded74703ed2c139"
+dependencies = [
+ "bytes",
+ "hex",
+ "hmac 0.12.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "jiff",
+ "miette",
+ "rustls 0.23.40",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
 name = "bestool-postgres"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,6 +3053,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3511,6 +3535,7 @@ dependencies = [
  "aws-sdk-sts",
  "aws-smithy-mocks",
  "axum",
+ "bestool-kopia",
  "clap",
  "commons-errors",
  "commons-servers",
@@ -5126,6 +5151,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -6694,6 +6720,15 @@ name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ aws-sdk-sts = "1.107.0"
 aws-smithy-mocks = "0.2.6"
 axum = "0.8.9"
 axum-test = "20.0.0"
-# bestool-kopia's SigV4 re-signing proxy (S3P spec). Pinned to the PR branch
-# until the crate publishes the `proxy` feature to crates.io, then revert to a
-# plain version requirement. NOTE: the `proxy` feature pulls in a `ring` rustls
-# provider alongside the workspace's `aws-lc-rs` one.
-bestool-kopia = { git = "https://github.com/beyondessential/bestool", branch = "s3-proxy", features = [
+# bestool-kopia's SigV4 re-signing proxy (S3P spec). bestool#529 is merged to
+# main but not yet released, so pin to a main rev until the crate publishes the
+# `proxy` feature to crates.io, then revert to a plain version requirement. The
+# proxy feature uses the workspace's `aws-lc-rs` rustls provider.
+bestool-kopia = { git = "https://github.com/beyondessential/bestool", rev = "ebd4663cfe48743404b3117cca4db3ff71a0a053", features = [
 	"proxy",
 ] }
 clap = "4.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,13 @@ aws-sdk-sts = "1.107.0"
 aws-smithy-mocks = "0.2.6"
 axum = "0.8.9"
 axum-test = "20.0.0"
+# bestool-kopia's SigV4 re-signing proxy (S3P spec). Pinned to the PR branch
+# until the crate publishes the `proxy` feature to crates.io, then revert to a
+# plain version requirement. NOTE: the `proxy` feature pulls in a `ring` rustls
+# provider alongside the workspace's `aws-lc-rs` one.
+bestool-kopia = { git = "https://github.com/beyondessential/bestool", branch = "s3-proxy", features = [
+	"proxy",
+] }
 clap = "4.6.1"
 diesel = "2.3.9"
 diesel-async = "0.9.0"

--- a/crates/jobs/Cargo.toml
+++ b/crates/jobs/Cargo.toml
@@ -17,6 +17,7 @@ aws-sdk-cloudwatch.workspace = true
 aws-sdk-s3.workspace = true
 aws-sdk-sts.workspace = true
 axum.workspace = true
+bestool-kopia.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 commons-errors = { path = "../commons-errors" }
 commons-servers = { path = "../commons-servers" }

--- a/crates/jobs/src/backup/creds_server.rs
+++ b/crates/jobs/src/backup/creds_server.rs
@@ -31,14 +31,15 @@ use std::{
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, sts::AssumeRoleProvider};
 use aws_sdk_sts::config::{Credentials, ProvideCredentials, Region, SharedCredentialsProvider};
-use bestool_kopia::proxy::{
-	self, BoxError, CredentialProvider, Credentials as ProxyCredentials, RunningProxy, S3ProxyConfig,
-};
 use axum::{
 	Json, Router,
 	extract::State,
 	http::{HeaderMap, StatusCode, header::AUTHORIZATION},
 	routing::get,
+};
+use bestool_kopia::proxy::{
+	self, BoxError, CredentialProvider, Credentials as ProxyCredentials, RunningProxy,
+	S3ProxyConfig,
 };
 use jiff::Timestamp;
 use serde::Serialize;
@@ -196,7 +197,8 @@ struct RefreshingAssumeRole {
 impl CredentialProvider for RefreshingAssumeRole {
 	fn credentials(
 		&self,
-	) -> Pin<Box<dyn Future<Output = std::result::Result<ProxyCredentials, BoxError>> + Send + '_>> {
+	) -> Pin<Box<dyn Future<Output = std::result::Result<ProxyCredentials, BoxError>> + Send + '_>>
+	{
 		Box::pin(async move {
 			let mut cached = self.cached.lock().await;
 			let still_fresh = cached.as_ref().is_some_and(|c| match c.expiry() {

--- a/crates/jobs/src/backup/creds_server.rs
+++ b/crates/jobs/src/backup/creds_server.rs
@@ -21,13 +21,19 @@
 
 use std::{
 	collections::HashMap,
+	future::Future,
 	net::{Ipv4Addr, SocketAddr},
+	pin::Pin,
 	sync::{Arc, Mutex},
+	time::{Duration, SystemTime},
 };
 
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, sts::AssumeRoleProvider};
-use aws_sdk_sts::config::{ProvideCredentials, Region, SharedCredentialsProvider};
+use aws_sdk_sts::config::{Credentials, ProvideCredentials, Region, SharedCredentialsProvider};
+use bestool_kopia::proxy::{
+	self, BoxError, CredentialProvider, Credentials as ProxyCredentials, RunningProxy, S3ProxyConfig,
+};
 use axum::{
 	Json, Router,
 	extract::State,
@@ -134,6 +140,83 @@ impl CredsServer {
 			access_key_id: creds.access_key_id().to_string(),
 			secret_access_key: creds.secret_access_key().to_string(),
 			session_token: creds.session_token().unwrap_or_default().to_string(),
+		})
+	}
+
+	/// Spawn a loopback [SigV4 re-signing proxy](bestool_kopia::proxy) for a long
+	/// kopia op (maintenance), fronting `s3.<region>.amazonaws.com`. kopia connects
+	/// to the returned proxy's [`endpoint`](RunningProxy::endpoint) with dummy keys;
+	/// the proxy re-signs each request with credentials assumed for `role_arn`,
+	/// refreshed ahead of expiry — so the op isn't capped at the ~1h
+	/// assumed-session lifetime the static [`resolve`](Self::resolve) path is. Drop
+	/// the handle (or call [`shutdown`](RunningProxy::shutdown)) when the op ends.
+	pub async fn spawn_maintenance_proxy(
+		&self,
+		role_arn: &str,
+		region: &str,
+	) -> Result<RunningProxy> {
+		let provider = SharedCredentialsProvider::new(
+			AssumeRoleProvider::builder(role_arn)
+				.session_name("canopy-maintenance")
+				.region(Region::new(region.to_string()))
+				.configure(&self.sdk_config)
+				.build()
+				.await,
+		);
+		let provider: Arc<dyn CredentialProvider> = Arc::new(RefreshingAssumeRole {
+			provider,
+			cached: tokio::sync::Mutex::new(None),
+		});
+		let config = S3ProxyConfig {
+			upstream: format!("https://s3.{region}.amazonaws.com"),
+			upstream_host: format!("s3.{region}.amazonaws.com"),
+			region: region.to_string(),
+		};
+		proxy::spawn(config, provider)
+			.await
+			.context("spawning the s3 re-signing proxy for maintenance")
+	}
+}
+
+/// Refresh the assumed session this far ahead of its expiry, so the proxy never
+/// signs a request with credentials that lapse mid-flight.
+const PROXY_CREDS_REFRESH_SKEW: Duration = Duration::from_secs(300);
+
+/// A [`CredentialProvider`] for the proxy that assumes a role via the SDK and
+/// caches the session, re-assuming a few minutes before expiry. The proxy calls
+/// it once per request, so it must be cheap when the cached session is still
+/// valid; the SDK refreshes the base (IRSA) identity under the hood, and this
+/// cache refreshes the assumed session, so a long op keeps signing with live
+/// credentials.
+struct RefreshingAssumeRole {
+	provider: SharedCredentialsProvider,
+	cached: tokio::sync::Mutex<Option<Credentials>>,
+}
+
+impl CredentialProvider for RefreshingAssumeRole {
+	fn credentials(
+		&self,
+	) -> Pin<Box<dyn Future<Output = std::result::Result<ProxyCredentials, BoxError>> + Send + '_>> {
+		Box::pin(async move {
+			let mut cached = self.cached.lock().await;
+			let still_fresh = cached.as_ref().is_some_and(|c| match c.expiry() {
+				Some(exp) => exp > SystemTime::now() + PROXY_CREDS_REFRESH_SKEW,
+				None => true, // no expiry (shouldn't happen for STS) → treat as fresh
+			});
+			if !still_fresh {
+				let fresh = self
+					.provider
+					.provide_credentials()
+					.await
+					.map_err(|e| Box::new(e) as BoxError)?;
+				*cached = Some(fresh);
+			}
+			let c = cached.as_ref().expect("populated just above");
+			Ok(ProxyCredentials {
+				access_key: c.access_key_id().to_string(),
+				secret_key: c.secret_access_key().to_string(),
+				session_token: c.session_token().map(str::to_string),
+			})
 		})
 	}
 }

--- a/crates/jobs/src/backup/inspection.rs
+++ b/crates/jobs/src/backup/inspection.rs
@@ -89,6 +89,7 @@ async fn run_inspect_op(
 		session_token: creds.session_token,
 		region: config.region.clone(),
 		password,
+		proxy_endpoint: None,
 	};
 	let region = config.region.as_deref().unwrap_or_default();
 	kopia::run_inspect(&env, &config.bucket, &config.prefix, region).await

--- a/crates/jobs/src/backup/kopia.rs
+++ b/crates/jobs/src/backup/kopia.rs
@@ -11,13 +11,22 @@
 //!
 //! ## Credentials
 //!
-//! The pod runs as the shared `canopy-jobs` IRSA identity. kopia's S3 backend
-//! gets per-op creds for the group's **maintenance** role by polling the
-//! loopback container-credentials endpoint ([`super::creds_server`]) — minio-go
-//! re-polls before expiry, so a run isn't capped at the 1h chained-session
-//! limit. The per-op env (`AWS_CONTAINER_CREDENTIALS_FULL_URI` + token, with the
-//! pod's web-identity vars scrubbed) plus `KOPIA_PASSWORD` is carried by
-//! [`KopiaEnv`].
+//! The pod runs as the shared `canopy-jobs` IRSA identity. For an op, Canopy
+//! assumes the group's **maintenance** role and gives kopia's S3 backend its
+//! credentials one of two ways, both carried by [`KopiaEnv`] (which also carries
+//! `KOPIA_PASSWORD`):
+//!
+//! - **Short ops** (init, inspection, rotation) take the assumed role's static
+//!   credentials via `AWS_*` env. These are ~1h-lived, fine for a short op.
+//! - **Long maintenance** is routed through the bestool-kopia SigV4 re-signing
+//!   proxy ([`super::creds_server::CredsServer::spawn_maintenance_proxy`]): kopia
+//!   connects to a loopback endpoint with dummy keys (`proxy_endpoint` set) and
+//!   the proxy re-signs each request with freshly-refreshed credentials, so the
+//!   run isn't capped at the assumed-session lifetime (maintenance can exceed an
+//!   hour). See the S3P spec.
+//!
+//! Either way the pod's own IRSA / container-creds env vars are scrubbed off the
+//! kopia subprocess so they can't shadow the per-op credentials.
 
 use std::collections::BTreeMap;
 use std::process::Output;
@@ -40,37 +49,49 @@ pub const MAINTENANCE_HOST: &str = "canopy-maintenance";
 // ===========================================================================
 
 /// The per-op environment applied to every kopia [`Command`]. kopia's S3 backend
-/// (minio-go) gets its AWS creds by polling our loopback container-credentials
-/// endpoint (`AWS_CONTAINER_CREDENTIALS_FULL_URI` + a raw `Authorization` token),
-/// which mints + refreshes the group's maintenance-role session. See
-/// [`super::creds_server`].
+/// (minio-go) reads its AWS creds from `AWS_*` env. For short ops these are the
+/// group's assumed-role static creds; for long maintenance they're dummy keys and
+/// the request is re-signed by the proxy (`proxy_endpoint`). `KOPIA_PASSWORD`
+/// carries the repo passphrase.
 #[derive(Debug, Clone)]
 pub struct KopiaEnv {
-	/// `AWS_ACCESS_KEY_ID` — assumed-role static creds (kopia's S3 connector
-	/// requires real keys; it can't use the container-creds endpoint).
+	/// `AWS_ACCESS_KEY_ID` — the assumed role's static key for direct ops, or a
+	/// dummy value when `proxy_endpoint` is set (the proxy holds the real creds).
 	pub access_key_id: String,
-	/// `AWS_SECRET_ACCESS_KEY`.
+	/// `AWS_SECRET_ACCESS_KEY` (real, or dummy under the proxy).
 	pub secret_access_key: String,
-	/// `AWS_SESSION_TOKEN` (assumed-role creds are always session creds).
+	/// `AWS_SESSION_TOKEN`. Empty under the proxy (dummy creds aren't STS); set
+	/// for direct assumed-role creds. An empty value is not exported.
 	pub session_token: String,
 	/// The group's region (`AWS_REGION`), if set.
 	pub region: Option<String>,
 	/// The repo passphrase, read from the group's k8s Secret (`KOPIA_PASSWORD`).
 	pub password: String,
+	/// When set, kopia's S3 backend is pointed at this loopback proxy endpoint
+	/// (`host:port`) with TLS disabled, and the credentials above are meaningless
+	/// dummies — the [SigV4 re-signing proxy](super::creds_server) holds and
+	/// refreshes the real credentials. When `None`, kopia talks to S3 directly
+	/// with the static creds above.
+	pub proxy_endpoint: Option<String>,
 }
 
 impl KopiaEnv {
 	/// Apply the per-op env to a `kopia` Command. kopia 0.23.1's `s3` connector
-	/// requires real credentials (its CLI demands `--access-key`, defaulting from
-	/// `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) — it does
-	/// **not** honor `AWS_CONTAINER_CREDENTIALS_FULL_URI`. So pass the assumed-role
-	/// static creds via those env vars, and **scrub** the IRSA / container-creds
-	/// sources the pod injects so they can't shadow them in minio-go's chain.
+	/// requires credentials at parse time (its CLI demands `--access-key`,
+	/// defaulting from `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/
+	/// `AWS_SESSION_TOKEN`) — it does **not** honor the container-creds endpoint.
+	/// So pass creds via those env vars (real for direct ops, dummy under the
+	/// proxy), and **scrub** the IRSA / container-creds sources the pod injects so
+	/// they can't shadow them in minio-go's chain.
 	fn apply(&self, cmd: &mut Command) {
 		cmd.env("KOPIA_PASSWORD", &self.password);
 		cmd.env("AWS_ACCESS_KEY_ID", &self.access_key_id);
 		cmd.env("AWS_SECRET_ACCESS_KEY", &self.secret_access_key);
-		cmd.env("AWS_SESSION_TOKEN", &self.session_token);
+		if self.session_token.is_empty() {
+			cmd.env_remove("AWS_SESSION_TOKEN");
+		} else {
+			cmd.env("AWS_SESSION_TOKEN", &self.session_token);
+		}
 		for shadowing in [
 			"AWS_WEB_IDENTITY_TOKEN_FILE",
 			"AWS_ROLE_ARN",
@@ -84,6 +105,15 @@ impl KopiaEnv {
 		if let Some(region) = &self.region {
 			cmd.env("AWS_REGION", region);
 			cmd.env("AWS_DEFAULT_REGION", region);
+		}
+	}
+
+	/// The extra `s3` connector flags for the proxy, when one is in use:
+	/// `--endpoint <host:port> --disable-tls`. Empty for the direct path.
+	fn s3_endpoint_flags(&self) -> Vec<&str> {
+		match &self.proxy_endpoint {
+			Some(ep) => vec!["--endpoint", ep.as_str(), "--disable-tls"],
+			None => Vec::new(),
 		}
 	}
 }
@@ -356,26 +386,25 @@ fn short_stderr(stderr: &[u8]) -> String {
 /// IS the maintenance owner (required for `maintenance run`; harmless for
 /// read-only inspect).
 pub async fn connect(env: &KopiaEnv, bucket: &str, prefix: &str, region: &str) -> Result<()> {
-	run_kopia_ok(
-		env,
-		&[
-			"repository",
-			"connect",
-			"s3",
-			"--bucket",
-			bucket,
-			"--prefix",
-			prefix,
-			"--region",
-			region,
-			"--override-username",
-			MAINTENANCE_USER,
-			"--override-hostname",
-			MAINTENANCE_HOST,
-		],
-	)
-	.await
-	.context("cannot connect to repository")?;
+	let mut args = vec![
+		"repository",
+		"connect",
+		"s3",
+		"--bucket",
+		bucket,
+		"--prefix",
+		prefix,
+		"--region",
+		region,
+		"--override-username",
+		MAINTENANCE_USER,
+		"--override-hostname",
+		MAINTENANCE_HOST,
+	];
+	args.extend(env.s3_endpoint_flags());
+	run_kopia_ok(env, &args)
+		.await
+		.context("cannot connect to repository")?;
 	Ok(())
 }
 
@@ -464,21 +493,19 @@ pub async fn run_init(
 	create_new: bool,
 ) -> Result<()> {
 	if create_new {
-		let create = run_kopia(
-			env,
-			&[
-				"repository",
-				"create",
-				"s3",
-				"--bucket",
-				bucket,
-				"--prefix",
-				prefix,
-				"--region",
-				region,
-			],
-		)
-		.await?;
+		let mut create_args = vec![
+			"repository",
+			"create",
+			"s3",
+			"--bucket",
+			bucket,
+			"--prefix",
+			prefix,
+			"--region",
+			region,
+		];
+		create_args.extend(env.s3_endpoint_flags());
+		let create = run_kopia(env, &create_args).await?;
 		if !create.status.success() {
 			connect(env, bucket, prefix, region)
 				.await

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -10,10 +10,11 @@
 //! concurrency.
 //!
 //! Retention is resolved per-`(group, type)` (schedule override → type default →
-//! org floor) and applied per source by the kopia layer. Canopy assumes the
-//! group's role and passes the resulting (static, ~1h) credentials to the kopia
-//! subprocess via `AWS_*` env (kopia's S3 connector requires real keys); it reads
-//! `KOPIA_PASSWORD` from the group's k8s Secret.
+//! org floor) and applied per source by the kopia layer. Init uses the group
+//! role's static credentials directly; maintenance — which can outlive a single
+//! assumed-role session — is driven through the SigV4 re-signing proxy (see
+//! [`super::creds_server::CredsServer::spawn_maintenance_proxy`] and the kopia
+//! layer). `KOPIA_PASSWORD` is read from the group's k8s Secret.
 
 use std::{collections::HashSet, time::Duration};
 
@@ -70,7 +71,7 @@ async fn retention_map_for_group(
 }
 
 /// Build the per-op kopia env from the assumed-role static creds, the group's
-/// region, and its repo password.
+/// region, and its repo password. The direct (non-proxy) path — used by init.
 fn kopia_env(
 	creds: &ResolvedCreds,
 	config: &ServerGroupBackupConfig,
@@ -82,6 +83,7 @@ fn kopia_env(
 		session_token: creds.session_token.clone(),
 		region: config.region.clone(),
 		password,
+		proxy_endpoint: None,
 	}
 }
 
@@ -327,17 +329,20 @@ fn spawn_maint(worker: &Worker, config: ServerGroupBackupConfig, kind: Maintenan
 }
 
 /// The kopia side of a maintenance op.
+///
+/// Maintenance can run well over an hour (large repos), past the lifetime of a
+/// single assumed-role session, so it's driven through the SigV4 re-signing
+/// proxy: kopia connects to a loopback endpoint with dummy keys and the proxy
+/// re-signs each request with freshly-refreshed maintenance-role credentials.
+/// (A region is required to address the proxy's upstream; a region-less config
+/// — which kopia's `--region` would already choke on — falls back to the direct
+/// static-creds path.)
 async fn run_maint_op(
 	worker: &Worker,
 	config: &ServerGroupBackupConfig,
 	kind: MaintenanceKind,
 ) -> anyhow::Result<kopia::MaintOutcome> {
 	let password = worker.read_repo_password(&config.repo_password_ref).await?;
-	let creds = worker
-		.creds
-		.resolve(&config.maintenance_role_arn, config.region.as_deref())
-		.await?;
-	let env = kopia_env(&creds, config, password);
 	let retention = {
 		let mut db = worker
 			.pool
@@ -348,16 +353,38 @@ async fn run_maint_op(
 			.await
 			.map_err(|e| anyhow::anyhow!(e))?
 	};
-	let region = config.region.as_deref().unwrap_or_default();
-	kopia::run_maintenance(
-		&env,
-		&config.bucket,
-		&config.prefix,
-		region,
-		kind,
-		&retention,
-	)
-	.await
+
+	match config.region.as_deref().filter(|r| !r.is_empty()) {
+		Some(region) => {
+			let proxy = worker
+				.creds
+				.spawn_maintenance_proxy(&config.maintenance_role_arn, region)
+				.await?;
+			// Dummy creds — the proxy holds and refreshes the real ones.
+			let env = KopiaEnv {
+				access_key_id: "canopy-proxy".to_string(),
+				secret_access_key: "canopy-proxy".to_string(),
+				session_token: String::new(),
+				region: Some(region.to_string()),
+				password,
+				proxy_endpoint: Some(proxy.endpoint()),
+			};
+			let result =
+				kopia::run_maintenance(&env, &config.bucket, &config.prefix, region, kind, &retention)
+					.await;
+			proxy.shutdown().await;
+			result
+		}
+		None => {
+			// No region: keep the direct static-creds path (best-effort, ~1h cap).
+			let creds = worker
+				.creds
+				.resolve(&config.maintenance_role_arn, config.region.as_deref())
+				.await?;
+			let env = kopia_env(&creds, config, password);
+			kopia::run_maintenance(&env, &config.bucket, &config.prefix, "", kind, &retention).await
+		}
+	}
 }
 
 async fn tick(worker: &Worker) -> Result<(), String> {

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -369,9 +369,15 @@ async fn run_maint_op(
 				password,
 				proxy_endpoint: Some(proxy.endpoint()),
 			};
-			let result =
-				kopia::run_maintenance(&env, &config.bucket, &config.prefix, region, kind, &retention)
-					.await;
+			let result = kopia::run_maintenance(
+				&env,
+				&config.bucket,
+				&config.prefix,
+				region,
+				kind,
+				&retention,
+			)
+			.await;
 			proxy.shutdown().await;
 			result
 		}

--- a/crates/jobs/src/backup/rotation.rs
+++ b/crates/jobs/src/backup/rotation.rs
@@ -49,6 +49,7 @@ fn kopia_env(
 		session_token: creds.session_token.clone(),
 		region: config.region.clone(),
 		password,
+		proxy_endpoint: None,
 	}
 }
 


### PR DESCRIPTION
🤖 Wires in bestool's `bestool-kopia` proxy crate (beyondessential/bestool#529) and routes long maintenance ops through it.

## Why

The merged static-creds fix gives kopia the maintenance role's assumed-role credentials via `AWS_*` env. Those are ~1h-lived — fine for the short ops (init, stats, inspection, rotation), but maintenance on a mid-size repo has run 40 minutes and climbing, too close to (and able to exceed) the session lifetime. kopia binds its S3 credentials once at process start and can't refresh mid-run, so a long maintenance can lose its credentials partway through.

## What

- Adds `bestool-kopia` (the shared crate from the S3P spec) with its `proxy` feature.
- `CredsServer::spawn_maintenance_proxy` assumes the maintenance role behind a small cache that re-assumes a few minutes ahead of expiry, and spawns the loopback SigV4 re-signing proxy fronting `s3.<region>.amazonaws.com`.
- `KopiaEnv` gains `proxy_endpoint`: when set, `apply()` exports dummy keys (no session token) and the s3 connector gets `--endpoint <loopback> --disable-tls`, so kopia talks to the proxy and the proxy re-signs each request with live credentials. The maintenance op spawns a proxy, runs `kopia::run_maintenance` against it, then shuts it down.
- Short ops (init, inspection, rotation) keep the direct static-creds path (`proxy_endpoint: None`). A region-less config falls back to the direct path too (kopia's `--region` would already choke without one).

## Notes / flags

- **Dependency source**: bestool#529 is merged to bestool `main` but not yet released, so `bestool-kopia` is pinned to a `main` rev. Reverts to a plain crates.io version requirement once the `proxy` feature publishes (noted in `Cargo.toml`).
- **rustls provider**: resolved — bestool switched the proxy crate to the workspace's `aws-lc-rs` provider (`spawn` installs `aws_lc_rs`), so it no longer pulls a second `ring` provider. (`ring` still appears transitively via pre-existing deps like rcgen / aws-smithy's rustls 0.21, as before — unchanged by this PR.)
- **Pre-existing race (not introduced here, but surfaced)**: kopia ops share the default config dir (`~/.config/kopia/repository.config`) and concurrency defaults to 4, so two concurrent ops on different groups can clobber each other's connection — the static path has this today too. The proxy doesn't introduce it but changes the failure signature. A focused follow-up could isolate per-op kopia config (e.g. a group-keyed `KOPIA_CONFIG_PATH`, safe because the in-flight set already serialises ops per group). Happy to do that next.

The device-side backup/restore proxy path lives in bestool; this is the canopy/maintenance consumer.
