### PR TITLE
chore: rebrand to BES International

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -104,7 +104,7 @@ jobs:
             type=raw,value=latest
             type=raw,value=${{ steps.tag.outputs.value }}
           labels: |
-            org.opencontainers.image.vendor=BES
+            org.opencontainers.image.vendor=BES International
             org.opencontainers.image.title=Canopy
             org.opencontainers.image.url=https://www.bes.au/products/tamanu/
             org.opencontainers.image.source=https://github.com/beyondessential/canopy/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ By participating, you are expected to uphold this code. Please report unacceptab
 ## Contributor License Agreement
 
 All open-source contributors to Tamanu will be required to sign this [Contributor License Agreement]
-(CLA) before BES can accept your contribution into the project code. Instructions on how to sign are
+(CLA) before BES International can accept your contribution into the project code. Instructions on how to sign are
 provided in the CLA document linked above.
 
 ## Our Philosophy

--- a/CONTRIBUTOR-LICENSE-AGREEMENT.md
+++ b/CONTRIBUTOR-LICENSE-AGREEMENT.md
@@ -2,7 +2,7 @@
 
 Thank you for taking the time to consider contributing, and welcome to the Tamanu project!
 
-We require our external contributors to sign a Contributor License Agreement ("CLA") in order to ensure that our projects remain licensed under source-available licenses such as BSL 1.1 and GPL 3.0, while allowing BES to build a cohesive, sustainable, and valuable global good.
+We require our external contributors to sign a Contributor License Agreement ("CLA") in order to ensure that our projects remain licensed under source-available licenses such as BSL 1.1 and GPL 3.0, while allowing BES International to build a cohesive, sustainable, and valuable global good.
 
 BES is committed to open licensing for our non-commercial software. A CLA enables BES to safely share, implement and support our products while keeping source-available licenses with all the rights those licenses grant to users.
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,7 @@
 Short version for non-lawyers:
 
 Canopy is licensed under GPL 3.0 and later.
-Commercial licensing is available via BES.
+Commercial licensing is available via BES International.
 
 
 Longer version:


### PR DESCRIPTION
🤖 Applies the BES brand guideline (first mention in a doc is "BES International", later mentions stay "BES", full legal / contracting entity is "BES International Limited") to the CD Docker vendor label and the governance docs.

Changes:
- .github/workflows/cd.yml: OCI `org.opencontainers.image.vendor` label `BES` → `BES International` (image url, source, and other labels untouched).
- COPYRIGHT: "Commercial licensing is available via BES." → "… via BES International."
- CONTRIBUTING.md: first company mention → "BES International"; later mentions left as "BES".
- CONTRIBUTOR-LICENSE-AGREEMENT.md: first company mention → "BES International"; later mentions left as "BES".

The README already uses "BES International" and is left as-is. Cargo authors, OpenAPI contact, bes.au links, the beyondessential org slug, and test fixtures are deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)