### PR TITLE
feat(private-web): show latest snapshot id in backup tables

### DIFF
--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -263,6 +263,13 @@ pub struct ServerBackupCapabilityView {
 	#[schema(value_type = String)]
 	pub r#type: BackupType,
 	pub enabled: bool,
+	/// kopia snapshot id of this server+type's most recent successful backup,
+	/// if any.
+	pub latest_snapshot_id: Option<String>,
+	/// When that snapshot was reported.
+	pub latest_snapshot_at: Option<Timestamp>,
+	/// Bytes uploaded by that run, if reported.
+	pub latest_snapshot_bytes: Option<i64>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -1124,6 +1131,9 @@ pub async fn stats(
 
 	// Pending requests + declared capabilities across the group's member servers.
 	let members = group.list_servers(&mut conn).await?;
+	// Latest successful backup per (server, type), to decorate each capability.
+	let latest_by =
+		BackupRun::latest_success_by_server_type_for_group(&mut conn, args.server_group_id).await?;
 	let mut pending_requests = Vec::new();
 	let mut capabilities = Vec::new();
 	for server in &members {
@@ -1137,8 +1147,12 @@ pub async fn stats(
 			});
 		}
 		for cap in ServerBackupCapability::list_for_server(&mut conn, server.id).await? {
+			let last = latest_by.get(&(cap.server_id, cap.r#type.clone()));
 			capabilities.push(ServerBackupCapabilityView {
 				server_id: cap.server_id,
+				latest_snapshot_id: last.and_then(|r| r.snapshot_id.clone()),
+				latest_snapshot_at: last.map(|r| r.reported_at),
+				latest_snapshot_bytes: last.and_then(|r| r.bytes_uploaded),
 				r#type: cap.r#type,
 				enabled: cap.enabled,
 			});
@@ -1171,15 +1185,19 @@ pub async fn capabilities(
 ) -> Result<Json<Vec<ServerBackupCapabilityView>>> {
 	let mut conn = state.db.get().await?;
 	let rows = ServerBackupCapability::list_for_server(&mut conn, args.server_id).await?;
-	Ok(Json(
-		rows.into_iter()
-			.map(|c| ServerBackupCapabilityView {
-				server_id: c.server_id,
-				r#type: c.r#type,
-				enabled: c.enabled,
-			})
-			.collect(),
-	))
+	let mut out = Vec::with_capacity(rows.len());
+	for c in rows {
+		let last = BackupRun::latest_success_for_server(&mut conn, c.server_id, &c.r#type).await?;
+		out.push(ServerBackupCapabilityView {
+			server_id: c.server_id,
+			latest_snapshot_id: last.as_ref().and_then(|r| r.snapshot_id.clone()),
+			latest_snapshot_at: last.as_ref().map(|r| r.reported_at),
+			latest_snapshot_bytes: last.as_ref().and_then(|r| r.bytes_uploaded),
+			r#type: c.r#type,
+			enabled: c.enabled,
+		});
+	}
+	Ok(Json(out))
 }
 
 /// Operator toggle of a `(server, type)` capability's enabled flag.

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -258,6 +258,41 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(runs.getByText("stats-srv")).toBeVisible();
 	});
 
+	test("recent run shows a truncated, copyable snapshot id", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "snap-group" });
+		const device = await seedDevice(sql);
+		const server = await seedServer(sql, {
+			name: "snap-srv",
+			groupId: group.id,
+			deviceId: device.id,
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+			intervalSeconds: 3600,
+		});
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			outcome: "success",
+			bytesUploaded: 2048,
+			snapshotId: "k0123456789abcdef0123",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const runs = page.getByRole("table").last();
+		// Shown truncated (not the full opaque id), with a copy button.
+		await expect(runs.getByText(/k0123456789/)).toBeVisible();
+		await expect(runs.getByText("k0123456789abcdef0123")).toBeHidden();
+		await expect(
+			runs.getByRole("button", { name: /copy snapshot id/i }),
+		).toBeVisible();
+	});
+
 	test("failed run shows expandable error detail and no upload size", async ({
 		page,
 		sql,
@@ -287,8 +322,9 @@ test.describe("backups ready: stats + backup-now", () => {
 		const runs = page.getByRole("table").last();
 		await expect(runs.getByText("err-srv")).toBeVisible();
 		await expect(runs.getByText("failure")).toBeVisible();
-		// A failed run uploaded nothing → "—", not "unknown".
-		await expect(runs.getByText("—")).toBeVisible();
+		// A failed run uploaded nothing and has no snapshot → "—" cells (Uploaded
+		// + Snapshot), not "unknown".
+		await expect(runs.getByRole("cell", { name: "—" }).first()).toBeVisible();
 
 		// Error detail is hidden until the row is expanded.
 		await expect(page.getByText(/disk quota exceeded/i)).toBeHidden();
@@ -511,6 +547,58 @@ test.describe("server backup capabilities", () => {
 		await expect(
 			page.getByText(/no backup types registered for this server/i),
 		).toBeVisible();
+	});
+
+	test("a capability shows its latest snapshot (id + size), copyable", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "snap-caps-group" });
+		const device = await seedDevice(sql);
+		const server = await seedServer(sql, {
+			name: "snap-caps-srv",
+			groupId: group.id,
+			deviceId: device.id,
+		});
+		await seedServerBackupCapability(sql, {
+			serverId: server.id,
+			type: "tamanu-postgres",
+		});
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			outcome: "success",
+			bytesUploaded: 2048,
+			snapshotId: "k0123456789abcdef0123",
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		const backups = page.locator("#backups");
+		await expect(backups.getByText(/k0123456789/)).toBeVisible();
+		await expect(backups.getByText(/2\.0 KiB/)).toBeVisible();
+		await expect(
+			backups.getByRole("button", { name: /copy snapshot id/i }),
+		).toBeVisible();
+	});
+
+	test("a capability with no successful backup shows 'no snapshot yet'", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "no-snap-group" });
+		const server = await seedServer(sql, {
+			name: "no-snap-srv",
+			groupId: group.id,
+		});
+		await seedServerBackupCapability(sql, {
+			serverId: server.id,
+			type: "tamanu-postgres",
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		const backups = page.locator("#backups");
+		await expect(backups.getByText(/no snapshot yet/i)).toBeVisible();
 	});
 
 	test("toggling a capability switch flips enabled in the DB", async ({

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -8305,6 +8305,29 @@
           "enabled": {
             "type": "boolean"
           },
+          "latest_snapshot_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When that snapshot was reported."
+          },
+          "latest_snapshot_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Bytes uploaded by that run, if reported."
+          },
+          "latest_snapshot_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "kopia snapshot id of this server+type's most recent successful backup,\nif any."
+          },
           "server_id": {
             "type": "string",
             "format": "uuid"

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3354,6 +3354,21 @@ export interface components {
          */
         ServerBackupCapabilityView: {
             enabled: boolean;
+            /**
+             * Format: date-time
+             * @description When that snapshot was reported.
+             */
+            latest_snapshot_at?: string | null;
+            /**
+             * Format: int64
+             * @description Bytes uploaded by that run, if reported.
+             */
+            latest_snapshot_bytes?: number | null;
+            /**
+             * @description kopia snapshot id of this server+type's most recent successful backup,
+             *     if any.
+             */
+            latest_snapshot_id?: string | null;
             /** Format: uuid */
             server_id: string;
             type: string;

--- a/private-web/src/components/SnapshotId.tsx
+++ b/private-web/src/components/SnapshotId.tsx
@@ -1,0 +1,91 @@
+import CheckIcon from "@mui/icons-material/Check";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { IconButton, Stack, Tooltip, Typography } from "@mui/material";
+import { useState } from "react";
+
+import { formatBytes } from "../lib/formatBytes";
+import TimeAgo from "./TimeAgo";
+
+/// A kopia snapshot id shown truncated (they're long and opaque), with a button
+/// to copy the full value. Renders "—" when there's no snapshot.
+export function SnapshotId({ id }: { id: string | null | undefined }) {
+	const [copied, setCopied] = useState(false);
+	if (!id) return <>—</>;
+	const onCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(id);
+			setCopied(true);
+			window.setTimeout(() => setCopied(false), 2000);
+		} catch {
+			/* clipboard may be unavailable; ignore */
+		}
+	};
+	const short = id.length > 12 ? `${id.slice(0, 12)}…` : id;
+	return (
+		<Stack
+			direction="row"
+			spacing={0.5}
+			component="span"
+			sx={{ alignItems: "center" }}
+		>
+			<Typography
+				component="code"
+				variant="body2"
+				sx={{ fontFamily: "monospace" }}
+				title={id}
+			>
+				{short}
+			</Typography>
+			<Tooltip title={copied ? "Copied" : "Copy snapshot ID"}>
+				<IconButton size="small" aria-label="Copy snapshot ID" onClick={onCopy}>
+					{copied ? (
+						<CheckIcon fontSize="inherit" />
+					) : (
+						<ContentCopyIcon fontSize="inherit" />
+					)}
+				</IconButton>
+			</Tooltip>
+		</Stack>
+	);
+}
+
+/// The latest snapshot for a backup type: its id (copyable), when it was taken,
+/// and how much it uploaded. Renders an explicit "no snapshot yet" when the
+/// type has never produced a successful backup.
+export function LatestSnapshot({
+	id,
+	at,
+	bytes,
+}: {
+	id: string | null | undefined;
+	at: string | null | undefined;
+	bytes: number | null | undefined;
+}) {
+	if (!id && !at) {
+		return (
+			<Typography variant="caption" color="text.secondary">
+				no snapshot yet
+			</Typography>
+		);
+	}
+	return (
+		<Stack
+			direction="row"
+			spacing={1}
+			useFlexGap
+			sx={{ alignItems: "center", flexWrap: "wrap" }}
+		>
+			<SnapshotId id={id} />
+			{at && (
+				<Typography variant="caption" color="text.secondary">
+					<TimeAgo timestamp={at} />
+				</Typography>
+			)}
+			{bytes != null && (
+				<Typography variant="caption" color="text.secondary">
+					{formatBytes(bytes)}
+				</Typography>
+			)}
+		</Stack>
+	);
+}

--- a/private-web/src/lib/formatBytes.ts
+++ b/private-web/src/lib/formatBytes.ts
@@ -1,0 +1,14 @@
+/// Human-readable byte size (binary units). Returns "unknown" for a missing
+/// value, so callers can pass an optional field straight through.
+export function formatBytes(bytes: number | null | undefined): string {
+	if (bytes == null) return "unknown";
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ["KiB", "MiB", "GiB", "TiB"];
+	let v = bytes / 1024;
+	let i = 0;
+	while (v >= 1024 && i < units.length - 1) {
+		v /= 1024;
+		i++;
+	}
+	return `${v.toFixed(1)} ${units[i]}`;
+}

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -39,8 +39,10 @@ import { useApi, useApiAction } from "../api";
 import { useReloadInterval } from "../hooks/useReloadInterval";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { humanSeconds } from "../lib/humanDuration";
+import { formatBytes } from "../lib/formatBytes";
 import { usePageTitle } from "../hooks/usePageTitle";
 import TimeAgo from "../components/TimeAgo";
+import { LatestSnapshot, SnapshotId } from "../components/SnapshotId";
 import {
 	BACKUP_STATUS_HELP,
 	BACKUP_STATUS_INTENT,
@@ -647,10 +649,13 @@ function RunRow({ run, members }: { run: BackupRun; members: ServerInfo[] }) {
 						? "—"
 						: formatBytes(run.bytes_uploaded)}
 				</TableCell>
+				<TableCell>
+					<SnapshotId id={run.snapshot_id} />
+				</TableCell>
 			</TableRow>
 			{hasError && (
 				<TableRow>
-					<TableCell colSpan={7} sx={{ py: 0, border: 0 }}>
+					<TableCell colSpan={8} sx={{ py: 0, border: 0 }}>
 						<Collapse in={open} timeout="auto" unmountOnExit>
 							<Alert severity="error" variant="outlined" sx={{ my: 1 }}>
 								<Typography
@@ -735,6 +740,7 @@ function StatsPanel({
 							<TableCell>Purpose</TableCell>
 							<TableCell>Outcome</TableCell>
 							<TableCell>Uploaded</TableCell>
+							<TableCell>Snapshot</TableCell>
 						</TableRow>
 					</TableHead>
 					<TableBody>
@@ -799,6 +805,9 @@ function RunsAndRequests({
 	const enabledFor = (serverId: string, type: string): boolean | undefined =>
 		capabilities.find((c) => c.server_id === serverId && c.type === type)
 			?.enabled;
+
+	const capFor = (serverId: string, type: string) =>
+		capabilities.find((c) => c.server_id === serverId && c.type === type);
 
 	const onRequest = async (serverId: string, type: string) => {
 		try {
@@ -875,19 +884,24 @@ function RunsAndRequests({
 									<Stack spacing={0.5} sx={{ alignItems: "flex-end" }}>
 										{types.map((t) => {
 											const req = pendingFor(m.id, t);
+											const cap = capFor(m.id, t);
 											return (
 												<Stack
 													key={t}
-													direction="row"
-													spacing={1}
-													sx={{ alignItems: "center" }}
+													spacing={0.25}
+													sx={{ alignItems: "flex-end" }}
 												>
-													<Typography
-														variant="body2"
-														sx={{ fontFamily: "monospace" }}
+													<Stack
+														direction="row"
+														spacing={1}
+														sx={{ alignItems: "center" }}
 													>
-														{t}
-													</Typography>
+														<Typography
+															variant="body2"
+															sx={{ fontFamily: "monospace" }}
+														>
+															{t}
+														</Typography>
 													{enabledFor(m.id, t) === false && (
 														<Tooltip title="This type isn't on the backup schedule for this server (toggle it on in the server's Backups section). You can still back it up on demand.">
 															<Chip
@@ -934,6 +948,12 @@ function RunsAndRequests({
 														)
 													)}
 												</Stack>
+												<LatestSnapshot
+													id={cap?.latest_snapshot_id}
+													at={cap?.latest_snapshot_at}
+													bytes={cap?.latest_snapshot_bytes}
+												/>
+											</Stack>
 											);
 										})}
 									</Stack>
@@ -969,15 +989,3 @@ function Stat({
 
 /// Format a byte count, rendering null as "unknown" (indicators always show a
 /// state, never hide).
-function formatBytes(bytes: number | null): string {
-	if (bytes == null) return "unknown";
-	if (bytes < 1024) return `${bytes} B`;
-	const units = ["KiB", "MiB", "GiB", "TiB"];
-	let v = bytes / 1024;
-	let i = 0;
-	while (v >= 1024 && i < units.length - 1) {
-		v /= 1024;
-		i++;
-	}
-	return `${v.toFixed(1)} ${units[i]}`;
-}

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -54,6 +54,7 @@ import SilencedRefsSection from "../components/SilencedRefsSection";
 import StatusDot from "../components/StatusDot";
 import TailnetIdentitySection from "../components/TailnetIdentitySection";
 import TimeAgo from "../components/TimeAgo";
+import { LatestSnapshot } from "../components/SnapshotId";
 import TimezoneTooltip from "../components/TimezoneTooltip";
 import VersionIndicator from "../components/VersionIndicator";
 import { HealthLegend, StatusLegend, VersionLegend } from "../components/Legends";
@@ -1724,9 +1725,16 @@ function BackupCapabilityRow({
 			spacing={2}
 			sx={{ alignItems: "center", justifyContent: "space-between", py: 0.5 }}
 		>
-			<Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-				{cap.type}
-			</Typography>
+			<Stack spacing={0.25} sx={{ minWidth: 0 }}>
+				<Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+					{cap.type}
+				</Typography>
+				<LatestSnapshot
+					id={cap.latest_snapshot_id}
+					at={cap.latest_snapshot_at}
+					bytes={cap.latest_snapshot_bytes}
+				/>
+			</Stack>
 			<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
 				{setCapability.error && (
 					<Typography variant="caption" color="error">


### PR DESCRIPTION
🤖 Surfaces kopia snapshot IDs in the backup UI.

## Recent runs table (group backup page)

Adds a **Snapshot** column showing each run's snapshot ID, truncated (they're long and opaque) with a button to copy the full value. Empty ("—") for runs with no snapshot (failures, restores).

## Per-server backup tables (server detail + group page)

Each (server, backup type) row now shows the **latest successful snapshot** for that type: its ID (copyable), when it was taken, and how much it uploaded — or an explicit "no snapshot yet" when the type has never produced a successful backup.

## Backend

ServerBackupCapabilityView carries the latest successful backup's snapshot id / time / bytes. Populated in both handlers that build it: backups stats (bulk per group via latest_success_by_server_type_for_group) and backups capabilities (per server). Both UI tables read this one DTO, so the server-detail and group views stay consistent. Regenerated openapi.json + api-types.ts.

## Shared

SnapshotId / LatestSnapshot components and a formatBytes lib (moved out of BackupPanel so it can be reused).

## Tests

Three new Playwright specs: the recent-runs snapshot column (truncated + copy button), a capability showing its latest snapshot (id + size, copyable), and the "no snapshot yet" empty state. Adjusted one existing failed-run assertion that now matches two "—" cells (Uploaded + the new Snapshot column).