### PR TITLE
feat(devices): device key management (add-from-key, per-key disable/enable)

### DIFF
--- a/crates/commons-servers/src/device_auth/keygen.rs
+++ b/crates/commons-servers/src/device_auth/keygen.rs
@@ -65,3 +65,13 @@ pub fn generate_device_key() -> Result<GeneratedDeviceKey> {
 		fingerprint,
 	})
 }
+
+/// Validate that `der` parses as a `SubjectPublicKeyInfo` — the public-key form
+/// device keys are stored as and mTLS auth matches against. Used when an
+/// operator registers a key from an externally-generated public key rather than
+/// having Canopy mint it.
+pub fn validate_spki_der(der: &[u8]) -> Result<()> {
+	SubjectPublicKeyInfo::from_der(der)
+		.map(|_| ())
+		.map_err(|e| AppError::BadRequest(format!("not a valid public key: {e}")))
+}

--- a/crates/database/src/devices.rs
+++ b/crates/database/src/devices.rs
@@ -447,11 +447,12 @@ impl Device {
 			.await
 			.map_err(AppError::from)?;
 
+		// All keys, active and inactive — the detail view shows disabled keys
+		// (greyed, re-enableable), active first then oldest-first.
 		let keys: Vec<DeviceKey> = device_keys::table
 			.select(DeviceKey::as_select())
 			.filter(device_keys::device_id.eq(device_id))
-			.filter(device_keys::is_active.eq(true))
-			.order(device_keys::created_at.asc())
+			.order((device_keys::is_active.desc(), device_keys::created_at.asc()))
 			.load(db)
 			.await
 			.map_err(AppError::from)?;
@@ -1152,6 +1153,21 @@ impl DeviceKey {
 
 		diesel::update(dsl::device_keys.filter(dsl::id.eq(key_id)))
 			.set(dsl::is_active.eq(false))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+
+		Ok(())
+	}
+
+	/// Re-enable a previously deactivated key. The inverse of [`deactivate`];
+	/// used by the operator's per-key controls to undo a disable (e.g. during a
+	/// botched rotation).
+	pub async fn reactivate(db: &mut AsyncPgConnection, key_id: Uuid) -> Result<()> {
+		use crate::schema::device_keys::dsl;
+
+		diesel::update(dsl::device_keys.filter(dsl::id.eq(key_id)))
+			.set(dsl::is_active.eq(true))
 			.execute(db)
 			.await
 			.map_err(AppError::from)?;

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -73,6 +73,7 @@ impl DeviceInfo {
 	pub fn name(&self) -> String {
 		self.keys
 			.iter()
+			.filter(|key| key.is_active)
 			.filter_map(|key| {
 				key.name
 					.as_ref()
@@ -113,6 +114,9 @@ pub struct DeviceKeyInfo {
 	pub name: Option<String>,
 	pub pem_data: String,
 	pub created_at: Timestamp,
+	/// Whether this key can currently authenticate. Inactive keys are kept for
+	/// history and can be re-enabled.
+	pub is_active: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -163,6 +167,7 @@ impl From<DeviceKey> for DeviceKeyInfo {
 			name: key.name,
 			pem_data: format_key_as_pem(&key.key_data),
 			created_at: key.created_at,
+			is_active: key.is_active,
 		}
 	}
 }
@@ -200,9 +205,12 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(connection_history))
 		.routes(routes!(connection_count))
 		.routes(routes!(list_trusted))
-		.routes(routes!(revoke))
+		.routes(routes!(disable_all_keys))
 		.routes(routes!(update_role))
 		.routes(routes!(provision_credential))
+		.routes(routes!(add_key))
+		.routes(routes!(deactivate_key))
+		.routes(routes!(reactivate_key))
 		.routes(routes!(search))
 		.routes(routes!(update_key_name))
 		.routes(routes!(attach_tailscale))
@@ -398,13 +406,13 @@ pub async fn list_trusted(
 	Ok(Json(Page { items, total }))
 }
 
-/// Revoke a device's access: deactivate its keys and detach any tailnet
-/// identity, so it can no longer authenticate. The row and its role are kept
-/// for history.
+/// Disable every active key on a device, so none of them can authenticate.
+/// The rows are kept (for history) and can be re-enabled individually. Tailnet
+/// identity, if any, is untouched — detach it separately.
 #[utoipa::path(
 	post,
-	path = "/revoke",
-	operation_id = "device_revoke",
+	path = "/disable_all_keys",
+	operation_id = "device_disable_all_keys",
 	tag = "devices",
 	security(("tailscale-admin" = [])),
 	request_body = DeviceIdArgs,
@@ -412,13 +420,13 @@ pub async fn list_trusted(
 		(status = 200),
 	),
 )]
-pub async fn revoke(
+pub async fn disable_all_keys(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
 	Json(args): Json<DeviceIdArgs>,
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
-	Device::revoke(&mut conn, args.device_id).await?;
+	Device::deactivate_keys(&mut conn, args.device_id).await?;
 	Ok(Json(()))
 }
 
@@ -562,6 +570,110 @@ pub async fn provision_credential(
 		key_age_base64,
 		passphrase,
 	}))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct AddKeyArgs {
+	pub device_id: Uuid,
+	/// The device's public key, PEM-encoded `SubjectPublicKeyInfo`
+	/// (`-----BEGIN PUBLIC KEY-----`). Bare base64 (no armor) is also accepted.
+	pub public_key_pem: String,
+	/// Display name for the key. Defaults to "Added key".
+	#[serde(default)]
+	pub name: Option<String>,
+}
+
+/// Register an externally-generated public key as an active key on a device.
+/// Unlike `provision_credential`, Canopy never sees a private key here — the
+/// operator supplies the public half of a keypair they hold.
+#[utoipa::path(
+	post,
+	path = "/add_key",
+	tag = "devices",
+	security(("tailscale-admin" = [])),
+	request_body = AddKeyArgs,
+	responses(
+		(status = 200, body = DeviceInfo),
+		(status = 400, body = ProblemDetailsSchema),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn add_key(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<AddKeyArgs>,
+) -> Result<Json<DeviceInfo>> {
+	use base64::Engine as _;
+
+	// Accept PEM armor or bare base64; decode to DER and validate it's an SPKI.
+	let b64: String = args
+		.public_key_pem
+		.lines()
+		.filter(|l| !l.trim_start().starts_with("-----"))
+		.collect::<Vec<_>>()
+		.join("");
+	let der = base64::engine::general_purpose::STANDARD
+		.decode(b64.trim())
+		.map_err(|e| AppError::BadRequest(format!("public key is not valid base64/PEM: {e}")))?;
+	keygen::validate_spki_der(&der)?;
+
+	let name = args
+		.name
+		.filter(|n| !n.trim().is_empty())
+		.unwrap_or_else(|| "Added key".to_string());
+
+	let mut conn = state.db.get().await?;
+	// 404s if the device doesn't exist.
+	Device::get_with_info(&mut conn, args.device_id).await?;
+	DeviceKey::create(&mut conn, args.device_id, der, Some(name)).await?;
+
+	let info = Device::get_with_info(&mut conn, args.device_id).await?;
+	Ok(Json(DeviceInfo::from_db(info, &state).await))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct KeyIdArgs {
+	pub key_id: Uuid,
+}
+
+/// Disable a single key so it can no longer authenticate. The row is kept and
+/// can be re-enabled; disabling one key of several lets a device rotate keys
+/// with no gap (add the new key, then disable the old).
+#[utoipa::path(
+	post,
+	path = "/deactivate_key",
+	tag = "devices",
+	security(("tailscale-admin" = [])),
+	request_body = KeyIdArgs,
+	responses((status = 200)),
+)]
+pub async fn deactivate_key(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<KeyIdArgs>,
+) -> Result<Json<()>> {
+	let mut conn = state.db.get().await?;
+	DeviceKey::deactivate(&mut conn, args.key_id).await?;
+	Ok(Json(()))
+}
+
+/// Re-enable a previously disabled key.
+#[utoipa::path(
+	post,
+	path = "/reactivate_key",
+	tag = "devices",
+	security(("tailscale-admin" = [])),
+	request_body = KeyIdArgs,
+	responses((status = 200)),
+)]
+pub async fn reactivate_key(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<KeyIdArgs>,
+) -> Result<Json<()>> {
+	let mut conn = state.db.get().await?;
+	DeviceKey::reactivate(&mut conn, args.key_id).await?;
+	Ok(Json(()))
 }
 
 #[derive(Deserialize, ToSchema)]

--- a/crates/private-server/tests/device_keys.rs
+++ b/crates/private-server/tests/device_keys.rs
@@ -1,0 +1,137 @@
+//! Tests for device key management: registering an externally-generated public
+//! key, per-key disable/enable, and disable-all.
+
+use base64::Engine as _;
+use commons_tests::server::{make_certificate, run};
+use serde_json::{Value, json};
+
+/// Provision a device and return `(device_id, first_key_id)`.
+async fn provision(private: &commons_tests::axum_test::TestServer) -> (String, String) {
+	let dev: Value = private
+		.post("/api/devices/provision_credential")
+		.json(&json!({ "role": "server" }))
+		.await
+		.json();
+	(
+		dev["device_id"].as_str().unwrap().to_owned(),
+		dev["key_id"].as_str().unwrap().to_owned(),
+	)
+}
+
+fn public_key_b64() -> String {
+	// A real DER SubjectPublicKeyInfo (P-256), base64'd — add_key accepts bare
+	// base64 or PEM armor.
+	let (spki, _cert) = make_certificate();
+	base64::engine::general_purpose::STANDARD.encode(spki)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn add_key_from_public_key() {
+	run(async |_conn, _public, private| {
+		let (device_id, _) = provision(&private).await;
+
+		private
+			.post("/api/devices/add_key")
+			.json(&json!({
+				"device_id": device_id,
+				"public_key_pem": public_key_b64(),
+				"name": "external",
+			}))
+			.await
+			.assert_status_ok();
+
+		let info: Value = private
+			.post("/api/devices/get_device_by_id")
+			.json(&json!({ "device_id": device_id }))
+			.await
+			.json();
+		let keys = info["keys"].as_array().unwrap();
+		assert_eq!(keys.len(), 2, "provisioned key + added key");
+		assert!(
+			keys.iter()
+				.any(|k| k["name"] == "external" && k["is_active"] == true),
+			"added key is present and active",
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn add_key_rejects_non_spki() {
+	run(async |_conn, _public, private| {
+		let (device_id, _) = provision(&private).await;
+		// Valid base64, but not a SubjectPublicKeyInfo.
+		let garbage = base64::engine::general_purpose::STANDARD.encode(b"not a key");
+		private
+			.post("/api/devices/add_key")
+			.json(&json!({ "device_id": device_id, "public_key_pem": garbage }))
+			.await
+			.assert_status_bad_request();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn disable_then_reenable_single_key() {
+	run(async |_conn, _public, private| {
+		let (device_id, key_id) = provision(&private).await;
+
+		private
+			.post("/api/devices/deactivate_key")
+			.json(&json!({ "key_id": key_id }))
+			.await
+			.assert_status_ok();
+		let info: Value = private
+			.post("/api/devices/get_device_by_id")
+			.json(&json!({ "device_id": device_id }))
+			.await
+			.json();
+		let keys = info["keys"].as_array().unwrap();
+		assert_eq!(keys.len(), 1, "disabled key still listed for history");
+		assert_eq!(keys[0]["is_active"], false);
+
+		private
+			.post("/api/devices/reactivate_key")
+			.json(&json!({ "key_id": key_id }))
+			.await
+			.assert_status_ok();
+		let info: Value = private
+			.post("/api/devices/get_device_by_id")
+			.json(&json!({ "device_id": device_id }))
+			.await
+			.json();
+		assert_eq!(info["keys"].as_array().unwrap()[0]["is_active"], true);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn disable_all_keys_keeps_rows_inactive() {
+	run(async |_conn, _public, private| {
+		let (device_id, _) = provision(&private).await;
+		private
+			.post("/api/devices/add_key")
+			.json(&json!({ "device_id": device_id, "public_key_pem": public_key_b64() }))
+			.await
+			.assert_status_ok();
+
+		private
+			.post("/api/devices/disable_all_keys")
+			.json(&json!({ "device_id": device_id }))
+			.await
+			.assert_status_ok();
+
+		let info: Value = private
+			.post("/api/devices/get_device_by_id")
+			.json(&json!({ "device_id": device_id }))
+			.await
+			.json();
+		let keys = info["keys"].as_array().unwrap();
+		assert_eq!(keys.len(), 2, "keys kept for history");
+		assert!(
+			keys.iter().all(|k| k["is_active"] == false),
+			"every key disabled",
+		);
+	})
+	.await;
+}

--- a/crates/private-server/tests/devices.rs
+++ b/crates/private-server/tests/devices.rs
@@ -171,7 +171,11 @@ async fn test_revoke_device() {
 		Device::revoke(&mut conn, device.id).await.unwrap();
 
 		let info = Device::get_with_info(&mut conn, device.id).await.unwrap();
-		assert!(info.keys.is_empty(), "active keys cleared");
+		// Keys are kept for history but deactivated — none can authenticate.
+		assert!(
+			info.keys.iter().all(|k| !k.is_active),
+			"all keys deactivated",
+		);
 		assert!(
 			info.device.tailscale_node_id.is_none(),
 			"tailnet identity detached",

--- a/private-web/e2e/device-keys.spec.ts
+++ b/private-web/e2e/device-keys.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "./test-fixtures";
+import { resetSeededTables, seedDevice, seedDeviceKey } from "./seed";
+
+// A throwaway P-256 public key (SubjectPublicKeyInfo PEM) for the add-from-key flow.
+const PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEv6HzSyPiyx1o98LE8fiIkFQ5u5pv
+dvabF1OOXhPzbKHPpoRAQsJQ3XecL2ONQ1NBco65X7QT82vr7m13i156jQ==
+-----END PUBLIC KEY-----`;
+
+test.describe("device key management", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("disable then re-enable a key", async ({ page, sql }) => {
+		const device = await seedDevice(sql, { role: "server" });
+		await seedDeviceKey(sql, {
+			deviceId: device.id,
+			name: "rotating-key",
+			isActive: true,
+		});
+
+		await page.goto(`/devices/${device.id}`);
+
+		// Disable the key — it stays listed, marked disabled, with an Enable action.
+		await page.getByRole("button", { name: "Disable", exact: true }).click();
+		await expect(page.getByText("disabled")).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Enable", exact: true }),
+		).toBeVisible();
+
+		// Re-enable it.
+		await page.getByRole("button", { name: "Enable", exact: true }).click();
+		await expect(
+			page.getByRole("button", { name: "Disable", exact: true }),
+		).toBeVisible();
+	});
+
+	test("add a key from a pasted public key", async ({ page, sql }) => {
+		const device = await seedDevice(sql, { role: "server" });
+		await seedDeviceKey(sql, {
+			deviceId: device.id,
+			name: "existing-key",
+			isActive: true,
+		});
+
+		await page.goto(`/devices/${device.id}`);
+		await expect(page.getByText("Public Keys (1)")).toBeVisible();
+
+		await page.getByRole("button", { name: "Add from public key" }).click();
+		await page.getByLabel("Public key (PEM)").fill(PUBLIC_KEY_PEM);
+		await page.getByLabel("Key name (optional)").fill("pasted-key");
+		await page.getByRole("button", { name: "Add key", exact: true }).click();
+
+		await expect(page.getByText("Public Keys (2)")).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "pasted-key", level: 6 }),
+		).toBeVisible();
+	});
+});

--- a/private-web/e2e/provision-credential.spec.ts
+++ b/private-web/e2e/provision-credential.spec.ts
@@ -41,7 +41,7 @@ test.describe("provision device credentials", () => {
 		await expect(page.getByText("e2e-provisioned")).toBeVisible();
 	});
 
-	test("provision credential on an existing device adds a key", async ({
+	test("generate a new key for an existing device", async ({
 		page,
 		sql,
 	}) => {
@@ -54,7 +54,7 @@ test.describe("provision device credentials", () => {
 
 		await page.goto(`/devices/${device.id}`);
 		await page
-			.getByRole("button", { name: "Provision credential" })
+			.getByRole("button", { name: "Generate new key" })
 			.click();
 		await page.getByRole("button", { name: "Provision", exact: true }).click();
 

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1572,6 +1572,62 @@
         }
       }
     },
+    "/api/devices/add_key": {
+      "post": {
+        "tags": [
+          "devices"
+        ],
+        "summary": "Register an externally-generated public key as an active key on a device.\nUnlike `provision_credential`, Canopy never sees a private key here — the\noperator supplies the public half of a keypair they hold.",
+        "operationId": "add_key",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddKeyArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/devices/attach_tailscale": {
       "post": {
         "tags": [
@@ -1712,6 +1768,35 @@
         ]
       }
     },
+    "/api/devices/deactivate_key": {
+      "post": {
+        "tags": [
+          "devices"
+        ],
+        "summary": "Disable a single key so it can no longer authenticate. The row is kept and\ncan be re-enabled; disabling one key of several lets a device rotate keys\nwith no gap (add the new key, then disable the old).",
+        "operationId": "deactivate_key",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KeyIdArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/devices/detach_tailscale": {
       "post": {
         "tags": [
@@ -1748,6 +1833,35 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/devices/disable_all_keys": {
+      "post": {
+        "tags": [
+          "devices"
+        ],
+        "summary": "Disable every active key on a device, so none of them can authenticate.\nThe rows are kept (for history) and can be re-enabled individually. Tailnet\nidentity, if any, is untouched — detach it separately.",
+        "operationId": "device_disable_all_keys",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceIdArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
           }
         },
         "security": [
@@ -2014,6 +2128,35 @@
         ]
       }
     },
+    "/api/devices/reactivate_key": {
+      "post": {
+        "tags": [
+          "devices"
+        ],
+        "summary": "Re-enable a previously disabled key.",
+        "operationId": "reactivate_key",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KeyIdArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/devices/resolve_tailnet_identifier": {
       "post": {
         "tags": [
@@ -2051,35 +2194,6 @@
                 }
               }
             }
-          }
-        },
-        "security": [
-          {
-            "tailscale-admin": []
-          }
-        ]
-      }
-    },
-    "/api/devices/revoke": {
-      "post": {
-        "tags": [
-          "devices"
-        ],
-        "summary": "Revoke a device's access: deactivate its keys and detach any tailnet\nidentity, so it can no longer authenticate. The row and its role are kept\nfor history.",
-        "operationId": "device_revoke",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DeviceIdArgs"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": ""
           }
         },
         "security": [
@@ -5425,6 +5539,30 @@
           }
         }
       },
+      "AddKeyArgs": {
+        "type": "object",
+        "required": [
+          "device_id",
+          "public_key_pem"
+        ],
+        "properties": {
+          "device_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name for the key. Defaults to \"Added key\"."
+          },
+          "public_key_pem": {
+            "type": "string",
+            "description": "The device's public key, PEM-encoded `SubjectPublicKeyInfo`\n(`-----BEGIN PUBLIC KEY-----`). Bare base64 (no armor) is also accepted."
+          }
+        }
+      },
       "AddKnownIssueArgs": {
         "type": "object",
         "required": [
@@ -6537,7 +6675,8 @@
           "id",
           "device_id",
           "pem_data",
-          "created_at"
+          "created_at",
+          "is_active"
         ],
         "properties": {
           "created_at": {
@@ -6551,6 +6690,10 @@
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "is_active": {
+            "type": "boolean",
+            "description": "Whether this key can currently authenticate. Inactive keys are kept for\nhistory and can be re-enabled."
           },
           "name": {
             "type": [
@@ -7501,6 +7644,18 @@
             "format": "uuid"
           },
           "issue_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "KeyIdArgs": {
+        "type": "object",
+        "required": [
+          "key_id"
+        ],
+        "properties": {
+          "key_id": {
             "type": "string",
             "format": "uuid"
           }

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -673,6 +673,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/devices/add_key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Register an externally-generated public key as an active key on a device.
+         *     Unlike `provision_credential`, Canopy never sees a private key here — the
+         *     operator supplies the public half of a keypair they hold.
+         */
+        post: operations["add_key"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/devices/attach_tailscale": {
         parameters: {
             query?: never;
@@ -721,6 +742,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/devices/deactivate_key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Disable a single key so it can no longer authenticate. The row is kept and
+         *     can be re-enabled; disabling one key of several lets a device rotate keys
+         *     with no gap (add the new key, then disable the old).
+         */
+        post: operations["deactivate_key"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/devices/detach_tailscale": {
         parameters: {
             query?: never;
@@ -731,6 +773,27 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["detach_tailscale"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/devices/disable_all_keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Disable every active key on a device, so none of them can authenticate.
+         *     The rows are kept (for history) and can be re-enabled individually. Tailnet
+         *     identity, if any, is untouched — detach it separately.
+         */
+        post: operations["device_disable_all_keys"];
         delete?: never;
         options?: never;
         head?: never;
@@ -839,6 +902,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/devices/reactivate_key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Re-enable a previously disabled key. */
+        post: operations["reactivate_key"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/devices/resolve_tailnet_identifier": {
         parameters: {
             query?: never;
@@ -855,27 +935,6 @@ export interface paths {
          *     hitting attach.
          */
         post: operations["resolve_tailnet_identifier"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/devices/revoke": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Revoke a device's access: deactivate its keys and detach any tailnet
-         *     identity, so it can no longer authenticate. The row and its role are kept
-         *     for history.
-         */
-        post: operations["device_revoke"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2279,6 +2338,17 @@ export interface components {
         AddArgs: {
             email: string;
         };
+        AddKeyArgs: {
+            /** Format: uuid */
+            device_id: string;
+            /** @description Display name for the key. Defaults to "Added key". */
+            name?: string | null;
+            /**
+             * @description The device's public key, PEM-encoded `SubjectPublicKeyInfo`
+             *     (`-----BEGIN PUBLIC KEY-----`). Bare base64 (no armor) is also accepted.
+             */
+            public_key_pem: string;
+        };
         AddKnownIssueArgs: {
             description: string;
             /** Format: uuid */
@@ -2649,6 +2719,11 @@ export interface components {
             device_id: string;
             /** Format: uuid */
             id: string;
+            /**
+             * @description Whether this key can currently authenticate. Inactive keys are kept for
+             *     history and can be re-enabled.
+             */
+            is_active: boolean;
             name?: string | null;
             pem_data: string;
         };
@@ -3049,6 +3124,10 @@ export interface components {
             id: string;
             /** Format: uuid */
             issue_id: string;
+        };
+        KeyIdArgs: {
+            /** Format: uuid */
+            key_id: string;
         };
         KnownIssueData: {
             author: string;
@@ -5360,6 +5439,45 @@ export interface operations {
             };
         };
     };
+    add_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AddKeyArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeviceInfo"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
     attach_tailscale: {
         parameters: {
             query?: never;
@@ -5456,6 +5574,27 @@ export interface operations {
             };
         };
     };
+    deactivate_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["KeyIdArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     detach_tailscale: {
         parameters: {
             query?: never;
@@ -5484,6 +5623,27 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
                 };
+            };
+        };
+    };
+    device_disable_all_keys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeviceIdArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -5658,6 +5818,27 @@ export interface operations {
             };
         };
     };
+    reactivate_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["KeyIdArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     resolve_tailnet_identifier: {
         parameters: {
             query?: never;
@@ -5687,27 +5868,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
                 };
-            };
-        };
-    };
-    device_revoke: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DeviceIdArgs"];
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };

--- a/private-web/src/components/AddPublicKeyDialog.tsx
+++ b/private-web/src/components/AddPublicKeyDialog.tsx
@@ -1,0 +1,103 @@
+import {
+	Alert,
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Stack,
+	TextField,
+	Typography,
+} from "@mui/material";
+import { useState } from "react";
+import { useApiAction } from "../api";
+
+/**
+ * Register an externally-generated public key on a device. Unlike generating a
+ * key (where Canopy mints the keypair), the operator supplies the public half
+ * of a keypair they already hold — Canopy never sees the private key.
+ */
+export default function AddPublicKeyDialog({
+	open,
+	onClose,
+	deviceId,
+	onAdded,
+}: {
+	open: boolean;
+	onClose: () => void;
+	deviceId: string;
+	onAdded?: () => void;
+}) {
+	const action = useApiAction("devices", "add_key");
+	const [pem, setPem] = useState("");
+	const [name, setName] = useState("");
+
+	const close = () => {
+		setPem("");
+		setName("");
+		action.reset();
+		onClose();
+	};
+
+	const onAdd = async () => {
+		try {
+			await action.call({
+				device_id: deviceId,
+				public_key_pem: pem,
+				name: name.trim() === "" ? null : name.trim(),
+			});
+			onAdded?.();
+			close();
+		} catch {
+			/* surfaced via action.error */
+		}
+	};
+
+	return (
+		<Dialog open={open} onClose={close} fullWidth maxWidth="sm">
+			<DialogTitle>Add from public key</DialogTitle>
+			<DialogContent>
+				<Stack spacing={2} sx={{ mt: 1 }}>
+					<Typography variant="body2" color="text.secondary">
+						Register a public key the device already holds. Paste the
+						PEM (<code>-----BEGIN PUBLIC KEY-----</code>). Canopy stores
+						only the public key.
+					</Typography>
+					<TextField
+						label="Public key (PEM)"
+						multiline
+						minRows={5}
+						value={pem}
+						onChange={(e) => setPem(e.target.value)}
+						placeholder={"-----BEGIN PUBLIC KEY-----\n…\n-----END PUBLIC KEY-----"}
+						disabled={action.pending}
+						slotProps={{ htmlInput: { style: { fontFamily: "monospace" } } }}
+					/>
+					<TextField
+						label="Key name (optional)"
+						size="small"
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						placeholder="Added key"
+						disabled={action.pending}
+					/>
+					{action.error && (
+						<Alert severity="error">{action.error.message}</Alert>
+					)}
+				</Stack>
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={close} disabled={action.pending}>
+					Cancel
+				</Button>
+				<Button
+					variant="contained"
+					onClick={onAdd}
+					disabled={action.pending || pem.trim() === ""}
+				>
+					{action.pending ? "Adding…" : "Add key"}
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}

--- a/private-web/src/components/ProvisionCredentialDialog.tsx
+++ b/private-web/src/components/ProvisionCredentialDialog.tsx
@@ -106,7 +106,7 @@ export default function ProvisionCredentialDialog({
 	return (
 		<Dialog open={open} onClose={close} fullWidth maxWidth="sm">
 			<DialogTitle>
-				{deviceId ? "Provision credential" : "Create device"}
+				{deviceId ? "Generate new key" : "Create device"}
 			</DialogTitle>
 			<DialogContent>
 				{result ? (

--- a/private-web/src/routes/DeviceDetail.tsx
+++ b/private-web/src/routes/DeviceDetail.tsx
@@ -2,6 +2,7 @@ import {
 	Alert,
 	Box,
 	Button,
+	Chip,
 	IconButton,
 	LinearProgress,
 	MenuItem,
@@ -19,6 +20,7 @@ import ServerShorty, {
 } from "../components/ServerShorty";
 import TailnetIdentitySection from "../components/TailnetIdentitySection";
 import ProvisionCredentialDialog from "../components/ProvisionCredentialDialog";
+import AddPublicKeyDialog from "../components/AddPublicKeyDialog";
 import { type ApiState, callApi, useApi, useApiAction } from "../api";
 import { deviceDisplayName } from "../components/DeviceShorty";
 import TimeAgo from "../components/TimeAgo";
@@ -140,16 +142,98 @@ function KeysBox({
 	device: DeviceInfo;
 	refresh: () => void;
 }) {
+	const [generateOpen, setGenerateOpen] = useState(false);
+	const [addOpen, setAddOpen] = useState(false);
+	const [confirmDisableAll, setConfirmDisableAll] = useState(false);
+	const disableAll = useApiAction("devices", "disable_all_keys");
+	const hasActiveKey = device.keys.some((k) => k.is_active);
+
+	const onDisableAll = async () => {
+		try {
+			await disableAll.call({ device_id: device.device.id });
+			setConfirmDisableAll(false);
+			refresh();
+		} catch {
+			/* surfaced via disableAll.error */
+		}
+	};
+
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
-			<Typography variant="h6" component="h2" gutterBottom>
-				Public Keys ({device.keys.length})
-			</Typography>
+			<Stack
+				direction="row"
+				spacing={1}
+				useFlexGap
+				sx={{
+					alignItems: "center",
+					justifyContent: "space-between",
+					flexWrap: "wrap",
+					mb: 1,
+				}}
+			>
+				<Typography variant="h6" component="h2">
+					Public Keys ({device.keys.length})
+				</Typography>
+				<Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: "wrap" }}>
+					<Button variant="outlined" onClick={() => setAddOpen(true)}>
+						Add from public key
+					</Button>
+					<Button variant="contained" onClick={() => setGenerateOpen(true)}>
+						Generate new key
+					</Button>
+					{hasActiveKey &&
+						(confirmDisableAll ? (
+							<>
+								<Button
+									variant="contained"
+									color="error"
+									onClick={onDisableAll}
+									disabled={disableAll.pending}
+								>
+									{disableAll.pending ? "Disabling…" : "Confirm disable all"}
+								</Button>
+								<Button
+									variant="outlined"
+									onClick={() => setConfirmDisableAll(false)}
+									disabled={disableAll.pending}
+								>
+									Cancel
+								</Button>
+							</>
+						) : (
+							<Button
+								variant="outlined"
+								color="error"
+								onClick={() => setConfirmDisableAll(true)}
+							>
+								Disable all keys
+							</Button>
+						))}
+				</Stack>
+			</Stack>
+			{disableAll.error && (
+				<Alert severity="error" sx={{ mb: 1 }}>
+					{disableAll.error.message}
+				</Alert>
+			)}
 			<Stack spacing={2}>
 				{device.keys.map((k) => (
 					<KeyRow key={k.id} keyData={k} onSaved={refresh} />
 				))}
 			</Stack>
+			<ProvisionCredentialDialog
+				open={generateOpen}
+				onClose={() => setGenerateOpen(false)}
+				deviceId={device.device.id}
+				role={device.device.role}
+				onProvisioned={refresh}
+			/>
+			<AddPublicKeyDialog
+				open={addOpen}
+				onClose={() => setAddOpen(false)}
+				deviceId={device.device.id}
+				onAdded={refresh}
+			/>
 		</Paper>
 	);
 }
@@ -164,6 +248,9 @@ function KeyRow({
 	const [editing, setEditing] = useState(false);
 	const [name, setName] = useState(keyData.name ?? "");
 	const action = useApiAction("devices", "update_key_name");
+	const disable = useApiAction("devices", "deactivate_key");
+	const enable = useApiAction("devices", "reactivate_key");
+	const toggling = disable.pending || enable.pending;
 
 	const save = async () => {
 		const trimmed = name.trim();
@@ -179,8 +266,18 @@ function KeyRow({
 		}
 	};
 
+	const onToggleActive = async () => {
+		try {
+			if (keyData.is_active) await disable.call({ key_id: keyData.id });
+			else await enable.call({ key_id: keyData.id });
+			onSaved();
+		} catch {
+			/* surfaced via disable/enable.error */
+		}
+	};
+
 	return (
-		<Box>
+		<Box sx={{ opacity: keyData.is_active ? 1 : 0.55 }}>
 			{editing ? (
 				<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
 					<TextField
@@ -216,21 +313,43 @@ function KeyRow({
 					spacing={1}
 					sx={{ alignItems: "center", justifyContent: "space-between" }}
 				>
-					<Typography variant="subtitle1">
-						{keyData.name ?? "Unnamed key"}
-					</Typography>
-					<IconButton
-						aria-label={`edit name for ${keyData.name ?? "key"}`}
-						size="small"
-						onClick={() => setEditing(true)}
-					>
-						<EditIcon fontSize="small" />
-					</IconButton>
+					<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+						<Typography variant="subtitle1">
+							{keyData.name ?? "Unnamed key"}
+						</Typography>
+						{!keyData.is_active && (
+							<Chip size="small" label="disabled" color="default" />
+						)}
+					</Stack>
+					<Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+						<Button
+							size="small"
+							variant="outlined"
+							color={keyData.is_active ? "error" : "primary"}
+							onClick={onToggleActive}
+							disabled={toggling}
+						>
+							{keyData.is_active
+								? disable.pending
+									? "Disabling…"
+									: "Disable"
+								: enable.pending
+									? "Enabling…"
+									: "Enable"}
+						</Button>
+						<IconButton
+							aria-label={`edit name for ${keyData.name ?? "key"}`}
+							size="small"
+							onClick={() => setEditing(true)}
+						>
+							<EditIcon fontSize="small" />
+						</IconButton>
+					</Stack>
 				</Stack>
 			)}
-			{action.error && (
+			{(action.error || disable.error || enable.error) && (
 				<Alert severity="error" sx={{ mt: 1 }}>
-					{action.error.message}
+					{(action.error ?? disable.error ?? enable.error)?.message}
 				</Alert>
 			)}
 			<Box
@@ -260,11 +379,7 @@ function RoleControls({
 }) {
 	const role = device.device.role;
 	const updateRoleAction = useApiAction("devices", "update_role");
-	const revokeAction = useApiAction("devices", "revoke");
-
 	const [selected, setSelected] = useState<DeviceRole>(role);
-	const [confirmRevoke, setConfirmRevoke] = useState(false);
-	const [provisionOpen, setProvisionOpen] = useState(false);
 
 	const onSave = async () => {
 		try {
@@ -278,101 +393,36 @@ function RoleControls({
 		}
 	};
 
-	const onRevoke = async () => {
-		try {
-			await revokeAction.call({ device_id: device.device.id });
-			setConfirmRevoke(false);
-			refresh();
-		} catch {
-			/* surfaced via revokeAction.error */
-		}
-	};
-
-	const pending = revokeAction.pending || updateRoleAction.pending;
-
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>
-			<Stack
-				direction="row"
-				spacing={2}
-				sx={{ alignItems: "center", justifyContent: "space-between" }}
-				useFlexGap
-			>
-				<Stack
-					direction="row"
-					spacing={1}
-					sx={{ alignItems: "center" }}
+			<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+				<Typography variant="body2">Role:</Typography>
+				<TextField
+					select
+					size="small"
+					value={selected}
+					onChange={(e) => setSelected(e.target.value as DeviceRole)}
+					disabled={updateRoleAction.pending}
 				>
-					<Typography variant="body2">Role:</Typography>
-					<TextField
-						select
-						size="small"
-						value={selected}
-						onChange={(e) => setSelected(e.target.value as DeviceRole)}
-						disabled={pending}
-					>
-						{TRUSTABLE_ROLES.map((r) => (
-							<MenuItem key={r} value={r}>
-								{r}
-							</MenuItem>
-						))}
-					</TextField>
-					<Button
-						variant="contained"
-						onClick={onSave}
-						disabled={pending || selected === role}
-					>
-						{updateRoleAction.pending ? "Saving…" : "Save"}
-					</Button>
-				</Stack>
-				<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
-					<Button
-						variant="outlined"
-						onClick={() => setProvisionOpen(true)}
-					>
-						Provision credential
-					</Button>
-					{confirmRevoke ? (
-						<Stack direction="row" spacing={1}>
-							<Button
-								variant="contained"
-								color="error"
-								onClick={onRevoke}
-								disabled={pending}
-							>
-								{revokeAction.pending ? "Revoking…" : "Confirm revoke"}
-							</Button>
-							<Button
-								variant="outlined"
-								onClick={() => setConfirmRevoke(false)}
-								disabled={pending}
-							>
-								Cancel
-							</Button>
-						</Stack>
-					) : (
-						<Button
-							variant="outlined"
-							color="error"
-							onClick={() => setConfirmRevoke(true)}
-						>
-							Revoke access
-						</Button>
-					)}
-				</Stack>
+					{TRUSTABLE_ROLES.map((r) => (
+						<MenuItem key={r} value={r}>
+							{r}
+						</MenuItem>
+					))}
+				</TextField>
+				<Button
+					variant="contained"
+					onClick={onSave}
+					disabled={updateRoleAction.pending || selected === role}
+				>
+					{updateRoleAction.pending ? "Saving…" : "Save"}
+				</Button>
 			</Stack>
-			{(revokeAction.error || updateRoleAction.error) && (
+			{updateRoleAction.error && (
 				<Alert severity="error" sx={{ mt: 1 }}>
-					{(revokeAction.error ?? updateRoleAction.error)?.message}
+					{updateRoleAction.error.message}
 				</Alert>
 			)}
-			<ProvisionCredentialDialog
-				open={provisionOpen}
-				onClose={() => setProvisionOpen(false)}
-				deviceId={device.device.id}
-				role={role}
-				onProvisioned={refresh}
-			/>
 		</Paper>
 	);
 }


### PR DESCRIPTION
🤖 Rework device key management — a follow-up to operator-provisioned credentials.

Addresses the gaps and UX confusion around device keys: the "generate a key" action was in the wrong place and unclearly named, there was no way to disable a key from the UI, and the only bulk action ("Revoke access") forced a revoke-then-regenerate outage.

## Changes

- **Add a key from a public key.** New "Add from public key" action + endpoint: paste a PEM (or bare base64 SubjectPublicKeyInfo) and an optional name to register an externally-generated key. Canopy never sees a private key on this path. The DER is validated as an SPKI before storing.
- **Generate new key**, relocated. The server-minting action (formerly "Provision credential", in the role section) moves into the Public Keys section and is renamed "Generate new key". Same one-shot encrypted-download dialog.
- **Per-key disable/enable.** Each key has a Disable/Enable control, so a device rotates keys with no gap — add the new key, then disable the old — instead of revoking and regenerating. Disabled keys stay listed (greyed) and can be re-enabled; `get_device_by_id` now returns inactive keys, with `is_active` on the key wire type.
- **Bulk action renamed.** "Revoke access" becomes "Disable all keys" (deactivates every active key; keys-only — tailnet detach remains its own control) and moves into the Public Keys section. The model-level `Device::revoke` used by server archival keeps its keys+detach behaviour.

## Notes

- The device-list badges and the device display name continue to reflect **active** keys only (a disabled key doesn't count toward the mTLS badge or become the display name).
- New endpoints: `add_key`, `deactivate_key`, `reactivate_key`, `disable_all_keys` (replaces `revoke`).
- Covered by Rust endpoint tests (add-from-key incl. rejecting non-SPKI, disable/re-enable, disable-all keeps rows) and Playwright specs (disable/enable, add-from-public-key, relocated generate-new-key).
