### PR TITLE
feat(backups): surface repo maintenance + alert on failed runs

### DIFF
--- a/crates/database/src/backup/refs.rs
+++ b/crates/database/src/backup/refs.rs
@@ -33,6 +33,12 @@ pub const RECONCILE_REPORT_GAP: &str = "backup-reconcile-report-gap";
 /// maintenance-cadence threshold. Group-scoped, `Error`.
 pub const MAINTENANCE_STALE: &str = "backup-maintenance-stale";
 
+/// A group whose most recently *finished* maintenance run failed. Distinct
+/// from [`MAINTENANCE_STALE`] (which fires on absence of success): this fires
+/// when maintenance is running but erroring. Group-scoped, `Error`. Clears
+/// when a newer run finishes successfully.
+pub const MAINTENANCE_ERROR: &str = "backup-maintenance-error";
+
 /// A run reported success but no matching repo snapshot landed (the device
 /// lied or the upload didn't persist). Group-scoped, `Error`.
 pub const RECONCILE_MISSING: &str = "backup-reconcile-missing";

--- a/crates/database/src/backup/staleness.rs
+++ b/crates/database/src/backup/staleness.rs
@@ -12,7 +12,10 @@
 use std::collections::HashMap;
 
 use commons_errors::Result;
-use commons_types::{backup::BackupType, issue::Severity};
+use commons_types::{
+	backup::{BackupType, RunOutcome},
+	issue::Severity,
+};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use jiff::{SignedDuration, Span, SpanRelativeTo, SpanRound, Timestamp, Unit};
@@ -326,10 +329,17 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 	Ok(filed)
 }
 
-/// Group-level maintenance staleness: a `status='ready'` group whose latest
-/// successful maintenance run (any kind) is older than [`MAINTENANCE_STALE_AFTER`]
-/// (or has none at all, past the threshold from its config creation) fires
-/// `backup-maintenance-stale`; a fresh success clears it.
+/// Group-level maintenance health, per `status='ready'` group:
+///
+/// - **Staleness** ([`refs::MAINTENANCE_STALE`]): latest *successful* run (any
+///   kind) older than [`MAINTENANCE_STALE_AFTER`] — or none at all, past the
+///   threshold from config creation. A fresh success clears it.
+/// - **Failure** ([`refs::MAINTENANCE_ERROR`]): the most recently *finished*
+///   run failed. Distinct from staleness — maintenance can run on cadence yet
+///   error every time. A newer successful run clears it.
+///
+/// Both are `Error` severity (open an incident + page). A group that is both
+/// stale and erroring files both, independently keyed.
 async fn sweep_maintenance(db: &mut AsyncPgConnection, now: Timestamp) -> Result<usize> {
 	use crate::schema::{backup_maintenance_runs as mr, server_group_backup_config as cfg};
 
@@ -384,6 +394,48 @@ async fn sweep_maintenance(db: &mut AsyncPgConnection, now: Timestamp) -> Result
 			)
 			.await?;
 			filed += 1;
+		}
+
+		// Failure leg: a group can run maintenance on cadence yet error every
+		// time, which staleness (absence-of-success) never catches. Key off the
+		// most recently *finished* run.
+		let latest_completed =
+			crate::backups::BackupMaintenanceRun::latest_completed_for_group(db, group_id).await?;
+		let err_active = open_group_issue_active(db, group_id, refs::MAINTENANCE_ERROR).await?;
+		match latest_completed {
+			Some(run) if run.outcome == Some(RunOutcome::Failure) => {
+				raise_group_event(
+					db,
+					group_id,
+					refs::MAINTENANCE_ERROR,
+					Severity::Error,
+					None,
+					&format!(
+						"Repo maintenance ({}) failed: {}",
+						run.kind,
+						run.error.as_deref().unwrap_or("(no detail reported)"),
+					),
+					true,
+				)
+				.await?;
+				filed += 1;
+			}
+			// Most recent finished run succeeded (or there is none): clear any
+			// open failure issue.
+			_ if err_active => {
+				raise_group_event(
+					db,
+					group_id,
+					refs::MAINTENANCE_ERROR,
+					Severity::Info,
+					None,
+					"Repo maintenance completed successfully again",
+					false,
+				)
+				.await?;
+				filed += 1;
+			}
+			_ => {}
 		}
 	}
 	Ok(filed)

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -1062,6 +1062,25 @@ impl BackupMaintenanceRun {
 			.map_err(AppError::from)
 	}
 
+	/// The most recently *finished* maintenance run for the group (any
+	/// outcome), ignoring runs still in flight (`outcome IS NULL`). Used by the
+	/// detection sweep to decide whether the latest concluded run failed.
+	pub async fn latest_completed_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<Option<Self>> {
+		use crate::schema::backup_maintenance_runs::dsl;
+
+		dsl::backup_maintenance_runs
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::outcome.is_not_null())
+			.order(dsl::finished_at.desc())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
 	/// Whether a run row still exists and is open (`outcome IS NULL`). Used by
 	/// the scheduler's crash-detection to mark a run failed when its Job
 	/// finished without ever reporting.

--- a/crates/database/tests/backup_detection.rs
+++ b/crates/database/tests/backup_detection.rs
@@ -107,6 +107,31 @@ async fn insert_ready_config(conn: &mut AsyncPgConnection, group_id: Uuid, age: 
 		.expect("backdate config created_at");
 }
 
+/// Insert a finished `backup_maintenance_runs` row, backdating both
+/// `started_at` and `finished_at` by `finished_age`.
+async fn insert_maintenance_run(
+	conn: &mut AsyncPgConnection,
+	group_id: Uuid,
+	kind: &str,
+	outcome: &str,
+	error: Option<&str>,
+	finished_age: SignedDuration,
+) {
+	let secs = finished_age.as_secs().to_string();
+	sql_query(
+		"INSERT INTO backup_maintenance_runs (group_id, kind, started_at, finished_at, outcome, error) \
+		 VALUES ($1, $2, NOW() - ($5 || ' seconds')::INTERVAL, NOW() - ($5 || ' seconds')::INTERVAL, $3, $4)",
+	)
+	.bind::<sql_types::Uuid, _>(group_id)
+	.bind::<sql_types::Text, _>(kind)
+	.bind::<sql_types::Text, _>(outcome)
+	.bind::<sql_types::Nullable<sql_types::Text>, _>(error)
+	.bind::<sql_types::Text, _>(secs)
+	.execute(conn)
+	.await
+	.expect("insert maintenance run");
+}
+
 async fn insert_schedule(
 	conn: &mut AsyncPgConnection,
 	group_id: Uuid,
@@ -770,6 +795,136 @@ async fn group_event_pages_even_when_all_members_unmonitored() {
 		assert!(
 			still_open.is_empty(),
 			"incident auto-closes when its only contributor recovers",
+		);
+	})
+	.await;
+}
+
+// ===========================================================================
+// Case 6 — maintenance failure (backup-maintenance-error)
+// ===========================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sweep_files_maintenance_error_when_latest_run_failed_then_clears_on_success() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		// Freshly-created config so maintenance-STALE does NOT also fire — this
+		// isolates the failure signal from absence-of-success.
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(1)).await;
+
+		// The most recently finished run failed an hour ago.
+		insert_maintenance_run(
+			&mut conn,
+			group_id,
+			"full",
+			"failure",
+			Some("kopia maintenance: connection refused"),
+			SignedDuration::from_hours(1),
+		)
+		.await;
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::staleness::sweep(&mut conn, &rows)
+			.await
+			.expect("sweep");
+
+		let issue = group_issue(&mut conn, group_id, refs::MAINTENANCE_ERROR)
+			.await
+			.expect("maintenance-error issue filed");
+		assert_eq!(issue.severity, Severity::Error.to_string());
+		assert!(issue.active, "failure issue is active");
+		assert_eq!(
+			group_issue_open_links(&mut conn, group_id, refs::MAINTENANCE_ERROR).await,
+			1,
+			"maintenance failure opens an incident",
+		);
+		// Staleness must NOT fire for a freshly-created group.
+		assert!(
+			group_issue(&mut conn, group_id, refs::MAINTENANCE_STALE)
+				.await
+				.is_none(),
+			"a recent config is not maintenance-stale",
+		);
+
+		// A newer successful run is now the latest finished run → clears it.
+		insert_maintenance_run(
+			&mut conn,
+			group_id,
+			"full",
+			"success",
+			None,
+			SignedDuration::from_secs(0),
+		)
+		.await;
+		database::backup::staleness::sweep(&mut conn, &rows)
+			.await
+			.expect("re-sweep");
+
+		let cleared = group_issue(&mut conn, group_id, refs::MAINTENANCE_ERROR)
+			.await
+			.expect("issue row persists");
+		assert!(
+			!cleared.active,
+			"failure issue cleared after a successful run",
+		);
+		assert_eq!(
+			group_issue_open_links(&mut conn, group_id, refs::MAINTENANCE_ERROR).await,
+			0,
+			"recovery removes the failure issue from its incident",
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn in_flight_run_does_not_clear_an_open_maintenance_error() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(1)).await;
+		insert_maintenance_run(
+			&mut conn,
+			group_id,
+			"full",
+			"failure",
+			Some("boom"),
+			SignedDuration::from_hours(1),
+		)
+		.await;
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::staleness::sweep(&mut conn, &rows)
+			.await
+			.expect("sweep");
+		assert!(
+			group_issue(&mut conn, group_id, refs::MAINTENANCE_ERROR)
+				.await
+				.expect("error filed")
+				.active
+		);
+
+		// A run that has started but not finished (outcome NULL) must be ignored:
+		// it is not evidence that the failure recovered.
+		database::BackupMaintenanceRun::start(
+			&mut conn,
+			group_id,
+			commons_types::backup::MaintenanceKind::Full,
+		)
+		.await
+		.expect("start in-flight run");
+		database::backup::staleness::sweep(&mut conn, &rows)
+			.await
+			.expect("re-sweep");
+
+		assert!(
+			group_issue(&mut conn, group_id, refs::MAINTENANCE_ERROR)
+				.await
+				.expect("error still present")
+				.active,
+			"an in-flight run must not clear the failure issue",
 		);
 	})
 	.await;

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -878,7 +878,8 @@ test.describe("backups ready: repo maintenance panel", () => {
 		await expect(panel.getByText("Healthy")).toBeVisible();
 		await expect(panel.getByText(/last successful maintenance/i)).toBeVisible();
 		await expect(panel.getByText("Full")).toBeVisible();
-		await expect(panel.getByText("success")).toBeVisible();
+		// exact: the "Last successful maintenance" caption also contains "success".
+		await expect(panel.getByText("success", { exact: true })).toBeVisible();
 		await expect(panel.getByText("1.0 MiB")).toBeVisible();
 	});
 
@@ -934,7 +935,8 @@ test.describe("backups ready: repo maintenance panel", () => {
 		const panel = page
 			.getByRole("heading", { name: /repo maintenance/i })
 			.locator("..");
-		await expect(panel.getByText("running")).toBeVisible();
+		// exact: the summary chip reads "Running" (capitalised); the row chip "running".
+		await expect(panel.getByText("running", { exact: true })).toBeVisible();
 		await expect(panel.getByText("Quick")).toBeVisible();
 	});
 });

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "./test-fixtures";
 import {
 	resetSeededTables,
 	seedBackupCredentialIssuance,
+	seedBackupMaintenanceRun,
 	seedBackupRepoStats,
 	seedBackupRun,
 	seedDevice,
@@ -831,5 +832,109 @@ test.describe("server backup capabilities", () => {
 		}).toPass();
 
 		await expect(toggle).toBeChecked();
+	});
+});
+
+test.describe("backups ready: repo maintenance panel", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("zero-state shows maintenance has never run", async ({ page, sql }) => {
+		const group = await seedServerGroup(sql, { name: "maint-empty" });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const panel = page
+			.getByRole("heading", { name: /repo maintenance/i })
+			.locator("..");
+		await expect(panel.getByText(/no maintenance has run yet/i)).toBeVisible();
+	});
+
+	test("a successful run shows Healthy, last-success time, and reclaimed bytes", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "maint-ok" });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+		await seedBackupMaintenanceRun(sql, {
+			groupId: group.id,
+			kind: "full",
+			outcome: "success",
+			bytesReclaimed: 1048576, // 1.0 MiB
+			finishedAgoSecs: 3600,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const panel = page
+			.getByRole("heading", { name: /repo maintenance/i })
+			.locator("..");
+		await expect(panel.getByText("Healthy")).toBeVisible();
+		await expect(panel.getByText(/last successful maintenance/i)).toBeVisible();
+		await expect(panel.getByText("Full")).toBeVisible();
+		await expect(panel.getByText("success")).toBeVisible();
+		await expect(panel.getByText("1.0 MiB")).toBeVisible();
+	});
+
+	test("a failed latest run shows the failure and expands to its error", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "maint-failed" });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+		// An older success, then a newer failure — the panel reads the latest.
+		await seedBackupMaintenanceRun(sql, {
+			groupId: group.id,
+			kind: "full",
+			outcome: "success",
+			finishedAgoSecs: 7 * 86400,
+		});
+		await seedBackupMaintenanceRun(sql, {
+			groupId: group.id,
+			kind: "full",
+			outcome: "failure",
+			error: "kopia maintenance: connection refused",
+			finishedAgoSecs: 3600,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const panel = page
+			.getByRole("heading", { name: /repo maintenance/i })
+			.locator("..");
+		await expect(panel.getByText(/last run failed/i)).toBeVisible();
+		// Error detail is hidden until the failed row is expanded.
+		await expect(page.getByText(/connection refused/i)).toBeHidden();
+		await panel.getByRole("button", { name: /show error/i }).click();
+		await expect(page.getByText(/connection refused/i)).toBeVisible();
+	});
+
+	test("an in-flight run renders as running", async ({ page, sql }) => {
+		const group = await seedServerGroup(sql, { name: "maint-running" });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+		await seedBackupMaintenanceRun(sql, {
+			groupId: group.id,
+			kind: "quick",
+			outcome: null, // still in flight
+			finishedAgoSecs: 60,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const panel = page
+			.getByRole("heading", { name: /repo maintenance/i })
+			.locator("..");
+		await expect(panel.getByText("running")).toBeVisible();
+		await expect(panel.getByText("Quick")).toBeVisible();
 	});
 });

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -443,6 +443,38 @@ export async function seedBackupRun(
 	return { id };
 }
 
+/** Seed a `backup_maintenance_runs` row. `finishedAgoSecs` backdates both
+ * `started_at` and `finished_at`; omit `outcome` for an in-flight run. */
+export async function seedBackupMaintenanceRun(
+	sql: Sql,
+	opts: {
+		groupId: string;
+		kind?: "quick" | "full";
+		outcome?: "success" | "failure" | null;
+		error?: string | null;
+		bytesReclaimed?: number | null;
+		finishedAgoSecs?: number;
+	},
+): Promise<void> {
+	const ago = String(opts.finishedAgoSecs ?? 0);
+	const outcome = opts.outcome ?? null;
+	await sql.query(
+		`INSERT INTO backup_maintenance_runs
+		 (group_id, kind, started_at, finished_at, outcome, error, bytes_reclaimed)
+		 VALUES ($1, $2, NOW() - ($3 || ' seconds')::interval,
+		         CASE WHEN $4::text IS NULL THEN NULL ELSE NOW() - ($3 || ' seconds')::interval END,
+		         $4, $5, $6)`,
+		[
+			opts.groupId,
+			opts.kind ?? "full",
+			ago,
+			outcome,
+			opts.error ?? null,
+			opts.bytesReclaimed ?? null,
+		],
+	);
+}
+
 /** Seed a `backup_credential_issuances` row. `issuedAgoSecs` controls how long
  * ago the creds were issued (default 0 = now); `ttlSecs` their lifetime. */
 export async function seedBackupCredentialIssuance(

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -980,8 +980,10 @@ function MaintenanceSummary({ runs }: { runs: BackupMaintenanceRun[] }) {
 }
 
 /// Repo maintenance: the at-a-glance health summary plus recent kopia
-/// maintenance cycles (full maintenance is what expires/reclaims; quick is the
-/// lighter compaction). Failed runs expand to their error.
+/// maintenance cycles. Every cycle expires snapshots per the retention policy
+/// (`kopia snapshot expire --delete`); full maintenance additionally reclaims
+/// the freed space, while quick is the lighter compaction. Failed runs expand
+/// to their error.
 function MaintenancePanel({ groupId }: { groupId: string }) {
 	const stats = useApi(
 		"backups",

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -49,6 +49,7 @@ import {
 	BACKUP_STATUS_LABEL,
 	type BackupConfigStatus,
 	type BackupConfigView,
+	type BackupMaintenanceRun,
 	type BackupRun,
 	type ServerInfo,
 } from "../types";
@@ -213,6 +214,7 @@ export default function BackupPanel() {
 				<>
 					<ServersPanel groupId={id} members={members} isAdmin={isAdmin} />
 					<SchedulesPanel groupId={id} isAdmin={isAdmin} />
+					<MaintenancePanel groupId={id} />
 					<RecentRunsPanel groupId={id} members={members} />
 				</>
 			)}
@@ -855,6 +857,172 @@ function RecentRunsPanel({
 						</TableBody>
 					</Table>
 				</Box>
+			)}
+		</Paper>
+	);
+}
+
+const MAINT_KIND_LABEL: Record<string, string> = {
+	quick: "Quick",
+	full: "Full",
+};
+
+/// One row of the maintenance table. Failed runs get an expand toggle that
+/// reveals the error in a collapsible sub-row (mirrors RunRow).
+function MaintRow({ run }: { run: BackupMaintenanceRun }) {
+	const [open, setOpen] = useState(false);
+	const hasError = Boolean(run.error);
+	const running = run.outcome == null;
+	return (
+		<>
+			<TableRow
+				sx={hasError ? { "& > *": { borderBottom: "unset" } } : undefined}
+			>
+				<TableCell padding="checkbox">
+					{hasError && (
+						<IconButton
+							size="small"
+							aria-label={open ? "Hide error" : "Show error"}
+							onClick={() => setOpen((o) => !o)}
+						>
+							{open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+						</IconButton>
+					)}
+				</TableCell>
+				<TableCell>
+					<TimeAgo timestamp={run.started_at} />
+				</TableCell>
+				<TableCell>{MAINT_KIND_LABEL[run.kind] ?? run.kind}</TableCell>
+				<TableCell>
+					{running ? (
+						<Chip size="small" label="running" color="info" />
+					) : (
+						<Chip
+							size="small"
+							label={run.outcome}
+							color={run.outcome === "success" ? "success" : "error"}
+						/>
+					)}
+				</TableCell>
+				<TableCell>
+					{run.finished_at ? <TimeAgo timestamp={run.finished_at} /> : "—"}
+				</TableCell>
+				<TableCell>
+					{run.bytes_reclaimed == null ? "—" : formatBytes(run.bytes_reclaimed)}
+				</TableCell>
+			</TableRow>
+			{hasError && (
+				<TableRow>
+					<TableCell colSpan={6} sx={{ py: 0, border: 0 }}>
+						<Collapse in={open} timeout="auto" unmountOnExit>
+							<Alert severity="error" variant="outlined" sx={{ my: 1 }}>
+								<Typography
+									component="pre"
+									variant="body2"
+									sx={{
+										m: 0,
+										fontFamily: "monospace",
+										whiteSpace: "pre-wrap",
+										wordBreak: "break-word",
+									}}
+								>
+									{run.error}
+								</Typography>
+							</Alert>
+						</Collapse>
+					</TableCell>
+				</TableRow>
+			)}
+		</>
+	);
+}
+
+/// At-a-glance "has maintenance run, and did it succeed" indicator derived from
+/// the recent runs. The authoritative overdue/failed alerting is the group
+/// incident (backup-maintenance-stale / backup-maintenance-error); this is the
+/// quick read for an operator looking at the panel.
+function MaintenanceSummary({ runs }: { runs: BackupMaintenanceRun[] }) {
+	if (runs.length === 0) {
+		return (
+			<Alert severity="warning" variant="outlined">
+				No maintenance has run yet.
+			</Alert>
+		);
+	}
+	const lastFinished = runs.find((r) => r.outcome != null);
+	const lastSuccess = runs.find((r) => r.outcome === "success");
+	const failing = lastFinished?.outcome === "failure";
+	return (
+		<Stack spacing={0.5}>
+			<Box>
+				{failing ? (
+					<Chip size="small" color="error" label="Last run failed" />
+				) : lastFinished ? (
+					<Chip size="small" color="success" label="Healthy" />
+				) : (
+					<Chip size="small" color="info" label="Running" />
+				)}
+			</Box>
+			<Typography variant="body2" color="text.secondary">
+				{lastSuccess ? (
+					<>
+						Last successful maintenance{" "}
+						<TimeAgo
+							timestamp={lastSuccess.finished_at ?? lastSuccess.started_at}
+						/>
+					</>
+				) : (
+					"No successful maintenance recorded yet."
+				)}
+			</Typography>
+		</Stack>
+	);
+}
+
+/// Repo maintenance: the at-a-glance health summary plus recent kopia
+/// maintenance cycles (full maintenance is what expires/reclaims; quick is the
+/// lighter compaction). Failed runs expand to their error.
+function MaintenancePanel({ groupId }: { groupId: string }) {
+	const stats = useApi(
+		"backups",
+		"stats",
+		{ server_group_id: groupId },
+		[groupId],
+	);
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }}>
+			<Typography variant="h6" component="h2" gutterBottom>
+				Repo maintenance
+			</Typography>
+			{stats.status === "loading" || stats.status === "idle" ? (
+				<LinearProgress />
+			) : stats.status === "error" ? (
+				<Alert severity="error">{stats.error.message}</Alert>
+			) : (
+				<Stack spacing={1.5}>
+					<MaintenanceSummary runs={stats.data.recent_maintenance} />
+					{stats.data.recent_maintenance.length > 0 && (
+						<Box sx={{ overflowX: "auto" }}>
+							<Table size="small">
+								<TableHead>
+									<TableRow>
+										<TableCell padding="checkbox" />
+										<TableCell>Started</TableCell>
+										<TableCell>Kind</TableCell>
+										<TableCell>Outcome</TableCell>
+										<TableCell>Finished</TableCell>
+										<TableCell>Reclaimed</TableCell>
+									</TableRow>
+								</TableHead>
+								<TableBody>
+									{stats.data.recent_maintenance.map((m) => (
+										<MaintRow key={m.id} run={m} />
+									))}
+								</TableBody>
+							</Table>
+						</Box>
+					)}
+				</Stack>
 			)}
 		</Paper>
 	);


### PR DESCRIPTION
🤖 The group backup page tracked maintenance runs in the DB and returned them from the `stats` endpoint as `recent_maintenance`, but never rendered them — and nothing alerted when a maintenance run *failed* (only the absence-of-success staleness check existed).

This adds both halves.

## UI — "Repo maintenance" panel

A new panel on the group backup page with:

- An at-a-glance health summary: `Healthy` / `Last run failed` / `Running`, plus when maintenance last completed successfully (or that it never has).
- A table of recent kopia maintenance cycles (started, kind, outcome, finished, reclaimed bytes), mirroring the recent-runs panel. Failed runs expand to their error.

This directly answers "has maintenance/expiry run, and did it succeed?", which previously had no UI indication at all.

## Alerting — `backup-maintenance-error`

A new group-scoped issue raised when the most recently *finished* maintenance run failed, cleared by a later successful run. `Error` severity, so it opens an incident and pages — consistent with the existing `backup-maintenance-stale` check. In-flight runs (no outcome yet) are ignored, so a started-but-unfinished run never clears an open failure.

This complements `backup-maintenance-stale` (no successful maintenance for 8 days), which catches a different failure mode: maintenance not running at all vs. running but erroring every time.

Per the discussion, the existing 8-day staleness threshold is left untouched.

Linear: TAM-6877