### PR TITLE
Accept and display arbitrary health data on restore checks

### DIFF
--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -145,7 +145,8 @@ A report carries:
 - the **outcome** — restored-and-healthy, or failed — and, on failure, an error description;
 - whether the restored database came up healthy, and its Postgres major version;
 - when the restore was observed;
-- the object-storage traffic the restore moved.
+- the object-storage traffic the restore moved;
+- optionally, arbitrary health data the consumer chooses to attach (e.g. cluster statistics, whether indexes needed fixing). Canopy stores and displays it as-is without interpreting it; specific fields may later be promoted to first-class, queryable form.
 
 Restored-and-healthy means the snapshot restored, the database started, and the consumer's readiness checks passed — a stronger statement than a snapshot merely existing.
 A failure covers any stage: the restore itself, the database failing to come up, or a readiness check failing.

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -317,6 +317,9 @@ pub struct BackupRestoreCheck {
 	pub s3_received_payload_bytes: Option<i64>,
 	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
 	pub reported_at: Timestamp,
+	/// Arbitrary health data the consumer sent (postgres cluster stats, whether
+	/// indexes needed fixing, …). Opaque to canopy — stored and displayed as-is.
+	pub health_details: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -340,6 +343,7 @@ pub struct NewBackupRestoreCheck {
 	pub s3_sent_payload_bytes: Option<i64>,
 	pub s3_received_raw_bytes: Option<i64>,
 	pub s3_received_payload_bytes: Option<i64>,
+	pub health_details: Option<serde_json::Value>,
 }
 
 impl BackupRestoreCheck {

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -116,6 +116,7 @@ diesel::table! {
 		s3_received_raw_bytes -> Nullable<Int8>,
 		s3_received_payload_bytes -> Nullable<Int8>,
 		reported_at -> Timestamptz,
+		health_details -> Nullable<Jsonb>,
 	}
 }
 

--- a/crates/database/tests/restore.rs
+++ b/crates/database/tests/restore.rs
@@ -59,6 +59,7 @@ fn new_check(
 		s3_sent_payload_bytes: None,
 		s3_received_raw_bytes: None,
 		s3_received_payload_bytes: None,
+		health_details: None,
 	}
 }
 
@@ -443,6 +444,57 @@ async fn sweep_overdue_raises_for_stale_replica_but_skips_gaps() {
 			.expect("sweep");
 		assert_eq!(filed, 1, "only the supported declaration is overdue");
 		assert_eq!(active_restore_issues(&mut conn, group).await, 1);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn records_and_returns_arbitrary_health_details() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn, "g").await;
+		let server = insert_server(&mut conn, group).await;
+
+		let details = serde_json::json!({
+			"cluster": { "live_tuples": 12345, "dead_tuples": 6 },
+			"indexes_fixed": true,
+		});
+		let mut check = new_check(
+			consumer,
+			group,
+			server,
+			RestoreIntent::from("verify"),
+			RunOutcome::Success,
+			true,
+		);
+		check.health_details = Some(details.clone());
+		BackupRestoreCheck::record_report(&mut conn, check)
+			.await
+			.expect("record");
+
+		let recent = BackupRestoreCheck::list_recent_for_group(&mut conn, group, 10)
+			.await
+			.expect("list");
+		assert_eq!(recent.len(), 1);
+		// Stored and returned verbatim (opaque to canopy).
+		assert_eq!(recent[0].health_details, Some(details));
+
+		// A report with no health data keeps the column NULL.
+		let plain = new_check(
+			consumer,
+			group,
+			server,
+			RestoreIntent::from("verify"),
+			RunOutcome::Success,
+			true,
+		);
+		BackupRestoreCheck::record_report(&mut conn, plain)
+			.await
+			.expect("record plain");
+		let recent = BackupRestoreCheck::list_recent_for_group(&mut conn, group, 10)
+			.await
+			.expect("list");
+		assert!(recent.iter().any(|c| c.health_details.is_none()));
 	})
 	.await;
 }

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -1869,6 +1869,9 @@
             "type": "string",
             "format": "uuid"
           },
+          "health_details": {
+            "description": "Arbitrary health data to record alongside the check (postgres cluster\nstats, whether indexes needed fixing, …). Stored and displayed as-is."
+          },
           "intent": {
             "type": "string"
           },

--- a/crates/public-server/src/restore.rs
+++ b/crates/public-server/src/restore.rs
@@ -399,6 +399,9 @@ pub struct VerificationArgs {
 	pub s3_sent_payload_bytes: Option<i64>,
 	pub s3_received_raw_bytes: Option<i64>,
 	pub s3_received_payload_bytes: Option<i64>,
+	/// Arbitrary health data to record alongside the check (postgres cluster
+	/// stats, whether indexes needed fixing, …). Stored and displayed as-is.
+	pub health_details: Option<serde_json::Value>,
 }
 
 #[utoipa::path(
@@ -447,6 +450,7 @@ async fn verification(
 			s3_sent_payload_bytes: args.s3_sent_payload_bytes,
 			s3_received_raw_bytes: args.s3_received_raw_bytes,
 			s3_received_payload_bytes: args.s3_received_payload_bytes,
+			health_details: args.health_details,
 		},
 	)
 	.await?;

--- a/migrations/2026-07-02-032141-0000_add_restore_check_health_details/down.sql
+++ b/migrations/2026-07-02-032141-0000_add_restore_check_health_details/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE backup_restore_checks DROP COLUMN health_details;

--- a/migrations/2026-07-02-032141-0000_add_restore_check_health_details/up.sql
+++ b/migrations/2026-07-02-032141-0000_add_restore_check_health_details/up.sql
@@ -1,0 +1,5 @@
+-- Arbitrary health data a restore consumer (e.g. PGRO) sends alongside a
+-- restore check: postgres cluster stats, whether indexes needed fixing, etc.
+-- Opaque to canopy for now (stored and displayed as-is); specific fields can be
+-- promoted to typed columns later if they need to drive alerts or filtering.
+ALTER TABLE backup_restore_checks ADD COLUMN health_details jsonb;

--- a/private-web/e2e/restore-replicas.spec.ts
+++ b/private-web/e2e/restore-replicas.spec.ts
@@ -172,6 +172,36 @@ test.describe("restore replicas", () => {
 		await expect(page.getByText("failed")).toBeVisible();
 	});
 
+	test("a restore check shows its postgres version and expandable health details", async ({
+		page,
+		sql,
+	}) => {
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		const groupId = await groupWithBackups(sql, "health-group");
+		const server = await seedServer(sql, { groupId, name: "health-srv" });
+		await seedRestoreCheck(sql, {
+			consumerDeviceId: consumer.id,
+			groupId,
+			serverId: server.id,
+			outcome: "success",
+			replicaHealthy: true,
+			postgresVersion: "16.3",
+			healthDetails: { indexes_fixed: true, live_tuples: 4242 },
+		});
+
+		await page.goto(`/groups/${groupId}/backups`);
+		const row = page.getByRole("row", { name: /health-srv/ });
+		await expect(row).toBeVisible();
+		// The postgres version is now surfaced in the table.
+		await expect(row.getByText("16.3")).toBeVisible();
+
+		// Health details are collapsed until expanded, then shown as JSON.
+		await expect(page.getByText(/live_tuples/)).toBeHidden();
+		await row.getByRole("button", { name: /show health details/i }).click();
+		await expect(page.getByText(/"indexes_fixed": true/)).toBeVisible();
+		await expect(page.getByText(/"live_tuples": 4242/)).toBeVisible();
+	});
+
 	test("declaring a replica through the dialog persists it", async ({
 		page,
 		sql,

--- a/private-web/e2e/restore-replicas.spec.ts
+++ b/private-web/e2e/restore-replicas.spec.ts
@@ -190,14 +190,18 @@ test.describe("restore replicas", () => {
 		});
 
 		await page.goto(`/groups/${groupId}/backups`);
-		const row = page.getByRole("row", { name: /health-srv/ });
-		await expect(row).toBeVisible();
+		// The checks table shows the server as a truncated id, not its name, so
+		// locate the check row by its own expand button rather than the server.
+		const detailsButton = page.getByRole("button", {
+			name: /show health details/i,
+		});
+		const row = page.getByRole("row").filter({ has: detailsButton });
 		// The postgres version is now surfaced in the table.
 		await expect(row.getByText("16.3")).toBeVisible();
 
 		// Health details are collapsed until expanded, then shown as JSON.
 		await expect(page.getByText(/live_tuples/)).toBeHidden();
-		await row.getByRole("button", { name: /show health details/i }).click();
+		await detailsButton.click();
 		await expect(page.getByText(/"indexes_fixed": true/)).toBeVisible();
 		await expect(page.getByText(/"live_tuples": 4242/)).toBeVisible();
 	});

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -660,14 +660,17 @@ export async function seedRestoreCheck(
 		outcome?: "success" | "failure";
 		replicaHealthy?: boolean;
 		error?: string | null;
+		postgresVersion?: string | null;
+		/** Arbitrary consumer-sent health data, stored as jsonb. */
+		healthDetails?: unknown;
 		/** ISO 8601; defaults to NOW(). */
 		observedAt?: string;
 	},
 ): Promise<void> {
 	await sql.query(
 		`INSERT INTO backup_restore_checks
-		 (replica_id, consumer_device_id, group_id, server_id, type, intent, snapshot_id, outcome, error, replica_healthy, observed_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, COALESCE($11::timestamptz, NOW()))`,
+		 (replica_id, consumer_device_id, group_id, server_id, type, intent, snapshot_id, outcome, error, replica_healthy, postgres_version, health_details, observed_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, COALESCE($13::timestamptz, NOW()))`,
 		[
 			opts.replicaId ?? null,
 			opts.consumerDeviceId,
@@ -679,6 +682,8 @@ export async function seedRestoreCheck(
 			opts.outcome ?? "success",
 			opts.error ?? null,
 			opts.replicaHealthy ?? true,
+			opts.postgresVersion ?? null,
+			opts.healthDetails === undefined ? null : JSON.stringify(opts.healthDetails),
 			opts.observedAt ?? null,
 		],
 	);

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -5813,6 +5813,9 @@
             "type": "string",
             "format": "uuid"
           },
+          "health_details": {
+            "description": "Arbitrary health data the consumer sent (postgres cluster stats, whether\nindexes needed fixing, …). Opaque to canopy — stored and displayed as-is."
+          },
           "id": {
             "type": "integer",
             "format": "int64"

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2417,6 +2417,11 @@ export interface components {
             error?: string | null;
             /** Format: uuid */
             group_id: string;
+            /**
+             * @description Arbitrary health data the consumer sent (postgres cluster stats, whether
+             *     indexes needed fixing, …). Opaque to canopy — stored and displayed as-is.
+             */
+            health_details?: unknown;
             /** Format: int64 */
             id: number;
             intent: string;

--- a/private-web/src/components/RestoreReplicasSection.tsx
+++ b/private-web/src/components/RestoreReplicasSection.tsx
@@ -1,10 +1,13 @@
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import {
 	Alert,
 	Box,
 	Button,
 	Chip,
+	Collapse,
 	Dialog,
 	DialogActions,
 	DialogContent,
@@ -29,6 +32,7 @@ import {
 } from "@mui/material";
 import { useState } from "react";
 import { ApiError, callApi, useApi } from "../api";
+import type { BackupRestoreCheck } from "../types";
 
 const WELL_KNOWN_INTENTS = ["verify", "analytics", "disaster-recovery"];
 
@@ -228,40 +232,20 @@ export default function RestoreReplicasSection({
 					<Table size="small">
 						<TableHead>
 							<TableRow>
+								<TableCell padding="checkbox" />
 								<TableCell>When</TableCell>
 								<TableCell>Server</TableCell>
 								<TableCell>Type</TableCell>
 								<TableCell>Intent</TableCell>
 								<TableCell>Outcome</TableCell>
+								<TableCell>PG version</TableCell>
 								<TableCell>Snapshot</TableCell>
 							</TableRow>
 						</TableHead>
 						<TableBody>
-							{checks.data.map((c) => {
-								const ok = c.outcome === "success" && c.replica_healthy;
-								return (
-									<TableRow key={c.id}>
-										<TableCell>
-											{new Date(c.observed_at).toLocaleString()}
-										</TableCell>
-										<TableCell>
-											{c.server_id ? c.server_id.slice(0, 8) : "—"}
-										</TableCell>
-										<TableCell>{c.type}</TableCell>
-										<TableCell>{c.intent}</TableCell>
-										<TableCell>
-											<Chip
-												label={ok ? "healthy" : "failed"}
-												color={ok ? "success" : "error"}
-												size="small"
-											/>
-										</TableCell>
-										<TableCell>
-											{c.snapshot_id ? c.snapshot_id.slice(0, 12) : "—"}
-										</TableCell>
-									</TableRow>
-								);
-							})}
+							{checks.data.map((c) => (
+								<CheckRow key={c.id} check={c} />
+							))}
 						</TableBody>
 					</Table>
 				</Paper>
@@ -458,5 +442,77 @@ function CreateReplicaDialog({
 				</Button>
 			</DialogActions>
 		</Dialog>
+	);
+}
+
+/** One restore-check row. When the consumer sent arbitrary `health_details`,
+ * the row expands to reveal it as pretty-printed JSON. */
+function CheckRow({ check }: { check: BackupRestoreCheck }) {
+	const [open, setOpen] = useState(false);
+	const ok = check.outcome === "success" && check.replica_healthy;
+	const hasDetails =
+		check.health_details != null &&
+		!(
+			typeof check.health_details === "object" &&
+			Object.keys(check.health_details).length === 0
+		);
+	return (
+		<>
+			<TableRow sx={hasDetails ? { "& > *": { borderBottom: "unset" } } : undefined}>
+				<TableCell padding="checkbox">
+					{hasDetails && (
+						<IconButton
+							size="small"
+							aria-label={open ? "Hide health details" : "Show health details"}
+							onClick={() => setOpen((o) => !o)}
+						>
+							{open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+						</IconButton>
+					)}
+				</TableCell>
+				<TableCell>{new Date(check.observed_at).toLocaleString()}</TableCell>
+				<TableCell>{check.server_id ? check.server_id.slice(0, 8) : "—"}</TableCell>
+				<TableCell>{check.type}</TableCell>
+				<TableCell>{check.intent}</TableCell>
+				<TableCell>
+					<Chip
+						label={ok ? "healthy" : "failed"}
+						color={ok ? "success" : "error"}
+						size="small"
+					/>
+				</TableCell>
+				<TableCell>{check.postgres_version ?? "—"}</TableCell>
+				<TableCell>
+					{check.snapshot_id ? check.snapshot_id.slice(0, 12) : "—"}
+				</TableCell>
+			</TableRow>
+			{hasDetails && (
+				<TableRow>
+					<TableCell sx={{ py: 0 }} colSpan={8}>
+						<Collapse in={open} timeout="auto" unmountOnExit>
+							<Box sx={{ my: 1 }}>
+								<Typography variant="caption" color="text.secondary">
+									Health details
+								</Typography>
+								<Box
+									component="pre"
+									sx={{
+										m: 0,
+										mt: 0.5,
+										p: 1,
+										fontSize: "0.75rem",
+										overflowX: "auto",
+										bgcolor: "action.hover",
+										borderRadius: 1,
+									}}
+								>
+									{JSON.stringify(check.health_details, null, 2)}
+								</Box>
+							</Box>
+						</Collapse>
+					</TableCell>
+				</TableRow>
+			)}
+		</>
 	);
 }

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -141,6 +141,7 @@ export type RetentionPolicy = Solidify<Schemas["RetentionPolicy"]>;
 export type BackupStatsView = Solidify<Schemas["BackupStatsView"]>;
 export type BackupRepoStats = Solidify<Schemas["BackupRepoStats"]>;
 export type BackupRun = Solidify<Schemas["BackupRun"]>;
+export type BackupRestoreCheck = Solidify<Schemas["BackupRestoreCheck"]>;
 export type BackupMaintenanceRun = Solidify<Schemas["BackupMaintenanceRun"]>;
 export type PendingRequestRow = Solidify<Schemas["PendingRequestRow"]>;
 export type ServerBackupCapabilityView = Solidify<


### PR DESCRIPTION
🤖 PGRO wants to attach free-form health data — postgres cluster stats, whether indexes needed fixing, etc. — to its restore-verification reports. The report API was fixed-column, so any extra fields were silently dropped (serde ignores unknown fields). This adds a place for it.

## API / storage
- New nullable `jsonb` column `backup_restore_checks.health_details`, accepted as an optional `health_details` field on `POST /restore-verification` and stored verbatim. Everything nests under that one field.
- Opaque to canopy for now — stored and displayed as-is. Specific fields can be promoted to typed columns later; jsonb stays queryable in the meantime.

## UI
- The recent-restore-checks table gains an expandable row that reveals the health data as pretty-printed JSON.
- It now also surfaces the **postgres version**, which was already recorded on each check but never displayed.

## Notes
- PGRO's side is a separate change in its own repo: it adds `health_details` to its report body. Until it does, the column stays null and the UI shows nothing extra.
- Touches `RestoreReplicasSection.tsx`, which the restore-intents PR (#304) also edits (different part of the file) — expect a trivial rebase conflict when the second of the two merges.

TAM-6880