### PR TITLE
feat(backups): next-run estimate + group name/cross-links on the backup page [TAM-6877]

### DIFF
--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -844,6 +844,10 @@ pub struct GroupTypeScheduleView {
 	pub effective_interval: Option<i64>,
 	pub effective_retention: RetentionPolicy,
 	pub has_override: bool,
+	/// When the next scheduled backup of this type is expected: the group's most
+	/// recent successful backup of the type plus the interval — or "now" if the
+	/// type is scheduled but has never succeeded yet. Null for manual-only types.
+	pub next_run_at: Option<Timestamp>,
 }
 
 /// Per enabled backup type, the group's effective schedule/retention (override
@@ -864,6 +868,25 @@ pub async fn group_schedules(
 	let mut conn = state.db.get().await?;
 	let types =
 		ServerBackupCapability::enabled_types_for_group(&mut conn, args.server_group_id).await?;
+
+	// Anchor for the next-expected-run estimate: the group's most recent
+	// successful backup per type (max over its servers).
+	let mut last_success: std::collections::HashMap<BackupType, Timestamp> =
+		std::collections::HashMap::new();
+	for ((_, ty), run) in
+		BackupRun::latest_success_by_server_type_for_group(&mut conn, args.server_group_id).await?
+	{
+		last_success
+			.entry(ty)
+			.and_modify(|t| {
+				if run.reported_at > *t {
+					*t = run.reported_at;
+				}
+			})
+			.or_insert(run.reported_at);
+	}
+	let now = Timestamp::now();
+
 	let mut out = Vec::with_capacity(types.len());
 	for ty in types {
 		let over = ServerGroupBackupSchedule::get(&mut conn, args.server_group_id, &ty).await?;
@@ -882,11 +905,20 @@ pub async fn group_schedules(
 					.and_then(|d| RetentionPolicy::from_json(&d.default_retention))
 			})
 			.unwrap_or(FLOOR_RETENTION);
+		// Scheduled types: latest success + interval (or now if never run yet).
+		// Manual-only types (no interval) have no expected next run.
+		let next_run_at = effective_interval.map(|secs| {
+			last_success
+				.get(&ty)
+				.and_then(|last| Timestamp::from_second(last.as_second() + secs).ok())
+				.unwrap_or(now)
+		});
 		out.push(GroupTypeScheduleView {
 			r#type: ty,
 			effective_interval,
 			effective_retention,
 			has_override: over.is_some(),
+			next_run_at,
 		});
 	}
 	Ok(Json(out))

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -461,6 +461,43 @@ async fn stats_includes_runs_and_pending_requests() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn group_schedules_reports_next_run_from_last_success_plus_interval() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let device_id = Uuid::new_v4();
+		let server_id = Uuid::new_v4();
+		conn.batch_execute(&format!(
+			"INSERT INTO devices (id, role) VALUES ('{device_id}', 'server');
+			 INSERT INTO servers (id, host, kind, group_id, device_id) VALUES \
+				('{server_id}', 'https://e.test', 'central', '{group_id}', '{device_id}');
+			 INSERT INTO server_backup_capabilities (server_id, type, enabled) VALUES \
+				('{server_id}', 'tamanu-postgres', true);
+			 -- A 1h scheduled interval and a successful backup at a known time.
+			 INSERT INTO server_group_backup_schedule (group_id, type, expected_interval) VALUES \
+				('{group_id}', 'tamanu-postgres', INTERVAL '3600 seconds');
+			 INSERT INTO backup_runs (id, device_id, group_id, server_id, type, purpose, outcome, reported_at) VALUES \
+				('{}', '{device_id}', '{group_id}', '{server_id}', 'tamanu-postgres', 'backup', 'success', '2026-06-01T00:00:00Z');",
+			Uuid::new_v4()
+		))
+		.await
+		.expect("seed schedule + run");
+
+		let resp = private
+			.post("/api/backups/group_schedules")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		let row = &body[0];
+		assert_eq!(row["type"], "tamanu-postgres");
+		assert_eq!(row["effective_interval"], 3600);
+		// next run = last success (00:00:00Z) + 1h.
+		assert_eq!(row["next_run_at"], "2026-06-01T01:00:00Z");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn update_region_and_delete() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -195,6 +195,8 @@ test.describe("backups ready: stats + backup-now", () => {
 		// No override yet → inherits the seeded canopy-wide default.
 		await expect(schedules.getByText("tamanu-postgres")).toBeVisible();
 		await expect(schedules.getByText("Inherited default")).toBeVisible();
+		// A scheduled type shows its next expected run (no successful run yet → now).
+		await expect(schedules.getByText(/next backup expected/i)).toBeVisible();
 
 		// Override the interval to 12h.
 		await page.getByRole("button", { name: /^override$/i }).click();
@@ -369,6 +371,40 @@ test.describe("backups ready: stats + backup-now", () => {
 			expect(rows).toHaveLength(1);
 			expect(rows[0]!.type).toBe("files");
 		}).toPass();
+	});
+
+	test("backup page names the group and cross-links to/from the server backup section", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "Linky Group" });
+		const server = await seedServer(sql, {
+			name: "linky-srv",
+			groupId: group.id,
+		});
+		await seedServerBackupCapability(sql, { serverId: server.id });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+
+		// Header carries the group name + a back-link to the group page.
+		await expect(
+			page.getByRole("heading", { name: /linky group backups/i }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("link", { name: /back to linky group/i }),
+		).toBeVisible();
+
+		// The server in the "back up now" panel links to its page's backup section.
+		await page.getByRole("link", { name: "linky-srv" }).click();
+		await expect(page).toHaveURL(new RegExp(`/servers/${server.id}#backups$`));
+
+		// That backup section links back to the group's backup page.
+		await page.getByRole("link", { name: /group backups/i }).click();
+		await expect(page).toHaveURL(new RegExp(`/groups/${group.id}/backups$`));
 	});
 
 	test("provisioning with init error shows retry", async ({ page, sql }) => {

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6413,6 +6413,14 @@
           "has_override": {
             "type": "boolean"
           },
+          "next_run_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When the next scheduled backup of this type is expected: the group's most\nrecent successful backup of the type plus the interval — or \"now\" if the\ntype is scheduled but has never succeeded yet. Null for manual-only types."
+          },
           "type": {
             "type": "string"
           }

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2584,6 +2584,13 @@ export interface components {
             effective_interval?: number | null;
             effective_retention: components["schemas"]["RetentionPolicy"];
             has_override: boolean;
+            /**
+             * Format: date-time
+             * @description When the next scheduled backup of this type is expected: the group's most
+             *     recent successful backup of the type plus the interval — or "now" if the
+             *     type is scheduled but has never succeeded yet. Null for manual-only types.
+             */
+            next_run_at?: string | null;
             type: string;
         };
         /**

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -12,6 +12,7 @@ import {
 	Divider,
 	FormControlLabel,
 	LinearProgress,
+	Link as MuiLink,
 	Paper,
 	Stack,
 	Switch,
@@ -47,7 +48,6 @@ import {
 
 export default function BackupPanel() {
 	const { id = "" } = useParams<{ id: string }>();
-	usePageTitle("Backups");
 	const isAdmin = useIsAdmin() === true;
 	const config = useApi(
 		"backups",
@@ -71,6 +71,9 @@ export default function BackupPanel() {
 		{ server_group_id: id },
 		[id],
 	);
+	const groupName =
+		group.status === "ok" ? group.data.group.name : undefined;
+	usePageTitle(groupName ? `Backups · ${groupName}` : "Backups");
 
 	const data =
 		configForTick.status === "ok"
@@ -89,9 +92,19 @@ export default function BackupPanel() {
 	if (data == null) {
 		return (
 			<Stack spacing={2}>
-				<Typography variant="h4" component="h1">
-					Backups
-				</Typography>
+				<Box>
+					<MuiLink
+						component={RouterLink}
+						to={`/groups/${id}`}
+						variant="body2"
+						underline="hover"
+					>
+						‹ Back to {groupName ?? "group"}
+					</MuiLink>
+					<Typography variant="h4" component="h1">
+						{groupName ? `${groupName} backups` : "Backups"}
+					</Typography>
+				</Box>
 				<Alert severity="info">Backups not set up for this group.</Alert>
 				{isAdmin && (
 					<Box>
@@ -115,35 +128,49 @@ export default function BackupPanel() {
 
 	return (
 		<Stack spacing={3}>
-			<Stack
-				direction="row"
-				spacing={2}
-				sx={{ alignItems: "center", justifyContent: "space-between" }}
-			>
-				<Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
-					<Typography variant="h4" component="h1">
-						Backups
-					</Typography>
-					<Chip
-						label={BACKUP_STATUS_LABEL[status]}
-						color={BACKUP_STATUS_INTENT[status]}
-						size="small"
-					/>
-				</Stack>
-				{isAdmin && (
-					<Stack direction="row" spacing={1}>
-						<Button
-							component={RouterLink}
-							to={`/groups/${id}/backups/config`}
-							variant="outlined"
-							startIcon={<EditIcon />}
-						>
-							Edit config
-						</Button>
-						<DeleteConfigButton groupId={id} onDeleted={configForTick.reload} />
+			<Box>
+				<MuiLink
+					component={RouterLink}
+					to={`/groups/${id}`}
+					variant="body2"
+					underline="hover"
+				>
+					‹ Back to {groupName ?? "group"}
+				</MuiLink>
+				<Stack
+					direction="row"
+					spacing={2}
+					sx={{
+						alignItems: "center",
+						justifyContent: "space-between",
+						mt: 0.5,
+					}}
+				>
+					<Stack direction="row" spacing={1.5} sx={{ alignItems: "center" }}>
+						<Typography variant="h4" component="h1">
+							{groupName ? `${groupName} backups` : "Backups"}
+						</Typography>
+						<Chip
+							label={BACKUP_STATUS_LABEL[status]}
+							color={BACKUP_STATUS_INTENT[status]}
+							size="small"
+						/>
 					</Stack>
-				)}
-			</Stack>
+					{isAdmin && (
+						<Stack direction="row" spacing={1}>
+							<Button
+								component={RouterLink}
+								to={`/groups/${id}/backups/config`}
+								variant="outlined"
+								startIcon={<EditIcon />}
+							>
+								Edit config
+							</Button>
+							<DeleteConfigButton groupId={id} onDeleted={configForTick.reload} />
+						</Stack>
+					)}
+				</Stack>
+			</Box>
 
 			<Alert severity={BACKUP_STATUS_INTENT[status]}>
 				{BACKUP_STATUS_HELP[status]}
@@ -320,6 +347,7 @@ type GroupTypeSchedule = {
 		keep_annual: number;
 	};
 	has_override: boolean;
+	next_run_at: string | null;
 };
 
 function TypeSchedule({
@@ -364,6 +392,12 @@ function TypeSchedule({
 				· retention latest {r.keep_latest}, daily {r.keep_daily}, weekly{" "}
 				{r.keep_weekly}, monthly {r.keep_monthly}, annual {r.keep_annual}
 			</Typography>
+			{schedule.effective_interval != null && schedule.next_run_at && (
+				<Typography variant="body2" color="text.secondary">
+					Next backup expected{" "}
+					<TimeAgo timestamp={schedule.next_run_at} />
+				</Typography>
+			)}
 			{editing && (
 				<OverrideEditor
 					groupId={groupId}
@@ -734,9 +768,15 @@ function RunsAndRequests({
 									justifyContent: "space-between",
 								}}
 							>
-								<Typography variant="body2" sx={{ pt: 0.75 }}>
+								<MuiLink
+									component={RouterLink}
+									to={`/servers/${m.id}#backups`}
+									variant="body2"
+									underline="hover"
+									sx={{ pt: 0.75 }}
+								>
 									{m.name ?? m.id.slice(0, 8)}
-								</Typography>
+								</MuiLink>
 								{types.length === 0 ? (
 									<Tooltip title="This server hasn't registered any backup types yet.">
 										{/* span so the tooltip works on the disabled button */}

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -37,7 +37,12 @@ import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import NotificationsOffOutlinedIcon from "@mui/icons-material/NotificationsOffOutlined";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Fragment, useEffect, useState } from "react";
-import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
+import {
+	Link as RouterLink,
+	useLocation,
+	useNavigate,
+	useParams,
+} from "react-router-dom";
 import ExternalUsersDetails, {
 	parseExternalUserSessions,
 } from "../components/ExternalUsersDetails";
@@ -108,6 +113,19 @@ export default function ServerDetail() {
 	);
 	const hasOpenIncident =
 		openIncidents.status === "ok" && openIncidents.data.length > 0;
+	// Honour a `#backups` anchor (linked from the group's backup page): once the
+	// detail has loaded and the section is painted, scroll it into view.
+	const location = useLocation();
+	const detailLoaded = detail.status === "ok";
+	useEffect(() => {
+		if (!detailLoaded || location.hash !== "#backups") return;
+		const frame = requestAnimationFrame(() => {
+			document
+				.getElementById("backups")
+				?.scrollIntoView({ behavior: "smooth", block: "start" });
+		});
+		return () => cancelAnimationFrame(frame);
+	}, [detailLoaded, location.hash]);
 	usePageTitle(
 		detail.status === "ok"
 			? (detail.data.server.name ?? "Unnamed server")
@@ -169,6 +187,7 @@ export default function ServerDetail() {
 			)}
 			<BackupCapabilitiesSection
 				serverId={data.server.id}
+				groupId={data.group?.id ?? null}
 				isAdmin={admin}
 			/>
 			{(data.server.notes || Object.keys(data.server.tags ?? {}).length > 0) && (
@@ -1616,9 +1635,11 @@ function SiblingServers({
 /// renders an explicit empty state rather than disappearing.
 function BackupCapabilitiesSection({
 	serverId,
+	groupId,
 	isAdmin,
 }: {
 	serverId: string;
+	groupId: string | null;
 	isAdmin: boolean;
 }) {
 	const caps = useApi(
@@ -1628,10 +1649,26 @@ function BackupCapabilitiesSection({
 		[serverId],
 	);
 	return (
-		<Paper variant="outlined" sx={{ p: 2 }}>
-			<Typography variant="h6" component="h2" gutterBottom>
-				Backups
-			</Typography>
+		<Paper id="backups" variant="outlined" sx={{ p: 2 }}>
+			<Stack
+				direction="row"
+				spacing={2}
+				sx={{ alignItems: "baseline", justifyContent: "space-between" }}
+			>
+				<Typography variant="h6" component="h2" gutterBottom>
+					Backups
+				</Typography>
+				{groupId && (
+					<MuiLink
+						component={RouterLink}
+						to={`/groups/${groupId}/backups`}
+						variant="body2"
+						underline="hover"
+					>
+						Group backups ›
+					</MuiLink>
+				)}
+			</Stack>
 			{caps.status === "loading" || caps.status === "idle" ? (
 				<LinearProgress />
 			) : caps.status === "error" ? (


### PR DESCRIPTION
🤖 Operator-feedback tweaks to the group backups page.

## Next expected run for scheduled backups
`group_schedules` now returns `next_run_at` per type: the group's most recent successful backup of that type plus the effective interval (or "now" if it's scheduled but has never succeeded yet; null for manual-only types). The schedule panel renders it as "Next backup expected `<relative>`". It's a cadence estimate anchored on the latest success across the group's servers — it doesn't model per-server jitter.

## Group name + back-link on the backup page
The page title is now `Backups · <group>`, the header reads "`<group>` backups", and a "‹ Back to `<group>`" link returns to the group page — in both the configured and zero-state views.

## Cross-links between the group backup page and the server's backup section
- Each server in the "Back up now" panel links to `/servers/:id#backups`; ServerDetail scrolls to that anchor once loaded.
- The server's Backups section (now `id="backups"`) has a "Group backups ›" link back to `/groups/:id/backups`.

## Tests
- Rust endpoint test for `next_run_at` (latest success + interval).
- e2e: next-run text in the schedule panel; a new spec covering the group name in the header, the back-link, the server→section link, and the section→group back-link.