### PR TITLE
Restore replicas: registered-intent–driven form + open-string RestoreIntent

### DIFF
--- a/crates/commons-types/src/backup.rs
+++ b/crates/commons-types/src/backup.rs
@@ -280,36 +280,20 @@ where
 	}
 }
 
-/// What a managed restore replica is for. Open by design, mirroring
-/// [`BackupType`]: a restore consumer advertises the intents it can satisfy and
-/// Canopy preserves any it does not model in `Custom` rather than rejecting it.
-/// Stored as `TEXT`; serializes as a plain string (no DB `CHECK`).
+/// What a managed restore replica is for. Fully open: a restore consumer
+/// advertises the intents it can satisfy and Canopy stores and dispatches them
+/// verbatim, never branching on any particular value. Stored as `TEXT`;
+/// serializes as a plain string (no DB `CHECK`). Well-known intents (`verify`,
+/// `analytics`, `disaster-recovery`) are documented in the restore-replicas
+/// spec, not enforced here.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, AsExpression, FromSqlRow)]
 #[diesel(sql_type = Text)]
-pub enum RestoreIntent {
-	/// A transient replica restored only to prove the snapshot is restorable.
-	Verify,
-	/// A persistent replica kept running for querying.
-	Analytics,
-	/// A periodic rehearsal of the full recovery path.
-	DisasterRecovery,
-	/// Any other intent name, preserved as advertised.
-	Custom(String),
-}
+pub struct RestoreIntent(pub String);
 
 impl RestoreIntent {
-	const VERIFY: &'static str = "verify";
-	const ANALYTICS: &'static str = "analytics";
-	const DISASTER_RECOVERY: &'static str = "disaster-recovery";
-
 	/// The wire/DB string for this intent.
 	pub fn as_str(&self) -> &str {
-		match self {
-			Self::Verify => Self::VERIFY,
-			Self::Analytics => Self::ANALYTICS,
-			Self::DisasterRecovery => Self::DISASTER_RECOVERY,
-			Self::Custom(s) => s,
-		}
+		&self.0
 	}
 }
 
@@ -321,12 +305,7 @@ impl Display for RestoreIntent {
 
 impl From<String> for RestoreIntent {
 	fn from(s: String) -> Self {
-		match s.as_str() {
-			Self::VERIFY => Self::Verify,
-			Self::ANALYTICS => Self::Analytics,
-			Self::DISASTER_RECOVERY => Self::DisasterRecovery,
-			_ => Self::Custom(s),
-		}
+		Self(s)
 	}
 }
 
@@ -345,10 +324,7 @@ impl FromStr for RestoreIntent {
 
 impl From<RestoreIntent> for String {
 	fn from(v: RestoreIntent) -> Self {
-		match v {
-			RestoreIntent::Custom(s) => s,
-			other => other.as_str().to_owned(),
-		}
+		v.0
 	}
 }
 
@@ -429,6 +405,24 @@ mod tests {
 		assert_eq!(
 			serde_json::from_str::<BackupType>("\"custom-x\"").unwrap(),
 			BackupType::Custom("custom-x".into()),
+		);
+	}
+
+	#[test]
+	fn restore_intent_is_an_open_string() {
+		assert_eq!(RestoreIntent::from("verify").to_string(), "verify");
+		assert_eq!(
+			RestoreIntent::from("anything-goes").as_str(),
+			"anything-goes"
+		);
+		// Round-trips through the wire as a plain string.
+		assert_eq!(
+			serde_json::to_string(&RestoreIntent::from("verify")).unwrap(),
+			"\"verify\""
+		);
+		assert_eq!(
+			serde_json::from_str::<RestoreIntent>("\"custom-x\"").unwrap(),
+			RestoreIntent::from("custom-x"),
 		);
 	}
 }

--- a/crates/database/tests/restore.rs
+++ b/crates/database/tests/restore.rs
@@ -123,12 +123,18 @@ async fn create_list_get_roundtrip() {
 
 		let created = RestoreReplica::create(
 			&mut conn,
-			new_replica(consumer, group, None, RestoreIntent::Verify, "verify-all"),
+			new_replica(
+				consumer,
+				group,
+				None,
+				RestoreIntent::from("verify"),
+				"verify-all",
+			),
 		)
 		.await
 		.expect("create");
 		assert_eq!(created.name, "verify-all");
-		assert_eq!(created.intent, RestoreIntent::Verify);
+		assert_eq!(created.intent, RestoreIntent::from("verify"));
 		assert!(created.enabled, "new declarations default to enabled");
 		assert_eq!(created.created_by.as_deref(), Some("op@example.com"));
 
@@ -162,7 +168,13 @@ async fn duplicate_scope_conflicts_but_server_scope_is_separate() {
 
 		RestoreReplica::create(
 			&mut conn,
-			new_replica(consumer, group, None, RestoreIntent::Verify, "group-wide"),
+			new_replica(
+				consumer,
+				group,
+				None,
+				RestoreIntent::from("verify"),
+				"group-wide",
+			),
 		)
 		.await
 		.expect("group-wide");
@@ -170,7 +182,7 @@ async fn duplicate_scope_conflicts_but_server_scope_is_separate() {
 		// Same (consumer, group, type, intent) group-wide scope → 409.
 		let dup = RestoreReplica::create(
 			&mut conn,
-			new_replica(consumer, group, None, RestoreIntent::Verify, "dup"),
+			new_replica(consumer, group, None, RestoreIntent::from("verify"), "dup"),
 		)
 		.await;
 		assert!(matches!(dup, Err(AppError::Conflict(_))), "got {dup:?}");
@@ -182,7 +194,7 @@ async fn duplicate_scope_conflicts_but_server_scope_is_separate() {
 				consumer,
 				group,
 				Some(server),
-				RestoreIntent::Verify,
+				RestoreIntent::from("verify"),
 				"server-scoped",
 			),
 		)
@@ -199,7 +211,7 @@ async fn update_and_delete() {
 		let group = insert_group(&mut conn, "g").await;
 		let r = RestoreReplica::create(
 			&mut conn,
-			new_replica(consumer, group, None, RestoreIntent::Verify, "n"),
+			new_replica(consumer, group, None, RestoreIntent::from("verify"), "n"),
 		)
 		.await
 		.expect("create");
@@ -252,7 +264,7 @@ async fn authorizes_only_with_enabled_matching_declaration() {
 
 		let r = RestoreReplica::create(
 			&mut conn,
-			new_replica(consumer, group, None, RestoreIntent::Verify, "n"),
+			new_replica(consumer, group, None, RestoreIntent::from("verify"), "n"),
 		)
 		.await
 		.expect("create");
@@ -298,7 +310,10 @@ async fn capability_register_replaces_set() {
 		RestoreConsumerCapability::register(
 			&mut conn,
 			consumer,
-			&[RestoreIntent::Verify, RestoreIntent::Analytics],
+			&[
+				RestoreIntent::from("verify"),
+				RestoreIntent::from("analytics"),
+			],
 		)
 		.await
 		.expect("register");
@@ -306,14 +321,23 @@ async fn capability_register_replaces_set() {
 			.await
 			.expect("list");
 		got.sort_by_key(|i| i.to_string());
-		assert_eq!(got, vec![RestoreIntent::Analytics, RestoreIntent::Verify]);
+		assert_eq!(
+			got,
+			vec![
+				RestoreIntent::from("analytics"),
+				RestoreIntent::from("verify")
+			]
+		);
 
 		// Re-register a different set: verify is kept, analytics dropped,
 		// disaster-recovery added.
 		RestoreConsumerCapability::register(
 			&mut conn,
 			consumer,
-			&[RestoreIntent::Verify, RestoreIntent::DisasterRecovery],
+			&[
+				RestoreIntent::from("verify"),
+				RestoreIntent::from("disaster-recovery"),
+			],
 		)
 		.await
 		.expect("re-register");
@@ -323,7 +347,10 @@ async fn capability_register_replaces_set() {
 		got.sort_by_key(|i| i.to_string());
 		assert_eq!(
 			got,
-			vec![RestoreIntent::DisasterRecovery, RestoreIntent::Verify]
+			vec![
+				RestoreIntent::from("disaster-recovery"),
+				RestoreIntent::from("verify")
+			]
 		);
 
 		// Empty set clears all capabilities.
@@ -352,7 +379,7 @@ async fn record_report_raises_then_recovers() {
 				consumer,
 				group,
 				server,
-				RestoreIntent::Verify,
+				RestoreIntent::from("verify"),
 				RunOutcome::Failure,
 				false,
 			),
@@ -368,7 +395,7 @@ async fn record_report_raises_then_recovers() {
 				consumer,
 				group,
 				server,
-				RestoreIntent::Verify,
+				RestoreIntent::from("verify"),
 				RunOutcome::Success,
 				true,
 			),
@@ -394,7 +421,7 @@ async fn record_report_unhealthy_success_still_raises() {
 				consumer,
 				group,
 				server,
-				RestoreIntent::Verify,
+				RestoreIntent::from("verify"),
 				RunOutcome::Success,
 				false,
 			),
@@ -414,12 +441,18 @@ async fn sweep_overdue_raises_for_stale_replica_but_skips_gaps() {
 		insert_server(&mut conn, group).await;
 
 		// Consumer supports only `verify`.
-		RestoreConsumerCapability::register(&mut conn, consumer, &[RestoreIntent::Verify])
+		RestoreConsumerCapability::register(&mut conn, consumer, &[RestoreIntent::from("verify")])
 			.await
 			.expect("register caps");
 
 		// A supported, freshness-bound declaration with no healthy check → overdue.
-		let mut verify = new_replica(consumer, group, None, RestoreIntent::Verify, "verify-all");
+		let mut verify = new_replica(
+			consumer,
+			group,
+			None,
+			RestoreIntent::from("verify"),
+			"verify-all",
+		);
 		verify.freshness = Some(PgDuration(SignedDuration::from_secs(3600)));
 		RestoreReplica::create(&mut conn, verify)
 			.await
@@ -430,7 +463,7 @@ async fn sweep_overdue_raises_for_stale_replica_but_skips_gaps() {
 			consumer,
 			group,
 			None,
-			RestoreIntent::Analytics,
+			RestoreIntent::from("analytics"),
 			"analytics-all",
 		);
 		analytics.freshness = Some(PgDuration(SignedDuration::from_secs(3600)));

--- a/private-web/e2e/restore-replicas.spec.ts
+++ b/private-web/e2e/restore-replicas.spec.ts
@@ -199,4 +199,59 @@ test.describe("restore replicas", () => {
 		);
 		expect(rows).toHaveLength(1);
 	});
+
+	test("the dialog auto-selects the sole consumer and defaults the name", async ({
+		page,
+		sql,
+	}) => {
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		await seedRestoreConsumerCapability(sql, {
+			deviceId: consumer.id,
+			intents: ["verify"],
+		});
+		const groupId = await groupWithBackups(sql, "solo-group");
+		await seedServer(sql, { groupId, name: "srv-a" });
+
+		await page.goto(`/groups/${groupId}/backups`);
+		await page.getByRole("button", { name: /declare replica/i }).click();
+		const dialog = page.getByRole("dialog");
+
+		// Name defaults to the kebab-cased group name (whole-group scope).
+		await expect(dialog.getByLabel("Name")).toHaveValue("solo-group");
+		// Picking a server folds the server name into the default.
+		await dialog.getByLabel("Server").click();
+		await page.getByRole("option", { name: "srv-a" }).click();
+		await expect(dialog.getByLabel("Name")).toHaveValue("solo-group-srv-a");
+
+		// The consumer was never picked, yet Declare succeeds — the sole consumer
+		// was auto-selected.
+		await dialog.getByRole("button", { name: /^declare$/i }).click();
+		await expect(
+			page.getByRole("row", { name: /solo-group-srv-a/ }),
+		).toBeVisible();
+	});
+
+	test("the intent dropdown offers only intents the consumer registered", async ({
+		page,
+		sql,
+	}) => {
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		await seedRestoreConsumerCapability(sql, {
+			deviceId: consumer.id,
+			intents: ["verify"],
+		});
+		const groupId = await groupWithBackups(sql, "intent-group");
+
+		await page.goto(`/groups/${groupId}/backups`);
+		await page.getByRole("button", { name: /declare replica/i }).click();
+		const dialog = page.getByRole("dialog");
+
+		await dialog.getByLabel("Intent").click();
+		await expect(page.getByRole("option", { name: "verify" })).toBeVisible();
+		// The formerly-hardcoded well-known intents are gone.
+		await expect(page.getByRole("option", { name: "analytics" })).toHaveCount(0);
+		await expect(
+			page.getByRole("option", { name: "disaster-recovery" }),
+		).toHaveCount(0);
+	});
 });

--- a/private-web/src/components/RestoreReplicasSection.tsx
+++ b/private-web/src/components/RestoreReplicasSection.tsx
@@ -27,10 +27,16 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ApiError, callApi, useApi } from "../api";
 
-const WELL_KNOWN_INTENTS = ["verify", "analytics", "disaster-recovery"];
+function kebabCase(s: string): string {
+	return s
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
 
 function formatError(err: unknown): string {
 	if (err instanceof ApiError) {
@@ -304,16 +310,15 @@ function CreateReplicaDialog({
 	const [consumerId, setConsumerId] = useState("");
 	const [serverId, setServerId] = useState(""); // "" = whole group
 	const [type, setType] = useState("tamanu-postgres");
-	const [intent, setIntent] = useState("verify");
+	const [intent, setIntent] = useState("");
 	const [name, setName] = useState("");
+	const [nameEdited, setNameEdited] = useState(false);
 	const [freshnessHours, setFreshnessHours] = useState("");
 	const [pending, setPending] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
 	const selectedConsumer = consumers.find((c) => c.device_id === consumerId);
-	const intentOptions = Array.from(
-		new Set([...(selectedConsumer?.intents ?? []), ...WELL_KNOWN_INTENTS]),
-	);
+	const intentOptions = selectedConsumer?.intents ?? [];
 	const servers =
 		detail.status === "ok"
 			? detail.data.servers.filter((s) => !s.archived)
@@ -323,8 +328,37 @@ function CreateReplicaDialog({
 			? typeDefaults.data.map((t) => t.type)
 			: ["tamanu-postgres"];
 
+	// Auto-select the sole consumer, if there's only one to choose from.
+	useEffect(() => {
+		if (!consumerId && consumers.length === 1) {
+			setConsumerId(consumers[0].device_id);
+		}
+	}, [consumers, consumerId]);
+
+	// Keep the intent on a value the selected consumer actually supports.
+	useEffect(() => {
+		if (intentOptions.length > 0 && !intentOptions.includes(intent)) {
+			setIntent(intentOptions[0]);
+		}
+	}, [intentOptions, intent]);
+
+	// Suggest a name from the group and (if picked) server, until the operator
+	// types their own.
+	const groupName = detail.status === "ok" ? detail.data.group.name : "";
+	const selectedServer = servers.find((s) => s.id === serverId);
+	const serverName = selectedServer
+		? (selectedServer.name ?? selectedServer.display_host ?? selectedServer.id)
+		: "";
+	const suggestedName = kebabCase(
+		[groupName, serverName].filter(Boolean).join("-"),
+	);
+	useEffect(() => {
+		if (!nameEdited) setName(suggestedName);
+	}, [suggestedName, nameEdited]);
+
 	const onSubmit = async () => {
 		if (!consumerId) return setError("Pick a consumer");
+		if (!intent) return setError("Pick an intent the consumer supports");
 		if (!name.trim()) return setError("Name cannot be empty");
 		const hours = freshnessHours.trim();
 		const freshness_seconds =
@@ -416,15 +450,11 @@ function CreateReplicaDialog({
 							value={intent}
 							onChange={(e) => setIntent(e.target.value)}
 						>
-							{intentOptions.map((i) => {
-								const supported = selectedConsumer?.intents.includes(i) ?? false;
-								return (
-									<MenuItem key={i} value={i}>
-										{i}
-										{!supported && " (unsupported — will be a gap)"}
-									</MenuItem>
-								);
-							})}
+							{intentOptions.map((i) => (
+								<MenuItem key={i} value={i}>
+									{i}
+								</MenuItem>
+							))}
 						</Select>
 					</FormControl>
 
@@ -433,7 +463,10 @@ function CreateReplicaDialog({
 						fullWidth
 						label="Name"
 						value={name}
-						onChange={(e) => setName(e.target.value)}
+						onChange={(e) => {
+							setName(e.target.value);
+							setNameEdited(true);
+						}}
 					/>
 
 					<TextField


### PR DESCRIPTION
🤖 Drop the hardcoded restore-intent set in favour of what consumers actually register, and simplify the backing type to match.

## Frontend — declare-replica form
- The intent dropdown offered a hardcoded `["verify", "analytics", "disaster-recovery"]` list unioned with the consumer's intents. It now shows **only** the selected consumer's registered intents, so an operator can only declare something a consumer can satisfy.
- Auto-select the sole consumer when only one is registered.
- Default the replica name to kebab-case of the group name (and the server name when scoped to a single server), until the operator types their own.
- Playwright coverage for auto-select, the name default, and the registered-only intent list.

## Backend — `RestoreIntent`
Nothing ever branched on the `Verify`/`Analytics`/`DisasterRecovery` variants — the value only round-trips to and from strings — so the enum was pure labeling. It's now a `RestoreIntent(String)` newtype.

The wire and DB forms are unchanged: it still serializes as a plain string, and every schema field already declared `value_type = String`, so there's no OpenAPI drift. The well-known intent names now live only in the restore-replicas spec, not in the type.

TAM-6877