### PR TITLE
feat(private-server): expose incidents and issues over MCP

### DIFF
--- a/.workhorse/specs/private-server/mcp.md
+++ b/.workhorse/specs/private-server/mcp.md
@@ -60,6 +60,20 @@ When the result is truncated to its bound, the result says so, so the client doe
 
 **Find backup problems** optionally narrows to one group, otherwise scans the whole fleet, and returns the current backup problems with a severity for each: server-and-type pairs whose last successful backup is overdue against its schedule, types that have never reported a backup, groups whose backup repository is in an error state, recent failed backup runs, and maintenance runs that appear stuck.
 
+### Incidents and issues
+
+An issue is a per-server (or per-group) condition raised from a known source under a stable reference, carrying a severity, a current active state, and a history of events; an incident aggregates the issues active for a group over a span of time, from when it opened until it closes or an operator resolves it.
+
+**Find incidents** takes a look-back window (in days, defaulting to a week) and optionally one group, and returns the incidents that were open at any point within that window — those still open, plus those that closed no earlier than the window start.
+Each is returned with its group, its status (open, closed, or operator-resolved), when it opened, closed, and was resolved, who resolved it and why, whether it ever escalated, and how many issues and events it covers.
+A status filter can narrow the result to only open or only resolved incidents.
+
+**Get incident** takes an incident identifier and returns the incident with the issues attached to it: each issue's severity, source, reference, message, owning server, active state, and when it joined and (if applicable) left the incident.
+
+**Find issues** returns issues across the fleet, filtered by active state, by severity, by group, by server, and by recency (issues last seen within a look-back window).
+
+**Get issue** takes an issue identifier and returns the issue with its recent events and the incidents it is or was part of.
+
 ## Result semantics
 
 A server's reported status reflects reports received within the recent-activity window; a server silent beyond that window reads as not recently seen rather than as a stale "up".
@@ -69,3 +83,5 @@ The health classifications this interface reports — a server's healthy / warni
 A client and an operator looking at the same server or group reach the same conclusion about whether it is healthy and whether its backups are in good order.
 
 Version adoption counts and the version distribution count live servers by the version each currently reports, so they reflect what is deployed now rather than what has ever been seen.
+
+An incident counts as open within a look-back window if it was open at any point in that window, not only if it opened within it: a long-running incident that opened earlier and is still open, or that closed during the window, is included.

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -165,6 +165,8 @@ pub struct IssueListFilters {
 	pub severities: Option<Vec<Severity>>,
 	/// Restrict to issues whose server belongs to this group.
 	pub server_group_id: Option<Uuid>,
+	/// When `Some`, restrict to issues last seen at or after this time.
+	pub since: Option<Timestamp>,
 }
 
 fn hash_event(
@@ -1258,6 +1260,9 @@ impl Issue {
 				.await?;
 			q = q.filter(dsl::server_id.eq_any(server_ids));
 		}
+		if let Some(since) = filters.since {
+			q = q.filter(dsl::last_seen.ge(jiff_diesel::Timestamp::from(since)));
+		}
 		q.order(dsl::last_seen.desc())
 			.limit(limit)
 			.load(db)
@@ -1662,6 +1667,36 @@ impl Incident {
 			.select(Self::as_select())
 			.filter(dsl::closed_at.is_null())
 			.order(dsl::opened_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Incidents that were open at any point at or after `since`: either still
+	/// open (`closed_at IS NULL`) or closed no earlier than `since`. Optionally
+	/// restricted to one group. Ordered newest-opened first. Drives historical
+	/// queries like "incidents open in the past week".
+	pub async fn list_open_since(
+		db: &mut AsyncPgConnection,
+		since: Timestamp,
+		group_id: Option<Uuid>,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::incidents::dsl;
+
+		let mut q = dsl::incidents
+			.select(Self::as_select())
+			.filter(
+				dsl::closed_at
+					.is_null()
+					.or(dsl::closed_at.ge(jiff_diesel::Timestamp::from(since))),
+			)
+			.into_boxed();
+		if let Some(gid) = group_id {
+			q = q.filter(dsl::server_group_id.eq(gid));
+		}
+		q.order(dsl::opened_at.desc())
 			.limit(limit)
 			.load(db)
 			.await

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -322,6 +322,7 @@ pub async fn list(
 			active_only: args.active_only.unwrap_or(true),
 			severities: args.severities,
 			server_group_id: args.server_group_id,
+			since: None,
 		},
 		args.limit.unwrap_or(DEFAULT_LIMIT),
 	)

--- a/crates/private-server/src/mcp.rs
+++ b/crates/private-server/src/mcp.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use commons_types::{
 	Uuid,
 	backup::{BackupConfigStatus, BackupPlacement, BackupRepoMode, RunOutcome},
+	issue::Severity,
 	server::{kind::ServerKind, rank::ServerRank},
 	status::{HealthState, ShortStatus},
 	version::VersionStr,
@@ -28,6 +29,7 @@ use database::{
 		ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
 	},
 	diesel_async::AsyncPgConnection,
+	issues::{Event, Incident, Issue, IssueListFilters},
 	server_groups::ServerGroup,
 	servers::Server,
 	statuses::Status,
@@ -120,6 +122,48 @@ pub struct EmptyArgs {}
 pub struct FindBackupProblemsArgs {
 	/// Narrow the scan to one group's id. Omit to scan the whole fleet.
 	pub group_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindIncidentsArgs {
+	/// Look back this many days; returns incidents that were open at any point in
+	/// the window (still open, or closed within it). Default 7.
+	pub since_days: Option<u32>,
+	/// Restrict to one group's id.
+	pub group_id: Option<String>,
+	/// Filter by status: `open` (not yet closed), `resolved` (operator-resolved),
+	/// or `all` (default).
+	pub status: Option<String>,
+	/// Max incidents to return (default 100).
+	pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IncidentIdArgs {
+	/// The incident's id.
+	pub incident_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindIssuesArgs {
+	/// Only currently-active, unresolved issues. Default true.
+	pub active_only: Option<bool>,
+	/// Filter to these severities: `critical`, `error`, `warning`, `info`, `debug`.
+	pub severities: Option<Vec<String>>,
+	/// Restrict to issues whose server is in this group's id.
+	pub group_id: Option<String>,
+	/// Restrict to one server's id.
+	pub server_id: Option<String>,
+	/// Only issues last seen within this many days.
+	pub since_days: Option<u32>,
+	/// Max issues to return (default 100).
+	pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IssueIdArgs {
+	/// The issue's id.
+	pub issue_id: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -331,6 +375,131 @@ struct BackupProblem {
 struct BackupProblems {
 	count: usize,
 	problems: Vec<BackupProblem>,
+}
+
+#[derive(Serialize)]
+struct IncidentSummary {
+	id: Uuid,
+	group_id: Uuid,
+	group_name: Option<String>,
+	/// `open` (not closed), `resolved` (operator-resolved), or `closed`.
+	status: &'static str,
+	opened_at: Timestamp,
+	closed_at: Option<Timestamp>,
+	resolved_at: Option<Timestamp>,
+	resolved_by: Option<String>,
+	resolved_reason: Option<String>,
+	/// Whether the incident ever escalated (a critical issue joined).
+	escalated: bool,
+	issue_count: i64,
+	event_count: i64,
+}
+
+#[derive(Serialize)]
+struct IncidentList {
+	count: usize,
+	since: Timestamp,
+	incidents: Vec<IncidentSummary>,
+}
+
+#[derive(Serialize)]
+struct IncidentIssueOut {
+	issue_id: Uuid,
+	severity: Severity,
+	source: String,
+	r#ref: String,
+	description: Option<String>,
+	message: String,
+	active: bool,
+	server_id: Option<Uuid>,
+	server_name: Option<String>,
+	first_seen: Timestamp,
+	last_seen: Timestamp,
+	joined_at: Timestamp,
+	/// None = still attached to the incident.
+	left_at: Option<Timestamp>,
+}
+
+#[derive(Serialize)]
+struct IncidentDetail {
+	id: Uuid,
+	group_id: Uuid,
+	group_name: Option<String>,
+	status: &'static str,
+	opened_at: Timestamp,
+	closed_at: Option<Timestamp>,
+	resolved_at: Option<Timestamp>,
+	resolved_by: Option<String>,
+	resolved_reason: Option<String>,
+	escalated_at: Option<Timestamp>,
+	created_at: Timestamp,
+	updated_at: Timestamp,
+	issues: Vec<IncidentIssueOut>,
+}
+
+#[derive(Serialize)]
+struct IssueSummary {
+	id: Uuid,
+	server_id: Option<Uuid>,
+	server_name: Option<String>,
+	group_id: Option<Uuid>,
+	source: String,
+	r#ref: String,
+	severity: Severity,
+	description: Option<String>,
+	message: String,
+	active: bool,
+	first_seen: Timestamp,
+	last_seen: Timestamp,
+	resolved_at: Option<Timestamp>,
+	snoozed_until: Option<Timestamp>,
+}
+
+#[derive(Serialize)]
+struct IssueList {
+	count: usize,
+	issues: Vec<IssueSummary>,
+}
+
+#[derive(Serialize)]
+struct EventOut {
+	created_at: Timestamp,
+	occurred_at: Option<Timestamp>,
+	severity: Severity,
+	description: Option<String>,
+	message: String,
+	active: bool,
+	occurrences: i32,
+	last_seen: Timestamp,
+}
+
+#[derive(Serialize)]
+struct IncidentRefOut {
+	incident_id: Uuid,
+	opened_at: Timestamp,
+	closed_at: Option<Timestamp>,
+}
+
+#[derive(Serialize)]
+struct IssueDetail {
+	id: Uuid,
+	server_id: Option<Uuid>,
+	server_name: Option<String>,
+	group_id: Option<Uuid>,
+	source: String,
+	r#ref: String,
+	severity: Severity,
+	description: Option<String>,
+	message: String,
+	active: bool,
+	first_seen: Timestamp,
+	last_seen: Timestamp,
+	resolved_at: Option<Timestamp>,
+	resolved_by: Option<String>,
+	resolved_reason: Option<String>,
+	snoozed_until: Option<Timestamp>,
+	recent_events: Vec<EventOut>,
+	incidents: Vec<IncidentRefOut>,
 }
 
 // ---------------------------------------------------------------------------
@@ -897,6 +1066,252 @@ impl CanopyMcp {
 			problems,
 		})
 	}
+
+	#[tool(
+		description = "List incidents that were open at any point in a recent window (default last \
+		               7 days), optionally for one group, with status, timing, and issue counts. \
+		               Use this for 'incidents open in the past week'."
+	)]
+	async fn find_incidents(
+		&self,
+		Parameters(args): Parameters<FindIncidentsArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let since = since_from_days(args.since_days.unwrap_or(7));
+		let group = parse_opt_uuid(&args.group_id, "group_id")?;
+		let limit = args.limit.unwrap_or(100);
+		let status = args.status.as_deref().unwrap_or("all");
+
+		let incidents: Vec<Incident> = Incident::list_open_since(&mut conn, since, group, limit)
+			.await
+			.map_err(mcp_err)?
+			.into_iter()
+			.filter(|i| match status {
+				"open" => i.closed_at.is_none(),
+				"resolved" => i.resolved_at.is_some(),
+				_ => true,
+			})
+			.collect();
+
+		let group_names = group_names(
+			&mut conn,
+			&unique(incidents.iter().map(|i| i.server_group_id)),
+		)
+		.await?;
+		let ids: Vec<Uuid> = incidents.iter().map(|i| i.id).collect();
+		let stats = Incident::stats_for(&self.state.db, &ids)
+			.await
+			.map_err(mcp_err)?;
+
+		let summaries: Vec<IncidentSummary> = incidents
+			.iter()
+			.map(|i| {
+				let s = stats.get(&i.id);
+				IncidentSummary {
+					id: i.id,
+					group_id: i.server_group_id,
+					group_name: group_names.get(&i.server_group_id).cloned(),
+					status: incident_status(i),
+					opened_at: i.opened_at,
+					closed_at: i.closed_at,
+					resolved_at: i.resolved_at,
+					resolved_by: i.resolved_by.clone(),
+					resolved_reason: i.resolved_reason.clone(),
+					escalated: i.escalated_at.is_some(),
+					issue_count: s.map_or(0, |s| s.issue_count),
+					event_count: s.map_or(0, |s| s.event_count),
+				}
+			})
+			.collect();
+
+		ok_json(&IncidentList {
+			count: summaries.len(),
+			since,
+			incidents: summaries,
+		})
+	}
+
+	#[tool(
+		description = "Full detail for one incident: timing, status, and the issues attached to it \
+		               (with their severities and messages)."
+	)]
+	async fn get_incident(
+		&self,
+		Parameters(args): Parameters<IncidentIdArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let id = parse_uuid(&args.incident_id, "incident_id")?;
+		let Ok((incident, rows)) = Incident::get_with_issues(&mut conn, id).await else {
+			return Ok(not_found(format!("no incident with id {id}")));
+		};
+		let group = ServerGroup::get_by_id(&mut conn, incident.server_group_id)
+			.await
+			.ok();
+		let names = Server::names_by_ids(
+			&mut conn,
+			&unique(rows.iter().filter_map(|(_, i)| i.server_id)),
+		)
+		.await
+		.map_err(mcp_err)?;
+
+		let issues = rows
+			.iter()
+			.map(|(link, iss)| IncidentIssueOut {
+				issue_id: iss.id,
+				severity: iss.severity,
+				source: iss.source.clone(),
+				r#ref: iss.r#ref.clone(),
+				description: iss.description.clone(),
+				message: iss.message.clone(),
+				active: iss.active,
+				server_id: iss.server_id,
+				server_name: iss
+					.server_id
+					.and_then(|s| names.get(&s))
+					.and_then(|(n, _)| n.clone()),
+				first_seen: iss.first_seen,
+				last_seen: iss.last_seen,
+				joined_at: link.joined_at,
+				left_at: link.left_at,
+			})
+			.collect();
+
+		ok_json(&IncidentDetail {
+			id: incident.id,
+			group_id: incident.server_group_id,
+			group_name: group.as_ref().map(|g| g.name.clone()),
+			status: incident_status(&incident),
+			opened_at: incident.opened_at,
+			closed_at: incident.closed_at,
+			resolved_at: incident.resolved_at,
+			resolved_by: incident.resolved_by.clone(),
+			resolved_reason: incident.resolved_reason.clone(),
+			escalated_at: incident.escalated_at,
+			created_at: incident.created_at,
+			updated_at: incident.updated_at,
+			issues,
+		})
+	}
+
+	#[tool(
+		description = "List issues across the fleet, filtered by active state, severity, group, \
+		               server, and recency. Issues are the per-(server,source,ref) events that make \
+		               up incidents."
+	)]
+	async fn find_issues(
+		&self,
+		Parameters(args): Parameters<FindIssuesArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let severities = parse_severities(&args.severities)?;
+		let group = parse_opt_uuid(&args.group_id, "group_id")?;
+		let server = parse_opt_uuid(&args.server_id, "server_id")?;
+		let since = args.since_days.map(since_from_days);
+		let limit = args.limit.unwrap_or(100);
+
+		let mut issues = Issue::list(
+			&mut conn,
+			IssueListFilters {
+				active_only: args.active_only.unwrap_or(true),
+				severities,
+				server_group_id: group,
+				since,
+			},
+			limit,
+		)
+		.await
+		.map_err(mcp_err)?;
+		if let Some(sid) = server {
+			issues.retain(|i| i.server_id == Some(sid));
+		}
+
+		let names = Server::names_by_ids(
+			&mut conn,
+			&unique(issues.iter().filter_map(|i| i.server_id)),
+		)
+		.await
+		.map_err(mcp_err)?;
+		let summaries: Vec<IssueSummary> =
+			issues.iter().map(|i| issue_summary(i, &names)).collect();
+		ok_json(&IssueList {
+			count: summaries.len(),
+			issues: summaries,
+		})
+	}
+
+	#[tool(
+		description = "Full detail for one issue: its fields, recent events, and the incidents it \
+		               is or was part of."
+	)]
+	async fn get_issue(
+		&self,
+		Parameters(args): Parameters<IssueIdArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let id = parse_uuid(&args.issue_id, "issue_id")?;
+		let Ok(issue) = Issue::get_by_id(&mut conn, id).await else {
+			return Ok(not_found(format!("no issue with id {id}")));
+		};
+		let events = Event::list_for_issue(&mut conn, id, 0, 20)
+			.await
+			.map_err(mcp_err)?;
+		let inc = Incident::for_issues(&mut conn, &[id])
+			.await
+			.map_err(mcp_err)?;
+		let server_name = match issue.server_id {
+			Some(sid) => Server::names_by_ids(&mut conn, &[sid])
+				.await
+				.map_err(mcp_err)?
+				.get(&sid)
+				.and_then(|(n, _)| n.clone()),
+			None => None,
+		};
+
+		let recent_events = events
+			.iter()
+			.map(|e| EventOut {
+				created_at: e.created_at,
+				occurred_at: e.occurred_at,
+				severity: e.severity,
+				description: e.description.clone(),
+				message: e.message.clone(),
+				active: e.active,
+				occurrences: e.occurrences,
+				last_seen: e.last_seen,
+			})
+			.collect();
+		let incidents = inc
+			.get(&id)
+			.into_iter()
+			.flatten()
+			.map(|r| IncidentRefOut {
+				incident_id: r.incident_id,
+				opened_at: r.opened_at,
+				closed_at: r.closed_at,
+			})
+			.collect();
+
+		ok_json(&IssueDetail {
+			id: issue.id,
+			server_id: issue.server_id,
+			server_name,
+			group_id: issue.server_group_id,
+			source: issue.source.clone(),
+			r#ref: issue.r#ref.clone(),
+			severity: issue.severity,
+			description: issue.description.clone(),
+			message: issue.message.clone(),
+			active: issue.active,
+			first_seen: issue.first_seen,
+			last_seen: issue.last_seen,
+			resolved_at: issue.resolved_at,
+			resolved_by: issue.resolved_by.clone(),
+			resolved_reason: issue.resolved_reason.clone(),
+			snoozed_until: issue.snoozed_until,
+			recent_events,
+			incidents,
+		})
+	}
 }
 
 impl CanopyMcp {
@@ -977,6 +1392,76 @@ fn version_str(v: &Version) -> String {
 
 fn first_line(s: &str) -> String {
 	s.lines().next().unwrap_or("").trim().to_string()
+}
+
+/// A timestamp `days` ago (clamped to a decade), for recency windows.
+fn since_from_days(days: u32) -> Timestamp {
+	let days = days.min(3650) as i64;
+	Timestamp::now() - SignedDuration::from_hours(24 * days)
+}
+
+fn incident_status(i: &Incident) -> &'static str {
+	if i.resolved_at.is_some() {
+		"resolved"
+	} else if i.closed_at.is_some() {
+		"closed"
+	} else {
+		"open"
+	}
+}
+
+fn parse_severities(v: &Option<Vec<String>>) -> Result<Option<Vec<Severity>>, McpError> {
+	match v {
+		Some(list) if !list.is_empty() => {
+			let mut out = Vec::with_capacity(list.len());
+			for s in list {
+				out.push(s.parse::<Severity>().map_err(|_| {
+					McpError::invalid_params(format!("invalid severity: {s}"), None)
+				})?);
+			}
+			Ok(Some(out))
+		}
+		_ => Ok(None),
+	}
+}
+
+async fn group_names(
+	conn: &mut AsyncPgConnection,
+	ids: &[Uuid],
+) -> Result<HashMap<Uuid, String>, McpError> {
+	let groups = ServerGroup::list_by_ids(conn, ids).await.map_err(mcp_err)?;
+	Ok(groups.into_iter().map(|g| (g.id, g.name)).collect())
+}
+
+/// Deduplicate a stream of ids, preserving first-seen order.
+fn unique(it: impl IntoIterator<Item = Uuid>) -> Vec<Uuid> {
+	let mut seen = std::collections::HashSet::new();
+	it.into_iter().filter(|x| seen.insert(*x)).collect()
+}
+
+fn issue_summary(
+	i: &Issue,
+	names: &HashMap<Uuid, (Option<String>, Option<String>)>,
+) -> IssueSummary {
+	IssueSummary {
+		id: i.id,
+		server_id: i.server_id,
+		server_name: i
+			.server_id
+			.and_then(|s| names.get(&s))
+			.and_then(|(n, _)| n.clone()),
+		group_id: i.server_group_id,
+		source: i.source.clone(),
+		r#ref: i.r#ref.clone(),
+		severity: i.severity,
+		description: i.description.clone(),
+		message: i.message.clone(),
+		active: i.active,
+		first_seen: i.first_seen,
+		last_seen: i.last_seen,
+		resolved_at: i.resolved_at,
+		snoozed_until: i.snoozed_until,
+	}
 }
 
 fn parse_opt<T: std::str::FromStr>(v: &Option<String>, field: &str) -> Result<Option<T>, McpError> {

--- a/crates/private-server/tests/mcp.rs
+++ b/crates/private-server/tests/mcp.rs
@@ -116,6 +116,10 @@ async fn initialize_and_list_tools() {
 			"get_version",
 			"fleet_summary",
 			"find_backup_problems",
+			"find_incidents",
+			"get_incident",
+			"find_issues",
+			"get_issue",
 		] {
 			assert!(body.contains(tool), "tools/list missing {tool}: {body}");
 		}
@@ -316,6 +320,154 @@ async fn fleet_summary_rolls_up() {
 		assert_eq!(s["counts"]["by_kind"]["facility"], 1);
 		assert_eq!(s["version_distribution"]["2.34.1"], 1);
 		assert_eq!(s["health"]["healthy"], 1);
+	})
+	.await
+}
+
+// --- incidents & issues ------------------------------------------------------
+
+const IGROUP: &str = "aaaaaaaa-0000-0000-0000-000000000001";
+const ISRV: &str = "aaaaaaaa-0000-0000-0000-000000000002";
+const ISSUE1: &str = "aaaaaaaa-0000-0000-0000-000000000011";
+const ISSUE2: &str = "aaaaaaaa-0000-0000-0000-000000000012";
+const INC_OPEN: &str = "aaaaaaaa-0000-0000-0000-0000000000a1";
+const INC_CLOSED: &str = "aaaaaaaa-0000-0000-0000-0000000000a2";
+
+/// Seed a group + server, two issues (one active error, one inactive warning),
+/// an open incident (2d ago) linked to the active issue, and a closed incident
+/// (opened 5d ago, closed 3d ago).
+async fn seed_incidents(conn: &mut impl SimpleAsyncConnection) {
+	conn.batch_execute(&format!(
+		"INSERT INTO server_groups (id, name) VALUES ('{IGROUP}', 'Inc Group'); \
+		 INSERT INTO servers (id, host, name, kind, group_id, is_monitored) VALUES \
+			('{ISRV}', 'https://inc', 'Inc Server', 'central', '{IGROUP}', true); \
+		 INSERT INTO issues (id, created_at, updated_at, server_id, source, ref, severity, description, message, active, first_seen, last_seen) VALUES \
+			('{ISSUE1}', NOW(), NOW(), '{ISRV}', 'test', 'r1', 'error', 'Disk full', 'disk usage 98%', true, NOW() - interval '2 days', NOW() - interval '1 hour'), \
+			('{ISSUE2}', NOW(), NOW(), '{ISRV}', 'test', 'r2', 'warning', NULL, 'slow query', false, NOW() - interval '10 days', NOW() - interval '9 days'); \
+		 INSERT INTO events (id, created_at, issue_id, severity, message, active, hash, occurrences, last_seen) VALUES \
+			(gen_random_uuid(), NOW() - interval '1 hour', '{ISSUE1}', 'error', 'disk usage 98%', true, '\\x00'::bytea, 3, NOW() - interval '1 hour'); \
+		 INSERT INTO incidents (id, created_at, updated_at, server_group_id, opened_at, closed_at) VALUES \
+			('{INC_OPEN}', NOW(), NOW(), '{IGROUP}', NOW() - interval '2 days', NULL), \
+			('{INC_CLOSED}', NOW(), NOW(), '{IGROUP}', NOW() - interval '5 days', NOW() - interval '3 days'); \
+		 INSERT INTO incident_issues (incident_id, issue_id, joined_at, left_at) VALUES \
+			('{INC_OPEN}', '{ISSUE1}', NOW() - interval '2 days', NULL);"
+	))
+	.await
+	.expect("seed incidents");
+}
+
+fn ids_of(list: &serde_json::Value, key: &str) -> Vec<String> {
+	list[key]
+		.as_array()
+		.unwrap()
+		.iter()
+		.map(|x| x["id"].as_str().unwrap().to_string())
+		.collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn incidents_window_status_and_detail() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed_incidents(&mut conn).await;
+
+		// Default 7-day window: both the still-open and the (closed 3d ago) incident.
+		let week = call_tool!(private, "find_incidents", serde_json::json!({}));
+		let week_ids = ids_of(&week, "incidents");
+		assert!(week_ids.contains(&INC_OPEN.to_string()));
+		assert!(
+			week_ids.contains(&INC_CLOSED.to_string()),
+			"7d window should include the incident closed 3d ago"
+		);
+		let open = week["incidents"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|i| i["id"] == INC_OPEN)
+			.unwrap();
+		assert_eq!(open["status"], "open");
+		assert_eq!(open["group_name"], "Inc Group");
+		assert_eq!(open["issue_count"], 1);
+
+		// 1-day window excludes the incident that closed 3 days ago.
+		let day = call_tool!(
+			private,
+			"find_incidents",
+			serde_json::json!({ "since_days": 1 })
+		);
+		let day_ids = ids_of(&day, "incidents");
+		assert!(day_ids.contains(&INC_OPEN.to_string()));
+		assert!(!day_ids.contains(&INC_CLOSED.to_string()));
+
+		// status=open excludes the closed one.
+		let only_open = call_tool!(
+			private,
+			"find_incidents",
+			serde_json::json!({ "status": "open" })
+		);
+		let open_ids = ids_of(&only_open, "incidents");
+		assert!(open_ids.contains(&INC_OPEN.to_string()));
+		assert!(!open_ids.contains(&INC_CLOSED.to_string()));
+
+		// Detail: the open incident carries its attached issue.
+		let detail = call_tool!(
+			private,
+			"get_incident",
+			serde_json::json!({ "incident_id": INC_OPEN })
+		);
+		let issues = detail["issues"].as_array().unwrap();
+		assert_eq!(issues.len(), 1);
+		assert_eq!(issues[0]["issue_id"], ISSUE1);
+		assert_eq!(issues[0]["severity"], "error");
+		assert_eq!(issues[0]["ref"], "r1");
+		assert_eq!(issues[0]["server_name"], "Inc Server");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn issues_filter_and_detail() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed_incidents(&mut conn).await;
+
+		// active_only (default true) → only the active error issue.
+		let active = call_tool!(private, "find_issues", serde_json::json!({}));
+		let active_ids = ids_of(&active, "issues");
+		assert!(active_ids.contains(&ISSUE1.to_string()));
+		assert!(!active_ids.contains(&ISSUE2.to_string()));
+
+		// active_only=false → the inactive one shows up too.
+		let all = call_tool!(
+			private,
+			"find_issues",
+			serde_json::json!({ "active_only": false })
+		);
+		let all_ids = ids_of(&all, "issues");
+		assert!(all_ids.contains(&ISSUE2.to_string()));
+
+		// severity filter.
+		let warnings = call_tool!(
+			private,
+			"find_issues",
+			serde_json::json!({ "active_only": false, "severities": ["warning"] })
+		);
+		let w = warnings["issues"].as_array().unwrap();
+		assert!(!w.is_empty() && w.iter().all(|i| i["severity"] == "warning"));
+
+		// Detail: events + the incident it belongs to.
+		let detail = call_tool!(
+			private,
+			"get_issue",
+			serde_json::json!({ "issue_id": ISSUE1 })
+		);
+		assert_eq!(detail["severity"], "error");
+		assert!(!detail["recent_events"].as_array().unwrap().is_empty());
+		let inc_ids: Vec<String> = detail["incidents"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.map(|i| i["incident_id"].as_str().unwrap().to_string())
+			.collect();
+		assert!(inc_ids.contains(&INC_OPEN.to_string()));
 	})
 	.await
 }


### PR DESCRIPTION
🤖 Extends the read-only MCP query interface to cover incidents and issues, so an agent can answer questions like "summarise all incidents that were open in the past week".

## New tools

- find_incidents — incidents that were open at any point in a look-back window (default 7 days), optionally for one group, each with status (open/closed/resolved), opened/closed/resolved timing, who resolved it and why, whether it escalated, and issue/event counts. A status filter narrows to open or resolved.
- get_incident — one incident plus the issues attached to it (severity, source, ref, message, owning server, active state, join/leave times).
- find_issues — issues across the fleet, filtered by active state, severity, group, server, and recency.
- get_issue — one issue plus its recent events and the incidents it is or was part of.

## Notes

- New DB query Incident::list_open_since implements "open at any point in the window" (still open, or closed no earlier than the window start) — not just "opened within it".
- Added an optional since filter to IssueListFilters/Issue::list for issue recency; the existing handler is unchanged behaviourally (passes None).
- Backup/incident health classifications continue to reuse the existing definitions; no new query semantics invented.
- Not added to openapi.json — MCP self-describes via tools/list, and no REST handler signatures changed.

Spec updated in .workhorse/specs/private-server/mcp.md.