### PR TITLE
feat: show 'backing up…' when a backup is in flight

### DIFF
--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -732,6 +732,31 @@ impl BackupCredentialIssuance {
 			.await
 			.map_err(AppError::from)
 	}
+
+	/// Latest *backup-purpose* credential issuance per `(device, type)` within a
+	/// group, as `(issued_at, expires_at)`. Keyed `(device_id, type)`; restore
+	/// issuances are excluded. Used to infer an in-flight backup: creds still
+	/// within their validity window with no newer run report.
+	pub async fn latest_backup_by_device_type_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<HashMap<(Uuid, BackupType), (Timestamp, Timestamp)>> {
+		use crate::schema::backup_credential_issuances::dsl;
+
+		let rows: Vec<Self> = dsl::backup_credential_issuances
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::purpose.eq(BackupPurpose::Backup))
+			.distinct_on((dsl::device_id, dsl::type_))
+			.order_by((dsl::device_id, dsl::type_, dsl::issued_at.desc()))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+
+		Ok(rows
+			.into_iter()
+			.map(|r| ((r.device_id, r.r#type.clone()), (r.issued_at, r.expires_at)))
+			.collect())
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -846,6 +871,35 @@ impl BackupRun {
 		Ok(rows
 			.into_iter()
 			.filter_map(|r| r.server_id.map(|sid| ((sid, r.r#type.clone()), r)))
+			.collect())
+	}
+
+	/// Latest *reported* backup per `(server, type)` within a group, regardless of
+	/// outcome (success or failure). Keyed `(server_id, type)`. Used to tell
+	/// whether a backup has been reported since credentials were last issued —
+	/// i.e. whether one is still in flight.
+	pub async fn latest_report_by_server_type_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<HashMap<(Uuid, BackupType), Timestamp>> {
+		use crate::schema::backup_runs::dsl;
+
+		let rows: Vec<Self> = dsl::backup_runs
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::purpose.eq(BackupPurpose::Backup))
+			.filter(dsl::server_id.is_not_null())
+			.distinct_on((dsl::server_id, dsl::type_))
+			.order_by((dsl::server_id, dsl::type_, dsl::reported_at.desc()))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+
+		Ok(rows
+			.into_iter()
+			.filter_map(|r| {
+				r.server_id
+					.map(|sid| ((sid, r.r#type.clone()), r.reported_at))
+			})
 			.collect())
 	}
 

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -18,6 +18,7 @@ use commons_types::{
 	Uuid,
 	backup::{BackupConfigStatus, BackupPlacement, BackupPurpose, BackupRepoMode, BackupType},
 };
+use database::backups::BackupCredentialIssuance;
 use database::diesel_async::AsyncPgConnection;
 use database::pg_duration::PgDuration;
 use database::{
@@ -274,6 +275,25 @@ async fn effective_interval_secs(
 		.map(|pg| pg.0.as_secs()))
 }
 
+/// `Some(issued_at)` when a backup looks in flight: a backup credential is still
+/// within its validity window (`now < expires_at`) and no run has been reported
+/// since it was issued. `None` otherwise. The window is the credential lifetime
+/// itself — once the creds expire the device can no longer be using them.
+fn processing_since(
+	now: Timestamp,
+	issuance: Option<(Timestamp, Timestamp)>,
+	last_report_at: Option<Timestamp>,
+) -> Option<Timestamp> {
+	let (issued, expires) = issuance?;
+	if now >= expires {
+		return None;
+	}
+	match last_report_at {
+		Some(reported) if reported >= issued => None,
+		_ => Some(issued),
+	}
+}
+
 /// Next expected backup for one `(server, type)`: the server's own last success
 /// plus the interval, or `now` (overdue) if scheduled-but-never-run. `None` when
 /// disabled or manual-only.
@@ -313,6 +333,10 @@ pub struct ServerBackupCapabilityView {
 	/// (no-interval) types. Per-server, so a lagging member isn't masked by a
 	/// freshly-backed-up sibling.
 	pub next_backup_at: Option<Timestamp>,
+	/// `Some(issued_at)` when a backup of this type appears to be in flight:
+	/// credentials were issued under an hour ago and no run has been reported
+	/// since. `None` otherwise. Lets the UI show a "backing up…" state.
+	pub processing_since: Option<Timestamp>,
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -1177,6 +1201,17 @@ pub async fn stats(
 	// Latest successful backup per (server, type), to decorate each capability.
 	let latest_by =
 		BackupRun::latest_success_by_server_type_for_group(&mut conn, args.server_group_id).await?;
+	// In-flight detection: latest backup-cred issuance per (device, type) and the
+	// latest reported run (any outcome) per (server, type).
+	let latest_issuance = BackupCredentialIssuance::latest_backup_by_device_type_for_group(
+		&mut conn,
+		args.server_group_id,
+	)
+	.await?;
+	let latest_report =
+		BackupRun::latest_report_by_server_type_for_group(&mut conn, args.server_group_id).await?;
+	let device_by_server: std::collections::HashMap<Uuid, Option<Uuid>> =
+		members.iter().map(|s| (s.id, s.device_id)).collect();
 	let now = Timestamp::now();
 	let mut intervals: std::collections::HashMap<BackupType, Option<i64>> =
 		std::collections::HashMap::new();
@@ -1203,6 +1238,14 @@ pub async fn stats(
 					v
 				}
 			};
+			let issuance = device_by_server
+				.get(&cap.server_id)
+				.copied()
+				.flatten()
+				.and_then(|d| latest_issuance.get(&(d, cap.r#type.clone())).copied());
+			let last_report = latest_report
+				.get(&(cap.server_id, cap.r#type.clone()))
+				.copied();
 			capabilities.push(ServerBackupCapabilityView {
 				server_id: cap.server_id,
 				latest_snapshot_id: last.and_then(|r| r.snapshot_id.clone()),
@@ -1214,6 +1257,7 @@ pub async fn stats(
 					last.map(|r| r.reported_at),
 					now,
 				),
+				processing_since: processing_since(now, issuance, last_report),
 				r#type: cap.r#type,
 				enabled: cap.enabled,
 			});
@@ -1245,11 +1289,20 @@ pub async fn capabilities(
 	Json(args): Json<ServerArgs>,
 ) -> Result<Json<Vec<ServerBackupCapabilityView>>> {
 	let mut conn = state.db.get().await?;
-	let group_id = Server::get_by_id(&mut conn, args.server_id)
+	let (group_id, device_id) = Server::get_by_id(&mut conn, args.server_id)
 		.await
 		.ok()
-		.and_then(|s| s.group_id);
+		.map(|s| (s.group_id, s.device_id))
+		.unwrap_or((None, None));
 	let now = Timestamp::now();
+	// Reuse the group-wide in-flight maps, then look up this server/device.
+	let (latest_issuance, latest_report) = match group_id {
+		Some(g) => (
+			BackupCredentialIssuance::latest_backup_by_device_type_for_group(&mut conn, g).await?,
+			BackupRun::latest_report_by_server_type_for_group(&mut conn, g).await?,
+		),
+		None => Default::default(),
+	};
 	let rows = ServerBackupCapability::list_for_server(&mut conn, args.server_id).await?;
 	let mut out = Vec::with_capacity(rows.len());
 	for c in rows {
@@ -1258,6 +1311,8 @@ pub async fn capabilities(
 			Some(g) => effective_interval_secs(&mut conn, g, &c.r#type).await?,
 			None => None,
 		};
+		let issuance = device_id.and_then(|d| latest_issuance.get(&(d, c.r#type.clone())).copied());
+		let last_report = latest_report.get(&(c.server_id, c.r#type.clone())).copied();
 		out.push(ServerBackupCapabilityView {
 			server_id: c.server_id,
 			latest_snapshot_id: last.as_ref().and_then(|r| r.snapshot_id.clone()),
@@ -1269,6 +1324,7 @@ pub async fn capabilities(
 				last.as_ref().map(|r| r.reported_at),
 				now,
 			),
+			processing_since: processing_since(now, issuance, last_report),
 			r#type: c.r#type,
 			enabled: c.enabled,
 		});

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "./test-fixtures";
 import {
 	resetSeededTables,
+	seedBackupCredentialIssuance,
 	seedBackupRepoStats,
 	seedBackupRun,
 	seedDevice,
@@ -644,6 +645,42 @@ test.describe("server backup capabilities", () => {
 		await page.goto(`/servers/${server.id}`);
 		const backups = page.locator("#backups");
 		await expect(backups.getByText(/no snapshot yet/i)).toBeVisible();
+	});
+
+	test("a recent issuance with no newer run shows 'backing up…'", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "inflight-group" });
+		const device = await seedDevice(sql);
+		const server = await seedServer(sql, {
+			name: "inflight-srv",
+			groupId: group.id,
+			deviceId: device.id,
+		});
+		await seedServerBackupCapability(sql, { serverId: server.id });
+		// Credentials issued 10 minutes ago, no run reported since → in flight.
+		await seedBackupCredentialIssuance(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			issuedAgoSecs: 600,
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		const backups = page.locator("#backups");
+		await expect(backups.getByText(/backing up…/i)).toBeVisible();
+
+		// A run reported after the issuance clears the in-flight state.
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			outcome: "success",
+			snapshotId: "kfreshsnap0001",
+		});
+		await page.reload();
+		await expect(backups.getByText(/backing up…/i)).toBeHidden();
+		await expect(backups.getByText(/kfreshsnap/)).toBeVisible();
 	});
 
 	test("toggling a capability switch flips enabled in the DB", async ({

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,7 +47,7 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_repo_stats, backup_maintenance_runs RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances RESTART IDENTITY CASCADE",
 	);
 }
 
@@ -432,6 +432,39 @@ export async function seedBackupRun(
 		],
 	);
 	return { id };
+}
+
+/** Seed a `backup_credential_issuances` row. `issuedAgoSecs` controls how long
+ * ago the creds were issued (default 0 = now); `ttlSecs` their lifetime. */
+export async function seedBackupCredentialIssuance(
+	sql: Sql,
+	opts: {
+		deviceId: string;
+		groupId: string;
+		type?: string;
+		purpose?: "backup" | "restore";
+		issuedAgoSecs?: number;
+		ttlSecs?: number;
+	},
+): Promise<void> {
+	await sql.query(
+		`INSERT INTO backup_credential_issuances
+		 (device_id, group_id, type, issued_at, expires_at, purpose, sts_assumed_role, bucket, prefix)
+		 VALUES ($1, $2, $3, NOW() - ($4 || ' seconds')::interval,
+		         NOW() - ($4 || ' seconds')::interval + ($5 || ' seconds')::interval,
+		         $6, $7, $8, $9)`,
+		[
+			opts.deviceId,
+			opts.groupId,
+			opts.type ?? "tamanu-postgres",
+			String(opts.issuedAgoSecs ?? 0),
+			String(opts.ttlSecs ?? 3600),
+			opts.purpose ?? "backup",
+			"arn:aws:iam::000:role/test",
+			"bes-test-bucket",
+			"",
+		],
+	);
 }
 
 /** Seed the cached `backup_repo_stats` row for a group. */

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -8335,6 +8335,14 @@
             "format": "date-time",
             "description": "When this server's next backup of this type is expected: the server's own\nlast success plus the effective interval, or \"now\" (overdue) if it's\nscheduled but has never succeeded. `None` for disabled or manual-only\n(no-interval) types. Per-server, so a lagging member isn't masked by a\nfreshly-backed-up sibling."
           },
+          "processing_since": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "`Some(issued_at)` when a backup of this type appears to be in flight:\ncredentials were issued under an hour ago and no run has been reported\nsince. `None` otherwise. Lets the UI show a \"backing up…\" state."
+          },
           "server_id": {
             "type": "string",
             "format": "uuid"

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3373,6 +3373,13 @@ export interface components {
              *     freshly-backed-up sibling.
              */
             next_backup_at?: string | null;
+            /**
+             * Format: date-time
+             * @description `Some(issued_at)` when a backup of this type appears to be in flight:
+             *     credentials were issued under an hour ago and no run has been reported
+             *     since. `None` otherwise. Lets the UI show a "backing up…" state.
+             */
+            processing_since?: string | null;
             /** Format: uuid */
             server_id: string;
             type: string;

--- a/private-web/src/components/BackupProcessingChip.tsx
+++ b/private-web/src/components/BackupProcessingChip.tsx
@@ -1,0 +1,32 @@
+import { Chip, CircularProgress, Tooltip } from "@mui/material";
+
+import TimeAgo from "./TimeAgo";
+
+/// Shown when a backup of a given type looks in flight: credentials were issued
+/// recently and no run has been reported since. `since` is the issuance time;
+/// `null`/absent renders nothing.
+export function BackupProcessingChip({
+	since,
+}: {
+	since: string | null | undefined;
+}) {
+	if (!since) return null;
+	return (
+		<Tooltip
+			title={
+				<>
+					Credentials issued <TimeAgo timestamp={since} />; awaiting the run
+					report.
+				</>
+			}
+		>
+			<Chip
+				size="small"
+				color="info"
+				variant="outlined"
+				icon={<CircularProgress size={12} color="inherit" />}
+				label="backing up…"
+			/>
+		</Tooltip>
+	);
+}

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -42,6 +42,7 @@ import { formatBytes } from "../lib/formatBytes";
 import { usePageTitle } from "../hooks/usePageTitle";
 import TimeAgo from "../components/TimeAgo";
 import { LatestSnapshot, SnapshotId } from "../components/SnapshotId";
+import { BackupProcessingChip } from "../components/BackupProcessingChip";
 import {
 	BACKUP_STATUS_HELP,
 	BACKUP_STATUS_INTENT,
@@ -988,6 +989,9 @@ function ServersPanel({
 															/>
 														</Tooltip>
 													)}
+													<BackupProcessingChip
+														since={cap?.processing_since}
+													/>
 												</Stack>
 											</TableCell>
 											<TableCell>

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -55,6 +55,7 @@ import StatusDot from "../components/StatusDot";
 import TailnetIdentitySection from "../components/TailnetIdentitySection";
 import TimeAgo from "../components/TimeAgo";
 import { LatestSnapshot } from "../components/SnapshotId";
+import { BackupProcessingChip } from "../components/BackupProcessingChip";
 import TimezoneTooltip from "../components/TimezoneTooltip";
 import VersionIndicator from "../components/VersionIndicator";
 import { HealthLegend, StatusLegend, VersionLegend } from "../components/Legends";
@@ -1726,9 +1727,12 @@ function BackupCapabilityRow({
 			sx={{ alignItems: "center", justifyContent: "space-between", py: 0.5 }}
 		>
 			<Stack spacing={0.25} sx={{ minWidth: 0 }}>
-				<Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-					{cap.type}
-				</Typography>
+				<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+					<Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+						{cap.type}
+					</Typography>
+					<BackupProcessingChip since={cap.processing_since} />
+				</Stack>
 				<LatestSnapshot
 					id={cap.latest_snapshot_id}
 					at={cap.latest_snapshot_at}


### PR DESCRIPTION
🤖 Surfaces an in-flight backup in the UI. A backup looks in flight when Canopy has issued credentials for a (server, type) and they're **still within their validity window**, with no run reported since — the device fetched creds to back up but hasn't reported a result yet.

## UI

A "backing up…" chip (spinner + tooltip "Credentials issued <time>; awaiting the run report") appears per (server, type) in:
- the group backup page's **Servers** table, and
- the **server-detail** Backups section.

## Backend

ServerBackupCapabilityView gains processing_since — Some(issued_at) when in flight, else None. Computed from two bulk queries:
- BackupCredentialIssuance::latest_backup_by_device_type_for_group — latest backup-purpose issuance per (device, type), returning (issued_at, expires_at),
- BackupRun::latest_report_by_server_type_for_group — latest reported run (any outcome) per (server, type).

Issuances are keyed by device, so they're correlated to a server via the server's device_id. **In flight = the credential hasn't expired yet (now < expires_at) AND no run reported at/after it was issued.** Using the issuance's real expires_at (rather than a fixed window) means the indicator tracks the actual STS credential lifetime — currently ~1h, but it self-corrects if that ever changes. Populated in both the stats and capabilities handlers.

## Tests

Playwright: a recent issuance with no newer run shows "backing up…", and a run reported afterwards clears it (and shows the fresh snapshot). Rust backups + openapi-drift tests pass. Added backup_credential_issuances to the e2e truncate set + a seed helper.