### PR TITLE
docs(slack): draft a dumb MCP-relay query path over Slack

### DIFF
--- a/docs/plans/slack-integration.md
+++ b/docs/plans/slack-integration.md
@@ -133,6 +133,159 @@ UI by some other path.
 - An end-to-end test for the inbound path: signed request → note inserted;
   unsigned → rejected; `bot_id` present → dropped.
 
+## Querying canopy from Slack (draft — exploratory)
+
+Once the bot-token app is installed, the same install can carry an inbound
+**query** path: a person (or an in-Slack agent) invokes a canopy query in a
+channel, canopy runs it and replies in-thread. The query runs against the
+**same read-only tool layer the MCP exposes** (`crates/private-server/src/mcp.rs`,
+spec `MCP`) — we do not build a second set of fleet queries.
+
+There is **no LLM in this path.** The Slack side is dumb: it names an MCP tool
+and its arguments, canopy dispatches to that tool, and the reply is the tool's
+JSON plus a deterministic, machine-generated summary. Interpreting free-text
+questions is out of scope — an agent that wants that runs its own model against
+`/api/mcp` directly. Slack just relays.
+
+### What's being reused
+
+`CanopyMcp` is a router of read-only tools (`find_servers`, `get_server`,
+`find_incidents`, `fleet_summary`, `find_backup_problems`, …) that shape lean
+JSON straight off the `database` read functions. A caller in Slack picks one of
+those tools and its args exactly as an MCP client would; canopy runs it and
+returns the result. Read-only means the worst a bad or malformed query can do is
+produce an unhelpful reply — nothing mutates the fleet.
+
+Dispatch is **in-process**: the query worker holds an `AppState` and drives the
+same tool router (or, more cleanly, the tool bodies are factored out of the
+`#[tool]` methods so both the MCP mount and this path call the same functions).
+No second query implementation, no network hop, and it works even though the
+MCP mount itself is Tailscale-only.
+
+### Invocation syntax
+
+The message carries a tool name plus arguments — the MCP call, spelled for a
+chat box. Two encodings, both parsed deterministically:
+
+- **Agent / precise:** a JSON object, e.g.
+  `@canopy {"tool": "find_incidents", "args": {"since_days": 7, "status": "open"}}`.
+- **Human shorthand:** `@canopy find_incidents since_days=7 status=open` —
+  `key=value` pairs coerced against the tool's argument schema.
+
+`@canopy help` (or `tools`) lists the available tools and their arguments,
+generated from the router's schemas — so discovery is also code, not docs that
+drift. Unknown tool or bad args → a deterministic error reply naming the
+offending field, mirroring the MCP `invalid_params` messages.
+
+App mention is the entry point, reusing the Events API path this plan already
+stands up: the inbound binary gains an `event.type == "app_mention"` branch. A
+mention outside a thread opens a thread for the answer; inside a thread it
+answers in place. (A slash command `/canopy …` is a possible addition but needs
+its own Request URL + `response_url` ack dance — deferred.)
+
+### Flow
+
+A single tool dispatch is one-to-a-few DB reads and normally well inside Slack's
+3-second Events API budget, but posting the reply (and any file upload) is a
+separate round-trip to Slack. To keep the ack path trivial and get durable
+retry on the Slack write, reuse the outbox-style queue:
+
+1. Inbound endpoint validates the signature (existing code), recognises an
+   `app_mention`, parses out `{tool, args}`, inserts a `slack_query` row,
+   returns `200 OK`.
+2. A worker (`crates/jobs/src/bin/slacker_query.rs`, mirroring `slacker_outbox`)
+   claims the row, dispatches the tool, and posts the reply — directly via
+   `chat.postMessage` + `files_upload_v2`, or by enqueuing an outbox row so all
+   Slack writes stay on one path.
+
+Parse/dispatch failures post a deterministic error into the thread rather than
+dropping silently.
+
+### The reply — deterministic summary + JSON attachment
+
+Tool JSON (a `find_servers` over the fleet, a `get_group` with backup history)
+easily blows past what's readable in a Slack message, and Slack caps section
+text around 3k characters. So the reply is **two-tier**:
+
+- **In the message:** a compact, machine-generated summary — *not* the raw JSON.
+  Each result type gets a small `summarize()` formatter (counts + the few fields
+  that matter), the same spirit as the Block Kit payloads above but for query
+  results. Examples:
+  - `find_servers` → `42 matched, 38 shown · 3 unhealthy, 5 unreachable`.
+  - `find_backup_problems` → `7 problems: 2 overdue, 1 provisioning error, 4 failed runs`.
+  - `fleet_summary` → the rollup counts inline.
+  These formatters are plain Rust over the typed result structs — no model.
+- **As an attachment:** the full tool result uploaded as a file **snippet** via
+  `files_upload_v2` into the same thread (`thread_ts` set), so agents get the
+  complete structured payload and humans can expand it. Format, to pick:
+  - `.json` — the raw tool result; the default, and what an agent consumes.
+  - `.csv` / `.md` table — friendlier for eyeballing server/incident lists;
+    could be offered for the list-shaped results.
+
+  Slack renders snippets inline with expand/collapse, so a big result doesn't
+  wall-of-text the channel but is one click (or one download) away. Small
+  results (under the section limit) can skip the attachment and inline the JSON
+  in a code block instead — threshold TBD.
+- **Deep links where one exists.** The summary can link to `PRIVATE_URL/...`
+  for a named server/group/incident so an operator lands on the page where they
+  can act. (`PRIVATE_URL` is the admin UI; see the URL-split rule.)
+
+### Auth & attribution
+
+The MCP mount gates on *any authenticated tailnet user* and logs the login.
+Over Slack there is no tailnet identity — the trust boundary is **workspace
+(and channel) membership**. Decisions to lock in:
+
+- Restrict the query path to a specific channel (or channel allow-list) — an
+  ops channel — rather than answering anywhere the bot is mentioned. The data
+  is read-only but not something to expose to a general workspace.
+- Attribute every query as `slack:<user-id>` in logs, matching the inbound-note
+  author convention, so who-asked-what stays auditable.
+- Reuse the existing `bot_id` / own-bot-id drop so the bot never answers itself
+  or loops on another bot's chatter.
+
+### Admin asks (additions to the list above)
+
+- `app_mentions:read` scope and the `app_mention` event subscription.
+- `files:write` scope (snippet uploads).
+
+### New config
+
+- `SLACK_QUERY_CHANNEL_ID` (or reuse `SLACK_CHANNEL_ID`) for the allow-list.
+- No API key or model config — there is no LLM in this path.
+
+### Schema additions (draft)
+
+```sql
+CREATE TABLE slack_query (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  channel      TEXT NOT NULL,
+  thread_ts    TEXT NOT NULL,
+  slack_user   TEXT NOT NULL,
+  tool         TEXT NOT NULL,   -- the MCP tool name invoked
+  args         JSONB NOT NULL,  -- parsed arguments
+  status       TEXT NOT NULL DEFAULT 'pending', -- pending | done | failed
+  answer_ts    TEXT,            -- ts of the posted reply
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  answered_at  TIMESTAMPTZ
+);
+```
+
+Mirrors `slack_outbox`'s claim/drain shape so the worker is a near-copy.
+
+### Open questions
+
+- **Dispatch reuse.** Confirm rmcp exposes a clean by-name invoke over the tool
+  router, or factor the tool bodies out of the `#[tool]` methods so the MCP
+  mount and this path share one set of functions (preferred — avoids depending
+  on rmcp internals).
+- **Summary coverage.** Which tools get a bespoke `summarize()` vs. a generic
+  "N records, see attachment" fallback.
+- **Inline vs. attachment threshold.** Byte/row cutoff for inlining JSON in a
+  code block instead of uploading a snippet.
+- **Rate guard.** Per-user or per-channel throttle to bound abuse (cheap, but a
+  fleet-wide `find_servers` in a loop is still noise).
+
 ## Open follow-ups (not blocking)
 
 - Per-rank or per-tag channel routing.


### PR DESCRIPTION
🤖 Extends `docs/plans/slack-integration.md` with a draft **query path**: a person or in-Slack agent invokes a canopy query in a channel, canopy runs it and replies in-thread.

Key design points:

- **No LLM in the path.** The Slack side is dumb — the message names an MCP tool and its arguments (JSON for agents, `key=value` shorthand for humans), canopy dispatches to the existing read-only `CanopyMcp` tool layer in-process, and relays the result. Free-text interpretation is out of scope; an agent that wants that runs its own model against `/api/mcp` directly.
- **Two-tier reply.** A deterministic, machine-generated `summarize()` line per result type in the message (e.g. `find_backup_problems → 7 problems: 2 overdue…`), with the full tool JSON as a `files_upload_v2` snippet in-thread. Small results can inline a code block instead.
- **Reuses existing machinery** — the Events API `app_mention` path, an outbox-style `slack_query` queue + worker, channel allow-list, and `slack:<user>` attribution.

Includes draft schema, invocation syntax, auth/attribution notes, admin-ask and config additions, and open questions (dispatch reuse, summary coverage, inline-vs-attachment threshold, rate guard).

This is plan/draft content only — no code changes.