### PR TITLE
feat(private-server): read-only MCP query interface

### DIFF
--- a/.workhorse/specs/private-server/mcp.md
+++ b/.workhorse/specs/private-server/mcp.md
@@ -1,0 +1,71 @@
+---
+id: MCP
+---
+
+# Fleet query interface
+
+A read-only query interface to the Canopy fleet, exposed for AI agents and other automated clients that operators run.
+It lets such a client discover servers and groups, read their status and health, learn what Tamanu versions exist and which are deployed, and inspect backup state and problems — without granting any ability to change the fleet.
+
+## Why it exists
+
+Operators increasingly investigate the fleet through AI agents rather than by hand.
+The operator web UI answers these questions for a human, and the operator API answers them for the web UI, but neither is a surface an agent can discover and call on its own: the agent would have to be told each endpoint and its request shape out of band.
+This interface gives an agent a single, self-describing entry point: it advertises the questions it can answer and the inputs each takes, so a client can enumerate the available queries and call them without prior knowledge of the fleet's internals.
+
+## Access and identity
+
+The interface is part of the operator-facing surface, alongside the operator API and web UI, and is never exposed on the device-facing surface.
+It speaks the Model Context Protocol over HTTP at `/api/mcp`.
+
+Every caller is identified by a tailnet user identity, the same identity the rest of the operator surface uses.
+The interface is available to any human tailnet user, not only to administrators, and is not reachable by tagged automation devices.
+Each query a caller makes is attributable to that identity.
+
+## Read-only
+
+Every query in this interface only reads.
+Nothing it exposes creates, modifies, deletes, or triggers any fleet action, and no query has a side effect beyond being recorded as having happened.
+Mutating the fleet is out of scope for this interface.
+
+## Queries
+
+The interface advertises a fixed catalogue of named queries, each with a described set of inputs and a structured result.
+A client can enumerate the catalogue and read each query's description and inputs before calling it.
+Results carry resolved human-readable labels (such as group and server names) alongside the identifiers they correspond to, so a result is legible on its own without a follow-up lookup.
+
+### Discovery
+
+**Find servers** takes an optional free-text term (matched against name, host, or identifier) and optional filters for kind, rank, and group, plus a flag to include archived servers.
+It returns a bounded list of matching servers in compact form — identifier, name, host, kind, rank, owning group, when each was last seen, its last known version, and its current health.
+When the result is truncated to its bound, the result says so, so the client does not mistake a partial list for the whole.
+
+**Find groups** takes an optional free-text term and returns the matching groups, each with its live member count, its effective version, the highest rank among its members, its backup configuration state, and when it last backed up.
+
+### Detail
+
+**Get server** takes a server identifier and returns the full record for one server: its own fields, its latest reported status (version, overall health and per-check health, host platform, database version, reachability, and when last seen), its owning group, the count of its siblings in that group, which backup types it is capable of, and the most recent successful backup for each.
+
+**Get group** takes a group identifier and returns the full record for one group: its own fields, its members in compact form with each member's version and health, its backup configuration and per-type schedules, its repository statistics, its recent backup and maintenance activity, and when its repository was last inspected.
+
+### Versions
+
+**List versions** optionally includes drafts and returns the known Tamanu versions, each with its number, release status, head release date, a changelog summary, and how many live servers currently report running it.
+
+**Get version** takes a version and returns its detail: its changelog, its known issues, the later versions available as updates from it, and which servers and groups currently run it.
+
+### Fleet triage
+
+**Fleet summary** takes no input and returns a fleet-wide overview: server counts by kind and rank, the distribution of deployed versions, a rollup of server health, the number of groups, and a rollup of backup health.
+
+**Find backup problems** optionally narrows to one group, otherwise scans the whole fleet, and returns the current backup problems with a severity for each: server-and-type pairs whose last successful backup is overdue against its schedule, types that have never reported a backup, groups whose backup repository is in an error state, recent failed backup runs, and maintenance runs that appear stuck.
+
+## Result semantics
+
+A server's reported status reflects reports received within the recent-activity window; a server silent beyond that window reads as not recently seen rather than as a stale "up".
+A server's last known version is retained without that window, so a long-offline server still reports the last version it ran.
+
+The health classifications this interface reports — a server's healthy / warning / unhealthy / unreachable state, and a backup's overdue, never-reported, failed, or stuck classifications — are the same classifications the operator web UI presents for the same data.
+A client and an operator looking at the same server or group reach the same conclusion about whether it is healthy and whether its backups are in good order.
+
+Version adoption counts and the version distribution count live servers by the version each currently reports, so they reflect what is deployed now rather than what has ever been seen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ When adding or changing a UI feature, add Playwright coverage for it in `private
 - Always check: `just check` for basic compilation
 - Run full test suite: `just test`
 - Run specific tests: `just test-name <test_name>`
-- Verify no compilation warnings in tests and main code
+- Verify no compilation warnings in tests and main code, and that `cargo fmt` has been run
 
 ### Tests run on a throwaway RAM-backed Postgres by default
 Each test creates and drops its own database (and runs every migration), and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1859,6 +1860,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1898,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +1928,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -2246,6 +2281,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -4201,6 +4242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4530,7 +4577,9 @@ dependencies = [
  "mime_guess",
  "public-server",
  "rcgen",
+ "rmcp",
  "rust-embed",
+ "schemars",
  "serde",
  "serde_json",
  "tokio",
@@ -4880,6 +4929,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4999,6 +5068,50 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5269,6 +5382,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5402,6 +5541,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5645,6 +5795,19 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -6028,6 +6191,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.40",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/README.md
+++ b/README.md
@@ -175,46 +175,13 @@ In production, the header should be set from a client certificate, as terminated
 - Nginx: use the `$ssl_client_escaped_cert` variable.
 - Caddy: use the `{http.request.tls.client.certificate_pem}` placeholder.
 
-### MCP query interface
-
-The `private-server` exposes a read-only [Model Context Protocol](https://modelcontextprotocol.io)
-endpoint at `/api/mcp`, so AI agents (Claude Code, Claude Desktop, etc.) with tailnet access can
-query the fleet. It is part of the operator surface — available to any authenticated tailnet user,
-not just admins — and never exposed on the device-facing `public-server`. Every tool is read-only;
-nothing it offers changes the fleet.
-
-Available tools:
-
-- `find_servers` / `get_server` — locate servers (by name, host, id, kind, rank, or group) and read
-  full detail (latest status, version, health, platform, owning group, backups).
-- `find_groups` / `get_group` — locate groups and read detail (members, backup config, schedules,
-  repo stats, recent backup/maintenance activity).
-- `list_versions` / `get_version` — known Tamanu versions, known issues, available updates, and
-  which servers run each.
-- `fleet_summary` — counts by kind/rank, version distribution, and health/backup rollups.
-- `find_backup_problems` — overdue/never-reported backups, provisioning errors, recent failed runs,
-  and stuck maintenance, each with a severity.
-
-#### Connecting
-
-In production the endpoint is behind the Tailscale ingress, which injects the caller's identity, so
-point your client at the private-server's tailnet URL with `/api/mcp` appended.
-
-For local development, run the API (`just watch-private-api`, which binds `127.0.0.1:8081`). Debug
-builds bypass Tailscale auth, so no headers are needed.
+### MCP
 
 Claude Code:
 
 ```console
-$ claude mcp add --transport http canopy-local http://127.0.0.1:8081/api/mcp
+$ claude mcp add --transport http canopy https://canopy.tail53aef.ts.net/api/mcp
 ```
 
 Then ask it things like "list the servers in group X" or "which backups are overdue".
 
-To browse the tools and call them by hand, use the MCP Inspector:
-
-```console
-$ npx @modelcontextprotocol/inspector
-```
-
-and connect it to `http://127.0.0.1:8081/api/mcp` (transport: Streamable HTTP).

--- a/README.md
+++ b/README.md
@@ -174,3 +174,47 @@ In production, the header should be set from a client certificate, as terminated
 
 - Nginx: use the `$ssl_client_escaped_cert` variable.
 - Caddy: use the `{http.request.tls.client.certificate_pem}` placeholder.
+
+### MCP query interface
+
+The `private-server` exposes a read-only [Model Context Protocol](https://modelcontextprotocol.io)
+endpoint at `/api/mcp`, so AI agents (Claude Code, Claude Desktop, etc.) with tailnet access can
+query the fleet. It is part of the operator surface — available to any authenticated tailnet user,
+not just admins — and never exposed on the device-facing `public-server`. Every tool is read-only;
+nothing it offers changes the fleet.
+
+Available tools:
+
+- `find_servers` / `get_server` — locate servers (by name, host, id, kind, rank, or group) and read
+  full detail (latest status, version, health, platform, owning group, backups).
+- `find_groups` / `get_group` — locate groups and read detail (members, backup config, schedules,
+  repo stats, recent backup/maintenance activity).
+- `list_versions` / `get_version` — known Tamanu versions, known issues, available updates, and
+  which servers run each.
+- `fleet_summary` — counts by kind/rank, version distribution, and health/backup rollups.
+- `find_backup_problems` — overdue/never-reported backups, provisioning errors, recent failed runs,
+  and stuck maintenance, each with a severity.
+
+#### Connecting
+
+In production the endpoint is behind the Tailscale ingress, which injects the caller's identity, so
+point your client at the private-server's tailnet URL with `/api/mcp` appended.
+
+For local development, run the API (`just watch-private-api`, which binds `127.0.0.1:8081`). Debug
+builds bypass Tailscale auth, so no headers are needed.
+
+Claude Code:
+
+```console
+$ claude mcp add --transport http canopy-local http://127.0.0.1:8081/api/mcp
+```
+
+Then ask it things like "list the servers in group X" or "which backups are overdue".
+
+To browse the tools and call them by hand, use the MCP Inspector:
+
+```console
+$ npx @modelcontextprotocol/inspector
+```
+
+and connect it to `http://127.0.0.1:8081/api/mcp` (transport: Streamable HTTP).

--- a/crates/private-server/Cargo.toml
+++ b/crates/private-server/Cargo.toml
@@ -31,7 +31,9 @@ lloggs = { workspace = true, features = ["miette-7"] }
 mime_guess = "2.0.5"
 miette = { workspace = true, features = ["fancy"] }
 public-server = { path = "../public-server", default-features = false }
+rmcp = { version = "1.8", features = ["server", "macros", "transport-streamable-http-server"] }
 rust-embed = { version = "8.11.0", features = ["mime-guess", "interpolate-folder-path"] }
+schemars = "1"
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = "1.0.150"
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "time"] }

--- a/crates/private-server/src/lib.rs
+++ b/crates/private-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod backup_probe;
 pub mod fns;
+pub mod mcp;
 pub mod openapi;
 pub mod spa;
 pub mod state;
@@ -19,10 +20,18 @@ pub fn routes(state: crate::state::AppState) -> commons_errors::Result<axum::rou
 	// device extractor. Everything else (admin API, Swagger, SPA) is
 	// human-only — the tagged-device guard 403s those callers up front
 	// rather than relying on downstream extractors' opportunistic checks.
+	// Read-only MCP query interface for tailnet agents. Mounted inside the
+	// non-public subtree so it inherits the tagged-device guard; gated on top
+	// by "any tailnet user" (see `mcp::require_tailnet_user`).
+	let mcp: Router<crate::state::AppState> = Router::new()
+		.fallback_service(mcp::service(state.clone()))
+		.layer(middleware::from_fn(mcp::require_tailnet_user));
+
 	let non_public = Router::new()
 		.merge(commons_servers::health::routes())
 		.merge(api_router)
 		.merge(SwaggerUi::new("/api/docs").url("/api/openapi.json", api_spec))
+		.nest("/api/mcp", mcp)
 		.fallback(spa::handler)
 		.layer(middleware::from_fn(
 			commons_servers::tailnet_guard::reject_tagged_devices,

--- a/crates/private-server/src/mcp.rs
+++ b/crates/private-server/src/mcp.rs
@@ -369,7 +369,9 @@ impl CanopyMcp {
 		servers.retain(|s| {
 			kind.as_ref().is_none_or(|k| &s.kind == k)
 				&& rank.as_ref().is_none_or(|r| s.rank.as_ref() == Some(r))
-				&& group.as_ref().is_none_or(|g| s.group_id.as_ref() == Some(g))
+				&& group
+					.as_ref()
+					.is_none_or(|g| s.group_id.as_ref() == Some(g))
 				&& q.as_deref().is_none_or(|q| server_matches(s, q))
 		});
 
@@ -481,8 +483,12 @@ impl CanopyMcp {
 			group_id: server.group_id,
 			group_name: group.as_ref().map(|g| g.name.clone()),
 			sibling_count,
-			reachability: latest.as_ref().map_or(ShortStatus::Gone, |s| s.short_status()),
-			health: latest.as_ref().map_or(HealthState::default(), |s| s.health_state()),
+			reachability: latest
+				.as_ref()
+				.map_or(ShortStatus::Gone, |s| s.short_status()),
+			health: latest
+				.as_ref()
+				.map_or(HealthState::default(), |s| s.health_state()),
 			latest_status,
 			backups,
 		})
@@ -654,10 +660,9 @@ impl CanopyMcp {
 		Parameters(args): Parameters<VersionArgs>,
 	) -> Result<CallToolResult, McpError> {
 		let mut conn = self.conn().await?;
-		let vs = args
-			.version
-			.parse::<VersionStr>()
-			.map_err(|_| McpError::invalid_params(format!("invalid version: {}", args.version), None))?;
+		let vs = args.version.parse::<VersionStr>().map_err(|_| {
+			McpError::invalid_params(format!("invalid version: {}", args.version), None)
+		})?;
 
 		let Ok(version) = Version::get_by_version(&mut conn, vs.clone()).await else {
 			return Ok(not_found(format!("no version {vs}")));
@@ -805,7 +810,10 @@ impl CanopyMcp {
 					group_id: row.group_id,
 					server_id: Some(row.server_id),
 					r#type: Some(row.r#type.to_string()),
-					detail: format!("no successful {} backup within its grace window", row.r#type),
+					detail: format!(
+						"no successful {} backup within its grace window",
+						row.r#type
+					),
 					since: row.last_success_at,
 				}),
 				StalenessVerdict::Never => problems.push(BackupProblem {
@@ -874,7 +882,10 @@ impl CanopyMcp {
 						group_id: c.group_id,
 						server_id: None,
 						r#type: None,
-						detail: format!("{} maintenance still running since {}", m.kind, m.started_at),
+						detail: format!(
+							"{} maintenance still running since {}",
+							m.kind, m.started_at
+						),
 						since: Some(m.started_at),
 					});
 				}
@@ -889,9 +900,7 @@ impl CanopyMcp {
 }
 
 impl CanopyMcp {
-	async fn conn(
-		&self,
-	) -> Result<impl std::ops::DerefMut<Target = AsyncPgConnection>, McpError> {
+	async fn conn(&self) -> Result<impl std::ops::DerefMut<Target = AsyncPgConnection>, McpError> {
 		self.state.db.get().await.map_err(mcp_err)
 	}
 
@@ -902,7 +911,9 @@ impl CanopyMcp {
 	) -> Result<HashMap<String, u32>, McpError> {
 		let servers = Server::get_all(conn, 0, None).await.map_err(mcp_err)?;
 		let ids: Vec<Uuid> = servers.iter().map(|s| s.id).collect();
-		let statuses = Status::latest_for_servers(conn, &ids).await.map_err(mcp_err)?;
+		let statuses = Status::latest_for_servers(conn, &ids)
+			.await
+			.map_err(mcp_err)?;
 		let mut adoption: HashMap<String, u32> = HashMap::new();
 		for st in &statuses {
 			if let Some(v) = &st.version {
@@ -951,9 +962,10 @@ fn summarize(s: &Server, st: Option<&Status>, group_name: Option<String>) -> Ser
 }
 
 fn server_matches(s: &Server, q: &str) -> bool {
-	s.name.as_deref().is_some_and(|n| n.to_lowercase().contains(q))
-		|| s
-			.host
+	s.name
+		.as_deref()
+		.is_some_and(|n| n.to_lowercase().contains(q))
+		|| s.host
 			.as_ref()
 			.is_some_and(|h| h.0.to_string().to_lowercase().contains(q))
 		|| s.id.to_string().contains(q)
@@ -967,10 +979,7 @@ fn first_line(s: &str) -> String {
 	s.lines().next().unwrap_or("").trim().to_string()
 }
 
-fn parse_opt<T: std::str::FromStr>(
-	v: &Option<String>,
-	field: &str,
-) -> Result<Option<T>, McpError> {
+fn parse_opt<T: std::str::FromStr>(v: &Option<String>, field: &str) -> Result<Option<T>, McpError> {
 	match v.as_deref() {
 		Some(s) => s
 			.parse::<T>()

--- a/crates/private-server/src/mcp.rs
+++ b/crates/private-server/src/mcp.rs
@@ -1,0 +1,1040 @@
+//! Read-only MCP (Model Context Protocol) query interface over the fleet.
+//!
+//! Spec: `.workhorse/specs/private-server/mcp.md` (id `MCP`).
+//!
+//! Mounted at `/api/mcp` on the operator surface, behind the tagged-device
+//! guard and an "any tailnet user" gate (see [`require_tailnet_user`]). Every
+//! tool only reads; nothing here mutates the fleet.
+//!
+//! Tools call the existing `database` read functions directly and shape lean,
+//! agent-legible JSON. The one piece of logic that must NOT be reimplemented is
+//! backup staleness ("overdue" / "never reported"): [`find_backup_problems`]
+//! and [`fleet_summary`] reuse [`database::backup::staleness`] so the verdicts
+//! match what the operator UI and the alerting sweep present.
+
+use std::collections::HashMap;
+
+use commons_types::{
+	Uuid,
+	backup::{BackupConfigStatus, BackupPlacement, BackupRepoMode, RunOutcome},
+	server::{kind::ServerKind, rank::ServerRank},
+	status::{HealthState, ShortStatus},
+	version::VersionStr,
+};
+use database::{
+	backup::staleness::{StalenessVerdict, scan_rows},
+	backups::{
+		BackupMaintenanceRun, BackupRepoSnapshot, BackupRepoStats, BackupRun,
+		ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
+	},
+	diesel_async::AsyncPgConnection,
+	server_groups::ServerGroup,
+	servers::Server,
+	statuses::Status,
+	version_known_issues::VersionKnownIssue,
+	versions::Version,
+};
+use jiff::{SignedDuration, Timestamp};
+use rmcp::{
+	ServerHandler,
+	handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+	model::{CallToolResult, Content, ErrorData as McpError, ServerCapabilities, ServerInfo},
+	tool, tool_handler, tool_router,
+	transport::streamable_http_server::{
+		StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+	},
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::state::AppState;
+
+/// A run still open this long after it started is treated as stuck.
+const STUCK_MAINTENANCE_AFTER: SignedDuration = SignedDuration::from_hours(6);
+/// Only the last day of failed runs is surfaced, to bound noise.
+const FAILED_RUN_WINDOW: SignedDuration = SignedDuration::from_hours(24);
+/// Default cap on `find_servers` results.
+const DEFAULT_SERVER_LIMIT: u64 = 200;
+
+#[derive(Clone)]
+pub struct CanopyMcp {
+	state: AppState,
+	tool_router: ToolRouter<CanopyMcp>,
+}
+
+// ---------------------------------------------------------------------------
+// Tool argument types (JSON Schema is generated from these). Identifiers are
+// taken as strings and parsed, so callers don't need a UUID schema.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindServersArgs {
+	/// Free-text term matched against name, host, or id (case-insensitive).
+	pub query: Option<String>,
+	/// Filter by kind: `central`, `facility`, or `canopy`.
+	pub kind: Option<String>,
+	/// Filter by rank: `production`, `clone`, `demo`, `test`, or `dev`.
+	pub rank: Option<String>,
+	/// Filter to one group's id.
+	pub group_id: Option<String>,
+	/// Include archived (soft-deleted) servers. Defaults to false.
+	pub include_archived: Option<bool>,
+	/// Max results to return (default 200).
+	pub limit: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ServerIdArgs {
+	/// The server's id.
+	pub server_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindGroupsArgs {
+	/// Free-text term matched against group name or id. Omit to list all.
+	pub query: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GroupIdArgs {
+	/// The group's id.
+	pub group_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListVersionsArgs {
+	/// Include draft (unpublished) versions. Defaults to false.
+	pub include_drafts: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct VersionArgs {
+	/// The Tamanu version, e.g. `2.34.1`.
+	pub version: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct EmptyArgs {}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindBackupProblemsArgs {
+	/// Narrow the scan to one group's id. Omit to scan the whole fleet.
+	pub group_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Output types.
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ServerSummary {
+	id: Uuid,
+	name: Option<String>,
+	host: Option<String>,
+	kind: ServerKind,
+	rank: Option<ServerRank>,
+	group_id: Option<Uuid>,
+	group_name: Option<String>,
+	is_monitored: bool,
+	archived: bool,
+	/// When the most recent status was received, if any.
+	last_seen: Option<Timestamp>,
+	/// Last known Tamanu version (retained even when long offline).
+	version: Option<VersionStr>,
+	reachability: ShortStatus,
+	health: HealthState,
+}
+
+#[derive(Serialize)]
+struct FindServersResult {
+	total_matched: usize,
+	returned: usize,
+	truncated: bool,
+	servers: Vec<ServerSummary>,
+}
+
+#[derive(Serialize)]
+struct StatusOut {
+	reported_at: Timestamp,
+	version: Option<VersionStr>,
+	health: HealthState,
+	healthy: bool,
+	reachability: ShortStatus,
+	platform: Option<String>,
+	postgres_version: Option<String>,
+	/// Raw per-check breakdown from the status push.
+	checks: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct BackupCapabilityOut {
+	r#type: String,
+	enabled: bool,
+	last_successful_backup_at: Option<Timestamp>,
+	last_snapshot_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ServerDetail {
+	id: Uuid,
+	name: Option<String>,
+	host: Option<String>,
+	kind: ServerKind,
+	rank: Option<ServerRank>,
+	cloud: Option<bool>,
+	is_monitored: bool,
+	archived: bool,
+	notes: String,
+	registered_at: Option<Timestamp>,
+	group_id: Option<Uuid>,
+	group_name: Option<String>,
+	sibling_count: usize,
+	reachability: ShortStatus,
+	health: HealthState,
+	latest_status: Option<StatusOut>,
+	backups: Vec<BackupCapabilityOut>,
+}
+
+#[derive(Serialize)]
+struct GroupList {
+	groups: Vec<GroupSummary>,
+}
+
+#[derive(Serialize)]
+struct GroupSummary {
+	id: Uuid,
+	name: String,
+	member_count: i64,
+	effective_version: Option<VersionStr>,
+	highest_rank: Option<ServerRank>,
+	backup_config: Option<BackupConfigStatus>,
+	last_backup_at: Option<Timestamp>,
+}
+
+#[derive(Serialize)]
+struct BackupConfigOut {
+	status: BackupConfigStatus,
+	bucket: String,
+	prefix: String,
+	region: Option<String>,
+	mode: BackupRepoMode,
+	placement: BackupPlacement,
+	last_init_error: Option<String>,
+	created_at: Timestamp,
+	updated_at: Timestamp,
+}
+
+#[derive(Serialize)]
+struct GroupBackups {
+	config: Option<BackupConfigOut>,
+	schedules: Vec<ServerGroupBackupSchedule>,
+	repo_stats: Option<BackupRepoStats>,
+	recent_runs: Vec<BackupRun>,
+	maintenance_runs: Vec<BackupMaintenanceRun>,
+	repo_snapshots: Vec<BackupRepoSnapshot>,
+	last_inspected_at: Option<Timestamp>,
+}
+
+#[derive(Serialize)]
+struct GroupDetail {
+	id: Uuid,
+	name: String,
+	notes: String,
+	tags: commons_types::server::TagMap,
+	effective_version: Option<VersionStr>,
+	created_at: Timestamp,
+	updated_at: Timestamp,
+	members: Vec<ServerSummary>,
+	backups: GroupBackups,
+}
+
+#[derive(Serialize)]
+struct VersionList {
+	versions: Vec<VersionSummary>,
+}
+
+#[derive(Serialize)]
+struct VersionSummary {
+	version: String,
+	status: String,
+	head_release_date: Option<Timestamp>,
+	changelog_summary: String,
+	/// Live servers currently reporting this version.
+	adoption: u32,
+}
+
+#[derive(Serialize)]
+struct ServerRef {
+	id: Uuid,
+	name: Option<String>,
+}
+
+#[derive(Serialize)]
+struct VersionDetail {
+	version: String,
+	status: String,
+	head_release_date: Option<Timestamp>,
+	changelog: String,
+	known_issues: Vec<VersionKnownIssue>,
+	available_updates: Vec<String>,
+	adoption_count: usize,
+	adopting_servers: Vec<ServerRef>,
+}
+
+#[derive(Serialize, Default)]
+struct Counts {
+	by_kind: HashMap<String, usize>,
+	by_rank: HashMap<String, usize>,
+}
+
+#[derive(Serialize, Default)]
+struct HealthRollup {
+	healthy: usize,
+	warning: usize,
+	unhealthy: usize,
+	unreachable: usize,
+}
+
+#[derive(Serialize, Default)]
+struct BackupRollup {
+	groups_configured: usize,
+	groups_ready: usize,
+	overdue: usize,
+	never_reported: usize,
+}
+
+#[derive(Serialize)]
+struct FleetSummary {
+	total_servers: usize,
+	groups: usize,
+	counts: Counts,
+	health: HealthRollup,
+	version_distribution: HashMap<String, usize>,
+	backups: BackupRollup,
+}
+
+#[derive(Serialize)]
+struct BackupProblem {
+	kind: &'static str,
+	severity: &'static str,
+	group_id: Uuid,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	server_id: Option<Uuid>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	r#type: Option<String>,
+	detail: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	since: Option<Timestamp>,
+}
+
+#[derive(Serialize)]
+struct BackupProblems {
+	count: usize,
+	problems: Vec<BackupProblem>,
+}
+
+// ---------------------------------------------------------------------------
+// Tools.
+// ---------------------------------------------------------------------------
+
+#[tool_router]
+impl CanopyMcp {
+	pub fn new(state: AppState) -> Self {
+		Self {
+			state,
+			tool_router: Self::tool_router(),
+		}
+	}
+
+	#[tool(
+		description = "Find servers by name/host/id substring, optionally filtered by kind, rank, \
+		               or group. Returns compact records with last-seen, version, and health."
+	)]
+	async fn find_servers(
+		&self,
+		Parameters(args): Parameters<FindServersArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let kind = parse_opt::<ServerKind>(&args.kind, "kind")?;
+		let rank = parse_opt::<ServerRank>(&args.rank, "rank")?;
+		let group = parse_opt_uuid(&args.group_id, "group_id")?;
+		let limit = args.limit.unwrap_or(DEFAULT_SERVER_LIMIT) as usize;
+
+		let mut servers = Server::get_all(&mut conn, 0, None).await.map_err(mcp_err)?;
+		if args.include_archived.unwrap_or(false) {
+			servers.extend(Server::list_archived(&mut conn).await.map_err(mcp_err)?);
+		}
+
+		let q = args.query.as_deref().map(str::to_lowercase);
+		servers.retain(|s| {
+			kind.as_ref().is_none_or(|k| &s.kind == k)
+				&& rank.as_ref().is_none_or(|r| s.rank.as_ref() == Some(r))
+				&& group.as_ref().is_none_or(|g| s.group_id.as_ref() == Some(g))
+				&& q.as_deref().is_none_or(|q| server_matches(s, q))
+		});
+
+		let total_matched = servers.len();
+		let truncated = total_matched > limit;
+		servers.truncate(limit);
+		if truncated {
+			tracing::info!(total_matched, limit, "find_servers result truncated");
+		}
+
+		let ids: Vec<Uuid> = servers.iter().map(|s| s.id).collect();
+		let statuses = Status::latest_for_servers(&mut conn, &ids)
+			.await
+			.map_err(mcp_err)?;
+		let st_by: HashMap<Uuid, &Status> = statuses.iter().map(|s| (s.server_id, s)).collect();
+		let group_names = Server::group_names_by_server_ids(&mut conn, &ids)
+			.await
+			.map_err(mcp_err)?;
+
+		let summaries: Vec<ServerSummary> = servers
+			.iter()
+			.map(|s| {
+				summarize(
+					s,
+					st_by.get(&s.id).copied(),
+					group_names.get(&s.id).cloned().flatten(),
+				)
+			})
+			.collect();
+
+		ok_json(&FindServersResult {
+			total_matched,
+			returned: summaries.len(),
+			truncated,
+			servers: summaries,
+		})
+	}
+
+	#[tool(
+		description = "Full detail for one server: fields, latest status (version, health, \
+		               platform, postgres), owning group, sibling count, and backups."
+	)]
+	async fn get_server(
+		&self,
+		Parameters(args): Parameters<ServerIdArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let id = parse_uuid(&args.server_id, "server_id")?;
+
+		let Ok(server) = Server::get_by_id(&mut conn, id).await else {
+			return Ok(not_found(format!("no server with id {id}")));
+		};
+
+		let latest = Status::latest_for_server(&mut conn, id)
+			.await
+			.map_err(mcp_err)?;
+		let last_versioned = Status::last_with_version_for_server(&mut conn, id)
+			.await
+			.map_err(mcp_err)?;
+		let version = latest
+			.as_ref()
+			.and_then(|s| s.version.clone())
+			.or_else(|| last_versioned.and_then(|s| s.version));
+
+		let group = match server.group_id {
+			Some(gid) => ServerGroup::get_by_id(&mut conn, gid).await.ok(),
+			None => None,
+		};
+		let sibling_count = server.siblings(&mut conn).await.map_err(mcp_err)?.len();
+
+		let caps = ServerBackupCapability::list_for_server(&mut conn, id)
+			.await
+			.map_err(mcp_err)?;
+		let mut backups = Vec::with_capacity(caps.len());
+		for cap in &caps {
+			let last = BackupRun::latest_success_for_server(&mut conn, id, &cap.r#type)
+				.await
+				.map_err(mcp_err)?;
+			backups.push(BackupCapabilityOut {
+				r#type: cap.r#type.to_string(),
+				enabled: cap.enabled,
+				last_successful_backup_at: last.as_ref().map(|r| r.reported_at),
+				last_snapshot_id: last.and_then(|r| r.snapshot_id),
+			});
+		}
+
+		let latest_status = latest.as_ref().map(|s| StatusOut {
+			reported_at: s.created_at,
+			version: version.clone(),
+			health: s.health_state(),
+			healthy: s.healthy,
+			reachability: s.short_status(),
+			platform: s.platform(),
+			postgres_version: s.postgres_version(),
+			checks: s.health.clone(),
+		});
+
+		ok_json(&ServerDetail {
+			id: server.id,
+			name: server.name.clone(),
+			host: server.host.as_ref().map(|h| h.0.to_string()),
+			kind: server.kind,
+			rank: server.rank,
+			cloud: server.cloud,
+			is_monitored: server.is_monitored,
+			archived: server.deleted_at.is_some(),
+			notes: server.notes.clone(),
+			registered_at: server.registered_at,
+			group_id: server.group_id,
+			group_name: group.as_ref().map(|g| g.name.clone()),
+			sibling_count,
+			reachability: latest.as_ref().map_or(ShortStatus::Gone, |s| s.short_status()),
+			health: latest.as_ref().map_or(HealthState::default(), |s| s.health_state()),
+			latest_status,
+			backups,
+		})
+	}
+
+	#[tool(
+		description = "Find server groups by name/id, with live member count, effective version, \
+		               highest member rank, backup config state, and last-backup time."
+	)]
+	async fn find_groups(
+		&self,
+		Parameters(args): Parameters<FindGroupsArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let groups = match args.query.as_deref() {
+			Some(q) if !q.is_empty() => ServerGroup::search(&mut conn, q).await.map_err(mcp_err)?,
+			_ => ServerGroup::list_all(&mut conn).await.map_err(mcp_err)?,
+		};
+		let ids: Vec<Uuid> = groups.iter().map(|g| g.id).collect();
+		let counts = ServerGroup::live_server_counts(&mut conn)
+			.await
+			.map_err(mcp_err)?;
+		let ranks = ServerGroup::highest_member_ranks(&mut conn, &ids)
+			.await
+			.map_err(mcp_err)?;
+		let configs = ServerGroupBackupConfig::list(&mut conn)
+			.await
+			.map_err(mcp_err)?;
+		let cfg_status: HashMap<Uuid, BackupConfigStatus> =
+			configs.iter().map(|c| (c.group_id, c.status)).collect();
+
+		let mut out = Vec::with_capacity(groups.len());
+		for g in &groups {
+			let last_backup_at = BackupRun::latest_backup_at_for_group(&mut conn, g.id)
+				.await
+				.map_err(mcp_err)?;
+			out.push(GroupSummary {
+				id: g.id,
+				name: g.name.clone(),
+				member_count: counts.get(&g.id).copied().unwrap_or(0),
+				effective_version: g.effective_version.clone(),
+				highest_rank: ranks.get(&g.id).cloned(),
+				backup_config: cfg_status.get(&g.id).copied(),
+				last_backup_at,
+			});
+		}
+		ok_json(&GroupList { groups: out })
+	}
+
+	#[tool(
+		description = "Full detail for one group: members (with version/health), backup config, \
+		               schedules, repo stats, and recent backup/maintenance activity."
+	)]
+	async fn get_group(
+		&self,
+		Parameters(args): Parameters<GroupIdArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let id = parse_uuid(&args.group_id, "group_id")?;
+		let Ok(group) = ServerGroup::get_by_id(&mut conn, id).await else {
+			return Ok(not_found(format!("no group with id {id}")));
+		};
+
+		let members = group.list_servers(&mut conn).await.map_err(mcp_err)?;
+		let mids: Vec<Uuid> = members.iter().map(|s| s.id).collect();
+		let statuses = Status::latest_for_servers(&mut conn, &mids)
+			.await
+			.map_err(mcp_err)?;
+		let st_by: HashMap<Uuid, &Status> = statuses.iter().map(|s| (s.server_id, s)).collect();
+		let member_summaries = members
+			.iter()
+			.map(|s| summarize(s, st_by.get(&s.id).copied(), Some(group.name.clone())))
+			.collect();
+
+		let config = ServerGroupBackupConfig::get(&mut conn, id)
+			.await
+			.map_err(mcp_err)?
+			.map(|c| BackupConfigOut {
+				status: c.status,
+				bucket: c.bucket,
+				prefix: c.prefix,
+				region: c.region,
+				mode: c.mode,
+				placement: c.placement,
+				last_init_error: c.last_init_error,
+				created_at: c.created_at,
+				updated_at: c.updated_at,
+			});
+		let schedules = ServerGroupBackupSchedule::list_for_group(&mut conn, id)
+			.await
+			.map_err(mcp_err)?;
+		let repo_stats = BackupRepoStats::get(&mut conn, id).await.map_err(mcp_err)?;
+		let recent_runs = BackupRun::list_for_group(&mut conn, id, 10)
+			.await
+			.map_err(mcp_err)?;
+		let maintenance_runs = BackupMaintenanceRun::list_for_group(&mut conn, id, 5)
+			.await
+			.map_err(mcp_err)?;
+		let repo_snapshots = BackupRepoSnapshot::list_for_group(&mut conn, id)
+			.await
+			.map_err(mcp_err)?;
+		let last_inspected_at = BackupRepoSnapshot::last_inspected_at_for_group(&mut conn, id)
+			.await
+			.map_err(mcp_err)?;
+
+		ok_json(&GroupDetail {
+			id: group.id,
+			name: group.name.clone(),
+			notes: group.notes.clone(),
+			tags: group.tags.clone(),
+			effective_version: group.effective_version.clone(),
+			created_at: group.created_at,
+			updated_at: group.updated_at,
+			members: member_summaries,
+			backups: GroupBackups {
+				config,
+				schedules,
+				repo_stats,
+				recent_runs,
+				maintenance_runs,
+				repo_snapshots,
+				last_inspected_at,
+			},
+		})
+	}
+
+	#[tool(
+		description = "List known Tamanu versions with release date, changelog summary, and how \
+		               many live servers currently run each."
+	)]
+	async fn list_versions(
+		&self,
+		Parameters(args): Parameters<ListVersionsArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let versions = if args.include_drafts.unwrap_or(false) {
+			Version::get_all_including_drafts(&mut conn).await
+		} else {
+			Version::get_all(&mut conn).await
+		}
+		.map_err(mcp_err)?;
+
+		let adoption = self.version_adoption(&mut conn).await?;
+
+		let mut out = Vec::with_capacity(versions.len());
+		for v in &versions {
+			let vs = version_str(v);
+			let head_release_date = match vs.parse::<VersionStr>() {
+				Ok(p) => Version::get_head_release_date(&mut conn, p).await.ok(),
+				Err(_) => None,
+			};
+			out.push(VersionSummary {
+				version: vs.clone(),
+				status: v.status.to_string(),
+				head_release_date,
+				changelog_summary: first_line(&v.changelog),
+				adoption: adoption.get(&vs).copied().unwrap_or(0),
+			});
+		}
+		ok_json(&VersionList { versions: out })
+	}
+
+	#[tool(
+		description = "Detail for one Tamanu version: changelog, known issues, available updates, \
+		               and which live servers run it."
+	)]
+	async fn get_version(
+		&self,
+		Parameters(args): Parameters<VersionArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let vs = args
+			.version
+			.parse::<VersionStr>()
+			.map_err(|_| McpError::invalid_params(format!("invalid version: {}", args.version), None))?;
+
+		let Ok(version) = Version::get_by_version(&mut conn, vs.clone()).await else {
+			return Ok(not_found(format!("no version {vs}")));
+		};
+
+		let known_issues =
+			VersionKnownIssue::list_for_minor(&mut conn, version.major, version.minor)
+				.await
+				.map_err(mcp_err)?;
+		let available_updates = Version::get_updates_for_version(&mut conn, vs.clone())
+			.await
+			.map_err(mcp_err)?
+			.into_iter()
+			.map(|u| format!("{}.{}.{}", u.major, u.minor, u.patch))
+			.collect();
+		let head_release_date = Version::get_head_release_date(&mut conn, vs.clone())
+			.await
+			.ok();
+
+		// Adoption: live servers whose latest status reports this version.
+		let servers = Server::get_all(&mut conn, 0, None).await.map_err(mcp_err)?;
+		let ids: Vec<Uuid> = servers.iter().map(|s| s.id).collect();
+		let statuses = Status::latest_for_servers(&mut conn, &ids)
+			.await
+			.map_err(mcp_err)?;
+		let target = vs.to_string();
+		let on_version: std::collections::HashSet<Uuid> = statuses
+			.iter()
+			.filter(|s| s.version.as_ref().map(|v| v.to_string()) == Some(target.clone()))
+			.map(|s| s.server_id)
+			.collect();
+		let adopting_servers: Vec<ServerRef> = servers
+			.iter()
+			.filter(|s| on_version.contains(&s.id))
+			.map(|s| ServerRef {
+				id: s.id,
+				name: s.name.clone(),
+			})
+			.collect();
+
+		ok_json(&VersionDetail {
+			version: target,
+			status: version.status.to_string(),
+			head_release_date,
+			changelog: version.changelog.clone(),
+			known_issues,
+			available_updates,
+			adoption_count: adopting_servers.len(),
+			adopting_servers,
+		})
+	}
+
+	#[tool(
+		description = "Fleet-wide overview: server counts by kind/rank, version distribution, a \
+		               health rollup, and a backup-health rollup."
+	)]
+	async fn fleet_summary(
+		&self,
+		Parameters(_): Parameters<EmptyArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let servers = Server::get_all(&mut conn, 0, None).await.map_err(mcp_err)?;
+		let ids: Vec<Uuid> = servers.iter().map(|s| s.id).collect();
+		let statuses = Status::latest_for_servers(&mut conn, &ids)
+			.await
+			.map_err(mcp_err)?;
+		let st_by: HashMap<Uuid, &Status> = statuses.iter().map(|s| (s.server_id, s)).collect();
+
+		let mut counts = Counts::default();
+		let mut health = HealthRollup::default();
+		let mut version_distribution: HashMap<String, usize> = HashMap::new();
+		for s in &servers {
+			*counts.by_kind.entry(s.kind.to_string()).or_default() += 1;
+			if let Some(r) = &s.rank {
+				*counts.by_rank.entry(r.to_string()).or_default() += 1;
+			}
+			let st = st_by.get(&s.id).copied();
+			match st.map_or(ShortStatus::Gone, |s| s.short_status()) {
+				ShortStatus::Down | ShortStatus::Gone => health.unreachable += 1,
+				_ => match st.map_or(HealthState::default(), |s| s.health_state()) {
+					HealthState::Healthy => health.healthy += 1,
+					HealthState::Warning => health.warning += 1,
+					HealthState::Unhealthy => health.unhealthy += 1,
+				},
+			}
+			if let Some(v) = st.and_then(|s| s.version.as_ref()) {
+				*version_distribution.entry(v.to_string()).or_default() += 1;
+			}
+		}
+
+		let groups = ServerGroup::list_all(&mut conn).await.map_err(mcp_err)?;
+		let configs = ServerGroupBackupConfig::list(&mut conn)
+			.await
+			.map_err(mcp_err)?;
+		let mut backups = BackupRollup {
+			groups_configured: configs.len(),
+			groups_ready: configs
+				.iter()
+				.filter(|c| c.status == BackupConfigStatus::Ready)
+				.count(),
+			..Default::default()
+		};
+		let now = Timestamp::now();
+		for row in scan_rows(&mut conn).await.map_err(mcp_err)? {
+			match row.classify(now, false) {
+				StalenessVerdict::Stale => backups.overdue += 1,
+				StalenessVerdict::Never => backups.never_reported += 1,
+				_ => {}
+			}
+		}
+
+		ok_json(&FleetSummary {
+			total_servers: servers.len(),
+			groups: groups.len(),
+			counts,
+			health,
+			version_distribution,
+			backups,
+		})
+	}
+
+	#[tool(
+		description = "Scan for current backup problems (fleet-wide, or one group): overdue and \
+		               never-reported backups, provisioning errors, recent failed runs, and stuck \
+		               maintenance. Each problem carries a severity."
+	)]
+	async fn find_backup_problems(
+		&self,
+		Parameters(args): Parameters<FindBackupProblemsArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let only_group = parse_opt_uuid(&args.group_id, "group_id")?;
+		let now = Timestamp::now();
+		let mut problems = Vec::new();
+
+		// Overdue / never-reported, from the canonical staleness scan.
+		for row in scan_rows(&mut conn).await.map_err(mcp_err)? {
+			if only_group.is_some_and(|g| row.group_id != g) {
+				continue;
+			}
+			match row.classify(now, false) {
+				StalenessVerdict::Stale => problems.push(BackupProblem {
+					kind: "overdue_backup",
+					severity: "error",
+					group_id: row.group_id,
+					server_id: Some(row.server_id),
+					r#type: Some(row.r#type.to_string()),
+					detail: format!("no successful {} backup within its grace window", row.r#type),
+					since: row.last_success_at,
+				}),
+				StalenessVerdict::Never => problems.push(BackupProblem {
+					kind: "never_backed_up",
+					severity: "warning",
+					group_id: row.group_id,
+					server_id: Some(row.server_id),
+					r#type: Some(row.r#type.to_string()),
+					detail: format!("never reported a successful {} backup", row.r#type),
+					since: None,
+				}),
+				_ => {}
+			}
+		}
+
+		// Per-group: provisioning errors, recent failed runs, stuck maintenance.
+		let configs = ServerGroupBackupConfig::list(&mut conn)
+			.await
+			.map_err(mcp_err)?;
+		for c in &configs {
+			if only_group.is_some_and(|g| c.group_id != g) {
+				continue;
+			}
+			if let Some(err) = &c.last_init_error {
+				problems.push(BackupProblem {
+					kind: "provisioning_error",
+					severity: "error",
+					group_id: c.group_id,
+					server_id: None,
+					r#type: None,
+					detail: err.clone(),
+					since: None,
+				});
+			}
+			for run in BackupRun::list_for_group(&mut conn, c.group_id, 20)
+				.await
+				.map_err(mcp_err)?
+			{
+				if run.outcome == RunOutcome::Failure
+					&& now.duration_since(run.reported_at) <= FAILED_RUN_WINDOW
+				{
+					problems.push(BackupProblem {
+						kind: "failed_run",
+						severity: "warning",
+						group_id: c.group_id,
+						server_id: run.server_id,
+						r#type: Some(run.r#type.to_string()),
+						detail: run
+							.error
+							.clone()
+							.unwrap_or_else(|| "backup run failed".into()),
+						since: Some(run.reported_at),
+					});
+				}
+			}
+			for m in BackupMaintenanceRun::list_for_group(&mut conn, c.group_id, 5)
+				.await
+				.map_err(mcp_err)?
+			{
+				if m.finished_at.is_none()
+					&& now.duration_since(m.started_at) > STUCK_MAINTENANCE_AFTER
+				{
+					problems.push(BackupProblem {
+						kind: "stuck_maintenance",
+						severity: "warning",
+						group_id: c.group_id,
+						server_id: None,
+						r#type: None,
+						detail: format!("{} maintenance still running since {}", m.kind, m.started_at),
+						since: Some(m.started_at),
+					});
+				}
+			}
+		}
+
+		ok_json(&BackupProblems {
+			count: problems.len(),
+			problems,
+		})
+	}
+}
+
+impl CanopyMcp {
+	async fn conn(
+		&self,
+	) -> Result<impl std::ops::DerefMut<Target = AsyncPgConnection>, McpError> {
+		self.state.db.get().await.map_err(mcp_err)
+	}
+
+	/// Count of live servers reporting each version (by version string).
+	async fn version_adoption(
+		&self,
+		conn: &mut AsyncPgConnection,
+	) -> Result<HashMap<String, u32>, McpError> {
+		let servers = Server::get_all(conn, 0, None).await.map_err(mcp_err)?;
+		let ids: Vec<Uuid> = servers.iter().map(|s| s.id).collect();
+		let statuses = Status::latest_for_servers(conn, &ids).await.map_err(mcp_err)?;
+		let mut adoption: HashMap<String, u32> = HashMap::new();
+		for st in &statuses {
+			if let Some(v) = &st.version {
+				*adoption.entry(v.to_string()).or_default() += 1;
+			}
+		}
+		Ok(adoption)
+	}
+}
+
+#[tool_handler(router = self.tool_router.clone())]
+impl ServerHandler for CanopyMcp {
+	fn get_info(&self) -> ServerInfo {
+		let mut info = ServerInfo::default();
+		info.instructions = Some(
+			"Read-only access to the Canopy fleet: servers, groups, health/status, Tamanu \
+			 versions, and backups. All data is live. Use find_* to locate entities and get_* \
+			 for detail; fleet_summary and find_backup_problems for triage."
+				.into(),
+		);
+		info.capabilities = ServerCapabilities::builder().enable_tools().build();
+		info
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+fn summarize(s: &Server, st: Option<&Status>, group_name: Option<String>) -> ServerSummary {
+	ServerSummary {
+		id: s.id,
+		name: s.name.clone(),
+		host: s.host.as_ref().map(|h| h.0.to_string()),
+		kind: s.kind,
+		rank: s.rank,
+		group_id: s.group_id,
+		group_name,
+		is_monitored: s.is_monitored,
+		archived: s.deleted_at.is_some(),
+		last_seen: st.map(|s| s.created_at),
+		version: st.and_then(|s| s.version.clone()),
+		reachability: st.map_or(ShortStatus::Gone, |s| s.short_status()),
+		health: st.map_or(HealthState::default(), |s| s.health_state()),
+	}
+}
+
+fn server_matches(s: &Server, q: &str) -> bool {
+	s.name.as_deref().is_some_and(|n| n.to_lowercase().contains(q))
+		|| s
+			.host
+			.as_ref()
+			.is_some_and(|h| h.0.to_string().to_lowercase().contains(q))
+		|| s.id.to_string().contains(q)
+}
+
+fn version_str(v: &Version) -> String {
+	format!("{}.{}.{}", v.major, v.minor, v.patch)
+}
+
+fn first_line(s: &str) -> String {
+	s.lines().next().unwrap_or("").trim().to_string()
+}
+
+fn parse_opt<T: std::str::FromStr>(
+	v: &Option<String>,
+	field: &str,
+) -> Result<Option<T>, McpError> {
+	match v.as_deref() {
+		Some(s) => s
+			.parse::<T>()
+			.map(Some)
+			.map_err(|_| McpError::invalid_params(format!("invalid {field}: {s}"), None)),
+		None => Ok(None),
+	}
+}
+
+fn parse_uuid(s: &str, field: &str) -> Result<Uuid, McpError> {
+	Uuid::parse_str(s).map_err(|_| McpError::invalid_params(format!("invalid {field}: {s}"), None))
+}
+
+fn parse_opt_uuid(v: &Option<String>, field: &str) -> Result<Option<Uuid>, McpError> {
+	v.as_deref().map(|s| parse_uuid(s, field)).transpose()
+}
+
+/// Serialize a payload into a tool result, providing both the structured
+/// content (for clients that read it) and a pretty-printed text fallback.
+fn ok_json<T: Serialize>(value: &T) -> Result<CallToolResult, McpError> {
+	let json = serde_json::to_value(value).map_err(mcp_err)?;
+	let text = serde_json::to_string_pretty(&json).map_err(mcp_err)?;
+	let mut result = CallToolResult::success(vec![Content::text(text)]);
+	result.structured_content = Some(json);
+	Ok(result)
+}
+
+/// A "ran successfully but found nothing" result the caller's client renders.
+fn not_found(message: String) -> CallToolResult {
+	CallToolResult::error(vec![Content::text(message)])
+}
+
+/// Map any internal/db error into an MCP protocol error.
+fn mcp_err(e: impl std::fmt::Display) -> McpError {
+	McpError::internal_error(e.to_string(), None)
+}
+
+// ---------------------------------------------------------------------------
+// Service wiring.
+// ---------------------------------------------------------------------------
+
+/// Build the tower service nested into the axum router at `/api/mcp`.
+pub fn service(state: AppState) -> StreamableHttpService<CanopyMcp, LocalSessionManager> {
+	StreamableHttpService::new(
+		move || Ok(CanopyMcp::new(state.clone())),
+		LocalSessionManager::default().into(),
+		StreamableHttpServerConfig::default(),
+	)
+}
+
+/// Gate the MCP mount on an authenticated tailnet user (any user, not only
+/// admins). Reuses the operator surface's `TailscaleUser` extractor, so the
+/// debug-build dev bypass applies in local dev and tests. The caller's login is
+/// logged so each query is attributable.
+pub async fn require_tailnet_user(
+	req: axum::extract::Request,
+	next: axum::middleware::Next,
+) -> Result<axum::response::Response, commons_errors::AppError> {
+	use axum::extract::FromRequestParts as _;
+	use commons_servers::tailscale_auth::TailscaleUser;
+
+	let (mut parts, body) = req.into_parts();
+	let user = TailscaleUser::from_request_parts(&mut parts, &()).await?;
+	tracing::info!(login = %user.login, "mcp request");
+	let req = axum::extract::Request::from_parts(parts, body);
+	Ok(next.run(req).await)
+}

--- a/crates/private-server/tests/mcp.rs
+++ b/crates/private-server/tests/mcp.rs
@@ -1,0 +1,300 @@
+//! Tests for the read-only MCP query interface mounted at `/api/mcp`.
+//!
+//! The debug build bypasses Tailscale auth, so no headers are needed. These
+//! drive the real protocol path (initialize → tools/call over Streamable HTTP)
+//! against seeded data and assert the structured results, so they cover both
+//! the wiring and each tool's data shaping.
+
+use commons_tests::diesel_async::SimpleAsyncConnection;
+
+/// The Streamable HTTP transport requires the client to accept both JSON and
+/// SSE on the POST leg.
+const ACCEPT: &str = "application/json, text/event-stream";
+
+/// Extract the JSON-RPC envelope from a Streamable HTTP response body, which is
+/// either a bare JSON object or an SSE stream whose `data:` line carries it.
+fn parse_envelope(body: &str) -> serde_json::Value {
+	let trimmed = body.trim_start();
+	if trimmed.starts_with('{') {
+		return serde_json::from_str(trimmed).expect("json body");
+	}
+	let data = body
+		.lines()
+		.filter_map(|l| l.strip_prefix("data:"))
+		.last()
+		.unwrap_or_else(|| panic!("no SSE data line in: {body}"));
+	serde_json::from_str(data.trim()).expect("json in SSE data line")
+}
+
+/// Initialize a session and return its id. Expanded inline so the test never
+/// has to name `axum_test::TestServer`.
+macro_rules! init_session {
+	($private:expr) => {{
+		let init = $private
+			.post("/api/mcp")
+			.add_header("accept", ACCEPT)
+			.json(&serde_json::json!({
+				"jsonrpc": "2.0", "id": 1, "method": "initialize",
+				"params": {
+					"protocolVersion": "2025-06-18",
+					"capabilities": {},
+					"clientInfo": { "name": "canopy-tests", "version": "0" }
+				}
+			}))
+			.await;
+		assert_eq!(init.status_code().as_u16(), 200, "initialize should 200");
+		let session = init
+			.headers()
+			.get("mcp-session-id")
+			.expect("session id")
+			.to_str()
+			.unwrap()
+			.to_owned();
+		$private
+			.post("/api/mcp")
+			.add_header("accept", ACCEPT)
+			.add_header("mcp-session-id", &session)
+			.json(&serde_json::json!({
+				"jsonrpc": "2.0", "method": "notifications/initialized"
+			}))
+			.await;
+		session
+	}};
+}
+
+/// Call a tool and return its `structuredContent`. Asserts the call succeeded
+/// (no JSON-RPC error and `isError` is not true).
+macro_rules! call_tool {
+	($private:expr, $session:expr, $name:expr, $args:expr) => {{
+		let resp = $private
+			.post("/api/mcp")
+			.add_header("accept", ACCEPT)
+			.add_header("mcp-session-id", &$session)
+			.json(&serde_json::json!({
+				"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+				"params": { "name": $name, "arguments": $args }
+			}))
+			.await;
+		assert_eq!(resp.status_code().as_u16(), 200, "{} should 200", $name);
+		let env = parse_envelope(&resp.text());
+		assert!(env.get("error").is_none(), "{} rpc error: {env}", $name);
+		let result = env.get("result").expect("result").clone();
+		assert_ne!(
+			result.get("isError").and_then(|v| v.as_bool()),
+			Some(true),
+			"{} returned a tool error: {result}",
+			$name
+		);
+		result
+			.get("structuredContent")
+			.cloned()
+			.unwrap_or(serde_json::Value::Null)
+	}};
+}
+
+/// Seed a group, two servers (one grouped + monitored with a fresh healthy
+/// status, one ungrouped), and a backup config + capability + schedule.
+const GROUP: &str = "11111111-1111-1111-1111-111111111111";
+const SRV_GROUPED: &str = "22222222-2222-2222-2222-222222222222";
+const SRV_UNGROUPED: &str = "33333333-3333-3333-3333-333333333333";
+
+async fn seed(conn: &mut impl SimpleAsyncConnection) {
+	conn.batch_execute(&format!(
+		"INSERT INTO server_groups (id, name) VALUES ('{GROUP}', 'Prod Group'); \
+		 INSERT INTO servers (id, host, name, kind, rank, group_id, is_monitored) VALUES \
+			('{SRV_GROUPED}', 'https://prod-central', 'Prod Central', 'central', 'production', '{GROUP}', true); \
+		 INSERT INTO servers (id, host, name, kind) VALUES \
+			('{SRV_UNGROUPED}', 'https://lonely', 'Lonely Facility', 'facility'); \
+		 INSERT INTO statuses (server_id, version, healthy, health, extra, created_at) VALUES \
+			('{SRV_GROUPED}', '2.34.1', true, '[]'::jsonb, \
+			 '{{\"pgVersion\": \"PostgreSQL 14.2 on x86_64-pc-linux-gnu\"}}'::jsonb, NOW() - interval '1 minute');"
+	))
+	.await
+	.expect("seed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn initialize_and_list_tools() {
+	commons_tests::server::run(async |_conn, _public, private| {
+		let session = init_session!(private);
+		let list = private
+			.post("/api/mcp")
+			.add_header("accept", ACCEPT)
+			.add_header("mcp-session-id", &session)
+			.json(&serde_json::json!({
+				"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}
+			}))
+			.await;
+		assert_eq!(list.status_code().as_u16(), 200);
+		let body = list.text();
+		for tool in [
+			"find_servers",
+			"get_server",
+			"find_groups",
+			"get_group",
+			"list_versions",
+			"get_version",
+			"fleet_summary",
+			"find_backup_problems",
+		] {
+			assert!(body.contains(tool), "tools/list missing {tool}: {body}");
+		}
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn find_servers_filters_and_decorates() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed(&mut conn).await;
+		let session = init_session!(private);
+
+		// Unfiltered: both seeded servers.
+		let all = call_tool!(private, session, "find_servers", serde_json::json!({}));
+		assert!(all["total_matched"].as_u64().unwrap() >= 2);
+
+		// Filter by kind=facility → only the ungrouped one.
+		let facility = call_tool!(
+			private,
+			session,
+			"find_servers",
+			serde_json::json!({ "kind": "facility" })
+		);
+		let servers = facility["servers"].as_array().unwrap();
+		assert_eq!(servers.len(), 1);
+		assert_eq!(servers[0]["id"], SRV_UNGROUPED);
+		assert_eq!(servers[0]["health"], "healthy");
+
+		// Query matches by name.
+		let q = call_tool!(
+			private,
+			session,
+			"find_servers",
+			serde_json::json!({ "query": "central" })
+		);
+		let names: Vec<&str> = q["servers"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.map(|s| s["name"].as_str().unwrap())
+			.collect();
+		assert_eq!(names, vec!["Prod Central"]);
+
+		// Bad enum → invalid params (protocol error).
+		let bad = private
+			.post("/api/mcp")
+			.add_header("accept", ACCEPT)
+			.add_header("mcp-session-id", &session)
+			.json(&serde_json::json!({
+				"jsonrpc": "2.0", "id": 9, "method": "tools/call",
+				"params": { "name": "find_servers", "arguments": { "kind": "nonsense" } }
+			}))
+			.await;
+		let env = parse_envelope(&bad.text());
+		assert!(
+			env.get("error").is_some() || env["result"]["isError"] == serde_json::json!(true),
+			"bad kind should error: {env}"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_server_detail_and_not_found() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed(&mut conn).await;
+		let session = init_session!(private);
+
+		let detail = call_tool!(
+			private,
+			session,
+			"get_server",
+			serde_json::json!({ "server_id": SRV_GROUPED })
+		);
+		assert_eq!(detail["name"], "Prod Central");
+		assert_eq!(detail["group_name"], "Prod Group");
+		assert_eq!(detail["latest_status"]["version"], "2.34.1");
+		assert_eq!(detail["latest_status"]["platform"], "Linux");
+
+		// Unknown id → tool error (isError), not a protocol error.
+		let missing = private
+			.post("/api/mcp")
+			.add_header("accept", ACCEPT)
+			.add_header("mcp-session-id", &session)
+			.json(&serde_json::json!({
+				"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+				"params": {
+					"name": "get_server",
+					"arguments": { "server_id": "44444444-4444-4444-4444-444444444444" }
+				}
+			}))
+			.await;
+		let env = parse_envelope(&missing.text());
+		assert_eq!(env["result"]["isError"], serde_json::json!(true));
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn group_listing_and_detail() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed(&mut conn).await;
+		let session = init_session!(private);
+
+		let groups = call_tool!(private, session, "find_groups", serde_json::json!({}));
+		let g = groups["groups"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|g| g["id"] == GROUP)
+			.expect("seeded group present");
+		assert_eq!(g["name"], "Prod Group");
+		assert_eq!(g["member_count"], 1);
+		assert_eq!(g["highest_rank"], "production");
+
+		let detail = call_tool!(
+			private,
+			session,
+			"get_group",
+			serde_json::json!({ "group_id": GROUP })
+		);
+		assert_eq!(detail["name"], "Prod Group");
+		let members = detail["members"].as_array().unwrap();
+		assert_eq!(members.len(), 1);
+		assert_eq!(members[0]["id"], SRV_GROUPED);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fleet_summary_rolls_up() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed(&mut conn).await;
+		let session = init_session!(private);
+
+		let s = call_tool!(private, session, "fleet_summary", serde_json::json!({}));
+		assert!(s["total_servers"].as_u64().unwrap() >= 2);
+		assert_eq!(s["counts"]["by_kind"]["facility"], 1);
+		assert_eq!(s["version_distribution"]["2.34.1"], 1);
+		assert_eq!(s["health"]["healthy"], 1);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backup_problems_scan_runs() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed(&mut conn).await;
+		let session = init_session!(private);
+		// No ready backup config seeded, so the scan returns an empty, well-formed set.
+		let p = call_tool!(
+			private,
+			session,
+			"find_backup_problems",
+			serde_json::json!({})
+		);
+		assert!(p["count"].is_number());
+		assert!(p["problems"].is_array());
+	})
+	.await
+}


### PR DESCRIPTION
🤖 Adds a read-only [Model Context Protocol](https://modelcontextprotocol.io) endpoint at `/api/mcp` on the private-server, so AI agents with tailnet access can query the fleet — find servers and groups, read status/health, Tamanu versions, and backup information.

Spec: `.workhorse/specs/private-server/mcp.md` (id `MCP`).

## Access

Part of the operator surface, behind the existing tagged-device guard and gated on **any authenticated tailnet user** (reuses the `TailscaleUser` extractor, so debug builds keep their dev-auth bypass). Never exposed on the device-facing `public-server`. Every tool is read-only.

## Tools

- `find_servers` / `get_server`
- `find_groups` / `get_group`
- `list_versions` / `get_version`
- `fleet_summary`
- `find_backup_problems`

All call existing `database` read functions. Backup overdue/never-reported classification reuses `database::backup::staleness` rather than reimplementing, so MCP verdicts match the operator UI and the alerting sweep.

## Notes

- Built on the official `rmcp` 1.8 SDK over Streamable HTTP, nested into the axum router as a tower service.
- Not added to `openapi.json` — MCP self-describes via `tools/list`, and no REST handlers changed.
- README has a new section on connecting Claude Code / the MCP Inspector.

TAM-6877