### PR TITLE
feat(backups): add new backup-type defaults from the UI

### DIFF
--- a/private-web/e2e/settings.spec.ts
+++ b/private-web/e2e/settings.spec.ts
@@ -24,10 +24,10 @@ test.describe("Settings", () => {
 	}) => {
 		await page.goto("/settings/backup-defaults");
 		// The seeded tamanu-postgres default is shown.
-		await expect(page.getByText("tamanu-postgres")).toBeVisible();
-
-		await page.getByLabel("Back up every (hours)").fill("8");
-		await page.getByRole("button", { name: /^save$/i }).click();
+		const card = page.getByTestId("type-default-tamanu-postgres");
+		await expect(card).toBeVisible();
+		await card.getByLabel("Back up every (hours)").fill("8");
+		await card.getByRole("button", { name: /^save$/i }).click();
 
 		await expect
 			.poll(async () => {
@@ -38,5 +38,44 @@ test.describe("Settings", () => {
 				return rows[0] ? Number(rows[0].secs) : null;
 			})
 			.toBe(28800);
+	});
+
+	test("backup defaults editor adds a new canopy-wide type default", async ({
+		page,
+		sql,
+	}) => {
+		await page.goto("/settings/backup-defaults");
+
+		const add = page.getByTestId("type-default-new");
+		await add.getByLabel("Backup type").fill("tamanu-files");
+		await add.getByLabel("Back up every (hours)").fill("12");
+		await add.getByRole("button", { name: /add type/i }).click();
+
+		// The new default lands in the DB...
+		await expect
+			.poll(async () => {
+				const rows = await sql.query<{ secs: string }>(
+					`SELECT EXTRACT(EPOCH FROM default_interval)::text AS secs
+					 FROM backup_type_defaults WHERE type = 'tamanu-files'`,
+				);
+				return rows[0] ? Number(rows[0].secs) : null;
+			})
+			.toBe(43200);
+
+		// ...and the list reloads to show it as its own editor card.
+		await expect(page.getByTestId("type-default-tamanu-files")).toBeVisible();
+	});
+
+	test("backup defaults editor blocks adding a duplicate type", async ({
+		page,
+	}) => {
+		await page.goto("/settings/backup-defaults");
+
+		const add = page.getByTestId("type-default-new");
+		await add.getByLabel("Backup type").fill("tamanu-postgres");
+		await expect(
+			add.getByText(/a default for this type already exists/i),
+		).toBeVisible();
+		await expect(add.getByRole("button", { name: /add type/i })).toBeDisabled();
 	});
 });

--- a/private-web/src/routes/BackupDefaults.tsx
+++ b/private-web/src/routes/BackupDefaults.tsx
@@ -2,6 +2,7 @@ import {
 	Alert,
 	Box,
 	Button,
+	Divider,
 	FormControlLabel,
 	LinearProgress,
 	Paper,
@@ -45,11 +46,22 @@ const RETENTION_FIELDS: Array<{ key: keyof Retention; label: string; floor?: num
 	{ key: "keep_annual", label: "Annual" },
 ];
 
+/// A blank default to seed the "add a type" editor: scheduled every 6h with the
+/// retention floor, matching the seeded `tamanu-postgres` default.
+const BLANK_DEFAULT: TypeDefault = {
+	type: "",
+	default_interval: 6 * 3600,
+	default_retention: FLOOR_RETENTION,
+	auto_enable: false,
+};
+
 /// Canopy-wide per-type backup defaults (`backup_type_defaults`): the schedule +
 /// retention each group inherits for a type unless it sets a per-group override.
 export default function BackupDefaults() {
 	usePageTitle("Backup defaults");
 	const defaults = useApi("backups", "type_defaults");
+	// Remounts the "add" editor to a blank state after a successful add.
+	const [addNonce, setAddNonce] = useState(0);
 
 	if (defaults.status === "loading" || defaults.status === "idle") {
 		return <LinearProgress />;
@@ -57,6 +69,8 @@ export default function BackupDefaults() {
 	if (defaults.status === "error") {
 		return <Alert severity="error">{defaults.error.message}</Alert>;
 	}
+
+	const existingTypes = defaults.data.map((d) => d.type);
 
 	return (
 		<Stack spacing={3}>
@@ -76,18 +90,37 @@ export default function BackupDefaults() {
 					/>
 				))
 			)}
+			<Divider />
+			<Typography variant="subtitle2">Add a backup type</Typography>
+			<TypeDefaultEditor
+				key={addNonce}
+				creating
+				existingTypes={existingTypes}
+				value={BLANK_DEFAULT}
+				onSaved={() => {
+					setAddNonce((n) => n + 1);
+					defaults.reload();
+				}}
+			/>
 		</Stack>
 	);
 }
 
 function TypeDefaultEditor({
 	value,
+	creating = false,
+	existingTypes = [],
 	onSaved,
 }: {
 	value: TypeDefault;
+	/// When set, the type name is editable and the action creates a new default.
+	creating?: boolean;
+	/// Types that already have a default — blocks creating a duplicate.
+	existingTypes?: string[];
 	onSaved: () => void;
 }) {
 	const save = useApiAction("backups", "set_type_default");
+	const [typeName, setTypeName] = useState(value.type);
 	const [scheduled, setScheduled] = useState(value.default_interval != null);
 	const [hours, setHours] = useState(
 		value.default_interval != null
@@ -99,13 +132,21 @@ function TypeDefaultEditor({
 		value.default_retention ?? FLOOR_RETENTION,
 	);
 
+	const trimmedType = typeName.trim();
+	const duplicate = creating && existingTypes.includes(trimmedType);
+
 	const floorError = RETENTION_FIELDS.filter(
 		(f) => f.floor != null && retention[f.key] < f.floor,
 	).map((f) => `${f.label} must be ≥ ${f.floor}`);
 
+	const canSave =
+		!save.pending &&
+		floorError.length === 0 &&
+		(!creating || (trimmedType !== "" && !duplicate));
+
 	const onSave = async () => {
 		await save.call({
-			type: value.type,
+			type: creating ? trimmedType : value.type,
 			default_interval: scheduled ? Math.max(1, Number(hours)) * 3600 : null,
 			default_retention: retention,
 			auto_enable: autoEnable,
@@ -114,9 +155,30 @@ function TypeDefaultEditor({
 	};
 
 	return (
-		<Paper variant="outlined" sx={{ p: 2 }}>
+		<Paper
+			variant="outlined"
+			sx={{ p: 2 }}
+			data-testid={creating ? "type-default-new" : `type-default-${value.type}`}
+		>
 			<Stack spacing={1.5}>
-				<Typography sx={{ fontFamily: "monospace" }}>{value.type}</Typography>
+				{creating ? (
+					<TextField
+						label="Backup type"
+						size="small"
+						value={typeName}
+						onChange={(e) => setTypeName(e.target.value)}
+						disabled={save.pending}
+						error={duplicate}
+						helperText={
+							duplicate
+								? "A default for this type already exists"
+								: "The type name bestool advertises, e.g. tamanu-postgres"
+						}
+						sx={{ width: 360 }}
+					/>
+				) : (
+					<Typography sx={{ fontFamily: "monospace" }}>{value.type}</Typography>
+				)}
 				<FormControlLabel
 					control={
 						<Switch
@@ -173,12 +235,14 @@ function TypeDefaultEditor({
 				)}
 				{save.error && <Alert severity="error">{save.error.message}</Alert>}
 				<Box>
-					<Button
-						variant="contained"
-						onClick={onSave}
-						disabled={save.pending || floorError.length > 0}
-					>
-						{save.pending ? "Saving…" : "Save"}
+					<Button variant="contained" onClick={onSave} disabled={!canSave}>
+						{creating
+							? save.pending
+								? "Adding…"
+								: "Add type"
+							: save.pending
+								? "Saving…"
+								: "Save"}
 					</Button>
 				</Box>
 			</Stack>


### PR DESCRIPTION
🤖 Settings → Backup defaults could only *edit* the canopy-wide type defaults that already existed (in practice just the seeded `tamanu-postgres`). There was no way to add a default for a new backup type from the UI, even though the `set_type_default` endpoint already upserts by type.

This adds an **"Add a backup type"** editor at the bottom of the page, reusing the existing schedule / retention / auto-enable controls with an editable, free-text type-name field. `BackupType` is open by design (any name bestool advertises is preserved as `Custom`), so the name is free text; the form blocks empty and duplicate names, and retention stays floor-validated. On add, the list reloads and the new type appears as its own editor card.

No backend change — purely the frontend affordance over the existing endpoint.

Playwright coverage in `settings.spec.ts`: adding a new type writes the row and renders its card, and a duplicate name disables the add button with an inline message. The pre-existing edit test is scoped to its card (the page now has more than one schedule field).