### PR TITLE
fix(private-server): return 404 for /.well-known/ OAuth discovery

### DIFF
--- a/crates/private-server/src/spa.rs
+++ b/crates/private-server/src/spa.rs
@@ -14,6 +14,16 @@ pub async fn handler(uri: Uri) -> impl IntoResponse {
 	let path = uri.path().trim_start_matches('/');
 	let is_asset = path.starts_with("assets/");
 
+	// Don't serve the SPA for `/.well-known/` probes. MCP clients (e.g. Claude
+	// Code) discover OAuth by fetching `/.well-known/oauth-protected-resource`;
+	// answering with `index.html` makes them fail with "Failed to parse JSON"
+	// instead of concluding there's no OAuth. A 404 means "not a protected
+	// resource — connect without OAuth" (this endpoint authenticates via the
+	// Tailscale ingress, not OAuth).
+	if path.starts_with(".well-known/") {
+		return (StatusCode::NOT_FOUND, "not found").into_response();
+	}
+
 	let resolved = if !is_asset && Assets::get(path).is_none() {
 		"index.html"
 	} else {

--- a/crates/private-server/tests/mcp.rs
+++ b/crates/private-server/tests/mcp.rs
@@ -144,6 +144,29 @@ async fn initialize_and_list_tools() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn oauth_discovery_is_404_not_spa() {
+	// Regression: MCP clients probe `/.well-known/oauth-*` for OAuth metadata.
+	// The SPA fallback used to answer 200 text/html, which clients fail to parse
+	// as JSON and report as "needs authentication". A 404 tells them there's no
+	// OAuth, so they connect with the ambient (Tailscale) identity instead.
+	commons_tests::server::run(async |_conn, _public, private| {
+		for path in [
+			"/.well-known/oauth-protected-resource",
+			"/.well-known/oauth-protected-resource/api/mcp",
+			"/.well-known/oauth-authorization-server",
+		] {
+			let resp = private.get(path).await;
+			assert_eq!(
+				resp.status_code().as_u16(),
+				404,
+				"{path} should be 404, not the SPA"
+			);
+		}
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn accepts_non_loopback_host() {
 	// Regression: rmcp's DNS-rebinding guard defaults to a loopback-only Host
 	// allowlist, which 403s the real tailnet deployment host. The endpoint is


### PR DESCRIPTION
🤖 Follow-up to #273. With the Host check fixed, the MCP endpoint's `initialize` returns 200, but Claude Code still reports `needs authentication` / `SDK auth failed: Failed to parse JSON`.

## Cause

MCP clients probe `/.well-known/oauth-protected-resource` (and friends) to discover OAuth. The SPA fallback answered those with `200 text/html` (the React `index.html`), so the client tried to `JSON.parse` HTML and failed — surfacing as "needs authentication".

Verified against the live deployment:

```
$ curl -i https://canopy.<tailnet>.ts.net/.well-known/oauth-protected-resource
HTTP/2 200
content-type: text/html; charset=utf-8
<!doctype html> ...
```

## Fix

Serve `404` for `/.well-known/` paths instead of the SPA. Per the MCP auth spec a 404 on the protected-resource metadata means "not an OAuth-protected resource", so the client connects with the ambient identity — which here is injected by the Tailscale ingress.

Adds a regression test asserting the OAuth discovery paths return 404.