### PR TITLE
feat(backups): validate the device role at onboarding via the probe [TAM-6877]

### DIFF
--- a/crates/private-server/src/backup_probe.rs
+++ b/crates/private-server/src/backup_probe.rs
@@ -1,19 +1,69 @@
 //! Synchronous bucket probe for the setup wizard.
 //!
-//! Before a config is saved, the wizard assumes the group's **maintenance** role
+//! Before a config is saved, the prober assumes the group's **maintenance** role
 //! and inspects the target bucket/prefix so the operator gets immediate
 //! feedback: empty, an existing kopia repo, other (forgotten) content, or
 //! inaccessible. This is **inspect-only** (S3 `HeadObject`/`ListObjectsV2`) —
 //! private-server has no kopia binary, so a typed passphrase is verified later
 //! at init time (wrong passphrase → `last_init_error`), not here.
 //!
+//! When a **device** role is supplied it also validates that role can be assumed
+//! both ways (plain backup + read-only restore session policy) with a read-only
+//! no-op. This is the one place the device/issuance role is validated proactively:
+//! preflight runs as `canopy-jobs` (which the device role doesn't trust), but
+//! private-server runs as `canopy-private`, which the device role *does* trust.
+//! Later trust drift surfaces as real device backups failing.
+//!
 //! `Aws` is the real prober; `Fake` is an injectable canned result for tests and
 //! the e2e binary (gated by `CANOPY_BACKUP_PROBER_FAKE`), mirroring
 //! [`commons_servers::backup_secrets::BackupSecrets`].
 
+use aws_sdk_sts::error::ProvideErrorMetadata;
 use commons_errors::Result;
 use serde::Serialize;
 use utoipa::ToSchema;
+
+/// Human-readable AWS SDK error detail: the bare `SdkError` `Display` is just
+/// "service error", so pull out the service code + message. (Mirrors
+/// `jobs::backup::preflight::aws_detail`; worth factoring into commons once the
+/// in-flight preflight PRs settle.)
+fn sdk_detail<E, R>(e: &aws_sdk_sts::error::SdkError<E, R>) -> String
+where
+	E: ProvideErrorMetadata + std::error::Error,
+{
+	match e.as_service_error() {
+		Some(svc) => format!(
+			"{}: {}",
+			svc.code().unwrap_or("Unknown"),
+			svc.message().unwrap_or("(no message)"),
+		),
+		None => format!("{e}"),
+	}
+}
+
+/// Read-only **restore** session policy (moved from preflight): `GetObject` on
+/// the prefix, an *unconditioned* `GetBucketLocation` (the `s3:prefix` key isn't
+/// populated for it, so conditioning it would silently deny), and a
+/// prefix-conditioned `ListBucket`. Assuming the device role with this at
+/// onboarding proves the role can carry the restore scope.
+fn restore_session_policy(bucket: &str, prefix: &str) -> String {
+	let object_arn = format!("arn:aws:s3:::{bucket}/{prefix}*");
+	let bucket_arn = format!("arn:aws:s3:::{bucket}");
+	serde_json::json!({
+		"Version": "2012-10-17",
+		"Statement": [
+			{ "Effect": "Allow", "Action": ["s3:GetObject"], "Resource": object_arn },
+			{ "Effect": "Allow", "Action": ["s3:GetBucketLocation"], "Resource": bucket_arn },
+			{
+				"Effect": "Allow",
+				"Action": ["s3:ListBucket"],
+				"Resource": bucket_arn,
+				"Condition": { "StringLike": { "s3:prefix": [format!("{prefix}*")] } }
+			}
+		]
+	})
+	.to_string()
+}
 
 /// Env var that forces the fake prober (no AWS needed). Set by the e2e fixture.
 const FAKE_ENV: &str = "CANOPY_BACKUP_PROBER_FAKE";
@@ -104,21 +154,30 @@ impl BucketProber {
 		Self::Fake(Some(state))
 	}
 
-	/// Inspect `bucket/prefix` by assuming `maintenance_role_arn`. Never errors
-	/// out — an assume/list failure becomes `Inaccessible` with the message.
+	/// Inspect `bucket/prefix` by assuming `maintenance_role_arn`, and — when
+	/// `device_role_arn` is given — validate the device/issuance role can be
+	/// assumed too. Never errors out — an assume/list failure becomes
+	/// `Inaccessible` with the message.
 	pub async fn probe(
 		&self,
 		bucket: &str,
 		prefix: &str,
 		region: Option<&str>,
 		maintenance_role_arn: &str,
+		device_role_arn: Option<&str>,
 	) -> Result<ProbeResult> {
 		match self {
 			Self::Fake(Some(state)) => Ok(ProbeResult::state(*state)),
 			Self::Fake(None) => Ok(ProbeResult::state(fake_state_for(bucket))),
-			Self::Aws(sdk) => {
-				Ok(probe_aws(sdk, bucket, prefix, region, maintenance_role_arn).await)
-			}
+			Self::Aws(sdk) => Ok(probe_aws(
+				sdk,
+				bucket,
+				prefix,
+				region,
+				maintenance_role_arn,
+				device_role_arn,
+			)
+			.await),
 		}
 	}
 }
@@ -137,34 +196,30 @@ fn fake_state_for(bucket: &str) -> ProbeState {
 	}
 }
 
-async fn probe_aws(
+/// Assume `role_arn` (optionally with a scoped session `policy`) and build an S3
+/// client from the returned creds. `Err(message)` on any failure.
+async fn assume_s3(
 	sdk: &aws_config::SdkConfig,
-	bucket: &str,
-	prefix: &str,
-	region: Option<&str>,
+	sts: &aws_sdk_sts::Client,
 	role_arn: &str,
-) -> ProbeResult {
-	let inaccessible = |e: String| ProbeResult {
-		state: ProbeState::Inaccessible,
-		error: Some(e),
-		object_sample: Vec::new(),
-	};
-
-	// Assume the maintenance role (full read) for the inspect.
-	let sts = aws_sdk_sts::Client::new(sdk);
-	let assumed = match sts
+	region: Option<&str>,
+	session: &str,
+	policy: Option<String>,
+) -> std::result::Result<aws_sdk_s3::Client, String> {
+	let mut req = sts
 		.assume_role()
 		.role_arn(role_arn)
-		.role_session_name("canopy-probe")
+		.role_session_name(session);
+	if let Some(policy) = policy {
+		req = req.policy(policy);
+	}
+	let assumed = req
 		.send()
 		.await
-	{
-		Ok(r) => r,
-		Err(e) => return inaccessible(format!("AssumeRole failed: {e}")),
-	};
-	let Some(creds) = assumed.credentials() else {
-		return inaccessible("AssumeRole returned no credentials".into());
-	};
+		.map_err(|e| format!("AssumeRole failed: {}", sdk_detail(&e)))?;
+	let creds = assumed
+		.credentials()
+		.ok_or_else(|| "AssumeRole returned no credentials".to_string())?;
 	let s3_creds = aws_sdk_s3::config::Credentials::new(
 		creds.access_key_id(),
 		creds.secret_access_key(),
@@ -176,7 +231,59 @@ async fn probe_aws(
 	if let Some(region) = region {
 		b = b.region(aws_sdk_s3::config::Region::new(region.to_string()));
 	}
-	let s3 = aws_sdk_s3::Client::from_conf(b.build());
+	Ok(aws_sdk_s3::Client::from_conf(b.build()))
+}
+
+async fn probe_aws(
+	sdk: &aws_config::SdkConfig,
+	bucket: &str,
+	prefix: &str,
+	region: Option<&str>,
+	maintenance_role_arn: &str,
+	device_role_arn: Option<&str>,
+) -> ProbeResult {
+	let inaccessible = |e: String| ProbeResult {
+		state: ProbeState::Inaccessible,
+		error: Some(e),
+		object_sample: Vec::new(),
+	};
+
+	let sts = aws_sdk_sts::Client::new(sdk);
+
+	// Validate the device/issuance role first (when supplied): assume it both ways
+	// and prove a read-only no-op, so a device-role trust/permission gap is caught
+	// at onboarding rather than only when a device first tries to back up.
+	if let Some(device_role_arn) = device_role_arn {
+		for restore in [false, true] {
+			let leg = if restore { "restore" } else { "backup" };
+			let policy = restore.then(|| restore_session_policy(bucket, prefix));
+			let s3 = match assume_s3(
+				sdk,
+				&sts,
+				device_role_arn,
+				region,
+				&format!("canopy-probe-{leg}"),
+				policy,
+			)
+			.await
+			{
+				Ok(s3) => s3,
+				Err(e) => return inaccessible(format!("device role ({leg}): {e}")),
+			};
+			if let Err(e) = s3.get_bucket_location().bucket(bucket).send().await {
+				return inaccessible(format!(
+					"device role ({leg}): GetBucketLocation failed: {}",
+					sdk_detail(&e)
+				));
+			}
+		}
+	}
+
+	// Assume the maintenance role (full read) for the inspect.
+	let s3 = match assume_s3(sdk, &sts, maintenance_role_arn, region, "canopy-probe", None).await {
+		Ok(s3) => s3,
+		Err(e) => return inaccessible(e),
+	};
 
 	// An existing kopia repo writes its format blob at `<prefix>kopia.repository`.
 	let marker = format!("{prefix}kopia.repository");
@@ -202,7 +309,7 @@ async fn probe_aws(
 		.await
 	{
 		Ok(o) => o,
-		Err(e) => return inaccessible(format!("ListObjectsV2 failed: {e}")),
+		Err(e) => return inaccessible(format!("ListObjectsV2 failed: {}", sdk_detail(&e))),
 	};
 	let storageconfig = format!("{prefix}.storageconfig");
 	let other: Vec<String> = listed
@@ -220,5 +327,34 @@ async fn probe_aws(
 			error: None,
 			object_sample: other.into_iter().take(5).collect(),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn restore_policy_has_unconditioned_get_bucket_location() {
+		let p = restore_session_policy("bes-kopia-backups-x", "");
+		let v: serde_json::Value = serde_json::from_str(&p).unwrap();
+		let stmts = v["Statement"].as_array().unwrap();
+		// GetBucketLocation must be its own statement with no Condition.
+		let gbl = stmts
+			.iter()
+			.find(|s| {
+				s["Action"]
+					.as_array()
+					.unwrap()
+					.iter()
+					.any(|a| a == "s3:GetBucketLocation")
+			})
+			.expect("GetBucketLocation present");
+		assert!(
+			gbl.get("Condition").is_none(),
+			"GetBucketLocation must be unconditioned"
+		);
+		// No mutation actions in the restore policy.
+		assert!(!p.contains("PutObject") && !p.contains("DeleteObject"));
 	}
 }

--- a/crates/private-server/src/backup_probe.rs
+++ b/crates/private-server/src/backup_probe.rs
@@ -280,7 +280,16 @@ async fn probe_aws(
 	}
 
 	// Assume the maintenance role (full read) for the inspect.
-	let s3 = match assume_s3(sdk, &sts, maintenance_role_arn, region, "canopy-probe", None).await {
+	let s3 = match assume_s3(
+		sdk,
+		&sts,
+		maintenance_role_arn,
+		region,
+		"canopy-probe",
+		None,
+	)
+	.await
+	{
 		Ok(s3) => s3,
 		Err(e) => return inaccessible(e),
 	};

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -581,6 +581,7 @@ pub async fn upsert(
 					&args.prefix,
 					args.region.as_deref(),
 					&args.maintenance_role_arn,
+					Some(&args.target_role_arn),
 				)
 				.await?;
 			match probe.state {
@@ -658,6 +659,11 @@ pub struct ProbeArgs {
 	pub region: Option<String>,
 	/// Maintenance role to assume for the inspect (full read).
 	pub maintenance_role_arn: String,
+	/// Device/issuance role to also validate (assume both ways + read-only no-op).
+	/// Optional; the wizard supplies it so a device-role trust gap is caught before
+	/// saving rather than only when a device first backs up.
+	#[serde(default)]
+	pub target_role_arn: Option<String>,
 }
 
 /// Inspect-probe result for the wizard: what's at `bucket/prefix`, plus whether
@@ -698,6 +704,7 @@ pub async fn probe(
 			&args.prefix,
 			args.region.as_deref(),
 			&args.maintenance_role_arn,
+			args.target_role_arn.as_deref(),
 		)
 		.await?;
 

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -7856,6 +7856,13 @@
               "string",
               "null"
             ]
+          },
+          "target_role_arn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Device/issuance role to also validate (assume both ways + read-only no-op).\nOptional; the wizard supplies it so a device-role trust gap is caught before\nsaving rather than only when a device first backs up."
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3156,6 +3156,12 @@ export interface components {
             maintenance_role_arn: string;
             prefix?: string;
             region?: string | null;
+            /**
+             * @description Device/issuance role to also validate (assume both ways + read-only no-op).
+             *     Optional; the wizard supplies it so a device-role trust gap is caught before
+             *     saving rather than only when a device first backs up.
+             */
+            target_role_arn?: string | null;
         };
         /**
          * @description Inspect-probe result for the wizard: what's at `bucket/prefix`, plus whether

--- a/private-web/src/routes/BackupConfig.tsx
+++ b/private-web/src/routes/BackupConfig.tsx
@@ -100,6 +100,7 @@ function ConfigForm({
 				prefix,
 				region: region.trim() === "" ? null : region,
 				maintenance_role_arn: maintenanceRoleArn,
+				target_role_arn: roleArn,
 			})) as ProbeResult;
 			setProbe(result);
 			setStep(1);


### PR DESCRIPTION
🤖 Follow-up to #260. Fills a real coverage gap surfaced while diagnosing the preflight incident.

## Why

The device/issuance role (`target_role_arn`) was validated by **no** path:
- every `probe` (wizard + `upsert`) assumes the **maintenance** role, not the device role;
- `create_shared` does no probe;
- preflight runs as `canopy-jobs`, which the device role deliberately doesn't trust (that's the #260 fix — preflight now checks the maintenance role).

So a broken device-role trust/permission would only show up when a device first tried to back up.

## What

The wizard/`upsert` probe runs in private-server as **`canopy-private`**, which the device role *does* trust (`deviceAssumeRolePolicy(issuer, private)` in ops). So the probe now also assumes the device role both ways (plain backup + read-only restore session policy) and does a read-only `GetBucketLocation` no-op — catching a device-role gap before the config is saved. `ProbeArgs` gains an optional `target_role_arn`; the wizard and `upsert` pass it.

Also gives the probe the same AWS-error-detail treatment #259 gave preflight (real code + message instead of "service error"), and moves `restore_session_policy` (+ its unit test) here from preflight.

## Not covered (by design)

- `create_shared`: the shared role ARNs aren't known to private-server at create time (the pod stamps them at init), so it can't probe the device role there. The shared device role's trust is owned by the ops backups-shared stack; and per the drift argument, a later device-role-trust regression surfaces as real device backups failing (existing `backup-never`/staleness alerts).