### PR TITLE
fix(backups): never-reported is a warning; mark not-scheduled types [TAM-6877]

### DIFF
--- a/crates/database/src/backup/staleness.rs
+++ b/crates/database/src/backup/staleness.rs
@@ -274,10 +274,15 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 				// `backup-never` clears on first success (it transitions to OK,
 				// not Recovered — there's no recovery message for it). Only file
 				// while it's still never-backed-up.
+				//
+				// Warning, not Error: a server that has *never* backed up (freshly
+				// set up, or blocked by an upstream issue) shouldn't open an
+				// incident. A *missed* backup — a server that was backing up and
+				// stopped (`Stale`, above) — is the Error that pages.
 				NewEvent {
 					source: refs::CANOPY_SOURCE.into(),
 					r#ref: never_ref,
-					severity: Some(Severity::Error),
+					severity: Some(Severity::Warning),
 					description: None,
 					message: format!(
 						"Server {label} has never reported a successful {} backup (expected since {})",

--- a/crates/database/tests/backup_detection.rs
+++ b/crates/database/tests/backup_detection.rs
@@ -446,7 +446,9 @@ async fn sweep_files_never_for_server_that_never_succeeded() {
 		let issue = server_issue(&mut conn, server_id, &nref)
 			.await
 			.expect("never issue filed");
-		assert_eq!(issue.severity, Severity::Error.to_string());
+		// Never-reported is a warning (so first-time setup doesn't open an
+		// incident); a *missed* backup is the error that pages.
+		assert_eq!(issue.severity, Severity::Warning.to_string());
 		assert!(issue.active);
 		// Staleness ref must NOT be filed when there's never been a success.
 		assert!(

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -356,6 +356,9 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(
 			panel.getByRole("button", { name: /backup now/i }),
 		).toHaveCount(2);
+		// The disabled-for-schedule type is marked, so it's clear it still has a
+		// button only for on-demand use.
+		await expect(panel.getByText(/not scheduled/i)).toBeVisible();
 
 		// Backing up the non-default type writes a request for exactly that type.
 		await panel

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -720,6 +720,12 @@ function RunsAndRequests({
 				p.purpose === "backup",
 		);
 
+	// Whether the server has this type toggled on (scheduled). `undefined` when
+	// the type isn't a declared capability (e.g. a lingering pending request).
+	const enabledFor = (serverId: string, type: string): boolean | undefined =>
+		capabilities.find((c) => c.server_id === serverId && c.type === type)
+			?.enabled;
+
 	const onRequest = async (serverId: string, type: string) => {
 		try {
 			await requestNow.call({
@@ -808,6 +814,15 @@ function RunsAndRequests({
 													>
 														{t}
 													</Typography>
+													{enabledFor(m.id, t) === false && (
+														<Tooltip title="This type isn't on the backup schedule for this server (toggle it on in the server's Backups section). You can still back it up on demand.">
+															<Chip
+																size="small"
+																variant="outlined"
+																label="not scheduled"
+															/>
+														</Tooltip>
+													)}
 													{req ? (
 														<>
 															<Chip


### PR DESCRIPTION
🤖 Two pieces of operator feedback on backup alerting.

## "Never reported" is a warning, not an error

A `backup-never:<type>` issue (a `(server, type)` that has never reported a successful backup) now files at **warning** severity instead of error. So first-time setup — or a server currently blocked by an upstream issue — no longer **opens an incident**. A *missed* backup (the `Stale` verdict: a server that was backing up and then stopped) stays an **error** and still pages.

## "Not scheduled" types are marked in the back-up-now panel

A backup type that's registered but **not toggled on** for a server still gets a "Backup now" button (a one-off request overrides the enabled gate — intentional), but that wasn't obvious. The panel now shows a "not scheduled" chip next to such a type, with a tooltip pointing at the server's Backups section to toggle it on.

## Not changed (re: "are 3 issues missing?")

No — for that group all four types are enabled, but `backup-never` only fires past an `anchor + 2×interval` grace. Only the hourly `tamanu-config` (2h grace) has elapsed its window; `tamanu-postgres` (6h→12h), `caddy-config`/`postgres-config` (1d→2d) surface as their grace elapses. That grace is intentional (avoids setup-time noise), and with these now being warnings they won't open an incident when they do appear. Happy to shorten the never-grace if you'd rather see them sooner.

## Tests

- Updated the sweep test to assert `backup-never` is a warning.
- Extended the multi-type e2e to assert the "not scheduled" chip on a disabled type.