### PR TITLE
feat(private-web): redesign group backup panel; per-server next-backup

### DIFF
--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -18,12 +18,13 @@ use commons_types::{
 	Uuid,
 	backup::{BackupConfigStatus, BackupPlacement, BackupPurpose, BackupRepoMode, BackupType},
 };
+use database::diesel_async::AsyncPgConnection;
 use database::pg_duration::PgDuration;
 use database::{
 	BackupMaintenanceRun, BackupRecoveryVerification, BackupRepoStats, BackupRequest, BackupRun,
 	BackupTypeDefault, NewBackupTypeDefault, NewServerGroupBackupConfig,
 	NewServerGroupBackupSchedule, RetentionPolicy, ServerBackupCapability, ServerGroupBackupConfig,
-	ServerGroupBackupSchedule, server_groups::ServerGroup,
+	ServerGroupBackupSchedule, server_groups::ServerGroup, servers::Server,
 };
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -256,6 +257,42 @@ pub struct BackupStatsView {
 /// One `(server, type)` backup capability and whether the operator has it
 /// enabled. `enabled` toggles whether the scheduler issues credentials and
 /// schedules runs for the pair.
+///
+/// Effective scheduled interval (seconds) for a `(group, type)`: the per-group
+/// override if set, else the canopy-wide default. `None` = manual-only.
+async fn effective_interval_secs(
+	conn: &mut AsyncPgConnection,
+	group_id: Uuid,
+	ty: &BackupType,
+) -> Result<Option<i64>> {
+	let over = ServerGroupBackupSchedule::get(conn, group_id, ty).await?;
+	let def = BackupTypeDefault::get(conn, ty).await?;
+	Ok(over
+		.as_ref()
+		.and_then(|s| s.expected_interval)
+		.or_else(|| def.as_ref().and_then(|d| d.default_interval))
+		.map(|pg| pg.0.as_secs()))
+}
+
+/// Next expected backup for one `(server, type)`: the server's own last success
+/// plus the interval, or `now` (overdue) if scheduled-but-never-run. `None` when
+/// disabled or manual-only.
+fn next_backup_at(
+	enabled: bool,
+	interval_secs: Option<i64>,
+	last_success_at: Option<Timestamp>,
+	now: Timestamp,
+) -> Option<Timestamp> {
+	if !enabled {
+		return None;
+	}
+	let secs = interval_secs?;
+	Some(match last_success_at {
+		Some(last) => Timestamp::from_second(last.as_second() + secs).unwrap_or(now),
+		None => now,
+	})
+}
+
 #[derive(Serialize, ToSchema)]
 pub struct ServerBackupCapabilityView {
 	pub server_id: Uuid,
@@ -270,6 +307,12 @@ pub struct ServerBackupCapabilityView {
 	pub latest_snapshot_at: Option<Timestamp>,
 	/// Bytes uploaded by that run, if reported.
 	pub latest_snapshot_bytes: Option<i64>,
+	/// When this server's next backup of this type is expected: the server's own
+	/// last success plus the effective interval, or "now" (overdue) if it's
+	/// scheduled but has never succeeded. `None` for disabled or manual-only
+	/// (no-interval) types. Per-server, so a lagging member isn't masked by a
+	/// freshly-backed-up sibling.
+	pub next_backup_at: Option<Timestamp>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -1134,6 +1177,9 @@ pub async fn stats(
 	// Latest successful backup per (server, type), to decorate each capability.
 	let latest_by =
 		BackupRun::latest_success_by_server_type_for_group(&mut conn, args.server_group_id).await?;
+	let now = Timestamp::now();
+	let mut intervals: std::collections::HashMap<BackupType, Option<i64>> =
+		std::collections::HashMap::new();
 	let mut pending_requests = Vec::new();
 	let mut capabilities = Vec::new();
 	for server in &members {
@@ -1148,11 +1194,26 @@ pub async fn stats(
 		}
 		for cap in ServerBackupCapability::list_for_server(&mut conn, server.id).await? {
 			let last = latest_by.get(&(cap.server_id, cap.r#type.clone()));
+			let interval = match intervals.get(&cap.r#type) {
+				Some(v) => *v,
+				None => {
+					let v = effective_interval_secs(&mut conn, args.server_group_id, &cap.r#type)
+						.await?;
+					intervals.insert(cap.r#type.clone(), v);
+					v
+				}
+			};
 			capabilities.push(ServerBackupCapabilityView {
 				server_id: cap.server_id,
 				latest_snapshot_id: last.and_then(|r| r.snapshot_id.clone()),
 				latest_snapshot_at: last.map(|r| r.reported_at),
 				latest_snapshot_bytes: last.and_then(|r| r.bytes_uploaded),
+				next_backup_at: next_backup_at(
+					cap.enabled,
+					interval,
+					last.map(|r| r.reported_at),
+					now,
+				),
 				r#type: cap.r#type,
 				enabled: cap.enabled,
 			});
@@ -1184,15 +1245,30 @@ pub async fn capabilities(
 	Json(args): Json<ServerArgs>,
 ) -> Result<Json<Vec<ServerBackupCapabilityView>>> {
 	let mut conn = state.db.get().await?;
+	let group_id = Server::get_by_id(&mut conn, args.server_id)
+		.await
+		.ok()
+		.and_then(|s| s.group_id);
+	let now = Timestamp::now();
 	let rows = ServerBackupCapability::list_for_server(&mut conn, args.server_id).await?;
 	let mut out = Vec::with_capacity(rows.len());
 	for c in rows {
 		let last = BackupRun::latest_success_for_server(&mut conn, c.server_id, &c.r#type).await?;
+		let interval = match group_id {
+			Some(g) => effective_interval_secs(&mut conn, g, &c.r#type).await?,
+			None => None,
+		};
 		out.push(ServerBackupCapabilityView {
 			server_id: c.server_id,
 			latest_snapshot_id: last.as_ref().and_then(|r| r.snapshot_id.clone()),
 			latest_snapshot_at: last.as_ref().map(|r| r.reported_at),
 			latest_snapshot_bytes: last.as_ref().and_then(|r| r.bytes_uploaded),
+			next_backup_at: next_backup_at(
+				c.enabled,
+				interval,
+				last.as_ref().map(|r| r.reported_at),
+				now,
+			),
 			r#type: c.r#type,
 			enabled: c.enabled,
 		});

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -186,17 +186,15 @@ test.describe("backups ready: stats + backup-now", () => {
 
 		await page.goto(`/groups/${group.id}/backups`);
 
-		// Scope to the schedule panel: the type now also appears in the "Back up
-		// now" panel (as a declared-type label), so a page-wide text match is
-		// ambiguous.
+		// Scope to the schedule panel: the type also appears in the Servers
+		// panel (as a declared-type label), so a page-wide text match is
+		// ambiguous. (Next-expected lives in the Servers panel now, not here.)
 		const schedules = page
 			.getByRole("heading", { name: /schedule & retention/i })
 			.locator("..");
 		// No override yet → inherits the seeded canopy-wide default.
 		await expect(schedules.getByText("tamanu-postgres")).toBeVisible();
 		await expect(schedules.getByText("Inherited default")).toBeVisible();
-		// A scheduled type shows its next expected run (no successful run yet → now).
-		await expect(schedules.getByText(/next backup expected/i)).toBeVisible();
 
 		// Override the interval to 12h.
 		await page.getByRole("button", { name: /^override$/i }).click();
@@ -426,7 +424,7 @@ test.describe("backups ready: stats + backup-now", () => {
 		// Both declared types are listed (the disabled-for-schedule one too, since
 		// a one-off backup-now overrides the enabled gate), each with its own button.
 		const panel = page
-			.getByRole("heading", { name: /back up now/i })
+			.getByRole("heading", { name: /^servers$/i })
 			.locator("..");
 		await expect(panel.getByText("tamanu-postgres")).toBeVisible();
 		await expect(panel.getByText("files")).toBeVisible();
@@ -438,9 +436,10 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(panel.getByText(/not scheduled/i)).toBeVisible();
 
 		// Backing up the non-default type writes a request for exactly that type.
+		// Scope to the files row so we click that type's button, not the other's.
 		await panel
-			.getByText("files")
-			.locator("..")
+			.getByRole("row")
+			.filter({ hasText: "files" })
 			.getByRole("button", { name: /backup now/i })
 			.click();
 		await expect(async () => {
@@ -451,6 +450,52 @@ test.describe("backups ready: stats + backup-now", () => {
 			expect(rows).toHaveLength(1);
 			expect(rows[0]!.type).toBe("files");
 		}).toPass();
+	});
+
+	test("servers panel shows per-server next-backup (a lagging member isn't masked)", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "lag-group" });
+		const device = await seedDevice(sql);
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+			intervalSeconds: 7200, // 2h
+		});
+		const ahead = await seedServer(sql, { name: "srv-ahead", groupId: group.id });
+		const behind = await seedServer(sql, {
+			name: "srv-behind",
+			groupId: group.id,
+		});
+		await seedServerBackupCapability(sql, { serverId: ahead.id });
+		await seedServerBackupCapability(sql, { serverId: behind.id });
+		// Only `ahead` has actually backed up.
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: ahead.id,
+			outcome: "success",
+			bytesUploaded: 4096,
+			snapshotId: "kdeadbeef0123cafe",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const panel = page
+			.getByRole("heading", { name: /^servers$/i })
+			.locator("..");
+		await expect(panel.getByText("Next backup")).toBeVisible();
+
+		// The ahead server's next backup is in the future; it has a snapshot.
+		const aheadRow = panel.getByRole("row").filter({ hasText: "srv-ahead" });
+		await expect(aheadRow.getByText(/^in /)).toBeVisible();
+		await expect(aheadRow.getByText(/kdeadbeef/)).toBeVisible();
+
+		// The behind server never backed up → due now (not masked by `ahead`).
+		const behindRow = panel.getByRole("row").filter({ hasText: "srv-behind" });
+		// exact: the "Backup now" button also contains "now".
+		await expect(behindRow.getByText("now", { exact: true })).toBeVisible();
+		await expect(behindRow.getByText(/no snapshot yet/i)).toBeVisible();
 	});
 
 	test("backup page names the group and cross-links to/from the server backup section", async ({

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -8295,7 +8295,6 @@
       },
       "ServerBackupCapabilityView": {
         "type": "object",
-        "description": "One `(server, type)` backup capability and whether the operator has it\nenabled. `enabled` toggles whether the scheduler issues credentials and\nschedules runs for the pair.",
         "required": [
           "server_id",
           "type",
@@ -8327,6 +8326,14 @@
               "null"
             ],
             "description": "kopia snapshot id of this server+type's most recent successful backup,\nif any."
+          },
+          "next_backup_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When this server's next backup of this type is expected: the server's own\nlast success plus the effective interval, or \"now\" (overdue) if it's\nscheduled but has never succeeded. `None` for disabled or manual-only\n(no-interval) types. Per-server, so a lagging member isn't masked by a\nfreshly-backed-up sibling."
           },
           "server_id": {
             "type": "string",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3347,11 +3347,6 @@ export interface components {
             /** Format: uuid */
             server_id: string;
         };
-        /**
-         * @description One `(server, type)` backup capability and whether the operator has it
-         *     enabled. `enabled` toggles whether the scheduler issues credentials and
-         *     schedules runs for the pair.
-         */
         ServerBackupCapabilityView: {
             enabled: boolean;
             /**
@@ -3369,6 +3364,15 @@ export interface components {
              *     if any.
              */
             latest_snapshot_id?: string | null;
+            /**
+             * Format: date-time
+             * @description When this server's next backup of this type is expected: the server's own
+             *     last success plus the effective interval, or "now" (overdue) if it's
+             *     scheduled but has never succeeded. `None` for disabled or manual-only
+             *     (no-interval) types. Per-server, so a lagging member isn't masked by a
+             *     freshly-backed-up sibling.
+             */
+            next_backup_at?: string | null;
             /** Format: uuid */
             server_id: string;
             type: string;

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -10,7 +10,6 @@ import {
 	DialogContent,
 	DialogContentText,
 	DialogTitle,
-	Divider,
 	FormControlLabel,
 	IconButton,
 	LinearProgress,
@@ -179,11 +178,27 @@ export default function BackupPanel() {
 				</Stack>
 			</Box>
 
-			<Alert severity={BACKUP_STATUS_INTENT[status]}>
-				{BACKUP_STATUS_HELP[status]}
-			</Alert>
+			{status !== "ready" && (
+				<Alert severity={BACKUP_STATUS_INTENT[status]}>
+					{BACKUP_STATUS_HELP[status]}
+				</Alert>
+			)}
 
-			<ConfigSummary config={data} />
+			{status === "ready" ? (
+				<Box
+					sx={{
+						display: "grid",
+						gap: 2,
+						gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
+						alignItems: "start",
+					}}
+				>
+					<ConfigSummary config={data} />
+					<RepoStatsPanel groupId={id} />
+				</Box>
+			) : (
+				<ConfigSummary config={data} />
+			)}
 
 			{status === "provisioning" && (
 				<ProvisioningCard
@@ -195,13 +210,9 @@ export default function BackupPanel() {
 
 			{status === "ready" && (
 				<>
+					<ServersPanel groupId={id} members={members} isAdmin={isAdmin} />
 					<SchedulesPanel groupId={id} isAdmin={isAdmin} />
-					<StatsPanel groupId={id} members={members} />
-					<RunsAndRequests
-						groupId={id}
-						members={members}
-						isAdmin={isAdmin}
-					/>
+					<RecentRunsPanel groupId={id} members={members} />
 				</>
 			)}
 		</Stack>
@@ -399,12 +410,6 @@ function TypeSchedule({
 				· retention latest {r.keep_latest}, daily {r.keep_daily}, weekly{" "}
 				{r.keep_weekly}, monthly {r.keep_monthly}, annual {r.keep_annual}
 			</Typography>
-			{schedule.effective_interval != null && schedule.next_run_at && (
-				<Typography variant="body2" color="text.secondary">
-					Next backup expected{" "}
-					<TimeAgo timestamp={schedule.next_run_at} />
-				</Typography>
-			)}
 			{editing && (
 				<OverrideEditor
 					groupId={groupId}
@@ -679,7 +684,55 @@ function RunRow({ run, members }: { run: BackupRun; members: ServerInfo[] }) {
 	);
 }
 
-function StatsPanel({
+/// Repository stats (top, beside the config summary). Read-only snapshot of the
+/// kopia repo's size/counts as of the last inspection.
+function RepoStatsPanel({ groupId }: { groupId: string }) {
+	const stats = useApi(
+		"backups",
+		"stats",
+		{ server_group_id: groupId },
+		[groupId],
+	);
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }}>
+			<Typography variant="h6" component="h2" gutterBottom>
+				Repository stats
+			</Typography>
+			{stats.status === "loading" || stats.status === "idle" ? (
+				<LinearProgress />
+			) : stats.status === "error" ? (
+				<Alert severity="error">{stats.error.message}</Alert>
+			) : stats.data.stats == null ? (
+				<Typography color="text.secondary">
+					No stats yet (awaiting first inspection).
+				</Typography>
+			) : (
+				<Stack spacing={0.5}>
+					<Stat label="Snapshots" value={stats.data.stats.snapshot_count} />
+					<Stat label="Sources" value={stats.data.stats.source_count} />
+					<Stat
+						label="Logical bytes"
+						value={formatBytes(stats.data.stats.logical_bytes)}
+					/>
+					<Stat
+						label="Physical bytes"
+						value={formatBytes(stats.data.stats.physical_bytes)}
+					/>
+					<Stat
+						label="Bucket bytes"
+						value={formatBytes(stats.data.stats.bucket_bytes)}
+					/>
+					<Typography variant="caption" color="text.secondary">
+						Observed <TimeAgo timestamp={stats.data.stats.observed_at} />
+					</Typography>
+				</Stack>
+			)}
+		</Paper>
+	);
+}
+
+/// The group's recent backup runs (bottom). Failed runs expand to their error.
+function RecentRunsPanel({
 	groupId,
 	members,
 }: {
@@ -692,69 +745,49 @@ function StatsPanel({
 		{ server_group_id: groupId },
 		[groupId],
 	);
-	if (stats.status === "loading" || stats.status === "idle") {
-		return <LinearProgress />;
-	}
-	if (stats.status === "error") {
-		return <Alert severity="error">{stats.error.message}</Alert>;
-	}
-	const s = stats.data.stats;
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
 			<Typography variant="h6" component="h2" gutterBottom>
-				Repository stats
-			</Typography>
-			{s == null ? (
-				<Typography color="text.secondary">
-					No stats yet (awaiting first inspection).
-				</Typography>
-			) : (
-				<Stack spacing={0.5}>
-					<Stat label="Snapshots" value={s.snapshot_count} />
-					<Stat label="Sources" value={s.source_count} />
-					<Stat label="Logical bytes" value={formatBytes(s.logical_bytes)} />
-					<Stat label="Physical bytes" value={formatBytes(s.physical_bytes)} />
-					<Stat
-						label="Bucket bytes"
-						value={formatBytes(s.bucket_bytes)}
-					/>
-					<Typography variant="caption" color="text.secondary">
-						Observed <TimeAgo timestamp={s.observed_at} />
-					</Typography>
-				</Stack>
-			)}
-			<Divider sx={{ my: 2 }} />
-			<Typography variant="subtitle1" gutterBottom>
 				Recent runs
 			</Typography>
-			{stats.data.recent_runs.length === 0 ? (
+			{stats.status === "loading" || stats.status === "idle" ? (
+				<LinearProgress />
+			) : stats.status === "error" ? (
+				<Alert severity="error">{stats.error.message}</Alert>
+			) : stats.data.recent_runs.length === 0 ? (
 				<Typography color="text.secondary">No runs reported yet.</Typography>
 			) : (
-				<Table size="small">
-					<TableHead>
-						<TableRow>
-							<TableCell padding="checkbox" />
-							<TableCell>When</TableCell>
-							<TableCell>Server</TableCell>
-							<TableCell>Type</TableCell>
-							<TableCell>Purpose</TableCell>
-							<TableCell>Outcome</TableCell>
-							<TableCell>Uploaded</TableCell>
-							<TableCell>Snapshot</TableCell>
-						</TableRow>
-					</TableHead>
-					<TableBody>
-						{stats.data.recent_runs.map((r) => (
-							<RunRow key={r.id} run={r} members={members} />
-						))}
-					</TableBody>
-				</Table>
+				<Box sx={{ overflowX: "auto" }}>
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell padding="checkbox" />
+								<TableCell>When</TableCell>
+								<TableCell>Server</TableCell>
+								<TableCell>Type</TableCell>
+								<TableCell>Purpose</TableCell>
+								<TableCell>Outcome</TableCell>
+								<TableCell>Uploaded</TableCell>
+								<TableCell>Snapshot</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{stats.data.recent_runs.map((r) => (
+								<RunRow key={r.id} run={r} members={members} />
+							))}
+						</TableBody>
+					</Table>
+				</Box>
 			)}
 		</Paper>
 	);
 }
 
-function RunsAndRequests({
+/// The group's servers and their backup types: per (server, type) the schedule
+/// state, when the next backup is expected (per-server, so a lagging member
+/// isn't masked by a freshly-backed-up sibling), the latest snapshot, and the
+/// on-demand "backup now" action.
+function ServersPanel({
 	groupId,
 	members,
 	isAdmin,
@@ -772,10 +805,8 @@ function RunsAndRequests({
 	const requestNow = useApiAction("backups", "request_now");
 	const cancel = useApiAction("backups", "cancel_request");
 
-	const pending =
-		stats.status === "ok" ? stats.data.pending_requests : [];
-	const capabilities =
-		stats.status === "ok" ? stats.data.capabilities : [];
+	const pending = stats.status === "ok" ? stats.data.pending_requests : [];
+	const capabilities = stats.status === "ok" ? stats.data.capabilities : [];
 
 	// The backup types to offer per server: the ones it has declared it can run
 	// (bestool fails fast on a type it has no definition for), unioned with any
@@ -791,31 +822,17 @@ function RunsAndRequests({
 		}
 		return [...set].sort();
 	};
-
 	const pendingFor = (serverId: string, type: string) =>
 		pending.find(
 			(p) =>
-				p.server_id === serverId &&
-				p.type === type &&
-				p.purpose === "backup",
+				p.server_id === serverId && p.type === type && p.purpose === "backup",
 		);
-
-	// Whether the server has this type toggled on (scheduled). `undefined` when
-	// the type isn't a declared capability (e.g. a lingering pending request).
-	const enabledFor = (serverId: string, type: string): boolean | undefined =>
-		capabilities.find((c) => c.server_id === serverId && c.type === type)
-			?.enabled;
-
 	const capFor = (serverId: string, type: string) =>
 		capabilities.find((c) => c.server_id === serverId && c.type === type);
 
 	const onRequest = async (serverId: string, type: string) => {
 		try {
-			await requestNow.call({
-				server_id: serverId,
-				type,
-				purpose: "backup",
-			});
+			await requestNow.call({ server_id: serverId, type, purpose: "backup" });
 			stats.reload();
 		} catch {
 			/* surfaced via requestNow.error */
@@ -823,87 +840,147 @@ function RunsAndRequests({
 	};
 	const onCancel = async (serverId: string, type: string) => {
 		try {
-			await cancel.call({
-				server_id: serverId,
-				type,
-				purpose: "backup",
-			});
+			await cancel.call({ server_id: serverId, type, purpose: "backup" });
 			stats.reload();
 		} catch {
 			/* surfaced via cancel.error */
 		}
 	};
 
+	const serverLink = (m: ServerInfo) => (
+		<MuiLink
+			component={RouterLink}
+			to={`/servers/${m.id}#backups`}
+			variant="body2"
+			underline="hover"
+		>
+			{m.name ?? m.id.slice(0, 8)}
+		</MuiLink>
+	);
+
+	const actionCell = (serverId: string, type: string) => {
+		const req = pendingFor(serverId, type);
+		if (req) {
+			return (
+				<Stack
+					direction="row"
+					spacing={1}
+					sx={{ alignItems: "center", justifyContent: "flex-end" }}
+				>
+					<Chip
+						size="small"
+						color="info"
+						label={
+							<>
+								requested <TimeAgo timestamp={req.requested_at} />
+							</>
+						}
+					/>
+					{isAdmin && (
+						<Button
+							size="small"
+							color="error"
+							onClick={() => onCancel(serverId, type)}
+							disabled={cancel.pending}
+						>
+							Cancel
+						</Button>
+					)}
+				</Stack>
+			);
+		}
+		return (
+			isAdmin && (
+				<Button
+					size="small"
+					variant="outlined"
+					startIcon={<BackupIcon />}
+					onClick={() => onRequest(serverId, type)}
+					disabled={requestNow.pending}
+				>
+					Backup now
+				</Button>
+			)
+		);
+	};
+
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
 			<Typography variant="h6" component="h2" gutterBottom>
-				Back up now
+				Servers
 			</Typography>
 			{members.length === 0 ? (
 				<Typography color="text.secondary">
 					No member servers in this group.
 				</Typography>
 			) : (
-				<Stack spacing={1} divider={<Divider />}>
-					{members.map((m) => {
-						const types = typesForServer(m.id);
-						return (
-							<Stack
-								key={m.id}
-								direction="row"
-								spacing={2}
-								sx={{
-									alignItems: "flex-start",
-									justifyContent: "space-between",
-								}}
-							>
-								<MuiLink
-									component={RouterLink}
-									to={`/servers/${m.id}#backups`}
-									variant="body2"
-									underline="hover"
-									sx={{ pt: 0.75 }}
-								>
-									{m.name ?? m.id.slice(0, 8)}
-								</MuiLink>
-								{types.length === 0 ? (
-									<Tooltip title="This server hasn't registered any backup types yet.">
-										{/* span so the tooltip works on the disabled button */}
-										<span>
-											<Button
-												size="small"
-												variant="outlined"
-												startIcon={<BackupIcon />}
-												disabled
-											>
-												Backup now
-											</Button>
-										</span>
-									</Tooltip>
-								) : (
-									<Stack spacing={0.5} sx={{ alignItems: "flex-end" }}>
-										{types.map((t) => {
-											const req = pendingFor(m.id, t);
-											const cap = capFor(m.id, t);
-											return (
-												<Stack
-													key={t}
-													spacing={0.25}
-													sx={{ alignItems: "flex-end" }}
-												>
-													<Stack
-														direction="row"
-														spacing={1}
-														sx={{ alignItems: "center" }}
-													>
-														<Typography
-															variant="body2"
-															sx={{ fontFamily: "monospace" }}
+				<Box sx={{ overflowX: "auto" }}>
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell>Server</TableCell>
+								<TableCell>Type</TableCell>
+								<TableCell>Next backup</TableCell>
+								<TableCell>Latest snapshot</TableCell>
+								<TableCell align="right">Actions</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{members.map((m) => {
+								const types = typesForServer(m.id);
+								if (types.length === 0) {
+									return (
+										<TableRow key={m.id}>
+											<TableCell>{serverLink(m)}</TableCell>
+											<TableCell colSpan={3}>
+												<Typography variant="body2" color="text.secondary">
+													No backup types registered yet
+												</Typography>
+											</TableCell>
+											<TableCell align="right">
+												<Tooltip title="This server hasn't registered any backup types yet.">
+													{/* span so the tooltip works on the disabled button */}
+													<span>
+														<Button
+															size="small"
+															variant="outlined"
+															startIcon={<BackupIcon />}
+															disabled
 														>
-															{t}
-														</Typography>
-													{enabledFor(m.id, t) === false && (
-														<Tooltip title="This type isn't on the backup schedule for this server (toggle it on in the server's Backups section). You can still back it up on demand.">
+															Backup now
+														</Button>
+													</span>
+												</Tooltip>
+											</TableCell>
+										</TableRow>
+									);
+								}
+								return types.map((t, i) => {
+									const cap = capFor(m.id, t);
+									return (
+										<TableRow key={`${m.id}:${t}`}>
+											{i === 0 && (
+												<TableCell
+													rowSpan={types.length}
+													sx={{ verticalAlign: "top" }}
+												>
+													{serverLink(m)}
+												</TableCell>
+											)}
+											<TableCell>
+												<Stack
+													direction="row"
+													spacing={1}
+													sx={{ alignItems: "center" }}
+												>
+													<Typography
+														variant="body2"
+														sx={{ fontFamily: "monospace" }}
+													>
+														{t}
+													</Typography>
+													{cap?.enabled === false && (
+														<Tooltip title="Not on the backup schedule for this server (toggle it on in the server's Backups section). You can still back it up on demand.">
 															<Chip
 																size="small"
 																variant="outlined"
@@ -911,57 +988,32 @@ function RunsAndRequests({
 															/>
 														</Tooltip>
 													)}
-													{req ? (
-														<>
-															<Chip
-																size="small"
-																color="info"
-																label={
-																	<>
-																		requested{" "}
-																		<TimeAgo timestamp={req.requested_at} />
-																	</>
-																}
-															/>
-															{isAdmin && (
-																<Button
-																	size="small"
-																	color="error"
-																	onClick={() => onCancel(m.id, t)}
-																	disabled={cancel.pending}
-																>
-																	Cancel
-																</Button>
-															)}
-														</>
-													) : (
-														isAdmin && (
-															<Button
-																size="small"
-																variant="outlined"
-																startIcon={<BackupIcon />}
-																onClick={() => onRequest(m.id, t)}
-																disabled={requestNow.pending}
-															>
-																Backup now
-															</Button>
-														)
-													)}
 												</Stack>
+											</TableCell>
+											<TableCell>
+												{cap?.next_backup_at ? (
+													<TimeAgo timestamp={cap.next_backup_at} />
+												) : (
+													<Typography variant="body2" color="text.secondary">
+														—
+													</Typography>
+												)}
+											</TableCell>
+											<TableCell>
 												<LatestSnapshot
 													id={cap?.latest_snapshot_id}
 													at={cap?.latest_snapshot_at}
 													bytes={cap?.latest_snapshot_bytes}
 												/>
-											</Stack>
-											);
-										})}
-									</Stack>
-								)}
-							</Stack>
-						);
-					})}
-				</Stack>
+											</TableCell>
+											<TableCell align="right">{actionCell(m.id, t)}</TableCell>
+										</TableRow>
+									);
+								});
+							})}
+						</TableBody>
+					</Table>
+				</Box>
 			)}
 			{(requestNow.error || cancel.error) && (
 				<Alert severity="error" sx={{ mt: 1 }}>


### PR DESCRIPTION
🤖 Reworks the group backup page and fixes a misleading "next backup expected".

## The bug it fixes

The schedule panel showed one group-level "next backup expected" per type, computed from the *most-recently-succeeded* server. If one member had backed up and another hadn't, the panel read "all good" and masked the lagging member. (Backups themselves were always per-server — only the headline was aggregated.)

Now next-expected is **per server**: a new next_backup_at on ServerBackupCapabilityView = that server's own last success + the effective interval, or "now" (overdue) if it's scheduled but has never succeeded. Computed in the stats and capabilities handlers; openapi + api-types regenerated.

## Layout changes

- **Repo stats** move to the top, in a second column beside the bucket/region config.
- **"Back up now" → "Servers"**, rebuilt as a proper table — Server | Type | Next backup | Latest snapshot | Actions — that spreads on wide screens (was a cramped flex row), and moved up to second position.
- **Recent runs** move to the bottom.
- Dropped the redundant "backups are active for this group" success banner (only non-ready states get an alert now).

## Tests

- `cargo` backups + openapi-drift tests pass.
- Playwright: updated the specs for the new layout and added one for the headline fix — a group with one server backed up and one not now shows the ahead server "in 1h" and the lagging server "now", proving per-server next-expected. 20 backups specs pass.