### PR TITLE
feat(backups): disable adopted-repo object-lock retention + on-demand full maintenance

### DIFF
--- a/.workhorse/specs/jobs/backup.md
+++ b/.workhorse/specs/jobs/backup.md
@@ -19,6 +19,7 @@ Canopy acts only on groups whose configuration is ready, runs at most one operat
 
 Canopy runs each group's repo maintenance on a cadence — clients are never granted the rights to.
 It enforces the group's retention as part of maintenance, and records every run's outcome so a stuck or failing maintenance is itself detectable.
+Maintenance also re-asserts that the repo carries no repo-level object-lock retention mode of its own, healing a repo that was imported with one before Canopy disabled it (see [BKO](../private-server/backup.md)).
 
 ## Passphrase rotation
 

--- a/.workhorse/specs/jobs/backup.md
+++ b/.workhorse/specs/jobs/backup.md
@@ -20,6 +20,7 @@ Canopy acts only on groups whose configuration is ready, runs at most one operat
 Canopy runs each group's repo maintenance on a cadence — clients are never granted the rights to.
 It enforces the group's retention as part of maintenance, and records every run's outcome so a stuck or failing maintenance is itself detectable.
 Maintenance also re-asserts that the repo carries no repo-level object-lock retention mode of its own, healing a repo that was imported with one before Canopy disabled it (see [BKO](../private-server/backup.md)).
+Beyond the cadence, an operator may request a one-off full maintenance run for a group (see [BKO](../private-server/backup.md)); Canopy runs it on the next scheduling opportunity, ahead of the jittered cadence slot, subject to the same one-run-per-group interlock — so a forced run never overlaps an in-flight one.
 
 ## Passphrase rotation
 

--- a/.workhorse/specs/private-server/backup.md
+++ b/.workhorse/specs/private-server/backup.md
@@ -58,10 +58,11 @@ Retention is floored to an organisational minimum; a configuration may deliberat
 
 A server participates in a type when that type is an enabled capability on it; an operator toggles participation per `(server, type)`.
 An operator may queue a one-off backup — or restore — for a `(server, type)` to run on the next cycle, and may cancel a queued one before it runs.
+An operator may also request a one-off full maintenance run for a group, to reclaim storage or apply repo-settings changes without waiting for the scheduled cadence, and may cancel it before the scheduler picks it up (see [BKJ](../jobs/backup.md)); at most one such request is pending per group.
 
 ## Status
 
-The operator can see, per group: the repo's size and cost basis, recent runs with their outcomes and errors, recent maintenance, the latest snapshot per server, and any in-flight or pending one-off requests.
+The operator can see, per group: the repo's size and cost basis, recent runs with their outcomes and errors, recent maintenance, the latest snapshot per server, and any in-flight or pending one-off requests — including a pending on-demand full maintenance request and who made it.
 
 ## Passphrase recovery
 

--- a/.workhorse/specs/private-server/backup.md
+++ b/.workhorse/specs/private-server/backup.md
@@ -42,7 +42,7 @@ When a configuration is created, Canopy probes the target bucket and classifies 
 The classification chooses the mode:
 
 - **from-birth** — an empty bucket; Canopy generates a fresh passphrase and creates a new repo.
-- **passphrase** — an existing repo; the operator supplies its passphrase and Canopy connects to it.
+- **passphrase** — an existing repo; the operator supplies its passphrase and Canopy connects to it. On adoption Canopy disables any repo-level object-lock retention the existing repo carries: immutability is the bucket's Object Lock and expiry is Canopy's maintenance, and a live repo-level retention mode would block both device writes and maintenance reclamation.
 
 A bucket holding unrelated content is refused rather than written into; Canopy never deletes to make room.
 Either way Canopy creates and owns the passphrase secret, and configuration and secret are created together — if the secret cannot be stored, the configuration is rolled back, so a configuration never exists without its passphrase.

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -121,6 +121,17 @@ pub struct ServerGroupBackupConfig {
 	pub last_init_error: Option<String>,
 	#[schema(value_type = String)]
 	pub placement: BackupPlacement,
+	/// Set when an operator has requested a one-off full maintenance run; the
+	/// scheduler honors it on its next tick (bypassing the cadence slot) and
+	/// clears it once the run is spawned. `None` = no pending request.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[diesel(
+		deserialize_as = jiff_diesel::NullableTimestamp,
+		serialize_as = jiff_diesel::NullableTimestamp,
+		treat_none_as_default_value = false
+	)]
+	pub force_full_maintenance_at: Option<Timestamp>,
+	pub force_full_maintenance_by: Option<String>,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -266,6 +277,47 @@ impl ServerGroupBackupConfig {
 			.get_result(db)
 			.await
 			.map_err(AppError::from)
+	}
+
+	/// Flag a one-off full maintenance run for the scheduler to pick up on its
+	/// next tick (bypassing the cadence slot). Idempotent: re-requesting refreshes
+	/// the timestamp/requester. `updated_at` is deliberately not touched — this is
+	/// operator intent, not a config edit.
+	pub async fn request_full_maintenance(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		requested_by: Option<&str>,
+	) -> Result<Self> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::update(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.set((
+				dsl::force_full_maintenance_at.eq(now),
+				dsl::force_full_maintenance_by.eq(requested_by),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Clear a pending full-maintenance request — called both when the scheduler
+	/// spawns the run and when an operator cancels a not-yet-picked-up request.
+	pub async fn clear_full_maintenance_request(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<()> {
+		use crate::schema::server_group_backup_config::dsl;
+
+		diesel::update(dsl::server_group_backup_config.filter(dsl::group_id.eq(group_id)))
+			.set((
+				dsl::force_full_maintenance_at.eq(None::<jiff_diesel::Timestamp>),
+				dsl::force_full_maintenance_by.eq(None::<String>),
+			))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
 	}
 
 	/// Advance (or reset) the lifecycle status (repo-init flow).

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -390,6 +390,8 @@ diesel::table! {
 		mode -> Text,
 		last_init_error -> Nullable<Text>,
 		placement -> Text,
+		force_full_maintenance_at -> Nullable<Timestamptz>,
+		force_full_maintenance_by -> Nullable<Text>,
 	}
 }
 

--- a/crates/jobs/src/backup/kopia.rs
+++ b/crates/jobs/src/backup/kopia.rs
@@ -522,6 +522,22 @@ pub async fn run_init(
 	// explicit so we own maintenance regardless of path). Idempotent.
 	connect(env, bucket, prefix, region).await?;
 
+	if !create_new {
+		// Adopting a pre-existing repo: it may carry operator-set kopia
+		// blob-retention (repo-level S3 Object Lock retention mode). Canopy
+		// does not use kopia's client-side lock-awareness — immutability is
+		// the bucket's default GOVERNANCE Object Lock and expiry is Canopy's
+		// maintenance. A live blob-retention mode would make every device
+		// write require `PutObjectRetention` (which the device creds lack) and
+		// keep maintenance from reclaiming space. Disable it on adoption.
+		// Idempotent: a no-op when retention is already off.
+		run_kopia_ok(
+			env,
+			&["repository", "set-parameters", "--retention-mode", "none"],
+		)
+		.await?;
+	}
+
 	// No sources exist yet: set a conservative GLOBAL baseline = the element-wise
 	// strictest (max) policy across the map (or the org floor when empty).
 	apply_policy(env, "--global", &strictest_policy(retention)).await?;
@@ -572,6 +588,17 @@ pub async fn run_maintenance(
 	retention: &RetentionMap,
 ) -> Result<MaintOutcome> {
 	connect(env, bucket, prefix, region).await?;
+
+	// Assert the repo carries no kopia blob-retention (repo-level Object Lock
+	// mode). `run_init` disables it on adoption, but repos imported before that
+	// existed — or one an operator re-enabled — would otherwise block writes and
+	// maintenance reclamation. Re-asserting here heals them. Idempotent: a no-op
+	// when retention is already off.
+	run_kopia_ok(
+		env,
+		&["repository", "set-parameters", "--retention-mode", "none"],
+	)
+	.await?;
 
 	// Assert per-source retention. List sources, and for each source whose type
 	// (the path tail) is a key in the retention map, set that type's policy.

--- a/crates/jobs/src/backup/maintenance.rs
+++ b/crates/jobs/src/backup/maintenance.rs
@@ -278,9 +278,12 @@ async fn provision_shared(
 
 /// Run a maintenance op in a spawned task: start the run row, read the password,
 /// resolve retention, run `kopia::run_maintenance`, then close the run row.
-fn spawn_maint(worker: &Worker, config: ServerGroupBackupConfig, kind: MaintenanceKind) {
+/// Returns whether the op was actually claimed and spawned (`false` when the
+/// group is already in-flight or the concurrency cap is hit — the caller should
+/// leave any triggering request in place so it fires on a later tick).
+fn spawn_maint(worker: &Worker, config: ServerGroupBackupConfig, kind: MaintenanceKind) -> bool {
 	let Some(guard) = worker.try_claim(config.group_id) else {
-		return;
+		return false;
 	};
 	let worker = worker.clone();
 	task::spawn(async move {
@@ -326,6 +329,7 @@ fn spawn_maint(worker: &Worker, config: ServerGroupBackupConfig, kind: Maintenan
 			}
 		}
 	});
+	true
 }
 
 /// The kopia side of a maintenance op.
@@ -421,6 +425,23 @@ async fn tick(worker: &Worker) -> Result<(), String> {
 		if in_flight.contains(&c.group_id) {
 			continue; // already mid-op
 		}
+
+		// Operator-forced full maintenance takes priority over the cadence and
+		// ignores the jitter slot: run it on the first free tick. Clear the
+		// request only once we've actually claimed + spawned, so a lost claim
+		// (in-flight / at the cap) leaves it to fire on a later tick.
+		if c.force_full_maintenance_at.is_some() {
+			if spawn_maint(worker, (*c).clone(), MaintenanceKind::Full) {
+				if let Err(e) =
+					ServerGroupBackupConfig::clear_full_maintenance_request(&mut db, c.group_id)
+						.await
+				{
+					error!(group = %c.group_id, "clearing forced-maintenance request failed: {e}");
+				}
+			}
+			continue;
+		}
+
 		let runs = BackupMaintenanceRun::list_for_group(&mut db, c.group_id, 20)
 			.await
 			.map_err(|e| e.to_string())?;
@@ -485,6 +506,8 @@ mod tests {
 			mode: commons_types::backup::BackupRepoMode::FromBirth,
 			last_init_error: last_init_error.map(str::to_string),
 			placement: commons_types::backup::BackupPlacement::External,
+			force_full_maintenance_at: None,
+			force_full_maintenance_by: None,
 		}
 	}
 

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -63,6 +63,8 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(create_repo))
 		.routes(routes!(request_now))
 		.routes(routes!(cancel_request))
+		.routes(routes!(request_maintenance))
+		.routes(routes!(cancel_maintenance))
 		.routes(routes!(stats))
 		.routes(routes!(capabilities))
 		.routes(routes!(set_capability))
@@ -108,6 +110,11 @@ pub struct BackupConfigView {
 	pub last_init_error: Option<String>,
 	pub created_at: Timestamp,
 	pub updated_at: Timestamp,
+	/// When an operator has requested a one-off full maintenance run that the
+	/// scheduler hasn't picked up yet; `None` = no pending request.
+	pub force_full_maintenance_at: Option<Timestamp>,
+	/// Who requested the pending full-maintenance run (Tailscale login).
+	pub force_full_maintenance_by: Option<String>,
 	/// Per-`(group,type)` schedule + retention overrides.
 	pub schedules: Vec<ScheduleView>,
 }
@@ -140,6 +147,8 @@ impl BackupConfigView {
 			last_init_error: config.last_init_error,
 			created_at: config.created_at,
 			updated_at: config.updated_at,
+			force_full_maintenance_at: config.force_full_maintenance_at,
+			force_full_maintenance_by: config.force_full_maintenance_by,
 			schedules,
 		})
 	}
@@ -1202,6 +1211,69 @@ pub async fn cancel_request(
 	let mut conn = state.db.get().await?;
 	BackupRequest::clear(&mut conn, args.server_id, &args.r#type, args.purpose).await?;
 	Ok(Json(()))
+}
+
+/// Request a one-off full maintenance run for a group. The scheduler picks it up
+/// on its next tick, bypassing the cadence jitter slot. Idempotent — re-request
+/// refreshes the pending flag. Requires the repo to be `ready`.
+#[utoipa::path(
+	post,
+	path = "/request_maintenance",
+	operation_id = "backups_request_maintenance",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = GroupArgs,
+	responses(
+		(status = 200, body = BackupConfigView),
+		(status = 404, body = ProblemDetailsSchema),
+		(status = 409, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn request_maintenance(
+	State(state): State<AppState>,
+	TailscaleAdmin(admin): TailscaleAdmin,
+	Json(args): Json<GroupArgs>,
+) -> Result<Json<BackupConfigView>> {
+	let mut conn = state.db.get().await?;
+	let config = require_config(&mut conn, args.server_group_id).await?;
+	if config.status != BackupConfigStatus::Ready {
+		return Err(AppError::Conflict(
+			"repo is not ready; maintenance can only run on a ready repo".into(),
+		));
+	}
+	let config = ServerGroupBackupConfig::request_full_maintenance(
+		&mut conn,
+		args.server_group_id,
+		Some(&admin.login),
+	)
+	.await?;
+	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
+}
+
+/// Cancel a pending full-maintenance request the scheduler hasn't picked up yet.
+/// A no-op if there's none pending (or the run already started).
+#[utoipa::path(
+	post,
+	path = "/cancel_maintenance",
+	operation_id = "backups_cancel_maintenance",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = GroupArgs,
+	responses(
+		(status = 200, body = BackupConfigView),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn cancel_maintenance(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<GroupArgs>,
+) -> Result<Json<BackupConfigView>> {
+	let mut conn = state.db.get().await?;
+	let config = require_config(&mut conn, args.server_group_id).await?;
+	ServerGroupBackupConfig::clear_full_maintenance_request(&mut conn, config.group_id).await?;
+	let config = require_config(&mut conn, args.server_group_id).await?;
+	Ok(Json(BackupConfigView::build(&mut conn, config).await?))
 }
 
 /// Stats panel: cached repo stats + recent runs + recent maintenance + pending

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -439,6 +439,82 @@ async fn request_now_upserts_and_cancel_deletes() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn request_maintenance_flags_and_cancel_clears() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		private
+			.post("/api/backups/create")
+			.json(&serde_json::json!({
+				"server_group_id": group_id,
+				"bucket": "b",
+				"target_role_arn": "arn",
+				"maintenance_role_arn": "maint-arn",
+				"mode": "from_birth",
+			}))
+			.await
+			.assert_status_ok();
+
+		// Not ready yet (provisioning) → 409.
+		private
+			.post("/api/backups/request_maintenance")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await
+			.assert_status_conflict();
+
+		conn.batch_execute(&format!(
+			"UPDATE server_group_backup_config SET status = 'ready' WHERE group_id = '{group_id}';"
+		))
+		.await
+		.expect("ready");
+
+		// Ready → flags the request and echoes it back on the view.
+		let resp = private
+			.post("/api/backups/request_maintenance")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert!(
+			!body["force_full_maintenance_at"].is_null(),
+			"request set the pending flag"
+		);
+
+		// Re-request is an idempotent refresh, not an error.
+		private
+			.post("/api/backups/request_maintenance")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await
+			.assert_status_ok();
+
+		// Cancel clears it.
+		let resp = private
+			.post("/api/backups/cancel_maintenance")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert!(
+			body["force_full_maintenance_at"].is_null(),
+			"cancel cleared the pending flag"
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn request_maintenance_missing_config_is_404() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		private
+			.post("/api/backups/request_maintenance")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await
+			.assert_status_not_found();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn stats_includes_runs_and_pending_requests() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;

--- a/migrations/2026-07-01-033651-0000_force_full_maintenance_request/down.sql
+++ b/migrations/2026-07-01-033651-0000_force_full_maintenance_request/down.sql
@@ -1,0 +1,3 @@
+alter table server_group_backup_config
+    drop column force_full_maintenance_at,
+    drop column force_full_maintenance_by;

--- a/migrations/2026-07-01-033651-0000_force_full_maintenance_request/up.sql
+++ b/migrations/2026-07-01-033651-0000_force_full_maintenance_request/up.sql
@@ -1,0 +1,6 @@
+-- Operator-requested one-off full maintenance run for a group, honored by the
+-- scheduler on its next tick (bypassing the cadence jitter slot). At most one
+-- pending request per group; cleared when the run is spawned or cancelled.
+alter table server_group_backup_config
+    add column force_full_maintenance_at timestamptz,
+    add column force_full_maintenance_by text;

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -848,9 +848,7 @@ test.describe("backups ready: repo maintenance panel", () => {
 		});
 
 		await page.goto(`/groups/${group.id}/backups`);
-		const panel = page
-			.getByRole("heading", { name: /repo maintenance/i })
-			.locator("..");
+		const panel = page.getByTestId("repo-maintenance");
 		await expect(panel.getByText(/no maintenance has run yet/i)).toBeVisible();
 	});
 
@@ -872,12 +870,11 @@ test.describe("backups ready: repo maintenance panel", () => {
 		});
 
 		await page.goto(`/groups/${group.id}/backups`);
-		const panel = page
-			.getByRole("heading", { name: /repo maintenance/i })
-			.locator("..");
+		const panel = page.getByTestId("repo-maintenance");
 		await expect(panel.getByText("Healthy")).toBeVisible();
 		await expect(panel.getByText(/last successful maintenance/i)).toBeVisible();
-		await expect(panel.getByText("Full")).toBeVisible();
+		// exact: the "Run full maintenance now" button also contains "full".
+		await expect(panel.getByText("Full", { exact: true })).toBeVisible();
 		// exact: the "Last successful maintenance" caption also contains "success".
 		await expect(panel.getByText("success", { exact: true })).toBeVisible();
 		await expect(panel.getByText("1.0 MiB")).toBeVisible();
@@ -908,9 +905,7 @@ test.describe("backups ready: repo maintenance panel", () => {
 		});
 
 		await page.goto(`/groups/${group.id}/backups`);
-		const panel = page
-			.getByRole("heading", { name: /repo maintenance/i })
-			.locator("..");
+		const panel = page.getByTestId("repo-maintenance");
 		await expect(panel.getByText(/last run failed/i)).toBeVisible();
 		// Error detail is hidden until the failed row is expanded.
 		await expect(page.getByText(/connection refused/i)).toBeHidden();
@@ -932,11 +927,93 @@ test.describe("backups ready: repo maintenance panel", () => {
 		});
 
 		await page.goto(`/groups/${group.id}/backups`);
-		const panel = page
-			.getByRole("heading", { name: /repo maintenance/i })
-			.locator("..");
+		const panel = page.getByTestId("repo-maintenance");
 		// exact: the summary chip reads "Running" (capitalised); the row chip "running".
 		await expect(panel.getByText("running", { exact: true })).toBeVisible();
 		await expect(panel.getByText("Quick")).toBeVisible();
+	});
+
+	test("an admin can queue and cancel an on-demand full maintenance run", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "maint-ondemand" });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const panel = page.getByTestId("repo-maintenance");
+
+		await panel
+			.getByRole("button", { name: /run full maintenance now/i })
+			.click();
+
+		// The pending request is echoed as a chip and persisted on the config row.
+		await expect(panel.getByText(/full run queued/i)).toBeVisible();
+		await expect
+			.poll(async () => {
+				const rows = await sql.query(
+					`SELECT 1 FROM server_group_backup_config
+					 WHERE group_id = $1 AND force_full_maintenance_at IS NOT NULL`,
+					[group.id],
+				);
+				return rows.length;
+			})
+			.toBe(1);
+
+		// Cancelling clears it and restores the request button.
+		await panel.getByRole("button", { name: /^cancel$/i }).click();
+		await expect(
+			panel.getByRole("button", { name: /run full maintenance now/i }),
+		).toBeVisible();
+		await expect
+			.poll(async () => {
+				const rows = await sql.query(
+					`SELECT 1 FROM server_group_backup_config
+					 WHERE group_id = $1 AND force_full_maintenance_at IS NOT NULL`,
+					[group.id],
+				);
+				return rows.length;
+			})
+			.toBe(0);
+	});
+
+	test("a full run in flight disables the request button and spins the indicator", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "maint-fullrunning" });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+		// A prior success (so the summary reads "Healthy", not "Running") plus a
+		// current full run still in flight (no outcome yet).
+		await seedBackupMaintenanceRun(sql, {
+			groupId: group.id,
+			kind: "full",
+			outcome: "success",
+			finishedAgoSecs: 7 * 86400,
+		});
+		await seedBackupMaintenanceRun(sql, {
+			groupId: group.id,
+			kind: "full",
+			outcome: null,
+			finishedAgoSecs: 30,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const panel = page.getByTestId("repo-maintenance");
+
+		// Header shows the spinning "Running" indicator (a progressbar). exact:
+		// the in-flight row chip reads lowercase "running".
+		await expect(panel.getByText("Running", { exact: true })).toBeVisible();
+		await expect(panel.getByRole("progressbar")).toBeVisible();
+		// A new full run can't be usefully requested while one is running.
+		await expect(
+			panel.getByRole("button", { name: /run full maintenance now/i }),
+		).toBeDisabled();
 	});
 });

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -157,6 +157,52 @@
         ]
       }
     },
+    "/api/backups/cancel_maintenance": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Cancel a pending full-maintenance request the scheduler hasn't picked up yet.\nA no-op if there's none pending (or the run already started).",
+        "operationId": "backups_cancel_maintenance",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupConfigView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/backups/cancel_request": {
       "post": {
         "tags": [
@@ -780,6 +826,62 @@
             }
           },
           "502": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/backups/request_maintenance": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Request a one-off full maintenance run for a group. The scheduler picks it up\non its next tick, bypassing the cadence jitter slot. Idempotent — re-request\nrefreshes the pending flag. Requires the repo to be `ready`.",
+        "operationId": "backups_request_maintenance",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackupConfigView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "409": {
             "description": "",
             "content": {
               "application/json": {
@@ -5545,6 +5647,21 @@
           "created_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "force_full_maintenance_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When an operator has requested a one-off full maintenance run that the\nscheduler hasn't picked up yet; `None` = no pending request."
+          },
+          "force_full_maintenance_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Who requested the pending full-maintenance run (Tailscale login)."
           },
           "last_init_error": {
             "type": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -52,6 +52,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/backups/cancel_maintenance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cancel a pending full-maintenance request the scheduler hasn't picked up yet.
+         *     A no-op if there's none pending (or the run already started).
+         */
+        post: operations["backups_cancel_maintenance"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/backups/cancel_request": {
         parameters: {
             query?: never;
@@ -336,6 +356,27 @@ export interface paths {
          *     recipient set.
          */
         post: operations["backups_recovery_verify"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/backups/request_maintenance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request a one-off full maintenance run for a group. The scheduler picks it up
+         *     on its next tick, bypassing the cadence jitter slot. Idempotent — re-request
+         *     refreshes the pending flag. Requires the repo to be `ready`.
+         */
+        post: operations["backups_request_maintenance"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2320,6 +2361,14 @@ export interface components {
             bucket: string;
             /** Format: date-time */
             created_at: string;
+            /**
+             * Format: date-time
+             * @description When an operator has requested a one-off full maintenance run that the
+             *     scheduler hasn't picked up yet; `None` = no pending request.
+             */
+            force_full_maintenance_at?: string | null;
+            /** @description Who requested the pending full-maintenance run (Tailscale login). */
+            force_full_maintenance_by?: string | null;
             last_init_error?: string | null;
             maintenance_role_arn: string;
             mode: string;
@@ -4288,6 +4337,37 @@ export interface operations {
             };
         };
     };
+    backups_cancel_maintenance: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupConfigView"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
     backups_cancel_request: {
         parameters: {
             query?: never;
@@ -4709,6 +4789,45 @@ export interface operations {
                 };
             };
             502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    backups_request_maintenance: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupConfigView"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -214,7 +214,12 @@ export default function BackupPanel() {
 				<>
 					<ServersPanel groupId={id} members={members} isAdmin={isAdmin} />
 					<SchedulesPanel groupId={id} isAdmin={isAdmin} />
-					<MaintenancePanel groupId={id} />
+					<MaintenancePanel
+						groupId={id}
+						config={data}
+						isAdmin={isAdmin}
+						onChanged={configForTick.reload}
+					/>
 					<RecentRunsPanel groupId={id} members={members} />
 				</>
 			)}
@@ -984,18 +989,135 @@ function MaintenanceSummary({ runs }: { runs: BackupMaintenanceRun[] }) {
 /// (`kopia snapshot expire --delete`); full maintenance additionally reclaims
 /// the freed space, while quick is the lighter compaction. Failed runs expand
 /// to their error.
-function MaintenancePanel({ groupId }: { groupId: string }) {
+function MaintenancePanel({
+	groupId,
+	config,
+	isAdmin,
+	onChanged,
+}: {
+	groupId: string;
+	config: BackupConfigView;
+	isAdmin: boolean;
+	onChanged: () => void;
+}) {
+	// Poll faster while a run is in flight so the "running" indicator appears and
+	// clears promptly; back off to a gentle cadence when idle.
+	const [running, setRunning] = useState(false);
+	const tick = useReloadInterval(running ? 5_000 : 30_000, "canopy-data-changed");
 	const stats = useApi(
 		"backups",
 		"stats",
 		{ server_group_id: groupId },
-		[groupId],
+		[groupId, tick],
 	);
+	const request = useApiAction("backups", "request_maintenance");
+	const cancel = useApiAction("backups", "cancel_maintenance");
+	const queued = config.force_full_maintenance_at != null;
+
+	// An open run (no outcome yet) is one that's currently in flight — the run row
+	// is written before the kopia work starts. `full` in flight blocks a useful
+	// new full request; any run in flight drives the spinner + poll cadence.
+	const recent =
+		stats.status === "ok" ? stats.data.recent_maintenance : [];
+	const fullRunning = recent.some((m) => m.outcome == null && m.kind === "full");
+	const anyRunning = recent.some((m) => m.outcome == null);
+	if (anyRunning !== running) setRunning(anyRunning);
+
+	const onRequest = async () => {
+		try {
+			await request.call({ server_group_id: groupId });
+			onChanged();
+		} catch {
+			/* surfaced via request.error */
+		}
+	};
+	const onCancel = async () => {
+		try {
+			await cancel.call({ server_group_id: groupId });
+			onChanged();
+		} catch {
+			/* surfaced via cancel.error */
+		}
+	};
+
 	return (
-		<Paper variant="outlined" sx={{ p: 2 }}>
-			<Typography variant="h6" component="h2" gutterBottom>
-				Repo maintenance
-			</Typography>
+		<Paper variant="outlined" sx={{ p: 2 }} data-testid="repo-maintenance">
+			<Stack
+				direction="row"
+				spacing={2}
+				sx={{
+					alignItems: "center",
+					justifyContent: "space-between",
+					mb: 1,
+				}}
+			>
+				<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+					<Typography variant="h6" component="h2">
+						Repo maintenance
+					</Typography>
+					{anyRunning && (
+						<Chip
+							size="small"
+							color="info"
+							variant="outlined"
+							icon={<CircularProgress size={12} thickness={6} />}
+							label="Running"
+						/>
+					)}
+				</Stack>
+				{isAdmin &&
+					(queued ? (
+						<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+							<Chip
+								size="small"
+								color="info"
+								label={
+									config.force_full_maintenance_by
+										? `Full run queued by ${config.force_full_maintenance_by}`
+										: "Full run queued"
+								}
+							/>
+							<Button
+								size="small"
+								color="inherit"
+								disabled={cancel.pending}
+								onClick={onCancel}
+							>
+								Cancel
+							</Button>
+						</Stack>
+					) : (
+						<Tooltip
+							title={
+								fullRunning
+									? "A full maintenance run is already in progress"
+									: ""
+							}
+						>
+							<span>
+								<Button
+									size="small"
+									variant="outlined"
+									disabled={request.pending || fullRunning}
+									onClick={onRequest}
+								>
+									Run full maintenance now
+								</Button>
+							</span>
+						</Tooltip>
+					))}
+			</Stack>
+			{(request.error || cancel.error) && (
+				<Alert severity="error" sx={{ mb: 1 }}>
+					{(request.error ?? cancel.error)?.message}
+				</Alert>
+			)}
+			{isAdmin && queued && (
+				<Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+					Queued — the scheduler picks it up within a minute; it runs once the
+					group has no other maintenance in flight.
+				</Typography>
+			)}
 			{stats.status === "loading" || stats.status === "idle" ? (
 				<LinearProgress />
 			) : stats.status === "error" ? (


### PR DESCRIPTION
🤖 Two related changes for adopting/managing kopia repos. Second commit builds on the first.

## 1. Disable repo-level object-lock retention on adopted repos

An adopted (passphrase-mode) kopia repo may carry its own repo-level object-lock retention (kopia's `blob.RetentionMode`). Canopy does not use kopia's client-side lock-awareness — immutability is the bucket's Object Lock and expiry is Canopy's maintenance — so a live repo-level retention mode would force every device write to need `PutObjectRetention` (which device creds lack) and stop maintenance from reclaiming space.

Disabled via `kopia repository set-parameters --retention-mode none` (idempotent; zeroes mode + period), in two places:
- **`run_init`** — on adoption (passphrase-mode branch only; from-birth repos never have it set).
- **`run_maintenance`** — re-asserted every run, healing repos imported before this fix (or one an operator re-enabled) within their next maintenance slot.

## 2. Operator-triggered on-demand full maintenance

`run_init` only runs at setup and maintenance heals lazily on the cadence (quick daily, full weekly). To reclaim/apply settings on a handful of groups without waiting — and because the repo passphrase and maintenance role live inside Canopy, so there's no clean operator-side manual route — this adds a "Run full maintenance now" control.

- **Migration + model**: `force_full_maintenance_at`/`by` on `server_group_backup_config`; request/clear helpers.
- **Scheduler**: `tick()` honors a pending request on the next free tick, bypassing the jitter slot, subject to the existing one-run-per-group interlock; the request is cleared only once claimed+spawned (a lost claim re-fires on a later tick).
- **Admin endpoints**: `backups/request_maintenance` + `cancel_maintenance`; `BackupConfigView` exposes the pending request + requester.
- **UI**: request/cancel in the Repo maintenance panel, a spinning "Running" indicator driven by an open (outcome-less) run row, and the request button disabled while a full run is in flight.

Specs BKO + BKJ updated; endpoint + Playwright e2e coverage for both.

TAM-6877