### PR TITLE
feat(devices): operator-provisioned device credentials

### DIFF
--- a/.workhorse/specs/private-server/provisioned-credentials.md
+++ b/.workhorse/specs/private-server/provisioned-credentials.md
@@ -1,0 +1,51 @@
+---
+id: DPK
+---
+
+# Operator-provisioned device credentials
+
+An operator provisions a trusted device and its authentication credential directly through Canopy, without the device performing a self-enrolment handshake.
+Canopy generates the keypair, records the public key against a new or existing device at an operator-chosen role, and returns the private key exactly once, encrypted under a freshly generated passphrase, for the operator to download and carry to the target host.
+
+## Why it exists
+
+Some trusted roles are not tied to a server enrolment, and some are operated by hand rather than by an agent on a managed server.
+Obtaining a credential for one of those roles otherwise means generating a keypair off-platform and registering its public key by hand.
+Provisioning the credential centrally removes that manual step: Canopy already holds and trusts the public key by the time the operator has the private key.
+
+## Scope
+
+This spec covers the operator-facing provisioning surface: creating or selecting a device, minting its credential, the one-time delivery of the private key, and the trust and lifecycle rules for provisioned keys.
+It does not cover the server enrolment handshake, which remains the path for agent-managed servers.
+
+## Provisioning
+
+Provisioning is available to operators only.
+
+The operator either creates a new device at a chosen role, or provisions an additional credential onto an existing device.
+Any trustable role may be provisioned: administrator, server, releaser, and backup-restore.
+
+On provisioning, Canopy generates a fresh device keypair and records its public key as an active key on the device.
+The key material and its representation match what device authentication accepts over mutual TLS: an elliptic-curve P-256 keypair, whose public half is stored as the subject public key info that authentication matches against.
+The device is set to the chosen role at the same time, and the credential is immediately valid for authentication — no further handshake or approval step is required before the host can use it.
+
+Provisioning a credential onto an existing device adds an active key alongside any it already has; it does not revoke the others.
+The operator manages the lifecycle of individual keys (naming, deactivation) through the existing per-key controls.
+
+## Delivery of the private key
+
+The private key is returned exactly once, at provisioning time.
+
+It is delivered in PKCS#8 PEM form, wrapped in a passphrase-encrypted file in the standard age format (scrypt recipient).
+The wrapping passphrase is freshly generated per provisioning and returned alongside the encrypted file; it is a short human-transcribable word sequence, to be shared out of band on a separate channel from the file.
+Because the file is standard age, the host decrypts it with the operator's ordinary secret-reveal tooling to recover the PEM.
+
+The response also carries the device identifier and a fingerprint of the public key, so the operator can correlate the credential with the device record in the management UI.
+
+## Non-retention of the private key
+
+Canopy never retains the private key.
+It exists only in memory for the duration of the provisioning request and in the encrypted file returned to the operator; it is never persisted to storage and never written to logs.
+
+If the encrypted file or its passphrase is lost, the credential cannot be recovered.
+Recovery is by provisioning a new key and deactivating or removing the old one; the lost private key's public half remains inert in the device record until the operator removes it.

--- a/crates/commons-servers/src/device_auth/keygen.rs
+++ b/crates/commons-servers/src/device_auth/keygen.rs
@@ -1,0 +1,67 @@
+//! Server-side minting of device keypairs for operator-provisioned
+//! credentials (see spec DPK). Canopy generates the keypair, keeps only the
+//! public [`GeneratedDeviceKey::spki_der`], and hands the private key back to
+//! the operator once. The private PEM here is sensitive — never persist or log
+//! it.
+
+use std::fmt::Write as _;
+
+use commons_errors::{AppError, Result};
+use rcgen::{
+	CertificateParams, DistinguishedName, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+	KeyUsagePurpose, PKCS_ECDSA_P256_SHA256,
+};
+use x509_parser::prelude::*;
+
+/// A freshly-minted device keypair.
+pub struct GeneratedDeviceKey {
+	/// PKCS#8 PEM of the private key. Sensitive: this is the material the
+	/// operator downloads, and it must never be persisted or logged.
+	pub private_key_pem: String,
+	/// DER `SubjectPublicKeyInfo`, byte-identical to what the mTLS path
+	/// extracts from a presented certificate (`subject_pki.raw`). This is what
+	/// gets stored in `device_keys.key_data`.
+	pub spki_der: Vec<u8>,
+	/// Lowercase hex SHA-256 of `spki_der`, for operator correlation in the UI.
+	pub fingerprint: String,
+}
+
+/// Generate a P-256 device keypair.
+///
+/// The SPKI is derived exactly as the auth path derives it — by self-signing a
+/// throwaway certificate and reading `subject_pki.raw` — so the bytes stored
+/// against the device are guaranteed to match what `spki_from_headers` would
+/// extract from a certificate this key later presents.
+pub fn generate_device_key() -> Result<GeneratedDeviceKey> {
+	let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+		.map_err(|e| AppError::custom(format!("generating device key: {e}")))?;
+	let private_key_pem = key.serialize_pem();
+
+	let mut params = CertificateParams::default();
+	params.is_ca = IsCa::NoCa;
+	params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+	params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+	params.distinguished_name = DistinguishedName::new();
+	let cert = params
+		.self_signed(&key)
+		.map_err(|e| AppError::custom(format!("self-signing device cert: {e}")))?;
+	let cert_pem = cert.pem();
+
+	let (_, pem) = parse_x509_pem(cert_pem.as_bytes())
+		.map_err(|e| AppError::custom(format!("parsing device cert pem: {e}")))?;
+	let (_, x509) = parse_x509_certificate(&pem.contents)
+		.map_err(|e| AppError::custom(format!("parsing device cert: {e}")))?;
+	let spki_der = x509.tbs_certificate.subject_pki.raw.to_vec();
+
+	let digest = ring::digest::digest(&ring::digest::SHA256, &spki_der);
+	let mut fingerprint = String::with_capacity(digest.as_ref().len() * 2);
+	for b in digest.as_ref() {
+		let _ = write!(fingerprint, "{b:02x}");
+	}
+
+	Ok(GeneratedDeviceKey {
+		private_key_pem,
+		spki_der,
+		fingerprint,
+	})
+}

--- a/crates/commons-servers/src/device_auth/keygen.rs
+++ b/crates/commons-servers/src/device_auth/keygen.rs
@@ -8,8 +8,8 @@ use std::fmt::Write as _;
 
 use commons_errors::{AppError, Result};
 use rcgen::{
-	CertificateParams, DistinguishedName, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-	KeyUsagePurpose, PKCS_ECDSA_P256_SHA256,
+	CertificateParams, DistinguishedName, ExtendedKeyUsagePurpose, IsCa, KeyPair, KeyUsagePurpose,
+	PKCS_ECDSA_P256_SHA256,
 };
 use x509_parser::prelude::*;
 

--- a/crates/commons-servers/src/device_auth/mod.rs
+++ b/crates/commons-servers/src/device_auth/mod.rs
@@ -33,6 +33,7 @@ use database::{
 
 use crate::tailnet_directory::TailnetDirectory;
 
+pub mod keygen;
 pub mod mtls;
 pub mod pop;
 pub mod tailnet;

--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -81,6 +81,25 @@ pub fn make_signing_certificate() -> (Vec<u8>, String, ring::signature::EcdsaKey
 	(key_data, cert_enc, signing_key)
 }
 
+/// Derive the DER `SubjectPublicKeyInfo` from a PKCS#8 PEM private key, exactly
+/// as the mTLS auth path derives it from a presented certificate: self-sign a
+/// throwaway cert and read `subject_pki.raw`. Used to prove a server-minted
+/// credential's stored public key matches the delivered private key.
+pub fn spki_from_key_pem(key_pem: &str) -> Vec<u8> {
+	let key = KeyPair::from_pem(key_pem).expect("rcgen key from pem");
+	let mut cert = CertificateParams::default();
+	cert.is_ca = IsCa::NoCa;
+	cert.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+	cert.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+	cert.distinguished_name = DistinguishedName::new();
+	let cert = cert.self_signed(&key).expect("sign cert");
+
+	let cert_pem = cert.pem();
+	let (_, pem_parsed) = parse_x509_pem(cert_pem.as_bytes()).expect("parse pem");
+	let (_, x509_cert) = parse_x509_certificate(&pem_parsed.contents).expect("parse cert");
+	x509_cert.tbs_certificate.subject_pki.raw.to_vec()
+}
+
 pub async fn run<F, T, Fut>(test: F) -> T
 where
 	F: FnOnce(AsyncPgConnection, TestServer, TestServer) -> Fut,

--- a/crates/database/src/devices.rs
+++ b/crates/database/src/devices.rs
@@ -126,6 +126,31 @@ impl Device {
 		Ok(device)
 	}
 
+	/// Create a device already at `role`, with one active key named `key_name`.
+	/// Used by operator-provisioned credentials (spec DPK), where Canopy mints
+	/// the keypair server-side and the device is trusted at its role from the
+	/// outset — unlike [`create`], which leaves the device untrusted and names
+	/// its key "Initial Key".
+	pub async fn create_at_role(
+		db: &mut AsyncPgConnection,
+		key: Vec<u8>,
+		role: DeviceRole,
+		key_name: Option<String>,
+	) -> Result<Self> {
+		use crate::schema::devices;
+
+		let device: Self = diesel::insert_into(devices::table)
+			.values(devices::role.eq(role))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)?;
+
+		DeviceKey::create(db, device.id, key, key_name).await?;
+
+		Ok(device)
+	}
+
 	pub async fn from_tailscale_node_id(
 		db: &mut AsyncPgConnection,
 		node_id: &str,

--- a/crates/private-server/src/fns.rs
+++ b/crates/private-server/src/fns.rs
@@ -26,6 +26,23 @@ pub struct Page<T> {
 	pub total: u64,
 }
 
+/// Generate a 4-word lowercase, hyphen-separated passphrase from the EFF large
+/// wordlist (~52 bits of entropy), e.g. `correct-horse-battery-staple`. Used to
+/// wrap secrets (enrollment tickets, provisioned device keys) that travel to an
+/// operator out of band.
+pub(crate) fn generate_passphrase() -> String {
+	use chbs::{config::BasicConfig, prelude::*, probability::Probability, word::WordList};
+
+	let config = BasicConfig {
+		words: 4,
+		word_provider: WordList::builtin_eff_large().sampler(),
+		separator: "-".into(),
+		capitalize_first: Probability::Never,
+		capitalize_words: Probability::Never,
+	};
+	config.to_scheme().generate()
+}
+
 pub fn routes() -> OpenApiRouter<crate::state::AppState> {
 	OpenApiRouter::new().nest(
 		"/api",

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -566,8 +566,8 @@ pub async fn provision_credential(
 	use base64::Engine as _;
 
 	if args.role == DeviceRole::Untrusted {
-		return Err(AppError::custom(
-			"cannot provision a credential at the untrusted role",
+		return Err(AppError::BadRequest(
+			"cannot provision a credential at the untrusted role".into(),
 		));
 	}
 

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -618,7 +618,11 @@ pub async fn provision_credential(
 	.map_err(|e| AppError::custom(format!("encrypting device key: {e}")))?;
 	let key_age_base64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
 
-	let filename = format!("canopy-{}-{}.pem.age", args.role, &generated.fingerprint[..12]);
+	let filename = format!(
+		"canopy-{}-{}.pem.age",
+		args.role,
+		&generated.fingerprint[..12]
+	);
 
 	Ok(Json(ProvisionedCredential {
 		device_id,

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use axum::Json;
 use axum::extract::State;
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
+use commons_servers::device_auth::keygen;
 use commons_servers::tailnet_directory::DirectoryEntry;
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use commons_types::{Uuid, device::DeviceRole};
@@ -203,6 +204,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(list_trusted))
 		.routes(routes!(untrust))
 		.routes(routes!(update_role))
+		.routes(routes!(provision_credential))
 		.routes(routes!(search))
 		.routes(routes!(update_key_name))
 		.routes(routes!(attach_tailscale))
@@ -501,6 +503,131 @@ pub async fn update_role(
 	let mut conn = state.db.get().await?;
 	Device::trust(&mut conn, args.device_id, args.role).await?;
 	Ok(Json(()))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct ProvisionArgs {
+	/// Role to trust the device at. Any trustable role is allowed; `untrusted`
+	/// is rejected.
+	pub role: DeviceRole,
+	/// Provision an additional credential onto this existing device. When
+	/// omitted, a new device is created at `role`.
+	#[serde(default)]
+	pub device_id: Option<Uuid>,
+	/// Display name for the new key. Defaults to "Provisioned key".
+	#[serde(default)]
+	pub key_name: Option<String>,
+}
+
+/// The one-time result of provisioning a device credential. The plaintext
+/// private key lives only inside `key_age_base64`; Canopy never persists it.
+#[derive(Serialize, ToSchema)]
+pub struct ProvisionedCredential {
+	pub device_id: Uuid,
+	pub key_id: Uuid,
+	/// Lowercase hex SHA-256 of the stored public key, to correlate the
+	/// credential with the device's key list.
+	pub fingerprint: String,
+	/// Suggested filename for the downloaded encrypted key.
+	pub filename: String,
+	/// Base64 (standard) of the age-encrypted PKCS#8 PEM private key. Decrypt
+	/// with `passphrase` (e.g. `bestool crypto reveal`) to recover the PEM.
+	pub key_age_base64: String,
+	/// Freshly-generated passphrase that decrypts `key_age_base64`. Share it
+	/// out-of-band, on a separate channel from the file.
+	pub passphrase: String,
+}
+
+/// Mint a device keypair server-side, store its public key as an active key on
+/// a new or existing device at the chosen role, and return the private key
+/// once, encrypted under a fresh passphrase (spec DPK). Canopy keeps only the
+/// public key; the private key is never persisted or logged.
+#[utoipa::path(
+	post,
+	path = "/provision_credential",
+	tag = "devices",
+	security(("tailscale-admin" = [])),
+	request_body = ProvisionArgs,
+	responses(
+		(status = 200, body = ProvisionedCredential),
+		(status = 400, body = ProblemDetailsSchema),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn provision_credential(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<ProvisionArgs>,
+) -> Result<Json<ProvisionedCredential>> {
+	use algae_cli::{
+		passphrases::{Passphrase, SecretString},
+		streams::encrypt_stream,
+	};
+	use base64::Engine as _;
+
+	if args.role == DeviceRole::Untrusted {
+		return Err(AppError::custom(
+			"cannot provision a credential at the untrusted role",
+		));
+	}
+
+	let mut conn = state.db.get().await?;
+
+	let generated = keygen::generate_device_key()?;
+	let key_name = args
+		.key_name
+		.filter(|n| !n.trim().is_empty())
+		.unwrap_or_else(|| "Provisioned key".to_string());
+
+	let (device_id, key) = match args.device_id {
+		Some(device_id) => {
+			// 404s if the device doesn't exist.
+			let existing = Device::get_with_info(&mut conn, device_id).await?;
+			let key =
+				DeviceKey::create(&mut conn, device_id, generated.spki_der, Some(key_name)).await?;
+			if existing.device.role != args.role {
+				Device::trust(&mut conn, device_id, args.role).await?;
+			}
+			(device_id, key)
+		}
+		None => {
+			let device =
+				Device::create_at_role(&mut conn, generated.spki_der, args.role, Some(key_name))
+					.await?;
+			let key = DeviceKey::find_by_device(&mut conn, device.id)
+				.await?
+				.into_iter()
+				.next()
+				.ok_or_else(|| AppError::custom("provisioned device has no key"))?;
+			(device.id, key)
+		}
+	};
+
+	// Encrypt the private PEM with a fresh passphrase (age/scrypt), the same
+	// primitives bestool's `crypto reveal` reads. The ciphertext is base64'd
+	// for transport; the passphrase travels out-of-band.
+	let passphrase = crate::fns::generate_passphrase();
+	let encryptor = Passphrase::new(SecretString::from(passphrase.clone()));
+	let mut encrypted = Vec::new();
+	encrypt_stream(
+		generated.private_key_pem.as_bytes(),
+		futures::io::Cursor::new(&mut encrypted),
+		Box::new(encryptor),
+	)
+	.await
+	.map_err(|e| AppError::custom(format!("encrypting device key: {e}")))?;
+	let key_age_base64 = base64::engine::general_purpose::STANDARD.encode(&encrypted);
+
+	let filename = format!("canopy-{}-{}.pem.age", args.role, &generated.fingerprint[..12]);
+
+	Ok(Json(ProvisionedCredential {
+		device_id,
+		key_id: key.id,
+		fingerprint: generated.fingerprint,
+		filename,
+		key_age_base64,
+		passphrase,
+	}))
 }
 
 #[derive(Deserialize, ToSchema)]

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -850,20 +850,6 @@ pub struct EnrollmentTicket {
 	pub expires_at: Timestamp,
 }
 
-/// Generate a 4-word lowercase, hyphen-separated passphrase from the EFF large
-/// wordlist (~52 bits of entropy), e.g. `correct-horse-battery-staple`.
-fn generate_passphrase() -> String {
-	use chbs::{config::BasicConfig, prelude::*, probability::Probability, word::WordList};
-
-	let config = BasicConfig {
-		words: 4,
-		word_provider: WordList::builtin_eff_large().sampler(),
-		separator: "-".into(),
-		capitalize_first: Probability::Never,
-		capitalize_words: Probability::Never,
-	};
-	config.to_scheme().generate()
-}
 
 /// Mint (or reissue) an enrollment token for a server and return the
 /// passphrase-encrypted ticket the operator runs through bestool, plus the
@@ -914,7 +900,7 @@ pub async fn mint_enrollment(
 	// Encrypt the payload with a fresh 4-word passphrase (age/scrypt), the same
 	// primitives bestool's `protect`/`reveal` use. The ciphertext is base64'd
 	// for transport; the passphrase travels out-of-band.
-	let passphrase = generate_passphrase();
+	let passphrase = crate::fns::generate_passphrase();
 	let key = Passphrase::new(SecretString::from(passphrase.clone()));
 
 	let mut encrypted = Vec::new();

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -850,7 +850,6 @@ pub struct EnrollmentTicket {
 	pub expires_at: Timestamp,
 }
 
-
 /// Mint (or reissue) an enrollment token for a server and return the
 /// passphrase-encrypted ticket the operator runs through bestool, plus the
 /// 4-word passphrase that decrypts it. The plaintext token lives only inside

--- a/crates/private-server/tests/provision_credential.rs
+++ b/crates/private-server/tests/provision_credential.rs
@@ -1,0 +1,151 @@
+//! Tests for operator-provisioned device credentials (spec DPK): Canopy mints
+//! the keypair, stores only the public key, and returns the private key once
+//! as a passphrase-encrypted age blob.
+
+use algae_cli::passphrases::{Passphrase, SecretString};
+use base64::Engine as _;
+use commons_tests::server::{run, spki_from_key_pem};
+use serde_json::{Value, json};
+
+/// Decrypt an age/scrypt blob (as returned base64) with `passphrase`.
+async fn reveal(key_age_base64: &str, passphrase: &str) -> String {
+	let ciphertext = base64::engine::general_purpose::STANDARD
+		.decode(key_age_base64)
+		.expect("base64 decode");
+	let mut out: Vec<u8> = Vec::new();
+	algae_cli::streams::decrypt_stream(
+		futures::io::Cursor::new(ciphertext),
+		&mut out,
+		Box::new(Passphrase::new(SecretString::from(passphrase.to_owned()))),
+	)
+	.await
+	.expect("decrypt");
+	String::from_utf8(out).expect("utf8 pem")
+}
+
+/// Decode the DER SPKI out of a "BEGIN PUBLIC KEY" PEM as returned by the
+/// device key list (`pem_data`).
+fn spki_from_public_pem(pem: &str) -> Vec<u8> {
+	let body: String = pem
+		.lines()
+		.filter(|l| !l.starts_with("-----"))
+		.collect::<String>();
+	base64::engine::general_purpose::STANDARD
+		.decode(body)
+		.expect("decode spki")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn provisions_new_device_at_role_with_revealable_key() {
+	run(async |_conn, _public, private| {
+		let res: Value = private
+			.post("/api/devices/provision_credential")
+			.json(&json!({ "role": "releaser" }))
+			.await
+			.json();
+
+		let device_id = res["device_id"].as_str().unwrap().to_owned();
+		let key_id = res["key_id"].as_str().unwrap().to_owned();
+		let passphrase = res["passphrase"].as_str().unwrap().to_owned();
+		let key_age = res["key_age_base64"].as_str().unwrap().to_owned();
+		assert!(
+			res["filename"].as_str().unwrap().ends_with(".pem.age"),
+			"filename should be a .pem.age download",
+		);
+		assert!(!passphrase.is_empty(), "passphrase returned");
+
+		// The blob decrypts to a PKCS#8 PEM private key.
+		let pem = reveal(&key_age, &passphrase).await;
+		assert!(
+			pem.contains("BEGIN PRIVATE KEY"),
+			"revealed material is a PKCS#8 PEM, got: {pem:.40}",
+		);
+
+		// The device now exists at the chosen role with exactly one active key,
+		// and that stored public key corresponds to the revealed private key —
+		// byte-for-byte what the mTLS path would extract from a cert.
+		let device: Value = private
+			.post("/api/devices/get_device_by_id")
+			.json(&json!({ "device_id": device_id }))
+			.await
+			.json();
+
+		assert_eq!(device["device"]["role"], "releaser");
+		let keys = device["keys"].as_array().unwrap();
+		assert_eq!(keys.len(), 1, "exactly one active key");
+		assert_eq!(keys[0]["id"].as_str().unwrap(), key_id);
+
+		let stored_spki = spki_from_public_pem(keys[0]["pem_data"].as_str().unwrap());
+		let derived_spki = spki_from_key_pem(&pem);
+		assert_eq!(
+			stored_spki, derived_spki,
+			"stored public key must match the revealed private key's SPKI",
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn provisions_onto_existing_device_and_updates_role() {
+	run(async |_conn, _public, private| {
+		// Create an initial releaser device.
+		let first: Value = private
+			.post("/api/devices/provision_credential")
+			.json(&json!({ "role": "releaser", "key_name": "first" }))
+			.await
+			.json();
+		let device_id = first["device_id"].as_str().unwrap().to_owned();
+
+		// Provision a second credential onto it, changing the role.
+		let second: Value = private
+			.post("/api/devices/provision_credential")
+			.json(&json!({
+				"role": "backup-restore",
+				"device_id": device_id,
+				"key_name": "second",
+			}))
+			.await
+			.json();
+		assert_eq!(second["device_id"].as_str().unwrap(), device_id);
+
+		let device: Value = private
+			.post("/api/devices/get_device_by_id")
+			.json(&json!({ "device_id": device_id }))
+			.await
+			.json();
+		assert_eq!(
+			device["device"]["role"], "backup-restore",
+			"role updated to match the new provisioning",
+		);
+		let keys = device["keys"].as_array().unwrap();
+		assert_eq!(keys.len(), 2, "prior key kept alongside the new one");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_untrusted_role() {
+	run(async |_conn, _public, private| {
+		private
+			.post("/api/devices/provision_credential")
+			.json(&json!({ "role": "untrusted" }))
+			.await
+			.assert_status_bad_request();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_device_is_not_found() {
+	run(async |_conn, _public, private| {
+		private
+			.post("/api/devices/provision_credential")
+			.json(&json!({
+				"role": "server",
+				"device_id": "00000000-0000-0000-0000-000000000000",
+			}))
+			.await
+			.assert_status_not_found();
+	})
+	.await;
+}

--- a/private-web/e2e/provision-credential.spec.ts
+++ b/private-web/e2e/provision-credential.spec.ts
@@ -17,7 +17,7 @@ test.describe("provision device credentials", () => {
 		await page
 			.getByLabel("Key name (optional)")
 			.fill("e2e-provisioned");
-		await page.getByRole("button", { name: "Provision" }).click();
+		await page.getByRole("button", { name: "Provision", exact: true }).click();
 
 		// One-shot result view: the "shown once" warning and a passphrase.
 		await expect(page.getByText(/shown once/i)).toBeVisible();
@@ -56,7 +56,7 @@ test.describe("provision device credentials", () => {
 		await page
 			.getByRole("button", { name: "Provision credential" })
 			.click();
-		await page.getByRole("button", { name: "Provision" }).click();
+		await page.getByRole("button", { name: "Provision", exact: true }).click();
 
 		const downloadPromise = page.waitForEvent("download");
 		await page.getByRole("button", { name: "Download key file" }).click();

--- a/private-web/e2e/provision-credential.spec.ts
+++ b/private-web/e2e/provision-credential.spec.ts
@@ -1,0 +1,71 @@
+import { readFile } from "node:fs/promises";
+import { expect, test } from "./test-fixtures";
+import { resetSeededTables, seedDevice, seedDeviceKey } from "./seed";
+
+test.describe("provision device credentials", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("create device mints a downloadable age-encrypted key", async ({
+		page,
+	}) => {
+		await page.goto("/devices/trusted");
+		await page.getByRole("button", { name: "Create device" }).click();
+
+		// Name the key so we can find the device in the list afterwards.
+		await page
+			.getByLabel("Key name (optional)")
+			.fill("e2e-provisioned");
+		await page.getByRole("button", { name: "Provision" }).click();
+
+		// One-shot result view: the "shown once" warning and a passphrase.
+		await expect(page.getByText(/shown once/i)).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Download key file" }),
+		).toBeVisible();
+
+		// The download is a standard age file.
+		const downloadPromise = page.waitForEvent("download");
+		await page.getByRole("button", { name: "Download key file" }).click();
+		const download = await downloadPromise;
+		expect(download.suggestedFilename()).toMatch(/\.pem\.age$/);
+		const path = await download.path();
+		const bytes = await readFile(path);
+		expect(bytes.subarray(0, 21).toString("ascii")).toBe(
+			"age-encryption.org/v1",
+		);
+
+		// Closing returns to the list, which now shows the new device by its key.
+		await page.getByRole("button", { name: /Done|Close/ }).click();
+		await expect(page.getByText("e2e-provisioned")).toBeVisible();
+	});
+
+	test("provision credential on an existing device adds a key", async ({
+		page,
+		sql,
+	}) => {
+		const device = await seedDevice(sql, { role: "releaser" });
+		await seedDeviceKey(sql, {
+			deviceId: device.id,
+			name: "original-key",
+			isActive: true,
+		});
+
+		await page.goto(`/devices/${device.id}`);
+		await page
+			.getByRole("button", { name: "Provision credential" })
+			.click();
+		await page.getByRole("button", { name: "Provision" }).click();
+
+		const downloadPromise = page.waitForEvent("download");
+		await page.getByRole("button", { name: "Download key file" }).click();
+		const download = await downloadPromise;
+		expect(download.suggestedFilename()).toMatch(/^canopy-releaser-.*\.pem\.age$/);
+
+		await page.getByRole("button", { name: /Done|Close/ }).click();
+
+		// The device now has two active keys.
+		await expect(page.getByText("Public Keys (2)")).toBeVisible();
+	});
+});

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -2003,6 +2003,62 @@
         ]
       }
     },
+    "/api/devices/provision_credential": {
+      "post": {
+        "tags": [
+          "devices"
+        ],
+        "summary": "Mint a device keypair server-side, store its public key as an active key on\na new or existing device at the chosen role, and return the private key\nonce, encrypted under a fresh passphrase (spec DPK). Canopy keeps only the\npublic key; the private key is never persisted or logged.",
+        "operationId": "provision_credential",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProvisionArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisionedCredential"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/devices/resolve_tailnet_identifier": {
       "post": {
         "tags": [
@@ -8476,6 +8532,71 @@
             "format": "uri",
             "description": "A URI reference identifying the problem type.",
             "example": "/errors/resource-not-found"
+          }
+        }
+      },
+      "ProvisionArgs": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "device_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Provision an additional credential onto this existing device. When\nomitted, a new device is created at `role`."
+          },
+          "key_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name for the new key. Defaults to \"Provisioned key\"."
+          },
+          "role": {
+            "$ref": "#/components/schemas/DeviceRole",
+            "description": "Role to trust the device at. Any trustable role is allowed; `untrusted`\nis rejected."
+          }
+        }
+      },
+      "ProvisionedCredential": {
+        "type": "object",
+        "description": "The one-time result of provisioning a device credential. The plaintext\nprivate key lives only inside `key_age_base64`; Canopy never persists it.",
+        "required": [
+          "device_id",
+          "key_id",
+          "fingerprint",
+          "filename",
+          "key_age_base64",
+          "passphrase"
+        ],
+        "properties": {
+          "device_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "filename": {
+            "type": "string",
+            "description": "Suggested filename for the downloaded encrypted key."
+          },
+          "fingerprint": {
+            "type": "string",
+            "description": "Lowercase hex SHA-256 of the stored public key, to correlate the\ncredential with the device's key list."
+          },
+          "key_age_base64": {
+            "type": "string",
+            "description": "Base64 (standard) of the age-encrypted PKCS#8 PEM private key. Decrypt\nwith `passphrase` (e.g. `bestool crypto reveal`) to recover the PEM."
+          },
+          "key_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "passphrase": {
+            "type": "string",
+            "description": "Freshly-generated passphrase that decrypts `key_age_base64`. Share it\nout-of-band, on a separate channel from the file."
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -833,6 +833,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/devices/provision_credential": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mint a device keypair server-side, store its public key as an active key on
+         *     a new or existing device at the chosen role, and return the private key
+         *     once, encrypted under a fresh passphrase (spec DPK). Canopy keeps only the
+         *     public key; the private key is never persisted or logged.
+         */
+        post: operations["provision_credential"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/devices/resolve_tailnet_identifier": {
         parameters: {
             query?: never;
@@ -3435,6 +3457,48 @@ export interface components {
              */
             type: string;
         };
+        ProvisionArgs: {
+            /**
+             * Format: uuid
+             * @description Provision an additional credential onto this existing device. When
+             *     omitted, a new device is created at `role`.
+             */
+            device_id?: string | null;
+            /** @description Display name for the new key. Defaults to "Provisioned key". */
+            key_name?: string | null;
+            /**
+             * @description Role to trust the device at. Any trustable role is allowed; `untrusted`
+             *     is rejected.
+             */
+            role: components["schemas"]["DeviceRole"];
+        };
+        /**
+         * @description The one-time result of provisioning a device credential. The plaintext
+         *     private key lives only inside `key_age_base64`; Canopy never persists it.
+         */
+        ProvisionedCredential: {
+            /** Format: uuid */
+            device_id: string;
+            /** @description Suggested filename for the downloaded encrypted key. */
+            filename: string;
+            /**
+             * @description Lowercase hex SHA-256 of the stored public key, to correlate the
+             *     credential with the device's key list.
+             */
+            fingerprint: string;
+            /**
+             * @description Base64 (standard) of the age-encrypted PKCS#8 PEM private key. Decrypt
+             *     with `passphrase` (e.g. `bestool crypto reveal`) to recover the PEM.
+             */
+            key_age_base64: string;
+            /** Format: uuid */
+            key_id: string;
+            /**
+             * @description Freshly-generated passphrase that decrypts `key_age_base64`. Share it
+             *     out-of-band, on a separate channel from the file.
+             */
+            passphrase: string;
+        };
         RecoveryChallengeResponse: {
             /**
              * @description The challenge ciphertext (`age` to the recipients), base64-encoded. The
@@ -5623,6 +5687,45 @@ export interface operations {
             };
             /** @description Both source and target hold tailscale identity or a server attachment. */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    provision_credential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProvisionArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProvisionedCredential"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/private-web/src/components/ProvisionCredentialDialog.tsx
+++ b/private-web/src/components/ProvisionCredentialDialog.tsx
@@ -1,0 +1,215 @@
+import {
+	Alert,
+	Box,
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	IconButton,
+	MenuItem,
+	Stack,
+	TextField,
+	Tooltip,
+	Typography,
+} from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import DownloadIcon from "@mui/icons-material/Download";
+import { useState } from "react";
+import { useApiAction } from "../api";
+import type { DeviceRole, ProvisionedCredential } from "../types";
+
+const TRUSTABLE_ROLES: DeviceRole[] = [
+	"server",
+	"releaser",
+	"admin",
+	"backup-restore",
+];
+
+/**
+ * Mint a device credential (spec DPK) and present it once. The private key is
+ * shown only inside the returned encrypted download and is never retrievable
+ * again, so the dialog makes the "shown once" nature explicit and discards the
+ * material on close.
+ *
+ * Two modes:
+ * - `deviceId` set: provision an additional key onto that device at `role`.
+ * - `deviceId` omitted: create a new device; the operator picks the role.
+ */
+export default function ProvisionCredentialDialog({
+	open,
+	onClose,
+	deviceId,
+	role: fixedRole,
+	onProvisioned,
+}: {
+	open: boolean;
+	onClose: () => void;
+	deviceId?: string;
+	role?: DeviceRole;
+	onProvisioned?: (result: ProvisionedCredential) => void;
+}) {
+	const action = useApiAction("devices", "provision_credential");
+	const [role, setRole] = useState<DeviceRole>(fixedRole ?? "server");
+	const [keyName, setKeyName] = useState("");
+	const [result, setResult] = useState<ProvisionedCredential | null>(null);
+	const [downloaded, setDownloaded] = useState(false);
+
+	const roleSelectable = !fixedRole;
+	const effectiveRole = fixedRole ?? role;
+
+	const reset = () => {
+		setResult(null);
+		setDownloaded(false);
+		setKeyName("");
+		setRole(fixedRole ?? "server");
+		action.reset();
+	};
+
+	const close = () => {
+		reset();
+		onClose();
+	};
+
+	const onProvision = async () => {
+		try {
+			const res = (await action.call({
+				role: effectiveRole,
+				device_id: deviceId ?? null,
+				key_name: keyName.trim() === "" ? null : keyName.trim(),
+			})) as ProvisionedCredential;
+			setResult(res);
+			onProvisioned?.(res);
+		} catch {
+			/* surfaced via action.error */
+		}
+	};
+
+	const download = () => {
+		if (!result) return;
+		const binary = atob(result.key_age_base64);
+		const bytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+		const url = URL.createObjectURL(
+			new Blob([bytes], { type: "application/octet-stream" }),
+		);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = result.filename;
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		URL.revokeObjectURL(url);
+		setDownloaded(true);
+	};
+
+	return (
+		<Dialog open={open} onClose={close} fullWidth maxWidth="sm">
+			<DialogTitle>
+				{deviceId ? "Provision credential" : "Create device"}
+			</DialogTitle>
+			<DialogContent>
+				{result ? (
+					<Stack spacing={2} sx={{ mt: 1 }}>
+						<Alert severity="warning">
+							This key is shown once. Download it and copy the passphrase
+							now — Canopy does not keep the private key and cannot show it
+							again.
+						</Alert>
+						<Box>
+							<Typography variant="caption" color="text.secondary">
+								Passphrase (share out of band)
+							</Typography>
+							<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+								<Typography
+									variant="body1"
+									sx={{ fontFamily: "monospace" }}
+								>
+									{result.passphrase}
+								</Typography>
+								<Tooltip title="Copy passphrase">
+									<IconButton
+										size="small"
+										onClick={() =>
+											navigator.clipboard?.writeText(result.passphrase)
+										}
+									>
+										<ContentCopyIcon fontSize="small" />
+									</IconButton>
+								</Tooltip>
+							</Stack>
+						</Box>
+						<Button
+							variant="contained"
+							startIcon={<DownloadIcon />}
+							onClick={download}
+						>
+							Download key file
+						</Button>
+						<Typography variant="body2" color="text.secondary">
+							Decrypt on the host with{" "}
+							<code>bestool crypto reveal {result.filename}</code> to recover
+							the PEM.
+						</Typography>
+					</Stack>
+				) : (
+					<Stack spacing={2} sx={{ mt: 1 }}>
+						<Typography variant="body2" color="text.secondary">
+							Canopy mints the keypair, stores the public key, and hands back
+							the private key once, encrypted under a generated passphrase.
+						</Typography>
+						{roleSelectable ? (
+							<TextField
+								select
+								label="Role"
+								size="small"
+								value={role}
+								onChange={(e) => setRole(e.target.value as DeviceRole)}
+								disabled={action.pending}
+							>
+								{TRUSTABLE_ROLES.map((r) => (
+									<MenuItem key={r} value={r}>
+										{r}
+									</MenuItem>
+								))}
+							</TextField>
+						) : (
+							<Typography variant="body2">
+								Role: <strong>{effectiveRole}</strong>
+							</Typography>
+						)}
+						<TextField
+							label="Key name (optional)"
+							size="small"
+							value={keyName}
+							onChange={(e) => setKeyName(e.target.value)}
+							placeholder="Provisioned key"
+							disabled={action.pending}
+						/>
+						{action.error && (
+							<Alert severity="error">{action.error.message}</Alert>
+						)}
+					</Stack>
+				)}
+			</DialogContent>
+			<DialogActions>
+				{result ? (
+					<Button onClick={close}>{downloaded ? "Done" : "Close"}</Button>
+				) : (
+					<>
+						<Button onClick={close} disabled={action.pending}>
+							Cancel
+						</Button>
+						<Button
+							variant="contained"
+							onClick={onProvision}
+							disabled={action.pending}
+						>
+							{action.pending ? "Provisioning…" : "Provision"}
+						</Button>
+					</>
+				)}
+			</DialogActions>
+		</Dialog>
+	);
+}

--- a/private-web/src/routes/DeviceDetail.tsx
+++ b/private-web/src/routes/DeviceDetail.tsx
@@ -18,6 +18,7 @@ import ServerShorty, {
 	type ServerInfo as ServerShortyInfo,
 } from "../components/ServerShorty";
 import TailnetIdentitySection from "../components/TailnetIdentitySection";
+import ProvisionCredentialDialog from "../components/ProvisionCredentialDialog";
 import { type ApiState, callApi, useApi, useApiAction } from "../api";
 import { deviceDisplayName } from "../components/DeviceShorty";
 import TimeAgo from "../components/TimeAgo";
@@ -269,6 +270,7 @@ function RoleControls({
 		role === "untrusted" ? "server" : role,
 	);
 	const [confirmUntrust, setConfirmUntrust] = useState(false);
+	const [provisionOpen, setProvisionOpen] = useState(false);
 
 	const onSave = async () => {
 		try {
@@ -342,7 +344,13 @@ function RoleControls({
 					</Button>
 				</Stack>
 				{role !== "untrusted" && (
-					<Box>
+					<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+						<Button
+							variant="outlined"
+							onClick={() => setProvisionOpen(true)}
+						>
+							Provision credential
+						</Button>
 						{confirmUntrust ? (
 							<Stack direction="row" spacing={1}>
 								<Button
@@ -370,7 +378,7 @@ function RoleControls({
 								Untrust
 							</Button>
 						)}
-					</Box>
+					</Stack>
 				)}
 			</Stack>
 			{(trustAction.error ||
@@ -380,6 +388,13 @@ function RoleControls({
 					{(trustAction.error ?? untrustAction.error ?? updateRoleAction.error)?.message}
 				</Alert>
 			)}
+			<ProvisionCredentialDialog
+				open={provisionOpen}
+				onClose={() => setProvisionOpen(false)}
+				deviceId={device.device.id}
+				role={role === "untrusted" ? undefined : role}
+				onProvisioned={refresh}
+			/>
 		</Paper>
 	);
 }

--- a/private-web/src/routes/DevicesList.tsx
+++ b/private-web/src/routes/DevicesList.tsx
@@ -1,12 +1,15 @@
 import {
 	Alert,
 	Box,
+	Button,
 	LinearProgress,
 	Pagination,
 	Stack,
 } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
 import { useState } from "react";
 import DeviceShorty from "../components/DeviceShorty";
+import ProvisionCredentialDialog from "../components/ProvisionCredentialDialog";
 import { useApi } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
 
@@ -19,6 +22,7 @@ export default function DevicesList({
 }) {
 	usePageTitle(scope === "trusted" ? "Trusted devices" : "Untrusted devices");
 	const [page, setPage] = useState(0);
+	const [createOpen, setCreateOpen] = useState(false);
 
 	const listFn = scope === "trusted" ? "list_trusted" : "list_untrusted";
 	const result = useApi(
@@ -33,6 +37,22 @@ export default function DevicesList({
 
 	return (
 		<Stack spacing={2}>
+			{scope === "trusted" && (
+				<Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+					<Button
+						variant="contained"
+						startIcon={<AddIcon />}
+						onClick={() => setCreateOpen(true)}
+					>
+						Create device
+					</Button>
+					<ProvisionCredentialDialog
+						open={createOpen}
+						onClose={() => setCreateOpen(false)}
+						onProvisioned={() => result.reload()}
+					/>
+				</Box>
+			)}
 			{result.status === "loading" || result.status === "idle" ? (
 				<LinearProgress />
 			) : result.status === "error" ? (

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -77,6 +77,7 @@ export type ServerKind = Solidify<Schemas["ServerKind"]>;
 export type ServerRank = Solidify<Schemas["ServerRank"]>;
 export type VersionStatus = Solidify<Schemas["VersionStatus"]>;
 export type DeviceRole = Solidify<Schemas["DeviceRole"]>;
+export type ProvisionedCredential = Solidify<Schemas["ProvisionedCredential"]>;
 export type Severity = Solidify<Schemas["Severity"]>;
 export type ResolvedReason = Solidify<Schemas["ResolvedReason"]>;
 


### PR DESCRIPTION
🤖 Operator-provisioned device credentials (spec DPK).

Getting a keypair-authenticated device with a non-server role (releaser, backup-restore) previously meant generating a keypair off-platform and authenticating by hand. This adds an operator-driven flow: create a device at the right role, and Canopy mints the keypair, stores only the public key, and hands the private key back once — encrypted under a generated passphrase, decryptable with `bestool crypto reveal`.

## How it works

- Canopy generates an ECDSA P-256 keypair server-side and stores only the DER `SubjectPublicKeyInfo` as an active `device_keys` row, at the operator's chosen role. The credential is immediately valid — no enrolment handshake.
- The private key is returned once, as a standard age/scrypt file (base64) under a fresh 4-word passphrase, using the same primitives as `mint_enrollment`. It is never persisted or logged; losing it means provisioning a new one.
- The download is a raw age v1 file, so `bestool crypto reveal <file>.age` decrypts it directly — no bestool changes.

## Surface

- `POST /api/devices/provision_credential` — new device at a role, or an added key on an existing device.
- UI: "Create device" on the trusted list and "Provision credential" on the device page, both a one-shot dialog (copy passphrase, download `.age`, shown-once warning).

## Notes

- The SPKI is derived exactly as the mTLS path extracts it (`subject_pki.raw`), and a round-trip test decrypts the returned blob and asserts the revealed private key's public half is byte-identical to the stored key.
- All trustable roles are eligible, including `server`. This is a weaker posture than server self-enrolment (Canopy briefly holds the private key and it transits a download); it is deliberate per the design discussion.

A follow-up PR retires the `untrusted` role and fixes server-binding to trust as `server`.
