### PR TITLE
feat(backups): show server + expandable error in recent runs

### DIFF
--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -253,6 +253,47 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(page.getByText(/bucket bytes:\s*unknown/i)).toBeVisible();
 		await expect(page.getByText(/recent runs/i)).toBeVisible();
 		await expect(page.getByText("success")).toBeVisible();
+		// The run carries a server_id, so the table names which server it's from.
+		const runs = page.getByRole("table").last();
+		await expect(runs.getByText("stats-srv")).toBeVisible();
+	});
+
+	test("failed run shows expandable error detail and no upload size", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "err-group" });
+		const device = await seedDevice(sql);
+		const server = await seedServer(sql, {
+			name: "err-srv",
+			groupId: group.id,
+			deviceId: device.id,
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+			intervalSeconds: 3600,
+		});
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			outcome: "failure",
+			error: "kopia: snapshot failed: disk quota exceeded",
+			bytesUploaded: null,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const runs = page.getByRole("table").last();
+		await expect(runs.getByText("err-srv")).toBeVisible();
+		await expect(runs.getByText("failure")).toBeVisible();
+		// A failed run uploaded nothing → "—", not "unknown".
+		await expect(runs.getByText("—")).toBeVisible();
+
+		// Error detail is hidden until the row is expanded.
+		await expect(page.getByText(/disk quota exceeded/i)).toBeHidden();
+		await runs.getByRole("button", { name: /show error/i }).click();
+		await expect(page.getByText(/disk quota exceeded/i)).toBeVisible();
 	});
 
 	test("backup-now writes a request row; cancel deletes it", async ({

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -4,6 +4,7 @@ import {
 	Button,
 	Chip,
 	CircularProgress,
+	Collapse,
 	Dialog,
 	DialogActions,
 	DialogContent,
@@ -11,6 +12,7 @@ import {
 	DialogTitle,
 	Divider,
 	FormControlLabel,
+	IconButton,
 	LinearProgress,
 	Link as MuiLink,
 	Paper,
@@ -29,6 +31,8 @@ import { useState } from "react";
 import BackupIcon from "@mui/icons-material/Backup";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
@@ -43,6 +47,7 @@ import {
 	BACKUP_STATUS_LABEL,
 	type BackupConfigStatus,
 	type BackupConfigView,
+	type BackupRun,
 	type ServerInfo,
 } from "../types";
 
@@ -189,7 +194,7 @@ export default function BackupPanel() {
 			{status === "ready" && (
 				<>
 					<SchedulesPanel groupId={id} isAdmin={isAdmin} />
-					<StatsPanel groupId={id} />
+					<StatsPanel groupId={id} members={members} />
 					<RunsAndRequests
 						groupId={id}
 						members={members}
@@ -594,7 +599,88 @@ function ProvisioningCard({
 	);
 }
 
-function StatsPanel({ groupId }: { groupId: string }) {
+/// Human label for the server a run came from. Falls back to the host or a
+/// short id when the server has no name, and to "—" for runs with no server.
+function serverLabel(
+	members: ServerInfo[],
+	serverId: string | null | undefined,
+): string {
+	if (!serverId) return "—";
+	const m = members.find((m) => m.id === serverId);
+	return m?.name || m?.display_host || serverId.slice(0, 8);
+}
+
+/// One row of the recent-runs table. Failed runs get an expand toggle that
+/// reveals the device-reported error detail in a collapsible sub-row.
+function RunRow({ run, members }: { run: BackupRun; members: ServerInfo[] }) {
+	const [open, setOpen] = useState(false);
+	const hasError = Boolean(run.error);
+	return (
+		<>
+			<TableRow sx={hasError ? { "& > *": { borderBottom: "unset" } } : undefined}>
+				<TableCell padding="checkbox">
+					{hasError && (
+						<IconButton
+							size="small"
+							aria-label={open ? "Hide error" : "Show error"}
+							onClick={() => setOpen((o) => !o)}
+						>
+							{open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+						</IconButton>
+					)}
+				</TableCell>
+				<TableCell>
+					<TimeAgo timestamp={run.reported_at} />
+				</TableCell>
+				<TableCell>{serverLabel(members, run.server_id)}</TableCell>
+				<TableCell>{run.type}</TableCell>
+				<TableCell>{run.purpose}</TableCell>
+				<TableCell>
+					<Chip
+						size="small"
+						label={run.outcome}
+						color={run.outcome === "success" ? "success" : "error"}
+					/>
+				</TableCell>
+				<TableCell>
+					{run.bytes_uploaded == null
+						? "—"
+						: formatBytes(run.bytes_uploaded)}
+				</TableCell>
+			</TableRow>
+			{hasError && (
+				<TableRow>
+					<TableCell colSpan={7} sx={{ py: 0, border: 0 }}>
+						<Collapse in={open} timeout="auto" unmountOnExit>
+							<Alert severity="error" variant="outlined" sx={{ my: 1 }}>
+								<Typography
+									component="pre"
+									variant="body2"
+									sx={{
+										m: 0,
+										fontFamily: "monospace",
+										whiteSpace: "pre-wrap",
+										wordBreak: "break-word",
+									}}
+								>
+									{run.error}
+								</Typography>
+							</Alert>
+						</Collapse>
+					</TableCell>
+				</TableRow>
+			)}
+		</>
+	);
+}
+
+function StatsPanel({
+	groupId,
+	members,
+}: {
+	groupId: string;
+	members: ServerInfo[];
+}) {
 	const stats = useApi(
 		"backups",
 		"stats",
@@ -642,7 +728,9 @@ function StatsPanel({ groupId }: { groupId: string }) {
 				<Table size="small">
 					<TableHead>
 						<TableRow>
+							<TableCell padding="checkbox" />
 							<TableCell>When</TableCell>
+							<TableCell>Server</TableCell>
 							<TableCell>Type</TableCell>
 							<TableCell>Purpose</TableCell>
 							<TableCell>Outcome</TableCell>
@@ -651,21 +739,7 @@ function StatsPanel({ groupId }: { groupId: string }) {
 					</TableHead>
 					<TableBody>
 						{stats.data.recent_runs.map((r) => (
-							<TableRow key={r.id}>
-								<TableCell>
-									<TimeAgo timestamp={r.reported_at} />
-								</TableCell>
-								<TableCell>{r.type}</TableCell>
-								<TableCell>{r.purpose}</TableCell>
-								<TableCell>
-									<Chip
-										size="small"
-										label={r.outcome}
-										color={r.outcome === "success" ? "success" : "error"}
-									/>
-								</TableCell>
-								<TableCell>{formatBytes(r.bytes_uploaded)}</TableCell>
-							</TableRow>
+							<RunRow key={r.id} run={r} members={members} />
 						))}
 					</TableBody>
 				</Table>


### PR DESCRIPTION
🤖 The backups "Recent runs" table is group-scoped — `BackupRun::list_for_group` returns runs across every member server, mingled together with no way to tell which server each run came from. It also discarded two pieces of information it was already receiving over the wire.

This adds, all frontend-only (no API change — the data was already in `recent_runs`):

- **Server column** — resolves each run's `server_id` against the group's member list (falls back to host, then a short id; `—` for runs with no server).
- **Expandable error detail** — failed runs carry an `error` reason (captured end-to-end in `backup_runs.error`) that the UI was throwing away. Failed rows now get an expand toggle that reveals the device-reported error in a collapsible sub-row.
- **Em dash for empty uploads** — a failed run uploads nothing, so its Uploaded cell showed `unknown`; it now shows `—`.

Playwright coverage extended in `backups.spec.ts`: the existing recent-runs test asserts the server name renders, and a new test seeds a failed run and checks the error is hidden until expanded and that Uploaded shows `—`.