### PR TITLE
ci(cd): build container image for arm64 only

### DIFF
--- a/.github/Dockerfile.native
+++ b/.github/Dockerfile.native
@@ -8,8 +8,6 @@ FROM docker.io/kopia/kopia:0.23.1 AS kopia
 
 FROM busybox:glibc
 
-ARG TARGETPLATFORM
-
 # Create user and group
 RUN addgroup -g 1000 tamanu && adduser -D -u 1000 -G tamanu tamanu
 
@@ -20,19 +18,8 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 # spawns it via a bare `kopia` (PATH lookup), so /usr/bin is correct.
 COPY --from=kopia /usr/bin/kopia /usr/bin/kopia
 
-# Copy all binaries from both architectures
-COPY --chmod=0755 amd64/ /tmp/bins/amd64/
-COPY --chmod=0755 arm64/ /tmp/bins/arm64/
-
-# Select and copy the correct binaries based on target platform
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-        cp /tmp/bins/amd64/* /usr/bin/; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        cp /tmp/bins/arm64/* /usr/bin/; \
-    else \
-        echo "Unknown platform: $TARGETPLATFORM"; exit 1; \
-    fi && \
-    rm -rf /tmp/bins
+# We only build for arm64.
+COPY --chmod=0755 arm64/ /usr/bin/
 
 # Public-server's Tera templates link to /static/public.css and /static/images/...
 # (private-server has its React bundle embedded in the binary).

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,9 +24,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: amd64
-            runner: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
           - arch: arm64
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
@@ -86,12 +83,6 @@ jobs:
       - id: tag
         run: echo "value=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-      - name: Download AMD64 binaries
-        uses: actions/download-artifact@v8
-        with:
-          name: binaries-amd64
-          path: .github/build-context/amd64/
-
       - name: Download ARM64 binaries
         uses: actions/download-artifact@v8
         with:
@@ -124,7 +115,7 @@ jobs:
         with:
           context: .github/build-context
           file: .github/Dockerfile.native
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
🤖 We never deploy the amd64 container image, and building it adds roughly 2 minutes to every CD run.

This drops amd64 from the pipeline:
- Remove the `amd64` entry from the `build-binaries` matrix.
- Remove the "Download AMD64 binaries" step from the image job.
- Set the image build `platforms` to `linux/arm64` only.
- Simplify `Dockerfile.native` to copy the single arch's binaries directly (the old two-arch `TARGETPLATFORM` selection would have failed once no `amd64/` context dir is produced).