### PR TITLE
fix(backups): grant kopia s3:DeleteObject (version-less) + reap delete-markers [TAM-6877]

### DIFF
--- a/crates/jobs/src/backup/provision.rs
+++ b/crates/jobs/src/backup/provision.rs
@@ -18,9 +18,8 @@ use aws_sdk_s3::types::{
 	AbortIncompleteMultipartUpload, BucketLifecycleConfiguration, BucketLocationConstraint,
 	BucketVersioningStatus, CreateBucketConfiguration, DefaultRetention, ExpirationStatus,
 	LifecycleExpiration, LifecycleRule, LifecycleRuleFilter, NoncurrentVersionExpiration,
-	ObjectLockConfiguration,
-	ObjectLockEnabled, ObjectLockRetentionMode, ObjectLockRule, PublicAccessBlockConfiguration,
-	Tag, Tagging, VersioningConfiguration,
+	ObjectLockConfiguration, ObjectLockEnabled, ObjectLockRetentionMode, ObjectLockRule,
+	PublicAccessBlockConfiguration, Tag, Tagging, VersioningConfiguration,
 };
 
 /// Default Object Lock retention applied bucket-wide (server-side on every PUT,

--- a/crates/jobs/src/backup/provision.rs
+++ b/crates/jobs/src/backup/provision.rs
@@ -17,7 +17,8 @@ use aws_sdk_s3::operation::create_bucket::CreateBucketError;
 use aws_sdk_s3::types::{
 	AbortIncompleteMultipartUpload, BucketLifecycleConfiguration, BucketLocationConstraint,
 	BucketVersioningStatus, CreateBucketConfiguration, DefaultRetention, ExpirationStatus,
-	LifecycleRule, LifecycleRuleFilter, NoncurrentVersionExpiration, ObjectLockConfiguration,
+	LifecycleExpiration, LifecycleRule, LifecycleRuleFilter, NoncurrentVersionExpiration,
+	ObjectLockConfiguration,
 	ObjectLockEnabled, ObjectLockRetentionMode, ObjectLockRule, PublicAccessBlockConfiguration,
 	Tag, Tagging, VersioningConfiguration,
 };
@@ -198,7 +199,8 @@ async fn create_bucket(s3: &aws_sdk_s3::Client, bucket: &str, region: &str) -> R
 }
 
 /// Reclaim lifecycle for the versioned, object-locked bucket: noncurrent
-/// versions expire (lock governs the actual delete time) and incomplete
+/// versions expire (lock governs the actual delete time), the delete-markers
+/// kopia leaves once their noncurrent version is gone are reaped, and incomplete
 /// multipart uploads are aborted.
 fn lifecycle() -> Result<BucketLifecycleConfiguration> {
 	let rule = LifecycleRule::builder()
@@ -208,6 +210,14 @@ fn lifecycle() -> Result<BucketLifecycleConfiguration> {
 		.noncurrent_version_expiration(
 			NoncurrentVersionExpiration::builder()
 				.noncurrent_days(1)
+				.build(),
+		)
+		// kopia deletes are version-less, so each leaves a delete-marker; once its
+		// last noncurrent version expires, clean up the dangling marker too (else
+		// they accumulate forever). Marker-only expiry — no Days/Date.
+		.expiration(
+			LifecycleExpiration::builder()
+				.expired_object_delete_marker(true)
 				.build(),
 		)
 		.abort_incomplete_multipart_upload(

--- a/crates/jobs/src/backup/tag_reconcile.rs
+++ b/crates/jobs/src/backup/tag_reconcile.rs
@@ -1,10 +1,17 @@
-//! Billing-tag reconcile. Per tick (slow, slot-jittered daily cadence), re-apply
-//! each `ready` group's `billing.*` tags to its bucket when they've drifted —
-//! catching group renames / rank changes (the bucket *name* can't follow a
-//! rename, but `billing.deployment` does). Covers both placements: shared buckets
-//! via the provisioner role, external (BYO) buckets via the group's maintenance
-//! role. Best-effort: on any error (e.g. an external account whose maintenance
-//! role doesn't yet grant `PutBucketTagging`), log + continue, never alert.
+//! Bucket reconcile. Per tick (slow, slot-jittered daily cadence), converge each
+//! `ready` group's bucket toward what canopy wants — so config changes reach
+//! already-provisioned buckets, not just newly-created ones:
+//!
+//! - **Shared** (canopy-managed): re-apply the whole idempotent provisioning
+//!   recipe via the provisioner role (object-lock, versioning, lifecycle incl.
+//!   delete-marker reaping, the TLS-only policy, and the `billing.*` tags).
+//! - **External** (BYO): reconcile only the `billing.*` tags via the group's
+//!   maintenance role — canopy never owns a BYO bucket's own config.
+//!
+//! Tag drift catches group renames / rank changes (the bucket *name* can't follow
+//! a rename, but `billing.deployment` does). Best-effort: on any error (e.g. an
+//! external account whose maintenance role doesn't yet grant `PutBucketTagging`),
+//! log + continue, never alert.
 
 use std::time::Duration;
 
@@ -72,11 +79,29 @@ async fn tick(db: &mut diesel_async::AsyncPgConnection) -> Result<(), String> {
 		let tags =
 			backup_bucket_billing_tags(&group.tags, &group.name, ranks.get(&c.group_id).copied());
 		let region = c.region.as_deref().unwrap_or("us-east-1");
-		match super::provision::reconcile_bucket_tags(&role_arn, &c.bucket, region, &tags).await {
-			Ok(true) => debug!(group = %c.group_id, "tag-reconcile: applied billing tags"),
-			Ok(false) => {}
-			// Best-effort: an external role without PutBucketTagging lands here.
-			Err(e) => warn!(group = %c.group_id, "tag-reconcile failed (non-fatal): {e:#}"),
+		let result = match c.placement {
+			// Shared buckets are canopy-managed: re-apply the whole (idempotent)
+			// provisioning recipe so changes to it — object-lock, lifecycle (incl.
+			// delete-marker reaping), the TLS-only policy, billing tags — converge
+			// on already-provisioned buckets, not just newly-created ones.
+			BackupPlacement::Shared => {
+				super::provision::ensure_bucket(&role_arn, &c.bucket, region, &tags)
+					.await
+					.map(|()| "reconciled shared bucket")
+			}
+			// BYO buckets: canopy owns only the billing tags, never the bucket's
+			// own config — reconcile tags alone, via the group's maintenance role.
+			BackupPlacement::External => {
+				super::provision::reconcile_bucket_tags(&role_arn, &c.bucket, region, &tags)
+					.await
+					.map(|changed| if changed { "applied billing tags" } else { "" })
+			}
+		};
+		match result {
+			Ok("") => {}
+			Ok(msg) => debug!(group = %c.group_id, "bucket-reconcile: {msg}"),
+			// Best-effort: e.g. an external role without PutBucketTagging lands here.
+			Err(e) => warn!(group = %c.group_id, "bucket-reconcile failed (non-fatal): {e:#}"),
 		}
 	}
 	Ok(())

--- a/crates/public-server/src/backup.rs
+++ b/crates/public-server/src/backup.rs
@@ -230,16 +230,21 @@ pub fn restore_session_policy(bucket: &str, prefix: &str) -> String {
 	.to_string()
 }
 
-/// Build the write-without-delete **backup** session policy for a bucket/prefix.
-/// Grants exactly the kopia `AWS_S3_MULTIPART_ACTIONS` set — **no**
-/// `DeleteObject`, **no** `PutObjectRetention` (the bucket's default Object Lock
-/// retention applies server-side) — scoped to this one bucket. Attached to every
-/// backup issuance: redundant for a dedicated per-bucket role (external), but the
-/// linchpin of shared-account isolation (the shared device role is broad over
-/// `bes-canopy-backup-*`, so the session policy is what confines a device's creds
-/// to its own bucket). `GetBucketLocation`/`ListBucketMultipartUploads` are
-/// unconditioned bucket-level; `ListBucket` is prefix-conditioned (the
-/// `s3:prefix` key isn't populated for the others).
+/// Build the **backup** session policy for a bucket/prefix. Grants the kopia
+/// multipart write set **plus `s3:DeleteObject`** — but **no**
+/// `s3:DeleteObjectVersion`, `s3:BypassGovernanceRetention`, or
+/// `s3:PutObjectRetention` — scoped to this one bucket. kopia needs delete to
+/// manage its own metadata (session markers, index compaction, manifests); on
+/// our versioned + GOVERNANCE-locked buckets a version-less `DeleteObject` only
+/// writes a delete-marker — the locked version stays immutable and is reclaimed
+/// by the bucket lifecycle once its lock lapses — so a compromised device still
+/// can't destroy backups (it can at most write recoverable delete-markers).
+/// Attached to every backup issuance: redundant for a dedicated per-bucket role
+/// (external), but the linchpin of shared-account isolation (the shared device
+/// role is broad over `bes-canopy-backup-*`, so the session policy is what
+/// confines a device's creds to its own bucket). `GetBucketLocation`/
+/// `ListBucketMultipartUploads` are unconditioned bucket-level; `ListBucket` is
+/// prefix-conditioned (the `s3:prefix` key isn't populated for the others).
 pub fn backup_session_policy(bucket: &str, prefix: &str) -> String {
 	serde_json::json!({
 		"Version": "2012-10-17",
@@ -249,6 +254,7 @@ pub fn backup_session_policy(bucket: &str, prefix: &str) -> String {
 				"Action": [
 					"s3:GetObject",
 					"s3:PutObject",
+					"s3:DeleteObject",
 					"s3:AbortMultipartUpload",
 					"s3:ListMultipartUploadParts",
 				],
@@ -579,15 +585,22 @@ mod tests {
 	}
 
 	#[test]
-	fn backup_policy_grants_write_without_delete_scoped_to_bucket() {
+	fn backup_policy_grants_delete_but_not_version_delete_or_retention() {
 		let policy = backup_session_policy("my-bucket", "");
 		let v: serde_json::Value = serde_json::from_str(&policy).unwrap();
 		let stmts = v["Statement"].as_array().unwrap();
 
-		// Object-level write set, scoped to the bucket.
+		// Object-level write+delete set, scoped to the bucket. DeleteObject is
+		// required so kopia can write its delete-markers (metadata management);
+		// it's version-less, so the locked version stays immutable.
 		assert_eq!(stmts[0]["Resource"], "arn:aws:s3:::my-bucket/*");
 		let obj_actions = stmts[0]["Action"].as_array().unwrap();
-		for needed in ["s3:GetObject", "s3:PutObject", "s3:AbortMultipartUpload"] {
+		for needed in [
+			"s3:GetObject",
+			"s3:PutObject",
+			"s3:DeleteObject",
+			"s3:AbortMultipartUpload",
+		] {
 			assert!(
 				obj_actions.contains(&serde_json::json!(needed)),
 				"missing {needed}"
@@ -599,9 +612,15 @@ mod tests {
 			serde_json::json!(["*"]),
 		);
 
-		// The device must never be able to delete or shorten locks.
+		// The device must never be able to remove a *locked version* or weaken a
+		// lock — only version-less DeleteObject (delete-markers) is allowed.
 		let blob = policy.to_lowercase();
-		for forbidden in ["deleteobject", "putobjectretention", "putbucketobjectlock"] {
+		for forbidden in [
+			"deleteobjectversion",
+			"bypassgovernanceretention",
+			"putobjectretention",
+			"putbucketobjectlock",
+		] {
 			assert!(
 				!blob.contains(forbidden),
 				"backup policy must not grant {forbidden}"


### PR DESCRIPTION
🤖 Device backups were failing `AccessDenied` on `s3:DeleteObject`. kopia genuinely needs delete to manage its own metadata (session markers, index compaction, manifests) — there's no working delete-less kopia mode. Denying it bought no protection: on our **versioned + GOVERNANCE-locked** buckets a *version-less* `DeleteObject` only writes a delete-marker; the locked version is immutable and reclaimed by lifecycle once the lock lapses. So a compromised device still can't destroy backups — the worst it can do is write recoverable delete-markers.

## Changes

- **`backup_session_policy`** (the per-issuance cap on every device cred, shared + external) now grants `s3:DeleteObject` — but **not** `s3:DeleteObjectVersion`, `s3:BypassGovernanceRetention`, or `s3:PutObjectRetention`, so a device can never remove a locked version or weaken a lock.
- **Provisioning recipe lifecycle** now also reaps **expired delete-markers** (`ExpiredObjectDeleteMarker`), so the markers kopia leaves don't accumulate once their noncurrent version is gone.
- **Shared-bucket reconcile** (`tag_reconcile`) now re-applies the **full idempotent recipe** for shared placement — so recipe changes (this lifecycle, the TLS-only policy, object-lock) converge on **already-provisioned** shared buckets, not just newly-created ones. External stays tags-only (canopy never owns a BYO bucket's config).

## Pairs with ops/pulumi

The session policy intersects with the device **role** policy, so the shared device role must also grant `DeleteObject` — done in a paired ops/pulumi change (shared `DEVICE_S3_ACTIONS` → `AWS_S3_DELETE_ACTIONS`; external role already grants it). That change also adds the delete-marker reaping to the external bucket lifecycle.

## Tests

- Updated the session-policy unit test: asserts `DeleteObject` is granted and `DeleteObjectVersion`/`BypassGovernanceRetention`/`PutObjectRetention` are still forbidden.
- Provision recipe + lifecycle-builder tests pass with the new rule.