### PR TITLE
Backfill backup snapshot sizes from inspection; flag reported/repo mismatches

### DIFF
--- a/.workhorse/specs/jobs/backup.md
+++ b/.workhorse/specs/jobs/backup.md
@@ -42,7 +42,8 @@ Canopy periodically inspects each group's repo against the storage directly, ind
 
 - it verifies repo integrity, and a failed verification is repo corruption;
 - it inventories the repo — the latest snapshot per source — as the ground truth a device's report is reconciled against;
-- it records repo size, logical and physical, and the storage cost basis for display.
+- it records repo size, logical and physical, and the storage cost basis for display;
+- it records each snapshot's logical size and matches it to the device run that produced it by snapshot id, so the repo's own size stands in when a run reported none, and is cross-checked against the size a run did report. A snapshot's recorded size is written once, because a snapshot is immutable.
 
 ## Upstream preflight
 
@@ -56,13 +57,14 @@ Canopy reconciles three sources — what a device reported, what credentials wer
 
 - **staleness** — a server with a prior successful backup but none recent, or one that has never backed up though it has been expected long enough.
 - **reconcile** — a device reported a successful backup but no matching snapshot landed (the report is false or the upload didn't persist), or a fresh snapshot exists but no recent report (the reporting path is broken).
+- **size** — a device reported a snapshot size that disagrees with the size the same snapshot occupies in the repo; only compared when both sizes are known and non-zero.
 - **maintenance** — a group whose maintenance is overdue, or whose most recent maintenance failed.
 
 ## Alerting
 
 Backup alerts are raised at one of two scopes:
 
-- **Per-server** signals (staleness, never-backed-up, the report-gap) are subject to the server's monitoring gate: still recorded for visibility, but they contribute to an incident only when the server is monitored, because some servers are intentionally intermittent.
+- **Per-server** signals (staleness, never-backed-up, the report-gap, the size discrepancy) are subject to the server's monitoring gate: still recorded for visibility, but they contribute to an incident only when the server is monitored, because some servers are intentionally intermittent.
 - **Group-level** signals (repo corruption, maintenance failure, missing-snapshot reconciliation, preflight failures, and restore-verification — see the managed restore replicas spec, `RST`) page regardless of any member's monitoring state, because they are control-plane or data-safety concerns that belong to no single server.
 
 Each signal has a stable key by which operators silence or snooze it and by which the interface and notifications refer to it; the keys are a contract and are not renamed without migrating stored silences.

--- a/crates/database/src/backup/reconcile.rs
+++ b/crates/database/src/backup/reconcile.rs
@@ -15,6 +15,13 @@
 //! - **neither** → genuinely stale; the staleness scan already owns it, emit
 //!   nothing.
 //!
+//! Independently, per `(server, type)`, the latest run that carries both a
+//! device-reported size and an inspection-observed size is compared:
+//!
+//! - **sizes disagree** (both non-zero) → `backup-reconcile-size-mismatch`
+//!   (`Warning`, per-server, non-paging). The device reported a snapshot size
+//!   that doesn't match what the repo holds.
+//!
 //! Freshness guard: if the repo inventory for the group is itself stale (its
 //! `observed_at` older than [`INVENTORY_STALE_AFTER`]), the "missing" verdict
 //! is skipped — a lagging inspector must not produce false "report lied"
@@ -66,6 +73,15 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 		s.drain().collect()
 	};
 	let snaps = snapshot_info(db, &group_ids).await?;
+
+	// Latest comparable (reported, observed) sizes per (server, type). A server
+	// belongs to one group, so keys don't collide across groups.
+	let mut sized: HashMap<(Uuid, BackupType), (i64, i64)> = HashMap::new();
+	for gid in &group_ids {
+		sized.extend(
+			crate::backups::BackupRun::latest_sized_by_server_type_for_group(db, *gid).await?,
+		);
+	}
 
 	let mut filed = 0usize;
 	for row in rows {
@@ -153,8 +169,64 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 			// verdict.
 			(true, false) => {}
 		}
+
+		// Size discrepancy: orthogonal to freshness. Compare the latest run that
+		// has both a reported and an observed size.
+		let size_ref = format!("{}:{}", refs::RECONCILE_SIZE_MISMATCH, row.r#type);
+		match sized.get(&(row.server_id, row.r#type.clone())) {
+			Some(&(reported, observed)) if reported != observed => {
+				let server = Server::get_by_id(db, row.server_id).await?;
+				NewEvent {
+					source: refs::CANOPY_SOURCE.into(),
+					r#ref: size_ref,
+					severity: Some(Severity::Warning),
+					description: None,
+					message: format!(
+						"Server {} reported a {} snapshot size of {reported} bytes but the repo holds {observed}",
+						server.id, row.r#type,
+					),
+					active: Some(true),
+					occurred_at: Some(now),
+				}
+				.save(db, row.server_id, row.device_id)
+				.await?;
+				filed += 1;
+			}
+			// Agree, or no comparable run → clear any open mismatch.
+			_ => {
+				filed += clear_size_mismatch(db, row, &size_ref, now).await?;
+			}
+		}
 	}
 	Ok(filed)
+}
+
+/// Clear an open per-server size-mismatch issue when the sizes agree again (or
+/// there's no longer a comparable run to disagree).
+async fn clear_size_mismatch(
+	db: &mut AsyncPgConnection,
+	row: &ScanRow,
+	size_ref: &str,
+	now: Timestamp,
+) -> Result<usize> {
+	if !crate::backup::staleness::open_server_issue_active(db, row.server_id, size_ref).await? {
+		return Ok(0);
+	}
+	NewEvent {
+		source: refs::CANOPY_SOURCE.into(),
+		r#ref: size_ref.to_string(),
+		severity: Some(Severity::Info),
+		description: None,
+		message: format!(
+			"Reported and repo {} snapshot sizes for {} agree again",
+			row.r#type, row.server_id
+		),
+		active: Some(false),
+		occurred_at: Some(now),
+	}
+	.save(db, row.server_id, row.device_id)
+	.await?;
+	Ok(1)
 }
 
 /// Clear an open per-server report-gap issue when the report path is healthy

--- a/crates/database/src/backup/refs.rs
+++ b/crates/database/src/backup/refs.rs
@@ -27,6 +27,11 @@ pub const NEVER: &str = "backup-never";
 /// `Warning` (non-paging on its own).
 pub const RECONCILE_REPORT_GAP: &str = "backup-reconcile-report-gap";
 
+/// A device reported a snapshot size that disagrees with the size the same
+/// snapshot occupies in the repo (compared only when both are known and
+/// non-zero). Server-scoped, `Warning` (non-paging on its own).
+pub const RECONCILE_SIZE_MISMATCH: &str = "backup-reconcile-size-mismatch";
+
 // --- group-level (page regardless of any member's is_monitored) ---
 
 /// A group whose last successful maintenance run is older than the

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -875,6 +875,10 @@ pub struct BackupRun {
 	pub s3_sent_payload_bytes: Option<i64>,
 	pub s3_received_raw_bytes: Option<i64>,
 	pub s3_received_payload_bytes: Option<i64>,
+	/// Logical size of this run's snapshot as observed by canopy's own repo
+	/// inspection, matched to the run by `snapshot_id`. Distinct from
+	/// `bytes_uploaded` (the device's own figure); written once by inspection.
+	pub snapshot_logical_bytes: Option<i64>,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -1033,6 +1037,63 @@ impl BackupRun {
 			.load(db)
 			.await
 			.map_err(AppError::from)
+	}
+
+	/// Fill `snapshot_logical_bytes` from repo inspection for runs matched by
+	/// snapshot id, only where it is still unset — write-once, since a snapshot
+	/// is immutable. `sizes` maps a snapshot id to its observed logical size.
+	/// Returns the number of runs updated.
+	pub async fn backfill_snapshot_logical_bytes(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		sizes: &[(String, i64)],
+	) -> Result<usize> {
+		use crate::schema::backup_runs::dsl;
+
+		let mut updated = 0usize;
+		for (snapshot_id, size) in sizes {
+			updated += diesel::update(dsl::backup_runs)
+				.filter(dsl::group_id.eq(group_id))
+				.filter(dsl::snapshot_id.eq(snapshot_id))
+				.filter(dsl::snapshot_logical_bytes.is_null())
+				.set(dsl::snapshot_logical_bytes.eq(size))
+				.execute(db)
+				.await
+				.map_err(AppError::from)?;
+		}
+		Ok(updated)
+	}
+
+	/// The latest backup run per `(server, type)` in a group that carries both a
+	/// device-reported size (`bytes_uploaded`) and an inspection-observed size
+	/// (`snapshot_logical_bytes`), both non-zero. Keyed `(server_id, type)` →
+	/// `(reported, observed)`. The basis for the size-discrepancy check.
+	pub async fn latest_sized_by_server_type_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<HashMap<(Uuid, BackupType), (i64, i64)>> {
+		use crate::schema::backup_runs::dsl;
+
+		let rows: Vec<Self> = dsl::backup_runs
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::purpose.eq(BackupPurpose::Backup))
+			.filter(dsl::server_id.is_not_null())
+			.filter(dsl::bytes_uploaded.is_not_null())
+			.filter(dsl::snapshot_logical_bytes.is_not_null())
+			.distinct_on((dsl::server_id, dsl::type_))
+			.order_by((dsl::server_id, dsl::type_, dsl::reported_at.desc()))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+
+		Ok(rows
+			.into_iter()
+			.filter_map(|r| {
+				let sid = r.server_id?;
+				let (up, snap) = (r.bytes_uploaded?, r.snapshot_logical_bytes?);
+				(up > 0 && snap > 0).then_some(((sid, r.r#type.clone()), (up, snap)))
+			})
+			.collect())
 	}
 }
 

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -137,6 +137,7 @@ diesel::table! {
 		s3_sent_payload_bytes -> Nullable<Int8>,
 		s3_received_raw_bytes -> Nullable<Int8>,
 		s3_received_payload_bytes -> Nullable<Int8>,
+		snapshot_logical_bytes -> Nullable<Int8>,
 	}
 }
 

--- a/crates/database/tests/backup_detection.rs
+++ b/crates/database/tests/backup_detection.rs
@@ -732,6 +732,147 @@ async fn reconcile_clears_report_gap_when_report_and_snapshot_agree() {
 	.await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_files_size_mismatch_when_reported_size_differs_from_repo() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let interval = SignedDuration::from_hours(12);
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+
+		// A reported run (bytes_uploaded = 42, snapshot_id "kopia-snap")...
+		insert_backup_success_aged(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(2),
+		)
+		.await;
+		// ...but inspection observed a different logical size for that snapshot.
+		BackupRun::backfill_snapshot_logical_bytes(
+			&mut conn,
+			group_id,
+			&[("kopia-snap".into(), 99)],
+		)
+		.await
+		.expect("backfill");
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("reconcile sweep");
+
+		let sref = typed_ref(refs::RECONCILE_SIZE_MISMATCH, &pg);
+		let issue = server_issue(&mut conn, server_id, &sref)
+			.await
+			.expect("size-mismatch issue filed");
+		assert_eq!(
+			issue.severity,
+			Severity::Warning.to_string(),
+			"size-mismatch is Warning (non-paging)",
+		);
+		assert!(issue.active);
+		assert_eq!(
+			server_issue_open_links(&mut conn, server_id, &sref).await,
+			0,
+			"Warning size-mismatch does not open an incident by itself",
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_clears_size_mismatch_when_latest_sizes_agree() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let interval = SignedDuration::from_hours(12);
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+
+		// An older run whose reported size disagrees with the repo → raises.
+		insert_backup_success_aged(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(5),
+		)
+		.await;
+		BackupRun::backfill_snapshot_logical_bytes(
+			&mut conn,
+			group_id,
+			&[("kopia-snap".into(), 99)],
+		)
+		.await
+		.expect("backfill mismatch");
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("first reconcile");
+		let sref = typed_ref(refs::RECONCILE_SIZE_MISMATCH, &pg);
+		assert!(
+			server_issue(&mut conn, server_id, &sref)
+				.await
+				.expect("size-mismatch open")
+				.active,
+			"precondition: size-mismatch is active",
+		);
+
+		// A newer run whose reported and observed sizes agree becomes the latest
+		// comparable run → clears. (Write-once backfill leaves the older run's
+		// recorded size untouched; only the new null row is filled.)
+		insert_backup_success_aged(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(1),
+		)
+		.await;
+		BackupRun::backfill_snapshot_logical_bytes(
+			&mut conn,
+			group_id,
+			&[("kopia-snap".into(), 42)],
+		)
+		.await
+		.expect("backfill match");
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan2");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("second reconcile");
+
+		let issue = server_issue(&mut conn, server_id, &sref)
+			.await
+			.expect("size-mismatch still present (now cleared)");
+		assert!(
+			!issue.active,
+			"size-mismatch cleared once latest sizes agree"
+		);
+		assert_eq!(issue.severity, Severity::Info.to_string());
+	})
+	.await;
+}
+
 // ===========================================================================
 // Case 5 — raise_group_event bypasses the is_monitored gate (NON-NEGOTIABLE)
 // ===========================================================================

--- a/crates/database/tests/backups.rs
+++ b/crates/database/tests/backups.rs
@@ -275,6 +275,113 @@ async fn backup_run_client_uuid_and_duplicate_is_conflict() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn backfill_snapshot_logical_bytes_writes_once() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let device_id = insert_device(&mut conn).await;
+
+		let id = Uuid::new_v4();
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				id,
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.expect("record");
+
+		// Matched by snapshot id ("kopia-snap-1" from new_run); starts unset.
+		let n = BackupRun::backfill_snapshot_logical_bytes(
+			&mut conn,
+			group_id,
+			&[("kopia-snap-1".into(), 1490)],
+		)
+		.await
+		.expect("backfill");
+		assert_eq!(n, 1);
+		let runs = BackupRun::list_for_group(&mut conn, group_id, 10)
+			.await
+			.unwrap();
+		assert_eq!(runs[0].snapshot_logical_bytes, Some(1490));
+
+		// Write-once: a later inspection with a different value doesn't clobber.
+		let n2 = BackupRun::backfill_snapshot_logical_bytes(
+			&mut conn,
+			group_id,
+			&[("kopia-snap-1".into(), 9999)],
+		)
+		.await
+		.expect("backfill again");
+		assert_eq!(n2, 0);
+		let runs = BackupRun::list_for_group(&mut conn, group_id, 10)
+			.await
+			.unwrap();
+		assert_eq!(runs[0].snapshot_logical_bytes, Some(1490));
+
+		// An unknown snapshot id matches nothing.
+		let n3 =
+			BackupRun::backfill_snapshot_logical_bytes(&mut conn, group_id, &[("nope".into(), 1)])
+				.await
+				.expect("backfill unknown");
+		assert_eq!(n3, 0);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn latest_sized_lists_only_runs_with_both_sizes() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let device_id = insert_device(&mut conn).await;
+
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.expect("record");
+
+		// Reported size present but not yet inspected → not comparable.
+		let map = BackupRun::latest_sized_by_server_type_for_group(&mut conn, group_id)
+			.await
+			.unwrap();
+		assert!(map.is_empty(), "no observed size yet → nothing to compare");
+
+		// After inspection fills the observed size, the pair is comparable.
+		BackupRun::backfill_snapshot_logical_bytes(
+			&mut conn,
+			group_id,
+			&[("kopia-snap-1".into(), 1490)],
+		)
+		.await
+		.expect("backfill");
+		let map = BackupRun::latest_sized_by_server_type_for_group(&mut conn, group_id)
+			.await
+			.unwrap();
+		assert_eq!(
+			map.get(&(server_id, BackupType::TamanuPostgres)),
+			Some(&(42, 1490)),
+			"reported 42 (new_run), observed 1490",
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn latest_success_ignores_restore_and_failure() {
 	TestDb::run(|mut conn, _url| async move {
 		let group_id = insert_group(&mut conn, "g").await;

--- a/crates/jobs/src/backup/complete.rs
+++ b/crates/jobs/src/backup/complete.rs
@@ -110,6 +110,12 @@ pub(crate) async fn complete_inspect(
 	.await
 	.map_err(|err| err.to_string())?;
 
+	// Fill each device run's snapshot size from the repo (write-once, matched by
+	// snapshot id). The size-discrepancy check reads it back off `backup_runs`.
+	database::backups::BackupRun::backfill_snapshot_logical_bytes(db, group_id, &outcome.snapshots)
+		.await
+		.map_err(|err| err.to_string())?;
+
 	let (severity, description, active) = corruption_decision(outcome.verify_ok);
 	database::backup::alerts::raise_group_event(
 		db,
@@ -300,6 +306,7 @@ mod tests {
 						type_: Some("tamanu-postgres".into()),
 						latest_snapshot_at: None,
 					}],
+					snapshots: vec![],
 				};
 				complete_inspect(&mut conn, group_id, &outcome)
 					.await

--- a/crates/jobs/src/backup/kopia.rs
+++ b/crates/jobs/src/backup/kopia.rs
@@ -202,13 +202,33 @@ pub struct KStats {
 	total_size: i64,
 }
 
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct KSummary {
+	#[serde(default)]
+	size: i64,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct KRootEntry {
+	#[serde(default)]
+	summ: KSummary,
+}
+
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Manifest {
+	/// The snapshot manifest id — what bestool reports as its `snapshot_id`.
+	#[serde(default)]
+	id: String,
 	source: KSource,
 	#[serde(rename = "startTime")]
 	start_time: Option<String>,
 	#[serde(default)]
 	stats: KStats,
+	/// The root directory entry; `summ.size` is the logical snapshot size
+	/// bestool records (it can't use `stats.totalSize`, which isn't known at
+	/// upload time), so it's the field to cross-check a device report against.
+	#[serde(rename = "rootEntry", default)]
+	root_entry: KRootEntry,
 }
 
 impl KSource {
@@ -255,6 +275,9 @@ pub struct Inspected {
 	pub source_count: i32,
 	pub logical_bytes: i64,
 	pub sources: Vec<SourceEntry>,
+	/// `(snapshot id, logical size)` for every snapshot with a non-empty id,
+	/// for matching back to the device runs that produced them.
+	pub snapshots: Vec<(String, i64)>,
 }
 
 /// Reduce a parsed snapshot-manifest list to per-source latest entries + counts
@@ -284,11 +307,18 @@ pub fn inspect_manifests(manifests: &[Manifest]) -> Inspected {
 		})
 		.collect();
 
+	let snapshots = manifests
+		.iter()
+		.filter(|m| !m.id.is_empty())
+		.map(|m| (m.id.clone(), m.root_entry.summ.size))
+		.collect();
+
 	Inspected {
 		snapshot_count: manifests.len() as i32,
 		source_count: groups.len() as i32,
 		logical_bytes,
 		sources,
+		snapshots,
 	}
 }
 
@@ -643,6 +673,9 @@ pub struct InspectOutcome {
 	/// Physical (stored) bytes from `kopia content stats`; `None` if unparseable.
 	pub physical_bytes: Option<i64>,
 	pub sources: Vec<SourceEntry>,
+	/// `(snapshot id, logical size)` for every snapshot, matched back to the
+	/// device runs that produced them by the completion logic.
+	pub snapshots: Vec<(String, i64)>,
 }
 
 /// Connect, list snapshots, read physical stats, and verify (read-only). A
@@ -682,6 +715,7 @@ pub async fn run_inspect(
 		logical_bytes: inspected.logical_bytes,
 		physical_bytes,
 		sources: inspected.sources,
+		snapshots: inspected.snapshots,
 	})
 }
 
@@ -695,6 +729,7 @@ mod tests {
 
 	fn manifest(user: &str, host: &str, path: &str, start: &str, size: i64) -> Manifest {
 		Manifest {
+			id: format!("snap-{host}-{start}"),
 			source: KSource {
 				user_name: user.to_string(),
 				host: host.to_string(),
@@ -702,6 +737,9 @@ mod tests {
 			},
 			start_time: Some(start.to_string()),
 			stats: KStats { total_size: size },
+			root_entry: KRootEntry {
+				summ: KSummary { size },
+			},
 		}
 	}
 
@@ -761,6 +799,41 @@ mod tests {
 		assert_eq!(got.source_count, 0);
 		assert_eq!(got.logical_bytes, 0);
 		assert!(got.sources.is_empty());
+		assert!(got.snapshots.is_empty());
+	}
+
+	#[test]
+	fn parses_id_and_root_entry_size_for_matching() {
+		// The manifest id (what bestool reports as snapshot_id) and
+		// rootEntry.summ.size (the size bestool records) are what we match and
+		// cross-check against a device run.
+		let json = r#"[
+			{
+				"id": "k9c0ffee",
+				"source": {"host": "srv-1", "userName": "canopy", "path": "tamanu-postgres"},
+				"startTime": "2026-06-18T13:00:00Z",
+				"stats": {"totalSize": 1500},
+				"rootEntry": {"obj": "abc", "summ": {"size": 1490}}
+			}
+		]"#;
+		let manifests: Vec<Manifest> = serde_json::from_str(json).unwrap();
+		let got = inspect_manifests(&manifests);
+		assert_eq!(got.snapshots, vec![("k9c0ffee".to_string(), 1490)]);
+	}
+
+	#[test]
+	fn snapshots_skip_empty_ids() {
+		// An element without an id (shouldn't happen from kopia, but be safe)
+		// is dropped from the match set rather than matched to snapshot_id "".
+		let json = r#"[
+			{
+				"source": {"host": "srv-1", "userName": "canopy", "path": "tamanu-postgres"},
+				"startTime": "2026-06-18T13:00:00Z",
+				"rootEntry": {"summ": {"size": 10}}
+			}
+		]"#;
+		let manifests: Vec<Manifest> = serde_json::from_str(json).unwrap();
+		assert!(inspect_manifests(&manifests).snapshots.is_empty());
 	}
 
 	#[test]

--- a/migrations/2026-07-01-173625-0000_add_backup_run_snapshot_logical_bytes/down.sql
+++ b/migrations/2026-07-01-173625-0000_add_backup_run_snapshot_logical_bytes/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE backup_runs DROP COLUMN snapshot_logical_bytes;

--- a/migrations/2026-07-01-173625-0000_add_backup_run_snapshot_logical_bytes/up.sql
+++ b/migrations/2026-07-01-173625-0000_add_backup_run_snapshot_logical_bytes/up.sql
@@ -1,0 +1,6 @@
+-- The logical size of the snapshot this run produced, as observed by canopy's
+-- own repo inspection (kopia `rootEntry.summ.size`), matched to the run by
+-- snapshot id. Distinct from `bytes_uploaded` (what the device reported): kept
+-- separate so the two can be cross-checked. Written once per run, since a
+-- snapshot is immutable.
+ALTER TABLE backup_runs ADD COLUMN snapshot_logical_bytes bigint;

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -331,6 +331,40 @@ test.describe("backups ready: stats + backup-now", () => {
 		).toBeVisible();
 	});
 
+	test("run with no reported size falls back to the inspected snapshot size", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "size-group" });
+		const device = await seedDevice(sql);
+		const server = await seedServer(sql, {
+			name: "size-srv",
+			groupId: group.id,
+			deviceId: device.id,
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+			intervalSeconds: 3600,
+		});
+		// The device reported no size, but repo inspection observed the snapshot's
+		// logical size and backfilled it onto the run.
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			outcome: "success",
+			bytesUploaded: null,
+			snapshotLogicalBytes: 4096,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const runs = page.getByRole("table").last();
+		// Shown exactly (from inspection), not the "~" approximate S3 proxy.
+		await expect(runs.getByText("4.0 KiB")).toBeVisible();
+		await expect(runs.getByText("~4.0 KiB")).toHaveCount(0);
+	});
+
 	test("failed run shows expandable error detail and no upload size", async ({
 		page,
 		sql,

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -410,6 +410,7 @@ export async function seedBackupRun(
 		error?: string | null;
 		bytesUploaded?: number | null;
 		snapshotId?: string | null;
+		snapshotLogicalBytes?: number | null;
 		s3SentRawBytes?: number | null;
 		s3SentPayloadBytes?: number | null;
 		s3ReceivedRawBytes?: number | null;
@@ -420,8 +421,9 @@ export async function seedBackupRun(
 	await sql.query(
 		`INSERT INTO backup_runs
 		 (id, device_id, group_id, server_id, type, purpose, outcome, error, bytes_uploaded, snapshot_id,
-		  s3_sent_raw_bytes, s3_sent_payload_bytes, s3_received_raw_bytes, s3_received_payload_bytes)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+		  s3_sent_raw_bytes, s3_sent_payload_bytes, s3_received_raw_bytes, s3_received_payload_bytes,
+		  snapshot_logical_bytes)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
 		[
 			id,
 			opts.deviceId,
@@ -437,6 +439,7 @@ export async function seedBackupRun(
 			opts.s3SentPayloadBytes ?? null,
 			opts.s3ReceivedRawBytes ?? null,
 			opts.s3ReceivedPayloadBytes ?? null,
+			opts.snapshotLogicalBytes ?? null,
 		],
 	);
 	return { id };

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -5982,6 +5982,14 @@
               "null"
             ]
           },
+          "snapshot_logical_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Logical size of this run's snapshot as observed by canopy's own repo\ninspection, matched to the run by `snapshot_id`. Distinct from\n`bytes_uploaded` (the device's own figure); written once by inspection."
+          },
           "type": {
             "type": "string"
           }

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2471,6 +2471,13 @@ export interface components {
             /** Format: uuid */
             server_id?: string | null;
             snapshot_id?: string | null;
+            /**
+             * Format: int64
+             * @description Logical size of this run's snapshot as observed by canopy's own repo
+             *     inspection, matched to the run by `snapshot_id`. Distinct from
+             *     `bytes_uploaded` (the device's own figure); written once by inspection.
+             */
+            snapshot_logical_bytes?: number | null;
             type: string;
         };
         BackupStatsView: {

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -677,10 +677,20 @@ function RunRow({ run, members }: { run: BackupRun; members: ServerInfo[] }) {
 	const hasS3 = hasS3Traffic(run);
 	const expandable = hasError || hasS3;
 	// bestool reports an explicit upload size for some backup types; when it's
-	// absent, the S3 payload-sent tally is the closest proxy (marked approximate).
+	// absent, canopy's own repo inspection fills in the snapshot's logical size
+	// (exact, but from a different source), and failing that the S3 payload-sent
+	// tally is the closest proxy (marked approximate).
+	const fromInspect =
+		run.bytes_uploaded == null && run.snapshot_logical_bytes != null;
 	const uploadedApprox =
-		run.bytes_uploaded == null && run.s3_sent_payload_bytes != null;
-	const uploaded = run.bytes_uploaded ?? run.s3_sent_payload_bytes ?? null;
+		run.bytes_uploaded == null &&
+		run.snapshot_logical_bytes == null &&
+		run.s3_sent_payload_bytes != null;
+	const uploaded =
+		run.bytes_uploaded ??
+		run.snapshot_logical_bytes ??
+		run.s3_sent_payload_bytes ??
+		null;
 	return (
 		<>
 			<TableRow sx={expandable ? { "& > *": { borderBottom: "unset" } } : undefined}>
@@ -714,6 +724,10 @@ function RunRow({ run, members }: { run: BackupRun; members: ServerInfo[] }) {
 					) : uploadedApprox ? (
 						<Tooltip title="Approximate: from S3 payload sent (no explicit upload size reported)">
 							<span>~{formatBytes(uploaded)}</span>
+						</Tooltip>
+					) : fromInspect ? (
+						<Tooltip title="From repo inspection (the device reported no size)">
+							<span>{formatBytes(uploaded)}</span>
 						</Tooltip>
 					) : (
 						formatBytes(uploaded)


### PR DESCRIPTION
🤖 bestool records a snapshot's logical size in its run report (`bytes_uploaded`), but not always. Canopy's repo inspection sees the same figure (kopia `rootEntry.summ.size`) for every snapshot, so it now records each snapshot's logical size and matches it back to the run that produced it by snapshot id — filling the gap, and cross-checking what the device reported.

## Data
- New nullable `backup_runs.snapshot_logical_bytes`, written **once** by inspection (a snapshot is immutable), kept distinct from the device-reported `bytes_uploaded` so provenance survives. Not part of the device report — inspection is its only writer.

## Inspection
- `Manifest` now parses the snapshot `id` and `rootEntry.summ.size` — the same field bestool records (it can't use `stats.totalSize`, unknown at upload time), so the cross-check is exact rather than a different quantity.
- `complete_inspect` backfills matching runs: `SET snapshot_logical_bytes = <size> WHERE snapshot_id = <id> AND snapshot_logical_bytes IS NULL`.

## Detection
- Reconcile raises a per-server Warning `backup-reconcile-size-mismatch:<type>` (monitoring-gated, non-paging, like the report-gap) when a run's reported and inspected sizes are both known, non-zero, and disagree; it recovers when the latest comparable run agrees.

## UI
- The recent-runs size cell falls back to the inspected size when the device reported none — shown exactly and tagged as from inspection — ahead of the existing approximate S3-payload proxy.

## Note
The exact-equality check assumes `bytes_uploaded` equals `rootEntry.summ.size` for the same snapshot. bestool sources it from that field, so it should hold; if it ever diverges (kopia version, rounding) the check would need to become a tolerance rather than exact inequality.

TAM-6877