### PR TITLE
feat(status): source server version from payload tamanuVersion

### DIFF
--- a/crates/commons-servers/src/headers.rs
+++ b/crates/commons-servers/src/headers.rs
@@ -1,4 +1,7 @@
-use axum::{extract::FromRequestParts, http::request::Parts};
+use axum::{
+	extract::{FromRequestParts, OptionalFromRequestParts},
+	http::request::Parts,
+};
 use commons_errors::AppError;
 use commons_types::version::VersionStr;
 
@@ -23,5 +26,28 @@ where
 			.parse()?;
 
 		Ok(VersionHeader(param))
+	}
+}
+
+impl<S> OptionalFromRequestParts<S> for VersionHeader
+where
+	S: Send + Sync,
+{
+	type Rejection = AppError;
+
+	/// `None` when the header is absent — the version is now sourced
+	/// primarily from the status payload's `tamanuVersion`, so a sender
+	/// that omits `X-Version` is no longer an error. A present-but-malformed
+	/// header still rejects (a garbage version is a client bug worth surfacing).
+	async fn from_request_parts(
+		parts: &mut Parts,
+		state: &S,
+	) -> Result<Option<Self>, Self::Rejection> {
+		if parts.headers.get(X_VERSION).is_none() {
+			return Ok(None);
+		}
+		<Self as FromRequestParts<S>>::from_request_parts(parts, state)
+			.await
+			.map(Some)
 	}
 }

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -1846,7 +1846,7 @@
         "allOf": [
           {
             "type": "object",
-            "description": "Free-form additional data (uptime, postgres version, timezone,\nhostname, etc.). Stored verbatim in `statuses.extra` and\nsurfaced as raw JSON in the status snapshot."
+            "description": "Free-form additional data (uptime, postgres version, timezone,\nhostname, etc.). Stored verbatim in `statuses.extra` and\nsurfaced as raw JSON in the status snapshot.\n\nA `tamanuVersion` here is used as the server's tracked version\n(compared against the published version catalog), superseding the\nlegacy `X-Version` request header. If both are present,\n`tamanuVersion` wins; if neither is, the status is versionless."
           },
           {
             "type": "object",

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::str::FromStr as _;
 
 use axum::{
 	Json,
@@ -8,7 +9,10 @@ use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::{
 	backup_jobs::backups_due_now_for_server, device_auth::ServerDevice, headers::VersionHeader,
 };
-use commons_types::{backup::BackupType, device::DeviceRole, issue::Severity, status::CheckResult};
+use commons_types::{
+	backup::BackupType, device::DeviceRole, issue::Severity, status::CheckResult,
+	version::VersionStr,
+};
 use database::{
 	Db,
 	devices::Device,
@@ -68,6 +72,11 @@ pub struct StatusPayload {
 	/// Free-form additional data (uptime, postgres version, timezone,
 	/// hostname, etc.). Stored verbatim in `statuses.extra` and
 	/// surfaced as raw JSON in the status snapshot.
+	///
+	/// A `tamanuVersion` here is used as the server's tracked version
+	/// (compared against the published version catalog), superseding the
+	/// legacy `X-Version` request header. If both are present,
+	/// `tamanuVersion` wins; if neither is, the status is versionless.
 	#[serde(flatten)]
 	#[schema(additional_properties = true, value_type = Object)]
 	pub extra: serde_json::Map<String, serde_json::Value>,
@@ -151,7 +160,7 @@ async fn create(
 	Path(server_id): Path<Uuid>,
 	State(db): State<Db>,
 	device: ServerDevice,
-	current_version: VersionHeader,
+	current_version: Option<VersionHeader>,
 	body: Option<Json<serde_json::Value>>,
 ) -> Result<Json<StatusResponse>> {
 	let mut db = db.get().await?;
@@ -179,6 +188,12 @@ async fn create(
 	let raw = body.map(|j| j.0).unwrap_or(serde_json::Value::Null);
 	let (healthy, health, extra) = split_health_from_extra(raw)?;
 
+	// The server version canopy tracks (and compares against the published
+	// version catalog) is the Tamanu version. Prefer the payload's
+	// `tamanuVersion` extra; fall back to the legacy `X-Version` header for
+	// reporters that predate carrying it in the body. Either may be absent.
+	let version = resolve_version(&extra, current_version.map(|v| v.0));
+
 	let Some(health) = health else {
 		// Legacy format (no `health` array). Off by default — only servers an
 		// operator has explicitly opted in via `allow_legacy_status` may use
@@ -186,7 +201,7 @@ async fn create(
 		if !server.allow_legacy_status {
 			return Err(AppError::BadRequest("`health` array is required".into()));
 		}
-		let status = create_legacy_status(&mut db, server_id, id, extra, current_version.0).await?;
+		let status = create_legacy_status(&mut db, server_id, id, extra, version).await?;
 		return Ok(Json(StatusResponse { status, backup_now }));
 	};
 
@@ -207,7 +222,7 @@ async fn create(
 			let status = NewStatus {
 				server_id,
 				device_id: Some(id),
-				version: Some(current_version.0),
+				version,
 				extra,
 				healthy,
 				health,
@@ -236,7 +251,7 @@ async fn create_legacy_status(
 	server_id: Uuid,
 	device_id: Uuid,
 	extra: serde_json::Value,
-	version: commons_types::version::VersionStr,
+	version: Option<VersionStr>,
 ) -> Result<Status> {
 	let (healthy, health) = match Status::latest_for_server(db, server_id).await? {
 		Some(prior) => (prior.healthy, prior.health),
@@ -245,13 +260,27 @@ async fn create_legacy_status(
 	NewStatus {
 		server_id,
 		device_id: Some(device_id),
-		version: Some(version),
+		version,
 		extra,
 		healthy,
 		health,
 	}
 	.save(db)
 	.await
+}
+
+/// Resolve the server version to record on this status. Prefers the payload's
+/// `tamanuVersion` extra (the version bestool now carries in the body), parsed
+/// as a semver; falls back to the `X-Version` header for reporters that still
+/// send it there. Returns `None` when neither is present or parseable — the
+/// `statuses.version` column is nullable and every consumer already handles a
+/// versionless row.
+fn resolve_version(extra: &serde_json::Value, header: Option<VersionStr>) -> Option<VersionStr> {
+	extra
+		.get("tamanuVersion")
+		.and_then(|v| v.as_str())
+		.and_then(|s| VersionStr::from_str(s).ok())
+		.or(header)
 }
 
 /// Per-push event filing. Warning/failed checks land at

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -2506,3 +2506,140 @@ async fn status_one_off_request_surfaced_then_cleared_by_report() {
 	)
 	.await
 }
+
+// -----------------------------------------------------------------
+// Version sourcing: `tamanuVersion` payload extra supersedes the
+// legacy `X-Version` header, and the header is now optional.
+// -----------------------------------------------------------------
+
+#[derive(QueryableByName)]
+struct VersionRow {
+	#[diesel(sql_type = sql_types::Nullable<sql_types::Text>)]
+	version: Option<String>,
+}
+
+async fn fetch_latest_version(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+) -> Option<String> {
+	let row: VersionRow = sql_query(
+		"SELECT version FROM statuses WHERE server_id = $1 ORDER BY created_at DESC LIMIT 1",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.get_result(conn)
+	.await
+	.expect("fetch latest status version");
+	row.version
+}
+
+/// `run_with_device_auth` sends `X-Version: 3.4.5` by default. A payload
+/// carrying `tamanuVersion` wins over that header.
+#[tokio::test(flavor = "multi_thread")]
+async fn submit_status_version_prefers_tamanu_version_over_header() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+
+			post_status(
+				&public,
+				&cert,
+				server_id,
+				serde_json::json!({ "tamanuVersion": "2.11.0", "health": [] }),
+			)
+			.await;
+
+			assert_eq!(
+				fetch_latest_version(&mut conn, server_id).await.as_deref(),
+				Some("2.11.0"),
+				"tamanuVersion in the payload supersedes the X-Version header"
+			);
+		},
+	)
+	.await
+}
+
+/// With no `tamanuVersion` in the payload, the version falls back to the
+/// `X-Version` header (here the helper's default `3.4.5`).
+#[tokio::test(flavor = "multi_thread")]
+async fn submit_status_version_falls_back_to_header() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+
+			post_status(
+				&public,
+				&cert,
+				server_id,
+				serde_json::json!({ "health": [] }),
+			)
+			.await;
+
+			assert_eq!(
+				fetch_latest_version(&mut conn, server_id).await.as_deref(),
+				Some("3.4.5"),
+				"absent tamanuVersion falls back to the X-Version header"
+			);
+		},
+	)
+	.await
+}
+
+/// The `X-Version` header is now optional: a push with no header but a
+/// `tamanuVersion` in the body is accepted and records the payload version.
+#[tokio::test(flavor = "multi_thread")]
+async fn submit_status_version_without_header_uses_payload() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+
+			// Drop every default header (including the helper's X-Version),
+			// then restore only what device auth / client IP need.
+			let response = public
+				.post(&format!("/status/{server_id}"))
+				.clear_headers()
+				.add_header("Forwarded", "for=192.0.1.60")
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "tamanuVersion": "2.12.3", "health": [] }))
+				.await;
+			response.assert_status_ok();
+
+			assert_eq!(
+				fetch_latest_version(&mut conn, server_id).await.as_deref(),
+				Some("2.12.3"),
+				"missing X-Version is fine when the payload carries tamanuVersion"
+			);
+		},
+	)
+	.await
+}
+
+/// Neither source present: the push still succeeds and the row is
+/// versionless (the column is nullable).
+#[tokio::test(flavor = "multi_thread")]
+async fn submit_status_versionless_when_neither_present() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+
+			let response = public
+				.post(&format!("/status/{server_id}"))
+				.clear_headers()
+				.add_header("Forwarded", "for=192.0.1.60")
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "health": [] }))
+				.await;
+			response.assert_status_ok();
+
+			assert_eq!(
+				fetch_latest_version(&mut conn, server_id).await,
+				None,
+				"no tamanuVersion and no X-Version ⇒ versionless status"
+			);
+		},
+	)
+	.await
+}


### PR DESCRIPTION
🤖 The status-push handler now reads the tracked server version from the payload’s `tamanuVersion` extra, falling back to the `X-Version` request header when absent.

Why: bestool currently duplicates the Tamanu version into the `X-Version` header purely so canopy can read it, which is annoying to maintain. Rich healthchecks already carry `tamanuVersion` in the status body, so canopy can pull it from there and let reporters drop the header.

What changed:
- `VersionHeader` is now optionally extractable — a missing `X-Version` yields `None` instead of rejecting. A present-but-malformed value still rejects.
- The push handler resolves the version as `tamanuVersion` (parsed as semver) → `X-Version` header → none. Both the normal and legacy (`allow_legacy_status`) paths use it.
- `statuses.version` was already nullable, so a push with neither source is simply recorded versionless; no downstream consumer breaks.

The pingtask that reads `X-Version` off a foreign server’s `/api/public/ping` response is unchanged — that path has no status payload to pull `tamanuVersion` from.

No OpenAPI regen needed: `X-Version` was never a declared spec param.