### PR TITLE
Add canopy-mcp plugin for Claude Tag integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+	"name": "canopy",
+	"owner": {
+		"name": "BES International"
+	},
+	"plugins": [
+		{
+			"name": "canopy-mcp",
+			"source": "./plugins/canopy-mcp",
+			"description": "Read-only fleet queries against Canopy: Tamanu servers, groups, versions, backups, incidents, and issues."
+		}
+	]
+}

--- a/plugins/canopy-mcp/.claude-plugin/plugin.json
+++ b/plugins/canopy-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+	"name": "canopy-mcp",
+	"version": "1.0.0",
+	"description": "Read-only fleet queries against Canopy: Tamanu servers, groups, versions, backups, incidents, and issues. Requires a Canopy MCP bearer token credential for meta.tamanu.app."
+}

--- a/plugins/canopy-mcp/.mcp.json
+++ b/plugins/canopy-mcp/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"canopy": {
+			"type": "http",
+			"url": "https://meta.tamanu.app/mcp"
+		}
+	}
+}

--- a/plugins/canopy-mcp/README.md
+++ b/plugins/canopy-mcp/README.md
@@ -1,0 +1,24 @@
+# canopy-mcp plugin
+
+Points agents at the internet-facing mount of Canopy's read-only MCP fleet
+query interface (`https://meta.tamanu.app/mcp`). The `.mcp.json` carries no
+credentials: the endpoint requires a bearer token, which must be supplied by
+the agent platform (for Claude Tag, the admin Connections credential proxy).
+
+Setup for Claude Tag (admin, at claude.ai/admin-settings/claude-tag):
+
+1. Mint a token in the Canopy operator UI: Settings → MCP access. The
+   `canopy_mcp_…` secret is shown once. Tokens expire after one year; a
+   rotation alert fires 15 days out.
+2. In the Access bundle's Credentials tab, use **Connect another app**:
+   credential type **Bearer**, paste the secret, allowed website
+   `meta.tamanu.app`.
+3. Add this repository as an organization plugin source and attach the
+   `canopy-mcp` plugin to the bundle.
+4. Verify by asking Claude to run the `fleet_summary` tool; the token's
+   "Last used" column in Canopy's Settings → MCP access updates within a
+   minute.
+
+Operators on the tailnet don't need this plugin or a token — use the tailnet
+mount instead: `claude mcp add --transport http canopy
+https://canopy.tail53aef.ts.net/api/mcp`.


### PR DESCRIPTION
## Summary
Adds a new `canopy-mcp` plugin that enables Claude Tag to query Canopy's read-only MCP fleet interface. The plugin points to the internet-facing endpoint at `https://meta.tamanu.app/mcp` and integrates with Claude Tag's credential proxy for bearer token authentication.

## Changes
- **Plugin configuration** (`.mcp.json`): Defines HTTP MCP server pointing to Canopy's meta endpoint
- **Plugin metadata** (`plugin.json`): Registers the plugin with version 1.0.0 and description
- **Marketplace registration** (`marketplace.json`): Lists the plugin in the organization's plugin source
- **Setup documentation** (`README.md`): Comprehensive guide for Claude Tag admins covering:
  - Token minting in Canopy operator UI
  - Credential configuration in Claude Tag's Access bundle
  - Plugin attachment and verification steps
  - Alternative tailnet mount option for operators on the tailnet

## Implementation Details
- No credentials are embedded in `.mcp.json`; the bearer token is supplied by the agent platform's credential proxy
- Tokens are managed in Canopy's Settings → MCP access with one-year expiration and 15-day rotation alerts
- Provides read-only access to fleet queries: servers, groups, versions, backups, incidents, and issues

https://claude.ai/code/session_01EhJM5FyWvP6SbAD1bQwvR8