### PR TITLE
fix(openapi): unique operationIds + CI guard against duplicates

### DIFF
--- a/crates/private-server/tests/openapi_spec.rs
+++ b/crates/private-server/tests/openapi_spec.rs
@@ -86,3 +86,40 @@ fn spec_path_count() {
 		paths.len()
 	);
 }
+
+/// `operationId` must be unique across the whole document (OpenAPI requires it,
+/// and codegen/tooling keys off it). utoipa defaults an operation's id to the
+/// handler's function name, so two same-named handlers in different modules
+/// silently collide — set an explicit `operation_id` in the `#[utoipa::path]`
+/// to disambiguate.
+#[test]
+fn no_duplicate_operation_ids() {
+	let spec = build_spec();
+	let paths = spec["paths"].as_object().expect("paths object");
+
+	let mut by_id: std::collections::BTreeMap<String, Vec<String>> = Default::default();
+	for (path, item) in paths {
+		let ops = item.as_object().expect("path item object");
+		for (method, op) in ops {
+			// Non-operation keys (parameters, summary, …) aren't objects with
+			// an operationId, so they fall through this filter.
+			if let Some(id) = op.get("operationId").and_then(|v| v.as_str()) {
+				by_id
+					.entry(id.to_string())
+					.or_default()
+					.push(format!("{} {path}", method.to_uppercase()));
+			}
+		}
+	}
+
+	let dupes: Vec<String> = by_id
+		.iter()
+		.filter(|(_, uses)| uses.len() > 1)
+		.map(|(id, uses)| format!("{id}: {}", uses.join(", ")))
+		.collect();
+	assert!(
+		dupes.is_empty(),
+		"duplicate operationIds (invalid OpenAPI) — set an explicit `operation_id`:\n{}",
+		dupes.join("\n"),
+	);
+}

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -18,7 +18,7 @@
         "tags": [
           "artifacts"
         ],
-        "operationId": "create",
+        "operationId": "register_artifact",
         "parameters": [
           {
             "name": "version",
@@ -111,7 +111,7 @@
         "tags": [
           "backup"
         ],
-        "operationId": "capabilities",
+        "operationId": "register_backup_capabilities",
         "requestBody": {
           "content": {
             "application/json": {
@@ -159,7 +159,7 @@
         "tags": [
           "backup"
         ],
-        "operationId": "credentials",
+        "operationId": "mint_backup_credentials",
         "requestBody": {
           "content": {
             "application/json": {
@@ -363,7 +363,7 @@
         "tags": [
           "events"
         ],
-        "operationId": "create",
+        "operationId": "submit_event",
         "requestBody": {
           "content": {
             "application/json": {
@@ -438,7 +438,7 @@
         "tags": [
           "restore"
         ],
-        "operationId": "capabilities",
+        "operationId": "register_restore_capabilities",
         "requestBody": {
           "content": {
             "application/json": {
@@ -466,7 +466,7 @@
         "tags": [
           "restore"
         ],
-        "operationId": "credentials",
+        "operationId": "mint_restore_credentials",
         "requestBody": {
           "content": {
             "application/json": {
@@ -597,7 +597,7 @@
         "tags": [
           "servers"
         ],
-        "operationId": "list",
+        "operationId": "list_servers",
         "responses": {
           "200": {
             "description": "Publicly-listed central servers, ordered by rank then name.",
@@ -710,7 +710,7 @@
         "tags": [
           "statuses"
         ],
-        "operationId": "create",
+        "operationId": "submit_status",
         "parameters": [
           {
             "name": "server_id",
@@ -844,7 +844,7 @@
         "tags": [
           "versions"
         ],
-        "operationId": "list",
+        "operationId": "list_versions",
         "responses": {
           "200": {
             "description": "All published versions.",
@@ -911,7 +911,7 @@
         "tags": [
           "versions"
         ],
-        "operationId": "create",
+        "operationId": "create_version",
         "parameters": [
           {
             "name": "version",

--- a/crates/public-server/src/artifacts.rs
+++ b/crates/public-server/src/artifacts.rs
@@ -23,6 +23,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 #[utoipa::path(
 	post,
 	path = "/{version}/{artifact_type}/{platform}",
+	operation_id = "register_artifact",
 	tag = "artifacts",
 	security(("releaser-device" = [])),
 	params(

--- a/crates/public-server/src/backup.rs
+++ b/crates/public-server/src/backup.rs
@@ -141,6 +141,7 @@ pub struct CapabilitiesArgs {
 #[utoipa::path(
 	post,
 	path = "/backup-capabilities",
+	operation_id = "register_backup_capabilities",
 	tag = "backup",
 	security(("server-device" = [])),
 	request_body = CapabilitiesArgs,
@@ -285,6 +286,7 @@ pub fn backup_session_policy(bucket: &str, prefix: &str) -> String {
 #[utoipa::path(
 	post,
 	path = "/backup-credentials",
+	operation_id = "mint_backup_credentials",
 	tag = "backup",
 	security(("server-device" = [])),
 	request_body = CredentialsArgs,

--- a/crates/public-server/src/events.rs
+++ b/crates/public-server/src/events.rs
@@ -17,6 +17,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 #[utoipa::path(
 	post,
 	path = "/events",
+	operation_id = "submit_event",
 	tag = "events",
 	security(("server-device" = [])),
 	request_body = NewEvent,

--- a/crates/public-server/src/restore.rs
+++ b/crates/public-server/src/restore.rs
@@ -67,6 +67,7 @@ pub struct CapabilitiesArgs {
 #[utoipa::path(
 	post,
 	path = "/restore-capabilities",
+	operation_id = "register_restore_capabilities",
 	tag = "restore",
 	security(("backup-restore-device" = [])),
 	request_body = CapabilitiesArgs,
@@ -278,6 +279,7 @@ pub struct RestoreCredentials {
 #[utoipa::path(
 	post,
 	path = "/restore-credentials",
+	operation_id = "mint_restore_credentials",
 	tag = "restore",
 	security(("backup-restore-device" = [])),
 	request_body = CredentialsArgs,

--- a/crates/public-server/src/servers.rs
+++ b/crates/public-server/src/servers.rs
@@ -62,6 +62,7 @@ fn rank_order(rank: &Option<ServerRank>) -> u32 {
 #[utoipa::path(
 	get,
 	path = "/",
+	operation_id = "list_servers",
 	tag = "servers",
 	responses(
 		(status = 200, description = "Publicly-listed central servers, ordered by rank then name.", body = Vec<PublicServer>),

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -131,6 +131,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 #[utoipa::path(
 	post,
 	path = "/{server_id}",
+	operation_id = "submit_status",
 	tag = "statuses",
 	security(("server-device" = [])),
 	params(

--- a/crates/public-server/src/versions.rs
+++ b/crates/public-server/src/versions.rs
@@ -160,6 +160,7 @@ pub fn parse_markdown(text: &str) -> String {
 #[utoipa::path(
 	get,
 	path = "/",
+	operation_id = "list_versions",
 	tag = "versions",
 	responses(
 		(status = 200, description = "All published versions.", body = Vec<Version>),
@@ -175,6 +176,7 @@ async fn list(State(db): State<Db>) -> Result<Json<Vec<Version>>> {
 #[utoipa::path(
 	post,
 	path = "/{version}",
+	operation_id = "create_version",
 	tag = "versions",
 	security(("releaser-device" = [])),
 	params(("version" = String, Path)),

--- a/crates/public-server/tests/openapi_spec.rs
+++ b/crates/public-server/tests/openapi_spec.rs
@@ -69,6 +69,43 @@ fn committed_spec_matches_generated() {
 	);
 }
 
+/// `operationId` must be unique across the whole document (OpenAPI requires it,
+/// and codegen/tooling keys off it). utoipa defaults an operation's id to the
+/// handler's function name, so two same-named handlers in different modules
+/// (e.g. several `create`s) silently collide — set an explicit `operation_id`
+/// in the `#[utoipa::path]` to disambiguate.
+#[test]
+fn no_duplicate_operation_ids() {
+	let spec = build_spec();
+	let paths = spec["paths"].as_object().expect("paths object");
+
+	let mut by_id: std::collections::BTreeMap<String, Vec<String>> = Default::default();
+	for (path, item) in paths {
+		let ops = item.as_object().expect("path item object");
+		for (method, op) in ops {
+			// Non-operation keys (parameters, summary, …) aren't objects with
+			// an operationId, so they fall through this filter.
+			if let Some(id) = op.get("operationId").and_then(|v| v.as_str()) {
+				by_id
+					.entry(id.to_string())
+					.or_default()
+					.push(format!("{} {path}", method.to_uppercase()));
+			}
+		}
+	}
+
+	let dupes: Vec<String> = by_id
+		.iter()
+		.filter(|(_, uses)| uses.len() > 1)
+		.map(|(id, uses)| format!("{id}: {}", uses.join(", ")))
+		.collect();
+	assert!(
+		dupes.is_empty(),
+		"duplicate operationIds (invalid OpenAPI) — set an explicit `operation_id`:\n{}",
+		dupes.join("\n"),
+	);
+}
+
 #[test]
 fn spec_excludes_html_and_streaming_routes() {
 	let spec = build_spec();


### PR DESCRIPTION
utoipa defaults an operation’s `operationId` to the handler’s function name, so same-named handlers in different modules collided in the public-server spec. Duplicate operationIds are invalid OpenAPI and break codegen/tooling that keys off them.

🤖 The collisions were all in the public spec:
- `create` ×4 → `register_artifact`, `submit_event`, `submit_status`, `create_version`
- `list` ×2 → `list_versions`, `list_servers`
- `credentials` ×2 → `mint_backup_credentials`, `mint_restore_credentials`
- `capabilities` ×2 → `register_backup_capabilities`, `register_restore_capabilities`

Each now sets an explicit `operation_id` in its `#[utoipa::path]`; the spec is regenerated. The private spec was already collision-free.

To stop this recurring, both `crates/public-server/tests/openapi_spec.rs` and `crates/private-server/tests/openapi_spec.rs` gain a `no_duplicate_operation_ids` test that walks the generated document and fails if any operationId is used twice — so it’s caught by `just test` in CI, alongside the existing drift check.

`api-types.ts` is unaffected (it derives from the private spec, which didn’t change).