### PR TITLE
feat(status): source Node.js version from payload nodeVersion

### DIFF
--- a/crates/database/src/bin/seed.rs
+++ b/crates/database/src/bin/seed.rs
@@ -837,6 +837,7 @@ async fn seed_statuses(
 			"pgVersion": pg,
 			"tamanuVersion": tamanu,
 			"bestoolVersion": "2.10.5",
+			"nodeVersion": "20.11.0",
 			"uptimeSecs": uptime,
 		})
 	}

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -465,6 +465,16 @@ impl Status {
 			.map(|vers| vers.trim_end_matches(',').into())
 	}
 
+	/// Node.js runtime version the server reported in its status payload
+	/// (`nodeVersion` extra), if present. Preferred over scraping the device
+	/// connection's User-Agent (see [`crate::devices::DeviceConnection::nodejs_version`]),
+	/// which only reflects whichever transport happened to set that header.
+	pub fn node_version(&self) -> Option<String> {
+		self.extra("nodeVersion")
+			.and_then(|v| v.as_str())
+			.map(ToOwned::to_owned)
+	}
+
 	/// Server's self-reported health state derived from this status
 	/// row's per-check results. The top-level `healthy` bool is being
 	/// retired from the wire (absent ⇒ true on ingestion), so this

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -526,7 +526,11 @@ pub async fn get_detail(
 
 		let platform = st.platform();
 		let postgres = st.postgres_version();
-		let nodejs = connection.and_then(|d| d.nodejs_version());
+		// Prefer the payload-reported `nodeVersion`; fall back to the device
+		// connection's User-Agent.
+		let nodejs = st
+			.node_version()
+			.or_else(|| connection.and_then(|d| d.nodejs_version()));
 		let version_distance = latest_version
 			.as_ref()
 			.and_then(|lv| st.distance_from_version(lv));

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -315,18 +315,23 @@ pub async fn snapshot(
 		Ok(v) => status.distance_from_version(&v.as_semver()),
 		Err(_) => None,
 	};
-	// nodejs lives on the *latest* device connection rather than a
-	// contemporary one — the device-side connection metadata isn't
-	// versioned in lockstep with status pushes, and looking up "as
-	// of" would mostly mislead.
-	let nodejs = if let Some(dev_id) = status.device_id {
-		DeviceConnection::get_latest_from_device_ids(&mut conn, [dev_id].into_iter())
-			.await?
-			.into_iter()
-			.next()
-			.and_then(|d| d.nodejs_version())
-	} else {
-		None
+	// Prefer the Node.js version the server reported in its status payload
+	// (`nodeVersion`). Fall back to scraping the *latest* device connection's
+	// User-Agent — that metadata isn't versioned in lockstep with status
+	// pushes, so looking it up "as of" a time would mostly mislead.
+	let nodejs = match status.node_version() {
+		Some(v) => Some(v),
+		None => {
+			if let Some(dev_id) = status.device_id {
+				DeviceConnection::get_latest_from_device_ids(&mut conn, [dev_id].into_iter())
+					.await?
+					.into_iter()
+					.next()
+					.and_then(|d| d.nodejs_version())
+			} else {
+				None
+			}
+		}
 	};
 	let min_chrome_version = if let Some(ref v) = status.version {
 		super::servers::compute_min_chrome_version(&mut conn, v).await

--- a/crates/private-server/tests/private_statuses.rs
+++ b/crates/private-server/tests/private_statuses.rs
@@ -820,6 +820,8 @@ struct SnapshotData {
 	healthy: Option<bool>,
 	#[serde(default)]
 	health: Option<serde_json::Value>,
+	#[serde(default)]
+	nodejs: Option<String>,
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -852,6 +854,84 @@ async fn snapshot_returns_latest_when_at_omitted() {
 		assert_eq!(data.healthy, Some(false), "latest is the most recent");
 		let health = data.health.unwrap();
 		assert_eq!(health.as_array().unwrap().len(), 1);
+	})
+	.await
+}
+
+/// The Node.js version reported in the status payload's `nodeVersion` extra
+/// is preferred over the value scraped from the device connection's User-Agent.
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_prefers_payload_node_version_over_user_agent() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO devices (id, role) VALUES
+			('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'server');
+
+			INSERT INTO servers (id, host, kind, device_id) VALUES
+			('20000000-0000-0000-0000-000000000010', 'https://node.example.com', 'central', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+
+			INSERT INTO device_connections (device_id, ip, user_agent) VALUES
+			('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '192.168.1.10', 'Tamanu/1.0.0 Node.js/18.20.5');
+
+			INSERT INTO statuses (server_id, device_id, created_at, healthy, health, extra) VALUES
+			('20000000-0000-0000-0000-000000000010', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', NOW() - INTERVAL '1 hour', true, '[]'::jsonb, '{\"nodeVersion\":\"20.11.0\"}'::jsonb)",
+		)
+		.await
+		.unwrap();
+
+		let r = private
+			.post("/api/statuses/snapshot")
+			.json(&serde_json::json!({
+				"server_id": "20000000-0000-0000-0000-000000000010"
+			}))
+			.await;
+		r.assert_status_ok();
+		let data: Option<SnapshotData> = r.json();
+		let data = data.expect("snapshot returned");
+		assert_eq!(
+			data.nodejs,
+			Some("20.11.0".to_string()),
+			"payload nodeVersion supersedes the User-Agent's Node.js token"
+		);
+	})
+	.await
+}
+
+/// With no `nodeVersion` in the payload, the snapshot falls back to the
+/// `Node.js/x` token in the device connection's User-Agent.
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_node_version_falls_back_to_user_agent() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO devices (id, role) VALUES
+			('cccccccc-cccc-cccc-cccc-cccccccccccc', 'server');
+
+			INSERT INTO servers (id, host, kind, device_id) VALUES
+			('20000000-0000-0000-0000-000000000011', 'https://node2.example.com', 'central', 'cccccccc-cccc-cccc-cccc-cccccccccccc');
+
+			INSERT INTO device_connections (device_id, ip, user_agent) VALUES
+			('cccccccc-cccc-cccc-cccc-cccccccccccc', '192.168.1.11', 'Tamanu/1.0.0 Node.js/18.20.5');
+
+			INSERT INTO statuses (server_id, device_id, created_at, healthy, health, extra) VALUES
+			('20000000-0000-0000-0000-000000000011', 'cccccccc-cccc-cccc-cccc-cccccccccccc', NOW() - INTERVAL '1 hour', true, '[]'::jsonb, '{}'::jsonb)",
+		)
+		.await
+		.unwrap();
+
+		let r = private
+			.post("/api/statuses/snapshot")
+			.json(&serde_json::json!({
+				"server_id": "20000000-0000-0000-0000-000000000011"
+			}))
+			.await;
+		r.assert_status_ok();
+		let data: Option<SnapshotData> = r.json();
+		let data = data.expect("snapshot returned");
+		assert_eq!(
+			data.nodejs,
+			Some("18.20.5".to_string()),
+			"absent nodeVersion falls back to the User-Agent"
+		);
 	})
 	.await
 }


### PR DESCRIPTION
Follow-up to #312 — same treatment, this time for the Node.js version.

🤖 The status snapshot and server-detail endpoints now read the Node.js runtime version from the status payload’s `nodeVersion` extra when present, falling back to scraping the `Node.js/x` token out of the device connection’s User-Agent.

Why: the Node version is currently only knowable by parsing bestool’s User-Agent (`Tamanu/x Node.js/y`). Rich healthchecks can report it directly, so canopy should prefer the payload and treat the User-Agent as a legacy fallback.

What changed:
- New `Status::node_version()` reads the `nodeVersion` extra.
- `fns/statuses.rs` (snapshot) prefers it and only does the device-connection lookup when it is absent.
- `fns/servers.rs` (server detail) prefers it, falling back to the already-fetched connection.
- Seed data grows a `nodeVersion` extra so the dev UI shows the new path.

Based on `status/version-from-payload` (#312); retarget to `main` once that merges.