### PR TITLE
feat(private-server): agent guidance + published flag for MCP incidents

### DIFF
--- a/.workhorse/specs/private-server/mcp.md
+++ b/.workhorse/specs/private-server/mcp.md
@@ -65,8 +65,13 @@ When the result is truncated to its bound, the result says so, so the client doe
 An issue is a per-server (or per-group) condition raised from a known source under a stable reference, carrying a severity, a current active state, and a history of events; an incident aggregates the issues active for a group over a span of time, from when it opened until it closes or an operator resolves it.
 
 **Find incidents** takes a look-back window (in days, defaulting to a week) and optionally one group, and returns the incidents that were open at any point within that window — those still open, plus those that closed no earlier than the window start.
-Each is returned with its group, its status (open, closed, or operator-resolved), when it opened, closed, and was resolved, who resolved it and why, whether it ever escalated, and how many issues and events it covers.
+Each is returned with its group, its status (open, closed, or operator-resolved), when it opened, closed, and was resolved, who resolved it and why, whether it ever escalated, how long it was open, whether it was published, and how many issues and events it covers.
 A status filter can narrow the result to only open or only resolved incidents.
+
+The window includes incidents that flapped open and shut within their group's grace period and so never surfaced to anyone.
+Each incident therefore carries a **published** flag — true when it actually notified operators, which happens only when it stayed open past its group's grace period or it escalated (a critical issue joined, which bypasses the grace) — and the result reports how many of the returned incidents were published.
+The raw event count an incident accumulated is not a measure of its duration or severity: a high count can belong to a sub-minute flap.
+A summary or ranking of incidents should count published incidents rather than raw rows unless raw activity is explicitly wanted.
 
 **Get incident** takes an incident identifier and returns the incident with the issues attached to it: each issue's severity, source, reference, message, owning server, active state, and when it joined and (if applicable) left the incident.
 

--- a/crates/database/src/slack_outbox/mod.rs
+++ b/crates/database/src/slack_outbox/mod.rs
@@ -167,6 +167,32 @@ impl SlackOutbox {
 		Ok(rows.into_iter().map(|(id, t)| (id, t.into())).collect())
 	}
 
+	/// Of `incident_ids`, those whose `incident_open` notice was actually
+	/// delivered to Slack — i.e. operators were paged. This is the
+	/// authoritative "the incident surfaced" signal: it excludes opens still
+	/// held in the grace window and opens cancelled or given up before
+	/// delivery. (Escalation produces a delivered open, so it's included.)
+	pub async fn delivered_open_ids(
+		db: &mut AsyncPgConnection,
+		incident_ids: &[Uuid],
+	) -> Result<std::collections::HashSet<Uuid>> {
+		use crate::schema::slack_outbox::dsl;
+		use std::collections::HashSet;
+
+		if incident_ids.is_empty() {
+			return Ok(HashSet::new());
+		}
+		let rows: Vec<Uuid> = dsl::slack_outbox
+			.select(dsl::incident_id)
+			.filter(dsl::kind.eq(KIND_INCIDENT_OPEN))
+			.filter(dsl::incident_id.eq_any(incident_ids))
+			.filter(dsl::delivered_at.is_not_null())
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(rows.into_iter().collect())
+	}
+
 	/// Claim up to `limit` pending rows in insertion order. Uses
 	/// `FOR UPDATE SKIP LOCKED` so multiple workers (or a worker plus a
 	/// hand-run reprocess) won't fight over the same row. The caller must

--- a/crates/private-server/src/mcp.rs
+++ b/crates/private-server/src/mcp.rs
@@ -32,6 +32,7 @@ use database::{
 	issues::{Event, Incident, Issue, IssueListFilters},
 	server_groups::ServerGroup,
 	servers::Server,
+	slack_outbox::SlackOutbox,
 	statuses::Status,
 	version_known_issues::VersionKnownIssue,
 	versions::Version,
@@ -391,13 +392,24 @@ struct IncidentSummary {
 	resolved_reason: Option<String>,
 	/// Whether the incident ever escalated (a critical issue joined).
 	escalated: bool,
+	/// Whether the incident actually surfaced to operators (its Slack open
+	/// notice was delivered): it outlived the group's grace window, or it
+	/// escalated. Incidents that flapped shut within the grace never published.
+	/// Prefer counting `published` incidents over raw rows.
+	published: bool,
+	/// How long the incident was (or has been) open, in seconds.
+	open_duration_secs: i64,
 	issue_count: i64,
+	/// Raw count of status events the incident accumulated. NOT a measure of
+	/// duration or severity — a high count can be a sub-minute flap.
 	event_count: i64,
 }
 
 #[derive(Serialize)]
 struct IncidentList {
 	count: usize,
+	/// How many of `count` actually surfaced to operators (see `published`).
+	published_count: usize,
 	since: Timestamp,
 	incidents: Vec<IncidentSummary>,
 }
@@ -432,6 +444,9 @@ struct IncidentDetail {
 	resolved_by: Option<String>,
 	resolved_reason: Option<String>,
 	escalated_at: Option<Timestamp>,
+	/// Whether the incident surfaced to operators (Slack open delivered).
+	published: bool,
+	open_duration_secs: i64,
 	created_at: Timestamp,
 	updated_at: Timestamp,
 	issues: Vec<IncidentIssueOut>,
@@ -1069,8 +1084,19 @@ impl CanopyMcp {
 
 	#[tool(
 		description = "List incidents that were open at any point in a recent window (default last \
-		               7 days), optionally for one group, with status, timing, and issue counts. \
-		               Use this for 'incidents open in the past week'."
+		               7 days), optionally for one group. Use this for 'incidents open in the past \
+		               week'.\n\n\
+		               IMPORTANT for summaries/ranking: count `published` incidents, not raw rows. \
+		               The window includes a large volume of sub-grace flapping (health checks that \
+		               recover/refire, alerts that self-clear in under a minute) that was recorded \
+		               but never surfaced to anyone. An incident is `published` only if its Slack \
+		               open notice was delivered: it stayed open past the group's grace window \
+		               (slack_open_delay, ~3 min by default) OR it escalated (a critical issue \
+		               joined, which bypasses the grace). `event_count` is raw status-event churn \
+		               and does NOT track duration or severity — a high-event incident can be a \
+		               sub-minute flap. A high count dominated by unpublished short-lived rows \
+		               usually means a twitchy alert/health-check threshold, not a real outage. \
+		               `published_count` gives the surfaced subset directly."
 	)]
 	async fn find_incidents(
 		&self,
@@ -1102,6 +1128,9 @@ impl CanopyMcp {
 		let stats = Incident::stats_for(&self.state.db, &ids)
 			.await
 			.map_err(mcp_err)?;
+		let published = SlackOutbox::delivered_open_ids(&mut conn, &ids)
+			.await
+			.map_err(mcp_err)?;
 
 		let summaries: Vec<IncidentSummary> = incidents
 			.iter()
@@ -1118,6 +1147,8 @@ impl CanopyMcp {
 					resolved_by: i.resolved_by.clone(),
 					resolved_reason: i.resolved_reason.clone(),
 					escalated: i.escalated_at.is_some(),
+					published: published.contains(&i.id),
+					open_duration_secs: open_duration_secs(i),
 					issue_count: s.map_or(0, |s| s.issue_count),
 					event_count: s.map_or(0, |s| s.event_count),
 				}
@@ -1126,6 +1157,7 @@ impl CanopyMcp {
 
 		ok_json(&IncidentList {
 			count: summaries.len(),
+			published_count: summaries.iter().filter(|s| s.published).count(),
 			since,
 			incidents: summaries,
 		})
@@ -1147,6 +1179,10 @@ impl CanopyMcp {
 		let group = ServerGroup::get_by_id(&mut conn, incident.server_group_id)
 			.await
 			.ok();
+		let published = SlackOutbox::delivered_open_ids(&mut conn, &[incident.id])
+			.await
+			.map_err(mcp_err)?
+			.contains(&incident.id);
 		let names = Server::names_by_ids(
 			&mut conn,
 			&unique(rows.iter().filter_map(|(_, i)| i.server_id)),
@@ -1187,6 +1223,8 @@ impl CanopyMcp {
 			resolved_by: incident.resolved_by.clone(),
 			resolved_reason: incident.resolved_reason.clone(),
 			escalated_at: incident.escalated_at,
+			published,
+			open_duration_secs: open_duration_secs(&incident),
 			created_at: incident.created_at,
 			updated_at: incident.updated_at,
 			issues,
@@ -1345,8 +1383,15 @@ impl ServerHandler for CanopyMcp {
 		let mut info = ServerInfo::default();
 		info.instructions = Some(
 			"Read-only access to the Canopy fleet: servers, groups, health/status, Tamanu \
-			 versions, and backups. All data is live. Use find_* to locate entities and get_* \
-			 for detail; fleet_summary and find_backup_problems for triage."
+			 versions, backups, and incidents/issues. All data is live. Use find_* to locate \
+			 entities and get_* for detail; fleet_summary and find_backup_problems for triage.\n\n\
+			 Incidents: an incident groups the issues active for a group over a span of time. \
+			 find_incidents returns everything open in the window, including heavy sub-grace \
+			 flapping that was recorded but never surfaced. When summarizing or ranking, count \
+			 `published` incidents (also given as `published_count`), not raw rows: an incident is \
+			 published only if it outlived the group's grace window (~3 min default) or escalated. \
+			 `event_count` is raw event churn, not duration or severity — a huge count can be a \
+			 sub-minute flap, usually a twitchy threshold rather than a real outage."
 				.into(),
 		);
 		info.capabilities = ServerCapabilities::builder().enable_tools().build();
@@ -1398,6 +1443,12 @@ fn first_line(s: &str) -> String {
 fn since_from_days(days: u32) -> Timestamp {
 	let days = days.min(3650) as i64;
 	Timestamp::now() - SignedDuration::from_hours(24 * days)
+}
+
+/// How long the incident was (or has been) open, in seconds.
+fn open_duration_secs(i: &Incident) -> i64 {
+	let end = i.closed_at.unwrap_or_else(Timestamp::now);
+	end.duration_since(i.opened_at).as_secs().max(0)
 }
 
 fn incident_status(i: &Incident) -> &'static str {

--- a/crates/private-server/tests/mcp.rs
+++ b/crates/private-server/tests/mcp.rs
@@ -350,7 +350,9 @@ async fn seed_incidents(conn: &mut impl SimpleAsyncConnection) {
 			('{INC_OPEN}', NOW(), NOW(), '{IGROUP}', NOW() - interval '2 days', NULL), \
 			('{INC_CLOSED}', NOW(), NOW(), '{IGROUP}', NOW() - interval '5 days', NOW() - interval '3 days'); \
 		 INSERT INTO incident_issues (incident_id, issue_id, joined_at, left_at) VALUES \
-			('{INC_OPEN}', '{ISSUE1}', NOW() - interval '2 days', NULL);"
+			('{INC_OPEN}', '{ISSUE1}', NOW() - interval '2 days', NULL); \
+		 INSERT INTO slack_outbox (kind, incident_id, payload, deliver_after, delivered_at, attempts) VALUES \
+			('incident_open', '{INC_OPEN}', '{{}}'::jsonb, NOW() - interval '2 days', NOW() - interval '2 days', 1);"
 	))
 	.await
 	.expect("seed incidents");
@@ -387,6 +389,17 @@ async fn incidents_window_status_and_detail() {
 		assert_eq!(open["status"], "open");
 		assert_eq!(open["group_name"], "Inc Group");
 		assert_eq!(open["issue_count"], 1);
+		// INC_OPEN has a delivered Slack open → published; INC_CLOSED has none.
+		assert_eq!(open["published"], true);
+		assert!(open["open_duration_secs"].as_i64().unwrap() > 0);
+		assert_eq!(week["published_count"], 1);
+		let closed = week["incidents"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|i| i["id"] == INC_CLOSED)
+			.unwrap();
+		assert_eq!(closed["published"], false);
 
 		// 1-day window excludes the incident that closed 3 days ago.
 		let day = call_tool!(
@@ -414,6 +427,7 @@ async fn incidents_window_status_and_detail() {
 			"get_incident",
 			serde_json::json!({ "incident_id": INC_OPEN })
 		);
+		assert_eq!(detail["published"], true);
 		let issues = detail["issues"].as_array().unwrap();
 		assert_eq!(issues.len(), 1);
 		assert_eq!(issues[0]["issue_id"], ISSUE1);


### PR DESCRIPTION
🤖 Gives MCP agents the context to interpret incidents correctly — they were over-counting raw flapping rows as real incidents.

Stacked on #277 (base will retarget to main once that merges).

## What an agent gets

- Each incident now carries **published** — true when it actually surfaced to operators (its Slack open notice was delivered), which happens only when it outlived its group's grace window (slack_open_delay, ~3 min default) or it escalated (a critical issue joined, bypassing the grace). find_incidents also returns **published_count**, and each incident gets **open_duration_secs**.
- published is derived from the slack_outbox (new SlackOutbox::delivered_open_ids) — the authoritative "it surfaced" signal. That's exact: it accounts for opens cancelled when an incident flaps shut within the grace, and for delivery give-ups. It is NOT a `now - opened_at >= 10min` approximation (the grace is per-group and defaults to 3 min, and a time guess would misclassify cancelled/failed deliveries).

## The help text

- The find_incidents tool description and the server-level instructions (returned at initialize) now explain that find_incidents includes heavy sub-grace flapping, that event_count is raw churn (not duration or severity — a huge count can be a sub-minute flap), and that summaries/rankings should count published incidents, not raw rows.

This is the mechanism for "give agents context": MCP clients read the server instructions on connect and the per-tool descriptions, so the guidance travels with the tools.

Spec updated; MCP tests extended to cover published / published_count.