### PR TITLE
feat(backups): inspect promptly after a backup is reported [TAM-6877]

### DIFF
--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -849,6 +849,26 @@ impl BackupRun {
 			.collect())
 	}
 
+	/// When the group last had a successful *backup* reported (any server/type),
+	/// or `None` if it never has. Drives prompt post-backup inspection.
+	pub async fn latest_backup_at_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<Option<Timestamp>> {
+		use crate::schema::backup_runs::dsl;
+
+		let row: Option<Self> = dsl::backup_runs
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::purpose.eq(BackupPurpose::Backup))
+			.filter(dsl::outcome.eq(RunOutcome::Success))
+			.order_by(dsl::reported_at.desc())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)?;
+		Ok(row.map(|r| r.reported_at))
+	}
+
 	/// Recent runs for a group, newest-first (stats panel).
 	pub async fn list_for_group(
 		db: &mut AsyncPgConnection,
@@ -1030,6 +1050,26 @@ impl BackupRepoSnapshot {
 			.load(db)
 			.await
 			.map_err(AppError::from)
+	}
+
+	/// When the group's repo was last inspected (newest `observed_at` across its
+	/// sources), or `None` if never. This table is written *only* by the
+	/// inspection Job — unlike `backup_repo_stats.observed_at`, which the daily
+	/// s3-metrics writer also bumps — so it's the clean "last inspected" signal.
+	pub async fn last_inspected_at_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<Option<Timestamp>> {
+		use crate::schema::backup_repo_snapshots::dsl;
+
+		let row: Option<Self> = dsl::backup_repo_snapshots
+			.filter(dsl::group_id.eq(group_id))
+			.order_by(dsl::observed_at.desc())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)?;
+		Ok(row.map(|r| r.observed_at))
 	}
 }
 

--- a/crates/database/tests/backups.rs
+++ b/crates/database/tests/backups.rs
@@ -464,6 +464,115 @@ async fn repo_snapshot_upsert_in_place() {
 	.await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn latest_backup_and_last_inspected_for_group() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let device_id = insert_device(&mut conn).await;
+
+		// Nothing reported / inspected yet.
+		assert!(
+			BackupRun::latest_backup_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap()
+				.is_none()
+		);
+		assert!(
+			BackupRepoSnapshot::last_inspected_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap()
+				.is_none()
+		);
+
+		// A failed backup and a successful restore don't count as a backup.
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Failure,
+			),
+		)
+		.await
+		.unwrap();
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Restore,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.unwrap();
+		assert!(
+			BackupRun::latest_backup_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap()
+				.is_none(),
+			"only successful backups count"
+		);
+
+		// A successful backup → its reported_at.
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.unwrap();
+		let runs = BackupRun::list_for_group(&mut conn, group_id, 10)
+			.await
+			.unwrap();
+		let success = runs
+			.iter()
+			.find(|r| r.purpose == BackupPurpose::Backup && r.outcome == RunOutcome::Success)
+			.unwrap();
+		assert_eq!(
+			BackupRun::latest_backup_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap(),
+			Some(success.reported_at)
+		);
+
+		// last-inspected comes from the (inspection-only) snapshots table.
+		let t: Timestamp = "2026-06-10T00:00:00.000001Z".parse().unwrap();
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{server_id}:/data"),
+			Some(server_id),
+			Some(&BackupType::TamanuPostgres),
+			Some(t),
+		)
+		.await
+		.unwrap();
+		let snaps = BackupRepoSnapshot::list_for_group(&mut conn, group_id)
+			.await
+			.unwrap();
+		assert_eq!(
+			BackupRepoSnapshot::last_inspected_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap(),
+			Some(snaps[0].observed_at)
+		);
+	})
+	.await;
+}
+
 // --- repo stats: two independent writers ------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/jobs/src/backup/inspection.rs
+++ b/crates/jobs/src/backup/inspection.rs
@@ -1,22 +1,24 @@
-//! Inspection scheduler. Per-minute tick: for each `ready` group
-//! due on its hash-jittered cadence, claim a per-group + concurrency slot and
-//! **spawn a tokio task** that runs a **read-only** kopia inspection in-process
-//! ([`super::kopia::run_inspect`]) and writes the ground truth inline
-//! ([`super::complete::complete_inspect`]): upserts `backup_repo_snapshots` +
-//! the repo fields of `backup_repo_stats`, and raises/recovers the group-level
-//! `CORRUPTION` alert off `verify_ok`.
+//! Inspection scheduler. Per-minute tick: for each `ready` group that's due,
+//! claim a per-group + concurrency slot and **spawn a tokio task** that runs a
+//! **read-only** kopia inspection in-process ([`super::kopia::run_inspect`]) and
+//! writes the ground truth inline ([`super::complete::complete_inspect`]):
+//! upserts `backup_repo_snapshots` + the repo fields of `backup_repo_stats`, and
+//! raises/recovers the group-level `CORRUPTION` alert off `verify_ok`.
 //!
 //! Inspection is read-only, but it still goes through the in-flight set
 //! ([`super::worker`]) so it doesn't overlap a maintenance run on the same repo.
 //!
-//! The per-group inspection cadence is the group's effective backup interval
-//! (min across enabled types' schedule/default `expected_interval`), floored to
-//! weekly.
+//! A group is due when **a backup has landed since its last inspection** (so the
+//! stats panel freshens shortly after a backup — including a manual "back up
+//! now" — rather than waiting), or otherwise on its **hash-jittered cadence**:
+//! the group's effective backup interval (min across enabled types'
+//! schedule/default `expected_interval`), floored to weekly, so corruption/drift
+//! is still caught on quiet repos.
 
 use std::time::Duration;
 
 use commons_servers::backup_jobs::{effective_interval_for_group, slot_is_due};
-use database::{BackupConfigStatus, ServerGroupBackupConfig};
+use database::{BackupConfigStatus, BackupRepoSnapshot, BackupRun, ServerGroupBackupConfig};
 use jiff::Timestamp;
 use tokio::{
 	task::{self, JoinHandle},
@@ -38,6 +40,22 @@ const INSPECT_FLOOR: Duration = Duration::from_secs(7 * 24 * 3600);
 fn secs_into(now: Timestamp, window: Duration) -> u64 {
 	let w = window.as_secs().max(1) as i64;
 	now.as_second().rem_euclid(w) as u64
+}
+
+/// Whether a backup has landed since the repo was last inspected — the signal to
+/// inspect promptly (so the stats panel freshens shortly after a backup,
+/// including a manual "back up now") instead of waiting for the weekly cadence.
+/// `latest_backup` is the group's newest successful backup; `last_inspected` is
+/// the newest inspection. Never-inspected with a backup present → due.
+fn backup_since_inspect(
+	latest_backup: Option<Timestamp>,
+	last_inspected: Option<Timestamp>,
+) -> bool {
+	match (latest_backup, last_inspected) {
+		(Some(backup), Some(inspected)) => backup > inspected,
+		(Some(_), None) => true,
+		(None, _) => false,
+	}
 }
 
 /// Run an inspection op in a spawned task: read the password, run
@@ -110,14 +128,25 @@ async fn tick(worker: &Worker) -> Result<(), String> {
 		if in_flight.contains(&c.group_id) {
 			continue; // already mid-op
 		}
-		// Per-group cadence: the group's effective backup interval, floored to
-		// weekly (also weekly when no enabled type has an interval).
+		// Inspect promptly once a backup has landed since the last inspection
+		// (so the panel freshens shortly after a backup / "back up now")...
+		let latest_backup = BackupRun::latest_backup_at_for_group(&mut db, c.group_id)
+			.await
+			.map_err(|e| e.to_string())?;
+		let last_inspected = BackupRepoSnapshot::last_inspected_at_for_group(&mut db, c.group_id)
+			.await
+			.map_err(|e| e.to_string())?;
+		let due_after_backup = backup_since_inspect(latest_backup, last_inspected);
+
+		// ...otherwise fall back to the per-group cadence: the group's effective
+		// backup interval, floored to weekly (also the floor when no enabled type
+		// has an interval), so corruption/drift is still caught on quiet repos.
 		let window = effective_interval_for_group(&mut db, c.group_id)
 			.await
 			.map_err(|e| e.to_string())?
 			.map_or(INSPECT_FLOOR, |i| i.max(INSPECT_FLOOR));
 		let into = secs_into(now, window);
-		if !slot_is_due(c.group_id, window, TICK, into) {
+		if !due_after_backup && !slot_is_due(c.group_id, window, TICK, into) {
 			continue;
 		}
 		spawn_inspect(worker, c.clone());
@@ -136,4 +165,25 @@ pub fn spawn(worker: Worker) -> JoinHandle<()> {
 			}
 		}
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn backup_since_inspect_decisions() {
+		let t0: Timestamp = "2026-06-01T00:00:00Z".parse().unwrap();
+		let t1: Timestamp = "2026-06-01T01:00:00Z".parse().unwrap();
+		// Backup newer than last inspection → due.
+		assert!(backup_since_inspect(Some(t1), Some(t0)));
+		// Inspection at/after the latest backup → not due.
+		assert!(!backup_since_inspect(Some(t0), Some(t1)));
+		assert!(!backup_since_inspect(Some(t0), Some(t0)));
+		// Backup present but never inspected → due.
+		assert!(backup_since_inspect(Some(t0), None));
+		// No successful backup yet → nothing to inspect for.
+		assert!(!backup_since_inspect(None, None));
+		assert!(!backup_since_inspect(None, Some(t0)));
+	}
 }


### PR DESCRIPTION
🤖 The inspection scheduler only ran on a weekly-floored, hash-jittered cadence, so the stats panel (snapshot counts, sources, logical bytes) could lag a fresh backup — including a manual "back up now" — by up to a week.

## What

The per-minute inspection tick now also inspects a group as soon as **a successful backup is newer than its last inspection**, falling back to the existing cadence otherwise (so corruption/drift is still caught on quiet repos). In practice the inspection lands within ~a minute of a backup being reported, with no cross-process signalling: the backups pod just notices the new `backup_runs` row.

"Last inspected" is read from `backup_repo_snapshots` (written **only** by the inspection Job), deliberately *not* `backup_repo_stats.observed_at` — that column is also bumped by the daily s3-metrics writer, so it would mask new backups.

New queries: `BackupRun::latest_backup_at_for_group` (newest successful backup) and `BackupRepoSnapshot::last_inspected_at_for_group` (newest inspection).

## Notes

- It's self-limiting: once an inspection completes, its `observed_at` is newer than the backup, so it won't re-fire until the next backup.
- Inspection is read-only and goes through the existing per-group in-flight lock, so it never overlaps maintenance on the same repo.

## Tests

- Unit test for the due-decision (`backup_since_inspect`).
- DB test for both queries (newest-wins; failed backups and successful *restores* don't count).