### PR TITLE
docs(openapi): advertise accepted request-body compression

### DIFF
--- a/crates/commons-servers/src/lib.rs
+++ b/crates/commons-servers/src/lib.rs
@@ -63,6 +63,25 @@ pub fn router(routes: Router<()>, client_ip_source: ClientIpSource) -> Router<()
 		.layer(ServerTimingLayer::new("srv"))
 }
 
+/// Content-Encodings the [`RequestDecompressionLayer`] applied in [`router`]
+/// transparently decodes on request bodies (courtesy of tower-http's
+/// `decompression-full` feature). Advertised in both OpenAPI specs via
+/// [`request_compression_extension`] so clients know large request bodies
+/// (status pushes, backup reports, event batches) may be — and are encouraged
+/// to be — sent compressed.
+pub const ACCEPTED_REQUEST_ENCODINGS: &[&str] = &["gzip", "br", "deflate", "zstd"];
+
+/// Value of the `x-request-compression` OpenAPI vendor extension. Built here,
+/// beside the decompression layer, so the advertised encodings can't drift from
+/// what the server actually accepts.
+pub fn request_compression_extension() -> serde_json::Value {
+	serde_json::json!({
+		"accepted": ACCEPTED_REQUEST_ENCODINGS,
+		"recommended": true,
+		"header": "Content-Encoding",
+	})
+}
+
 pub async fn serve(routes: Router<()>, addr: SocketAddr) -> commons_errors::Result<()> {
 	let service = routes.into_make_service_with_connect_info::<SocketAddr>();
 	let listener = TcpListener::bind(addr).await?;

--- a/crates/private-server/src/openapi.rs
+++ b/crates/private-server/src/openapi.rs
@@ -10,11 +10,11 @@ use utoipa::{
 	info(
 		title = "canopy private-server",
 		version = "",
-		description = "Admin/operator API for the canopy fleet manager. Requests are gated behind Tailscale auth; admin-only endpoints additionally check the caller is on the admin list.",
+		description = "Admin/operator API for the canopy fleet manager. Requests are gated behind Tailscale auth; admin-only endpoints additionally check the caller is on the admin list.\n\nRequest bodies may be sent compressed, and this is recommended for large payloads: the server transparently decodes `Content-Encoding: gzip`, `br`, `deflate`, or `zstd`. The accepted encodings are also listed structurally in the `x-request-compression` extension.",
 		contact(name = "BES Developers", email = "contact@bes.au"),
 		license(name = "GPL-3.0-or-later"),
 	),
-	modifiers(&SecuritySchemes),
+	modifiers(&SecuritySchemes, &RequestCompression),
 	tags(
 		(name = "admins", description = "Admin email allow-list management."),
 		(name = "backups", description = "Group backup-repo onboarding, scheduling, and stats."),
@@ -32,6 +32,25 @@ use utoipa::{
 	),
 )]
 pub struct ApiDoc;
+
+/// Advertises the request-body Content-Encodings the server accepts as the
+/// top-level `x-request-compression` vendor extension. Sourced from
+/// [`commons_servers::request_compression_extension`] so it tracks the actual
+/// decompression layer.
+struct RequestCompression;
+
+impl Modify for RequestCompression {
+	fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+		openapi.extensions = Some(
+			utoipa::openapi::extensions::ExtensionsBuilder::new()
+				.add(
+					"x-request-compression",
+					commons_servers::request_compression_extension(),
+				)
+				.build(),
+		);
+	}
+}
 
 struct SecuritySchemes;
 

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "canopy public-server",
-    "description": "Internet-facing API for the canopy fleet. Device-authenticated endpoints require an mTLS client certificate.",
+    "description": "Internet-facing API for the canopy fleet. Device-authenticated endpoints require an mTLS client certificate.\n\nRequest bodies may be sent compressed, and this is recommended for large payloads: the server transparently decodes `Content-Encoding: gzip`, `br`, `deflate`, or `zstd`. The accepted encodings are also listed structurally in the `x-request-compression` extension.",
     "contact": {
       "name": "BES Developers",
       "email": "contact@bes.au"
@@ -2235,5 +2235,15 @@
       "name": "versions",
       "description": "Canopy release versions and their downloadable artifacts."
     }
-  ]
+  ],
+  "x-request-compression": {
+    "accepted": [
+      "gzip",
+      "br",
+      "deflate",
+      "zstd"
+    ],
+    "header": "Content-Encoding",
+    "recommended": true
+  }
 }

--- a/crates/public-server/src/openapi.rs
+++ b/crates/public-server/src/openapi.rs
@@ -9,11 +9,11 @@ use utoipa::{Modify, OpenApi, openapi::security::SecurityScheme};
 	info(
 		title = "canopy public-server",
 		version = "",
-		description = "Internet-facing API for the canopy fleet. Device-authenticated endpoints require an mTLS client certificate.",
+		description = "Internet-facing API for the canopy fleet. Device-authenticated endpoints require an mTLS client certificate.\n\nRequest bodies may be sent compressed, and this is recommended for large payloads: the server transparently decodes `Content-Encoding: gzip`, `br`, `deflate`, or `zstd`. The accepted encodings are also listed structurally in the `x-request-compression` extension.",
 		contact(name = "BES Developers", email = "contact@bes.au"),
 		license(name = "GPL-3.0-or-later"),
 	),
-	modifiers(&SecuritySchemes),
+	modifiers(&SecuritySchemes, &RequestCompression),
 	tags(
 		(name = "artifacts", description = "Per-version artifact registration by releaser devices."),
 		(name = "backup", description = "Device backup credential minting, target config, capability registration, and run reporting."),
@@ -26,6 +26,25 @@ use utoipa::{Modify, OpenApi, openapi::security::SecurityScheme};
 	),
 )]
 pub struct ApiDoc;
+
+/// Advertises the request-body Content-Encodings the server accepts as the
+/// top-level `x-request-compression` vendor extension. Sourced from
+/// [`commons_servers::request_compression_extension`] so it tracks the actual
+/// decompression layer.
+struct RequestCompression;
+
+impl Modify for RequestCompression {
+	fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+		openapi.extensions = Some(
+			utoipa::openapi::extensions::ExtensionsBuilder::new()
+				.add(
+					"x-request-compression",
+					commons_servers::request_compression_extension(),
+				)
+				.build(),
+		);
+	}
+}
 
 struct SecuritySchemes;
 

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "canopy private-server",
-    "description": "Admin/operator API for the canopy fleet manager. Requests are gated behind Tailscale auth; admin-only endpoints additionally check the caller is on the admin list.",
+    "description": "Admin/operator API for the canopy fleet manager. Requests are gated behind Tailscale auth; admin-only endpoints additionally check the caller is on the admin list.\n\nRequest bodies may be sent compressed, and this is recommended for large payloads: the server transparently decodes `Content-Encoding: gzip`, `br`, `deflate`, or `zstd`. The accepted encodings are also listed structurally in the `x-request-compression` extension.",
     "contact": {
       "name": "BES Developers",
       "email": "contact@bes.au"
@@ -11287,5 +11287,15 @@
       "name": "versions",
       "description": "Canopy release versions and downloadable artifacts."
     }
-  ]
+  ],
+  "x-request-compression": {
+    "accepted": [
+      "gzip",
+      "br",
+      "deflate",
+      "zstd"
+    ],
+    "header": "Content-Encoding",
+    "recommended": true
+  }
 }


### PR DESCRIPTION
The router already wraps every endpoint in tower-http's `RequestDecompressionLayer` (`decompression-full`), so clients can send compressed request bodies today — it just isn’t documented anywhere.

🤖 This advertises it in both OpenAPI specs:
- A note in each spec’s `info.description` that request bodies may be sent compressed (recommended for large payloads) and which encodings are decoded.
- A structured, machine-readable top-level `x-request-compression` extension listing the accepted `Content-Encoding` values and `recommended: true`.

OpenAPI 3.1 has no first-class field for request `Content-Encoding` negotiation (the `Content-Encoding` header is explicitly not describable as a parameter), hence the vendor extension alongside the prose.

The accepted-encoding list (`gzip`, `br`, `deflate`, `zstd`) and the extension value live in `commons-servers` next to the decompression layer, so what we advertise can’t drift from what the server actually decodes. Regenerated `openapi.json` for both servers via `just gen-openapi`; `api-types.ts` is unaffected (a top-level extension produces no TS types).