### PR TITLE
fix(backups): wire backup-credential clients into private-server's /public mount [TAM-6877]

### DIFF
--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -232,6 +232,7 @@ where
 				ro_pool: None,
 				tailnet_directory: Some(directory),
 				kube: Some(public_server::state::BackupSecrets::memory()),
+				sts: None,
 				prober: private_server::backup_probe::BucketProber::fake(
 					private_server::backup_probe::ProbeState::Empty,
 				),

--- a/crates/private-server/src/lib.rs
+++ b/crates/private-server/src/lib.rs
@@ -32,9 +32,14 @@ pub fn routes(state: crate::state::AppState) -> commons_errors::Result<axum::rou
 		.nest(
 			"/public",
 			Router::from(public_server::routes().with_state(
-				public_server::state::AppState::from_db_with_directory(
+				// Wire the backup-credential clients (STS + kube Secret store) so the
+				// nested public API can issue backup credentials and serve the repo
+				// target/password, not just the DB-only endpoints.
+				public_server::state::AppState::for_nested_mount(
 					state.db.clone(),
 					state.tailnet_directory.clone(),
+					state.sts.clone(),
+					state.kube.clone(),
 				)?,
 			)),
 		)

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -31,6 +31,10 @@ pub struct AppState {
 	/// them here). `None` in non-cluster runs ⇒ onboarding returns 502. Reuses
 	/// the public-server's `BackupSecrets` (kube or in-memory).
 	pub kube: Option<BackupSecrets>,
+	/// STS client passed to the nested `/public` mount so device callers reaching
+	/// it can issue backup credentials (`AssumeRole`) like the standalone public
+	/// server. `None` in non-AWS/test runs.
+	pub sts: Option<aws_sdk_sts::Client>,
 	/// Bucket prober for the setup wizard (assume role + inspect S3). `Aws` in
 	/// prod; a `Fake` canned result in tests / the e2e binary.
 	pub prober: BucketProber,
@@ -73,12 +77,18 @@ impl AppState {
 
 		let kube = BackupSecrets::try_default().await;
 		let prober = BucketProber::try_default().await;
+		// For the nested `/public` mount's backup-credential issuance. Building
+		// the client needs no creds (they resolve per-call from the pod's IRSA
+		// identity), so this is always `Some` in a real run.
+		let aws = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+		let sts = Some(aws_sdk_sts::Client::new(&aws));
 
 		Ok(Self {
 			db: database::init(),
 			ro_pool,
 			tailnet_directory,
 			kube,
+			sts,
 			prober,
 			recovery_recipients: recovery_recipients_from_env(),
 			recovery_challenge: Arc::new(Mutex::new(None)),
@@ -97,6 +107,8 @@ impl AppState {
 			// In-memory secret store so onboarding (Secret creation) is exercised
 			// in tests without a cluster.
 			kube: Some(BackupSecrets::memory()),
+			// No real STS in tests; the nested-mount issuance path isn't exercised.
+			sts: None,
 			// Bucket-name-derived fake prober (matches the e2e fixture): a test
 			// drives each probe state by naming the bucket — `…existing…` → kopia
 			// repo, `…other…` → other content, `…denied…` → inaccessible, else empty.

--- a/crates/private-server/tests/device_admin_endpoints.rs
+++ b/crates/private-server/tests/device_admin_endpoints.rs
@@ -37,6 +37,7 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 			ro_pool: None,
 			tailnet_directory: Some(directory),
 			kube: None,
+			sts: None,
 			prober: private_server::backup_probe::BucketProber::fake(
 				private_server::backup_probe::ProbeState::Empty,
 			),

--- a/crates/private-server/tests/tailnet_device_auth.rs
+++ b/crates/private-server/tests/tailnet_device_auth.rs
@@ -83,6 +83,7 @@ async fn unknown_tailnet_node_auto_creates_untrusted_then_403s_role_gate() {
 				ro_pool: None,
 				tailnet_directory: Some(directory),
 				kube: None,
+				sts: None,
 				prober: private_server::backup_probe::BucketProber::fake(
 					private_server::backup_probe::ProbeState::Empty,
 				),

--- a/crates/public-server/src/state.rs
+++ b/crates/public-server/src/state.rs
@@ -111,6 +111,25 @@ impl AppState {
 			kube: None,
 		})
 	}
+
+	/// Like [`from_db_with_directory`](Self::from_db_with_directory) but with the
+	/// backup-credential clients wired in. private-server's nested `/public`
+	/// mount uses this so device callers reaching it can issue backup credentials
+	/// (STS `AssumeRole`) and fetch the repo target/password (kube Secret store)
+	/// exactly like the standalone public server — the bare `from_db*` base leaves
+	/// both `None`, which 502s the whole backup API.
+	pub fn for_nested_mount(
+		db: Db,
+		tailnet_directory: Option<TailnetDirectory>,
+		sts: Option<aws_sdk_sts::Client>,
+		kube: Option<BackupSecrets>,
+	) -> Result<Self> {
+		Ok(Self {
+			sts,
+			kube,
+			..Self::from_db_with_directory(db, tailnet_directory)?
+		})
+	}
 }
 
 impl FromRef<AppState> for crate::ratelimit::RateLimiter {


### PR DESCRIPTION
🤖 bestool hitting `/backup-target` got `upstream dependency failed: secret store not configured`.

## Cause

private-server mounts the public API at `/public` (device callers reach it over the tailnet). It built that mount's `AppState` with `from_db_with_directory`, which leaves **both** the STS client and the kube Secret store `None`. So every credential-bearing backup endpoint reached through the mount failed:
- `GET /backup-target` → "secret store not configured" (no kube → can't read the repo password),
- `POST /backup-credentials` → would 502 (no STS → can't AssumeRole).

The standalone public-server (`AppState::init()`) and private-server itself both already have these clients — only the nested mount was missing them.

## Fix

`public_server::state::AppState::for_nested_mount(db, dir, sts, kube)` wires the two clients in. private-server now also builds an STS client in `init()` and passes its own `kube` + that STS into the mount. So the whole backup API (`/backup-credentials`, `/backup-target`, `/backup-capabilities`, `/backup-report`) works identically whether a device reaches the standalone public-server or private-server's `/public` mount.

## Note on tests

The handler behaviour is covered by `public-server/tests/backup.rs`; this is a wiring change (compile-verified) so I didn't add a mount-specific integration test — a clean one would need to seed the harness's in-memory Secret store, which the test closure can't reach. Happy to add one (asserting the mount gets past the old "not configured" gate) if you'd like it.