### PR TITLE
fix(private-server): accept the deployment Host on the MCP endpoint

### DIFF
--- a/crates/private-server/src/mcp.rs
+++ b/crates/private-server/src/mcp.rs
@@ -1023,10 +1023,32 @@ fn mcp_err(e: impl std::fmt::Display) -> McpError {
 
 /// Build the tower service nested into the axum router at `/api/mcp`.
 pub fn service(state: AppState) -> StreamableHttpService<CanopyMcp, LocalSessionManager> {
+	let mut config = StreamableHttpServerConfig::default();
+	// rmcp's `allowed_hosts` defaults to loopback only — a DNS-rebinding defense
+	// aimed at browser-facing localhost MCP servers. That threat doesn't apply
+	// here: the endpoint is reachable only through the Tailscale ingress (which
+	// injects the caller's identity), behind the tagged-device guard and the
+	// tailnet-user gate, and serves no CORS headers, so a browser can't make a
+	// cross-origin POST to it. Left as-is the loopback default 403s the real
+	// deployment host, so disable it. An operator who wants to pin the Host
+	// allowlist anyway can set CANOPY_MCP_ALLOWED_HOSTS to a comma-separated
+	// list (e.g. `canopy.example.ts.net`); loopback stays allowed for dev.
+	match std::env::var("CANOPY_MCP_ALLOWED_HOSTS") {
+		Ok(list) if !list.trim().is_empty() => {
+			config.allowed_hosts.extend(
+				list.split(',')
+					.map(str::trim)
+					.filter(|s| !s.is_empty())
+					.map(ToOwned::to_owned),
+			);
+		}
+		_ => config = config.disable_allowed_hosts(),
+	}
+
 	StreamableHttpService::new(
 		move || Ok(CanopyMcp::new(state.clone())),
 		LocalSessionManager::default().into(),
-		StreamableHttpServerConfig::default(),
+		config,
 	)
 }
 

--- a/crates/private-server/tests/mcp.rs
+++ b/crates/private-server/tests/mcp.rs
@@ -144,6 +144,36 @@ async fn initialize_and_list_tools() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn accepts_non_loopback_host() {
+	// Regression: rmcp's DNS-rebinding guard defaults to a loopback-only Host
+	// allowlist, which 403s the real tailnet deployment host. The endpoint is
+	// gated by the ingress + tagged-device guard + tailnet-user check instead,
+	// so a non-loopback Host must be accepted.
+	commons_tests::server::run(async |_conn, _public, private| {
+		let init = private
+			.post("/api/mcp")
+			.add_header("accept", ACCEPT)
+			.add_header("host", "canopy.example.ts.net")
+			.json(&serde_json::json!({
+				"jsonrpc": "2.0", "id": 1, "method": "initialize",
+				"params": {
+					"protocolVersion": "2025-06-18",
+					"capabilities": {},
+					"clientInfo": { "name": "canopy-tests", "version": "0" }
+				}
+			}))
+			.await;
+		assert_eq!(
+			init.status_code().as_u16(),
+			200,
+			"non-loopback Host should be accepted, got: {}",
+			init.text()
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn find_servers_filters_and_decorates() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		seed(&mut conn).await;


### PR DESCRIPTION
🤖 The MCP endpoint (`/api/mcp`) returns `Forbidden: Host header is not allowed` for any non-loopback host, so connecting from the production tailnet URL fails — clients (Claude Code) surface this as "needs authentication".

## Cause

rmcp's Streamable HTTP transport ships a DNS-rebinding guard whose `allowed_hosts` defaults to loopback only (`localhost`, `127.0.0.1`, `::1`). That defense is aimed at browser-facing localhost MCP servers; it doesn't fit this deployment, where the endpoint is reachable only through the Tailscale ingress (which injects the caller's identity), behind the tagged-device guard and the tailnet-user gate, and serves no CORS headers (so a browser can't make a cross-origin POST to it).

## Fix

Disable the Host allowlist by default. An operator who still wants to pin it can set `CANOPY_MCP_ALLOWED_HOSTS` to a comma-separated list (e.g. `canopy.example.ts.net`); loopback stays allowed for local dev.

Adds a regression test asserting a non-loopback `Host` is accepted.