### PR TITLE
build(deps): use published bestool-kopia 0.2.0 from crates.io [TAM-6877]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1063,8 +1063,9 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bestool-kopia"
-version = "0.1.4"
-source = "git+https://github.com/beyondessential/bestool?rev=ebd4663cfe48743404b3117cca4db3ff71a0a053#ebd4663cfe48743404b3117cca4db3ff71a0a053"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd30e3b155c13e2657c9b740bb53715494588fc7eb5ae1f26d1577c4a34894ac"
 dependencies = [
  "bytes",
  "hex",
@@ -2206,7 +2207,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2357,7 +2358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3086,7 +3087,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3980,7 +3981,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4689,7 +4690,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4727,7 +4728,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5127,7 +5128,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5197,7 +5198,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5627,7 +5628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5662,7 +5663,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5792,7 +5793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6760,7 +6761,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,9 @@ aws-sdk-sts = "1.107.0"
 aws-smithy-mocks = "0.2.6"
 axum = "0.8.9"
 axum-test = "20.0.0"
-# bestool-kopia's SigV4 re-signing proxy (S3P spec). bestool#529 is merged to
-# main but not yet released, so pin to a main rev until the crate publishes the
-# `proxy` feature to crates.io, then revert to a plain version requirement. The
-# proxy feature uses the workspace's `aws-lc-rs` rustls provider.
-bestool-kopia = { git = "https://github.com/beyondessential/bestool", rev = "ebd4663cfe48743404b3117cca4db3ff71a0a053", features = [
-	"proxy",
-] }
+# bestool-kopia's SigV4 re-signing proxy (S3P spec). The proxy feature uses the
+# workspace's `aws-lc-rs` rustls provider.
+bestool-kopia = { version = "0.2.0", features = ["proxy"] }
 clap = "4.6.1"
 diesel = "2.3.9"
 diesel-async = "0.9.0"


### PR DESCRIPTION
🤖 Follow-up to #256, which landed with `bestool-kopia` pinned to a bestool `main` git rev because the crate wasn't released yet.

`bestool-kopia 0.2.0` is now published to crates.io **with the `proxy` feature**, so this drops the git pin and depends on the registry release:

```
bestool-kopia = { version = "0.2.0", features = ["proxy"] }
```

No code changes — same crate content as the pinned rev (0.2.0 is the release of the merged proxy work), still on the workspace's `aws-lc-rs` rustls provider. `cargo check -p jobs` compiles and the lockfile now resolves `bestool-kopia` from `registry+https://github.com/rust-lang/crates.io-index` instead of git.