### PR TITLE
fix(backups): resolve retention per declared type, not just enabled [TAM-6877]

### DIFF
--- a/crates/commons-servers/src/backup_jobs.rs
+++ b/crates/commons-servers/src/backup_jobs.rs
@@ -103,14 +103,16 @@ fn resolve_policy(override_json: Option<Value>, default_json: Option<Value>) -> 
 	}
 }
 
-/// Resolve the effective retention policy for each backup type enabled in the
-/// group: schedule override → type default → org floor, with the floor always
-/// enforced. Returns one `(type, policy)` pair per enabled type.
+/// Resolve the effective retention policy for each backup type **declared** in
+/// the group (not just enabled): schedule override → type default → org floor,
+/// with the floor always enforced. Returns one `(type, policy)` pair per declared
+/// type — so a manual backup of a non-scheduled (disabled) type is still retained
+/// under its own type policy rather than only the repo's global baseline.
 pub async fn effective_retention_for_group(
 	db: &mut AsyncPgConnection,
 	group_id: Uuid,
 ) -> Result<Vec<(BackupType, RetentionPolicy)>> {
-	let types = ServerBackupCapability::enabled_types_for_group(db, group_id).await?;
+	let types = ServerBackupCapability::declared_types_for_group(db, group_id).await?;
 	let mut out = Vec::with_capacity(types.len());
 	for ty in types {
 		let override_json = ServerGroupBackupSchedule::get(db, group_id, &ty)

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -504,21 +504,43 @@ impl ServerBackupCapability {
 	}
 
 	/// Distinct backup types that are **enabled** on any non-archived server in
-	/// the group — i.e. the types the group's repo is actively expected to
-	/// hold. The scheduler resolves a per-type retention/cadence for each of
-	/// these.
+	/// the group — i.e. the types the group is actively expected to back up on a
+	/// schedule. Used for scheduling cadence and staleness alerting.
 	pub async fn enabled_types_for_group(
 		db: &mut AsyncPgConnection,
 		group_id: Uuid,
 	) -> Result<Vec<BackupType>> {
+		Self::types_for_group(db, group_id, true).await
+	}
+
+	/// Distinct backup types **declared** (advertised by bestool) on any
+	/// non-archived server in the group, regardless of their enabled flag — i.e.
+	/// every type the repo can hold snapshots for, including manual-only
+	/// (disabled) ones. Retention is resolved per declared type so a manual
+	/// backup of a non-scheduled type still gets its own policy, not the global.
+	pub async fn declared_types_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<Vec<BackupType>> {
+		Self::types_for_group(db, group_id, false).await
+	}
+
+	async fn types_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		enabled_only: bool,
+	) -> Result<Vec<BackupType>> {
 		use crate::schema::{server_backup_capabilities as cap, servers};
 
-		cap::table
+		let mut q = cap::table
 			.inner_join(servers::table.on(servers::id.eq(cap::server_id)))
 			.filter(servers::group_id.eq(group_id))
 			.filter(servers::deleted_at.is_null())
-			.filter(cap::enabled.eq(true))
-			.select(cap::type_)
+			.into_boxed();
+		if enabled_only {
+			q = q.filter(cap::enabled.eq(true));
+		}
+		q.select(cap::type_)
 			.distinct()
 			.load::<BackupType>(db)
 			.await

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -857,8 +857,11 @@ pub struct GroupTypeScheduleView {
 	pub next_run_at: Option<Timestamp>,
 }
 
-/// Per enabled backup type, the group's effective schedule/retention (override
-/// or inherited default) — drives the per-type editor in the group panel.
+/// Per **declared** backup type (not just enabled), the group's effective
+/// schedule/retention (override or inherited default) — drives the per-type
+/// editor in the group panel. Includes non-scheduled (disabled) types, since a
+/// manual backup of one is still retained under its own type policy; those show
+/// a null `effective_interval` ("manual only").
 #[utoipa::path(
 	post,
 	path = "/group_schedules",
@@ -874,7 +877,7 @@ pub async fn group_schedules(
 ) -> Result<Json<Vec<GroupTypeScheduleView>>> {
 	let mut conn = state.db.get().await?;
 	let types =
-		ServerBackupCapability::enabled_types_for_group(&mut conn, args.server_group_id).await?;
+		ServerBackupCapability::declared_types_for_group(&mut conn, args.server_group_id).await?;
 
 	// Anchor for the next-expected-run estimate: the group's most recent
 	// successful backup per type (max over its servers).

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -498,6 +498,43 @@ async fn group_schedules_reports_next_run_from_last_success_plus_interval() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn group_schedules_includes_disabled_declared_types() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let server_id = Uuid::new_v4();
+		// A *declared but disabled* type (manual-only): retention still applies, so
+		// it must surface in schedule/retention as a manual-only entry.
+		conn.batch_execute(&format!(
+			"INSERT INTO servers (id, host, kind, group_id) VALUES \
+				('{server_id}', 'https://e.test', 'central', '{group_id}');
+			 INSERT INTO server_backup_capabilities (server_id, type, enabled) VALUES \
+				('{server_id}', 'files', false);"
+		))
+		.await
+		.expect("seed disabled capability");
+
+		let resp = private
+			.post("/api/backups/group_schedules")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		let row = body
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|r| r["type"] == "files")
+			.expect("disabled declared type appears in schedule/retention");
+		// Manual-only: no schedule, but a (floor) retention policy that applies to
+		// manual backups of this type.
+		assert!(row["effective_interval"].is_null());
+		assert!(row["next_run_at"].is_null());
+		assert!(row["effective_retention"]["keep_daily"].as_i64().unwrap() >= 7);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn update_region_and_delete() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -556,7 +556,7 @@
         "tags": [
           "backups"
         ],
-        "summary": "Per enabled backup type, the group's effective schedule/retention (override\nor inherited default) — drives the per-type editor in the group panel.",
+        "summary": "Per **declared** backup type (not just enabled), the group's effective\nschedule/retention (override or inherited default) — drives the per-type\neditor in the group panel. Includes non-scheduled (disabled) types, since a\nmanual backup of one is still retained under its own type policy; those show\na null `effective_interval` (\"manual only\").",
         "operationId": "backups_group_schedules",
         "requestBody": {
           "content": {

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -229,8 +229,11 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Per enabled backup type, the group's effective schedule/retention (override
-         *     or inherited default) — drives the per-type editor in the group panel.
+         * Per **declared** backup type (not just enabled), the group's effective
+         *     schedule/retention (override or inherited default) — drives the per-type
+         *     editor in the group panel. Includes non-scheduled (disabled) types, since a
+         *     manual backup of one is still retained under its own type policy; those show
+         *     a null `effective_interval` ("manual only").
          */
         post: operations["backups_group_schedules"];
         delete?: never;

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -321,8 +321,9 @@ function SchedulesPanel({
 				<Alert severity="error">{schedules.error.message}</Alert>
 			) : schedules.data.length === 0 ? (
 				<Alert severity="info">
-					No backup types are enabled for this group's servers yet. Each type
-					inherits the canopy-wide default until a server advertises it.
+					No backup types registered for this group's servers yet. Each type a
+					server advertises appears here — scheduled or manual-only — and
+					inherits the canopy-wide default retention until overridden.
 				</Alert>
 			) : (
 				<Stack spacing={2}>


### PR DESCRIPTION
🤖 The schedule/retention list omitted backup types that aren't enabled on any server — which raised the question of what retention a *manual* backup of a non-scheduled type gets.

## What was happening

Both the UI list (`group_schedules`) and the retention maintenance applies (`effective_retention_for_group`, which builds the per-source retention map) keyed off `enabled_types_for_group`. So a declared-but-disabled (manual-only) type was invisible in the panel **and** got no per-type retention policy — its manual backups fell under the repo's **global** kopia policy (the strictest across *enabled* types, floored), not the type's own default. That coupling of retention to the `enabled` flag was the surprise.

## Fix

`enabled` now gates only **scheduling + staleness**; **retention follows the type**:
- New `ServerBackupCapability::declared_types_for_group` (every advertised type, any enabled state).
- `effective_retention_for_group` (maintenance's retention map) and `group_schedules` (the UI) iterate **declared** types. A non-scheduled type shows with a null interval ("manual only") + its effective retention; maintenance applies each declared type's own policy regardless of enabled.
- Panel empty-state + docs reworded (registered, not enabled).

So a manual backup of a non-scheduled type is now retained under **that type's** effective retention (override → default → floor) — visible in the panel and consistent with what maintenance enforces.

## Tests

- New endpoint test: a declared-but-disabled type appears in `group_schedules` as manual-only (null interval/next-run) with a floor retention. Existing next-run test still passes.
- openapi regenerated (the only diff is the `group_schedules` doc-comment description).