### PR TITLE
deps: bump tower-http to 0.7 and k8s-openapi to 0.28 (with kube 4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +147,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -218,6 +242,12 @@ checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "asn1-rs"
@@ -1574,7 +1604,7 @@ dependencies = [
  "serde_urlencoded",
  "time",
  "tokio",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "x509-parser",
 ]
@@ -2414,6 +2444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2849,16 @@ dependencies = [
  "bitflags 2.13.0",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -3685,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
  "base64 0.22.1",
  "jiff",
@@ -3697,9 +3746,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
+checksum = "4bb9108095346a7096d11feeaff419c75dddcac1b2f59acb38d7bf3d13c3e146"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -3708,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
+checksum = "d0f628e05bc2264c21fe10d3d675117dc9b43ea3bf4fb07262a222679757537b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3731,21 +3780,21 @@ dependencies = [
  "rustls 0.23.40",
  "secrecy",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
+checksum = "c1b02f5933ba06140d58c7d6727f6c319f0962ec6a344aa5e21e475e891deaa8"
 dependencies = [
  "derive_more",
  "form_urlencoded",
@@ -4038,6 +4087,12 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -4632,7 +4687,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-postgres",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "utoipa",
  "utoipa-axum",
@@ -4732,7 +4787,7 @@ dependencies = [
  "tera",
  "timesimp",
  "tokio",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "utoipa",
  "utoipa-axum",
@@ -5062,7 +5117,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5566,6 +5621,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5650,19 +5724,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -6369,11 +6430,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "http-range-header",
- "httpdate",
  "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -6382,6 +6439,33 @@ dependencies = [
  "tower-service",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "async-compression",
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6632,12 +6716,6 @@ dependencies = [
  "crypto-common 0.1.6",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ futures = "0.3.32"
 http = "1.4.0"
 jiff = { version = "0.2.24", features = ["serde"] }
 # k8s-openapi requires exactly one Kubernetes-version feature, and the version
-# is pinned to 0.27 to match what kube 3.1 depends on (a mismatch causes a
-# duplicate k8s-openapi with no version feature → build failure). `v1_32` is a
+# is pinned to match what kube depends on (a mismatch causes a duplicate
+# k8s-openapi with no version feature → build failure). `v1_32` is a
 # conservative recent control-plane version — CONFIRM against the actual EKS
 # control-plane version with ops before release (see spec open-question).
-k8s-openapi = { version = "0.27.1", features = ["v1_32"] }
+k8s-openapi = { version = "0.28.0", features = ["v1_32"] }
 # Disable kube's default `ring` crypto backend and use `aws-lc-rs` instead, so
 # we don't pull in a second rustls provider alongside the one the AWS SDK and
 # the rest of the workspace already use.
-kube = { version = "3.1.0", default-features = false, features = [
+kube = { version = "4.0.0", default-features = false, features = [
 	"client",
 	"config",
 	"rustls-tls",

--- a/crates/commons-servers/Cargo.toml
+++ b/crates/commons-servers/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = "1.0.150"
 serde_urlencoded = "0.7.1"
 time = "0.3.47"
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-tower-http = { version = "0.6.11", features = [
+tower-http = { version = "0.7.0", features = [
 	"compression-full",
 	"decompression-full",
 	"fs",

--- a/crates/private-server/Cargo.toml
+++ b/crates/private-server/Cargo.toml
@@ -38,7 +38,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = "1.0.150"
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
 tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-serde_json-1", "with-uuid-1"] }
-tower-http = { version = "0.6.11", features = ["fs"] }
+tower-http = { version = "0.7.0", features = ["fs"] }
 tracing.workspace = true
 utoipa.workspace = true
 utoipa-axum.workspace = true

--- a/crates/public-server/Cargo.toml
+++ b/crates/public-server/Cargo.toml
@@ -44,7 +44,7 @@ serde = { workspace = true, features = ["derive"] }
 tera = { workspace = true, optional = true }
 tokio.workspace = true
 timesimp = { version = "1.0.0", optional = true }
-tower-http = { version = "0.6.11", optional = true, features = [
+tower-http = { version = "0.7.0", optional = true, features = [
 	"compression-full",
 	"fs",
 	"trace",


### PR DESCRIPTION
🤖 Supersedes the two standalone Dependabot PRs (#289, #291), which each needed manual follow-up to build.

## tower-http 0.6.11 → 0.7.0
Bumped in `commons-servers`, `private-server`, and `public-server`. Our usage (`CompressionLayer`, `RequestDecompressionLayer`, `TraceLayer`, `ServeDir`) is unaffected by the 0.7 breaking changes, so no code changes were needed. Transitive consumers (reqwest, axum-client-ip) stay on 0.6.11.

## k8s-openapi 0.27.1 → 0.28.0 + kube 3.1 → 4.0
Dependabot's #291 bumped k8s-openapi alone, which pins to whatever kube depends on. kube 3.1 still needs k8s-openapi 0.27, so the bump produced two copies of k8s-openapi (the exact failure the workspace Cargo.toml comment warns about). Bumping kube to 4.0 alongside resolves back to a single k8s-openapi 0.28. The `v1_32` feature is retained (0.28 drops 1.31 but keeps 1.32). kube 4.0's API is source-compatible with our `backup_secrets` usage — no code changes needed.

Closes #289
Closes #291