### PR TITLE
fix(openapi): give colliding request/response schemas unique names

### DIFF
--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -167,7 +167,7 @@ pub struct BackupConfigSummary {
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct GroupArgs {
+pub struct BackupsGroupArgs {
 	pub server_group_id: Uuid,
 }
 
@@ -380,7 +380,7 @@ pub struct SetCapabilityArgs {
 	operation_id = "backups_get",
 	tag = "backups",
 	security(("tailscale-user" = [])),
-	request_body = GroupArgs,
+	request_body = BackupsGroupArgs,
 	responses(
 		(status = 200, body = Option<BackupConfigView>),
 		(status = 404, body = ProblemDetailsSchema),
@@ -388,7 +388,7 @@ pub struct SetCapabilityArgs {
 )]
 pub async fn get(
 	State(state): State<AppState>,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<BackupsGroupArgs>,
 ) -> Result<Json<Option<BackupConfigView>>> {
 	let mut conn = state.db.get().await?;
 	// 404 if the group itself is missing.
@@ -965,12 +965,12 @@ pub struct GroupTypeScheduleView {
 	operation_id = "backups_group_schedules",
 	tag = "backups",
 	security(("tailscale-user" = [])),
-	request_body = GroupArgs,
+	request_body = BackupsGroupArgs,
 	responses((status = 200, body = Vec<GroupTypeScheduleView>)),
 )]
 pub async fn group_schedules(
 	State(state): State<AppState>,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<BackupsGroupArgs>,
 ) -> Result<Json<Vec<GroupTypeScheduleView>>> {
 	let mut conn = state.db.get().await?;
 	let types =
@@ -1141,7 +1141,7 @@ pub async fn set_type_default(
 	operation_id = "backups_create_repo",
 	tag = "backups",
 	security(("tailscale-admin" = [])),
-	request_body = GroupArgs,
+	request_body = BackupsGroupArgs,
 	responses(
 		(status = 200, body = BackupConfigView),
 		(status = 404, body = ProblemDetailsSchema),
@@ -1151,7 +1151,7 @@ pub async fn set_type_default(
 pub async fn create_repo(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<BackupsGroupArgs>,
 ) -> Result<Json<BackupConfigView>> {
 	let mut conn = state.db.get().await?;
 	let config = require_config(&mut conn, args.server_group_id).await?;
@@ -1222,7 +1222,7 @@ pub async fn cancel_request(
 	operation_id = "backups_request_maintenance",
 	tag = "backups",
 	security(("tailscale-admin" = [])),
-	request_body = GroupArgs,
+	request_body = BackupsGroupArgs,
 	responses(
 		(status = 200, body = BackupConfigView),
 		(status = 404, body = ProblemDetailsSchema),
@@ -1232,7 +1232,7 @@ pub async fn cancel_request(
 pub async fn request_maintenance(
 	State(state): State<AppState>,
 	TailscaleAdmin(admin): TailscaleAdmin,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<BackupsGroupArgs>,
 ) -> Result<Json<BackupConfigView>> {
 	let mut conn = state.db.get().await?;
 	let config = require_config(&mut conn, args.server_group_id).await?;
@@ -1258,7 +1258,7 @@ pub async fn request_maintenance(
 	operation_id = "backups_cancel_maintenance",
 	tag = "backups",
 	security(("tailscale-admin" = [])),
-	request_body = GroupArgs,
+	request_body = BackupsGroupArgs,
 	responses(
 		(status = 200, body = BackupConfigView),
 		(status = 404, body = ProblemDetailsSchema),
@@ -1267,7 +1267,7 @@ pub async fn request_maintenance(
 pub async fn cancel_maintenance(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<BackupsGroupArgs>,
 ) -> Result<Json<BackupConfigView>> {
 	let mut conn = state.db.get().await?;
 	let config = require_config(&mut conn, args.server_group_id).await?;
@@ -1284,7 +1284,7 @@ pub async fn cancel_maintenance(
 	operation_id = "backups_stats",
 	tag = "backups",
 	security(("tailscale-user" = [])),
-	request_body = GroupArgs,
+	request_body = BackupsGroupArgs,
 	responses(
 		(status = 200, body = BackupStatsView),
 		(status = 404, body = ProblemDetailsSchema),
@@ -1292,7 +1292,7 @@ pub async fn cancel_maintenance(
 )]
 pub async fn stats(
 	State(state): State<AppState>,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<BackupsGroupArgs>,
 ) -> Result<Json<BackupStatsView>> {
 	let mut conn = state.db.get().await?;
 	let group = ServerGroup::get_by_id(&mut conn, args.server_group_id).await?;
@@ -1469,13 +1469,13 @@ pub async fn set_capability(
 	operation_id = "backups_delete",
 	tag = "backups",
 	security(("tailscale-admin" = [])),
-	request_body = GroupArgs,
+	request_body = BackupsGroupArgs,
 	responses((status = 200), (status = 404, body = ProblemDetailsSchema)),
 )]
 pub async fn delete(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<BackupsGroupArgs>,
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
 	let config = require_config(&mut conn, args.server_group_id).await?;

--- a/crates/private-server/src/fns/bestool.rs
+++ b/crates/private-server/src/fns/bestool.rs
@@ -36,7 +36,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct ListArgs {
+pub struct BestoolListArgs {
 	pub offset: u64,
 	pub limit: Option<u64>,
 }
@@ -45,7 +45,7 @@ pub struct ListArgs {
 	post,
 	path = "/list_snippets",
 	tag = "bestool",
-	request_body = ListArgs,
+	request_body = BestoolListArgs,
 	responses(
 		(status = 200, body = Page<BestoolSnippetInfo>),
 		(status = 500, body = ProblemDetailsSchema),
@@ -53,7 +53,7 @@ pub struct ListArgs {
 )]
 pub async fn list_snippets(
 	State(state): State<AppState>,
-	Json(args): Json<ListArgs>,
+	Json(args): Json<BestoolListArgs>,
 ) -> Result<Json<Page<BestoolSnippetInfo>>> {
 	let mut conn = state.db.get().await?;
 	let total = database::BestoolSnippet::count_current(&mut conn).await? as u64;

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -677,7 +677,7 @@ pub async fn reactivate_key(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct SearchArgs {
+pub struct DeviceSearchArgs {
 	pub query: String,
 }
 
@@ -687,7 +687,7 @@ pub struct SearchArgs {
 	operation_id = "device_search",
 	tag = "devices",
 	security(("tailscale-admin" = [])),
-	request_body = SearchArgs,
+	request_body = DeviceSearchArgs,
 	responses(
 		(status = 200, body = Vec<DeviceInfo>),
 	),
@@ -695,7 +695,7 @@ pub struct SearchArgs {
 pub async fn search(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<SearchArgs>,
+	Json(args): Json<DeviceSearchArgs>,
 ) -> Result<Json<Vec<DeviceInfo>>> {
 	if args.query.trim().is_empty() {
 		return Ok(Json(vec![]));

--- a/crates/private-server/src/fns/healthchecks.rs
+++ b/crates/private-server/src/fns/healthchecks.rs
@@ -104,7 +104,7 @@ pub async fn list(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct UpdateArgs {
+pub struct HealthcheckUpdateArgs {
 	pub check_name: String,
 	pub severity: Severity,
 	/// Optional operator notes. `None` leaves the existing notes alone…
@@ -120,7 +120,7 @@ pub struct UpdateArgs {
 	operation_id = "healthcheck_update",
 	tag = "healthchecks",
 	security(("tailscale-admin" = [])),
-	request_body = UpdateArgs,
+	request_body = HealthcheckUpdateArgs,
 	responses(
 		(status = 200, description = "Updated catalog row.", body = HealthcheckSeverityData),
 		(status = 401, body = ProblemDetailsSchema),
@@ -130,7 +130,7 @@ pub struct UpdateArgs {
 pub async fn update(
 	State(state): State<AppState>,
 	admin: TailscaleAdmin,
-	Json(args): Json<UpdateArgs>,
+	Json(args): Json<HealthcheckUpdateArgs>,
 ) -> Result<Json<HealthcheckSeverityData>> {
 	let mut conn = state.db.get().await?;
 	let row = HealthcheckSeverity::update(

--- a/crates/private-server/src/fns/incidents.rs
+++ b/crates/private-server/src/fns/incidents.rs
@@ -170,7 +170,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct ListForServerArgs {
+pub struct IncidentListForServerArgs {
 	pub server_id: Uuid,
 	#[serde(default)]
 	pub include_closed: Option<bool>,
@@ -184,7 +184,7 @@ pub struct ListForServerArgs {
 	operation_id = "incident_list_for_server",
 	tag = "incidents",
 	security(("tailscale-user" = [])),
-	request_body = ListForServerArgs,
+	request_body = IncidentListForServerArgs,
 	responses(
 		(status = 200, body = Vec<IncidentData>),
 	),
@@ -192,7 +192,7 @@ pub struct ListForServerArgs {
 pub async fn list_for_server(
 	State(state): State<AppState>,
 	_user: TailscaleUser,
-	Json(args): Json<ListForServerArgs>,
+	Json(args): Json<IncidentListForServerArgs>,
 ) -> Result<Json<Vec<IncidentData>>> {
 	let mut conn = state.db.get().await?;
 	let incidents = Incident::list_for_server(
@@ -383,7 +383,7 @@ impl From<IncidentNote> for IncidentNoteData {
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct AddNoteArgs {
+pub struct IncidentAddNoteArgs {
 	pub incident_id: Uuid,
 	pub body: String,
 }
@@ -394,7 +394,7 @@ pub struct AddNoteArgs {
 	operation_id = "incident_add_note",
 	tag = "incidents",
 	security(("tailscale-admin" = [])),
-	request_body = AddNoteArgs,
+	request_body = IncidentAddNoteArgs,
 	responses(
 		(status = 200, body = IncidentNoteData),
 		(status = 400, body = ProblemDetailsSchema),
@@ -403,7 +403,7 @@ pub struct AddNoteArgs {
 pub async fn add_note(
 	State(state): State<AppState>,
 	admin: TailscaleAdmin,
-	Json(args): Json<AddNoteArgs>,
+	Json(args): Json<IncidentAddNoteArgs>,
 ) -> Result<Json<IncidentNoteData>> {
 	if args.body.trim().is_empty() {
 		return Err(AppError::custom("note body is required"));
@@ -414,7 +414,7 @@ pub async fn add_note(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct ListNotesArgs {
+pub struct IncidentListNotesArgs {
 	pub incident_id: Uuid,
 	#[serde(default)]
 	pub limit: Option<i64>,
@@ -426,7 +426,7 @@ pub struct ListNotesArgs {
 	operation_id = "incident_list_notes",
 	tag = "incidents",
 	security(("tailscale-user" = [])),
-	request_body = ListNotesArgs,
+	request_body = IncidentListNotesArgs,
 	responses(
 		(status = 200, body = Vec<IncidentNoteData>),
 	),
@@ -434,7 +434,7 @@ pub struct ListNotesArgs {
 pub async fn list_notes(
 	State(state): State<AppState>,
 	_user: TailscaleUser,
-	Json(args): Json<ListNotesArgs>,
+	Json(args): Json<IncidentListNotesArgs>,
 ) -> Result<Json<Vec<IncidentNoteData>>> {
 	let mut conn = state.db.get().await?;
 	let notes = IncidentNote::list_for_incident(
@@ -449,7 +449,7 @@ pub async fn list_notes(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct DeleteNoteArgs {
+pub struct IncidentDeleteNoteArgs {
 	pub note_id: Uuid,
 }
 
@@ -459,7 +459,7 @@ pub struct DeleteNoteArgs {
 	operation_id = "incident_delete_note",
 	tag = "incidents",
 	security(("tailscale-admin" = [])),
-	request_body = DeleteNoteArgs,
+	request_body = IncidentDeleteNoteArgs,
 	responses(
 		(status = 200),
 	),
@@ -467,7 +467,7 @@ pub struct DeleteNoteArgs {
 pub async fn delete_note(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<DeleteNoteArgs>,
+	Json(args): Json<IncidentDeleteNoteArgs>,
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
 	IncidentNote::delete(&mut conn, args.note_id).await?;

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -287,7 +287,7 @@ fn filter_from(active_only: Option<bool>) -> IssueFilter {
 
 #[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct ListArgs {
+pub struct IssueListArgs {
 	#[serde(default)]
 	pub active_only: Option<bool>,
 	#[serde(default)]
@@ -305,7 +305,7 @@ pub struct ListArgs {
 	operation_id = "issue_list",
 	tag = "issues",
 	security(("tailscale-user" = [])),
-	request_body = ListArgs,
+	request_body = IssueListArgs,
 	responses(
 		(status = 200, body = Vec<IssueData>),
 	),
@@ -313,7 +313,7 @@ pub struct ListArgs {
 pub async fn list(
 	State(state): State<AppState>,
 	_user: TailscaleUser,
-	Json(args): Json<ListArgs>,
+	Json(args): Json<IssueListArgs>,
 ) -> Result<Json<Vec<IssueData>>> {
 	let mut conn = state.db.get().await?;
 	let issues = Issue::list(
@@ -366,7 +366,7 @@ pub async fn list_for_device(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct ListForServerArgs {
+pub struct IssueListForServerArgs {
 	pub server_id: Uuid,
 	#[serde(default)]
 	pub active_only: Option<bool>,
@@ -380,7 +380,7 @@ pub struct ListForServerArgs {
 	operation_id = "issue_list_for_server",
 	tag = "issues",
 	security(("tailscale-user" = [])),
-	request_body = ListForServerArgs,
+	request_body = IssueListForServerArgs,
 	responses(
 		(status = 200, body = Vec<IssueData>),
 	),
@@ -388,7 +388,7 @@ pub struct ListForServerArgs {
 pub async fn list_for_server(
 	State(state): State<AppState>,
 	_user: TailscaleUser,
-	Json(args): Json<ListForServerArgs>,
+	Json(args): Json<IssueListForServerArgs>,
 ) -> Result<Json<Vec<IssueData>>> {
 	let mut conn = state.db.get().await?;
 	let issues = Issue::list_for_server(
@@ -495,7 +495,7 @@ pub struct IssueIdArgs {
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct ResolveArgs {
+pub struct IssueResolveArgs {
 	pub issue_id: Uuid,
 	pub reason: ResolvedReason,
 }
@@ -506,7 +506,7 @@ pub struct ResolveArgs {
 	operation_id = "issue_resolve",
 	tag = "issues",
 	security(("tailscale-admin" = [])),
-	request_body = ResolveArgs,
+	request_body = IssueResolveArgs,
 	responses(
 		(status = 200, body = IssueData),
 	),
@@ -514,7 +514,7 @@ pub struct ResolveArgs {
 pub async fn resolve(
 	State(state): State<AppState>,
 	admin: TailscaleAdmin,
-	Json(args): Json<ResolveArgs>,
+	Json(args): Json<IssueResolveArgs>,
 ) -> Result<Json<IssueData>> {
 	let mut conn = state.db.get().await?;
 	let issue = Issue::resolve(&mut conn, args.issue_id, &admin.0.login, args.reason).await?;
@@ -612,7 +612,7 @@ impl From<IssueNote> for IssueNoteData {
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct AddNoteArgs {
+pub struct IssueAddNoteArgs {
 	pub issue_id: Uuid,
 	pub body: String,
 }
@@ -623,7 +623,7 @@ pub struct AddNoteArgs {
 	operation_id = "issue_add_note",
 	tag = "issues",
 	security(("tailscale-admin" = [])),
-	request_body = AddNoteArgs,
+	request_body = IssueAddNoteArgs,
 	responses(
 		(status = 200, body = IssueNoteData),
 		(status = 400, body = ProblemDetailsSchema),
@@ -632,7 +632,7 @@ pub struct AddNoteArgs {
 pub async fn add_note(
 	State(state): State<AppState>,
 	admin: TailscaleAdmin,
-	Json(args): Json<AddNoteArgs>,
+	Json(args): Json<IssueAddNoteArgs>,
 ) -> Result<Json<IssueNoteData>> {
 	if args.body.trim().is_empty() {
 		return Err(AppError::custom("note body is required"));
@@ -643,7 +643,7 @@ pub async fn add_note(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct ListNotesArgs {
+pub struct IssueListNotesArgs {
 	pub issue_id: Uuid,
 	#[serde(default)]
 	pub limit: Option<i64>,
@@ -655,7 +655,7 @@ pub struct ListNotesArgs {
 	operation_id = "issue_list_notes",
 	tag = "issues",
 	security(("tailscale-user" = [])),
-	request_body = ListNotesArgs,
+	request_body = IssueListNotesArgs,
 	responses(
 		(status = 200, body = Vec<IssueNoteData>),
 	),
@@ -663,7 +663,7 @@ pub struct ListNotesArgs {
 pub async fn list_notes(
 	State(state): State<AppState>,
 	_user: TailscaleUser,
-	Json(args): Json<ListNotesArgs>,
+	Json(args): Json<IssueListNotesArgs>,
 ) -> Result<Json<Vec<IssueNoteData>>> {
 	let mut conn = state.db.get().await?;
 	let notes = IssueNote::list_for_issue(
@@ -676,7 +676,7 @@ pub async fn list_notes(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct DeleteNoteArgs {
+pub struct IssueDeleteNoteArgs {
 	pub note_id: Uuid,
 }
 
@@ -686,7 +686,7 @@ pub struct DeleteNoteArgs {
 	operation_id = "issue_delete_note",
 	tag = "issues",
 	security(("tailscale-admin" = [])),
-	request_body = DeleteNoteArgs,
+	request_body = IssueDeleteNoteArgs,
 	responses(
 		(status = 200),
 	),
@@ -694,7 +694,7 @@ pub struct DeleteNoteArgs {
 pub async fn delete_note(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<DeleteNoteArgs>,
+	Json(args): Json<IssueDeleteNoteArgs>,
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
 	IssueNote::delete(&mut conn, args.note_id).await?;

--- a/crates/private-server/src/fns/restore_replicas.rs
+++ b/crates/private-server/src/fns/restore_replicas.rs
@@ -83,12 +83,12 @@ pub struct RestoreConsumerView {
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct GroupArgs {
+pub struct RestoreReplicasGroupArgs {
 	pub server_group_id: Uuid,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CreateArgs {
+pub struct RestoreReplicasCreateArgs {
 	pub consumer_device_id: Uuid,
 	pub group_id: Uuid,
 	/// `None` = all current servers in the group.
@@ -107,7 +107,7 @@ pub struct CreateArgs {
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct UpdateArgs {
+pub struct RestoreReplicasUpdateArgs {
 	pub id: Uuid,
 	pub name: String,
 	pub overdue_after_seconds: Option<i64>,
@@ -207,12 +207,12 @@ async fn to_views(
 	operation_id = "restore_replicas_for_group",
 	tag = "restore_replicas",
 	security(("tailscale-user" = [])),
-	request_body = GroupArgs,
+	request_body = RestoreReplicasGroupArgs,
 	responses((status = 200, body = Vec<RestoreReplicaView>)),
 )]
 pub async fn for_group(
 	State(state): State<AppState>,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<RestoreReplicasGroupArgs>,
 ) -> Result<Json<Vec<RestoreReplicaView>>> {
 	let mut conn = state.db.get().await?;
 	let replicas = RestoreReplica::list_for_group(&mut conn, args.server_group_id).await?;
@@ -248,12 +248,12 @@ pub async fn consumers(State(state): State<AppState>) -> Result<Json<Vec<Restore
 	operation_id = "restore_replicas_checks",
 	tag = "restore_replicas",
 	security(("tailscale-user" = [])),
-	request_body = GroupArgs,
+	request_body = RestoreReplicasGroupArgs,
 	responses((status = 200, body = Vec<BackupRestoreCheck>)),
 )]
 pub async fn checks(
 	State(state): State<AppState>,
-	Json(args): Json<GroupArgs>,
+	Json(args): Json<RestoreReplicasGroupArgs>,
 ) -> Result<Json<Vec<BackupRestoreCheck>>> {
 	let mut conn = state.db.get().await?;
 	let rows =
@@ -267,7 +267,7 @@ pub async fn checks(
 	operation_id = "restore_replicas_create",
 	tag = "restore_replicas",
 	security(("tailscale-admin" = [])),
-	request_body = CreateArgs,
+	request_body = RestoreReplicasCreateArgs,
 	responses(
 		(status = 200, body = RestoreReplicaView),
 		(status = 409, description = "A matching declaration already exists.", body = ProblemDetailsSchema),
@@ -276,7 +276,7 @@ pub async fn checks(
 pub async fn create(
 	State(state): State<AppState>,
 	TailscaleAdmin(admin): TailscaleAdmin,
-	Json(args): Json<CreateArgs>,
+	Json(args): Json<RestoreReplicasCreateArgs>,
 ) -> Result<Json<RestoreReplicaView>> {
 	let mut conn = state.db.get().await?;
 	validate_params_for_intent(
@@ -311,7 +311,7 @@ pub async fn create(
 	operation_id = "restore_replicas_update",
 	tag = "restore_replicas",
 	security(("tailscale-admin" = [])),
-	request_body = UpdateArgs,
+	request_body = RestoreReplicasUpdateArgs,
 	responses(
 		(status = 200, body = RestoreReplicaView),
 		(status = 404, body = ProblemDetailsSchema),
@@ -320,7 +320,7 @@ pub async fn create(
 pub async fn update(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<UpdateArgs>,
+	Json(args): Json<RestoreReplicasUpdateArgs>,
 ) -> Result<Json<RestoreReplicaView>> {
 	let mut conn = state.db.get().await?;
 	// Validate parameter values against the intent's schema. Scope fields are

--- a/crates/private-server/src/fns/self_alerts.rs
+++ b/crates/private-server/src/fns/self_alerts.rs
@@ -107,7 +107,7 @@ pub async fn list(
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct ResolveArgs {
+pub struct SelfAlertsResolveArgs {
 	pub id: Uuid,
 }
 
@@ -117,7 +117,7 @@ pub struct ResolveArgs {
 	operation_id = "self_alerts_resolve",
 	tag = "self_alerts",
 	security(("tailscale-admin" = [])),
-	request_body = ResolveArgs,
+	request_body = SelfAlertsResolveArgs,
 	responses(
 		(status = 200, description = "Alert marked operator-resolved; a pending notification is cancelled."),
 		(status = 401, body = ProblemDetailsSchema),
@@ -128,7 +128,7 @@ pub struct ResolveArgs {
 pub async fn resolve(
 	State(state): State<AppState>,
 	TailscaleAdmin(admin): TailscaleAdmin,
-	Json(args): Json<ResolveArgs>,
+	Json(args): Json<SelfAlertsResolveArgs>,
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
 	Issue::resolve(&mut conn, args.id, &admin.login, ResolvedReason::Fixed).await?;

--- a/crates/private-server/src/fns/server_groups.rs
+++ b/crates/private-server/src/fns/server_groups.rs
@@ -162,7 +162,7 @@ pub async fn get(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct CreateArgs {
+pub struct ServerGroupsCreateArgs {
 	pub name: String,
 	#[serde(default)]
 	pub notes: String,
@@ -181,7 +181,7 @@ pub struct CreateArgs {
 	operation_id = "server_groups_create",
 	tag = "server_groups",
 	security(("tailscale-admin" = [])),
-	request_body = CreateArgs,
+	request_body = ServerGroupsCreateArgs,
 	responses(
 		(status = 200, body = ServerGroup),
 		(status = 400, body = ProblemDetailsSchema),
@@ -190,7 +190,7 @@ pub struct CreateArgs {
 pub async fn create(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<CreateArgs>,
+	Json(args): Json<ServerGroupsCreateArgs>,
 ) -> Result<Json<ServerGroup>> {
 	let mut conn = state.db.get().await?;
 	let group = ServerGroup::create(
@@ -207,7 +207,7 @@ pub async fn create(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct UpdateArgs {
+pub struct ServerGroupsUpdateArgs {
 	pub server_group_id: Uuid,
 	pub data: PartialServerGroup,
 }
@@ -218,7 +218,7 @@ pub struct UpdateArgs {
 	operation_id = "server_groups_update",
 	tag = "server_groups",
 	security(("tailscale-admin" = [])),
-	request_body = UpdateArgs,
+	request_body = ServerGroupsUpdateArgs,
 	responses(
 		(status = 200, body = ServerGroup),
 		(status = 400, body = ProblemDetailsSchema),
@@ -228,7 +228,7 @@ pub struct UpdateArgs {
 pub async fn update(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<UpdateArgs>,
+	Json(args): Json<ServerGroupsUpdateArgs>,
 ) -> Result<Json<ServerGroup>> {
 	let mut conn = state.db.get().await?;
 	let group = ServerGroup::update(&mut conn, args.server_group_id, args.data).await?;
@@ -302,7 +302,7 @@ pub async fn list_archived(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct SearchArgs {
+pub struct ServerGroupsSearchArgs {
 	pub query: String,
 }
 
@@ -312,14 +312,14 @@ pub struct SearchArgs {
 	operation_id = "server_groups_search",
 	tag = "server_groups",
 	security(("tailscale-user" = [])),
-	request_body = SearchArgs,
+	request_body = ServerGroupsSearchArgs,
 	responses(
 		(status = 200, body = Vec<ServerGroup>),
 	),
 )]
 pub async fn search(
 	State(state): State<AppState>,
-	Json(args): Json<SearchArgs>,
+	Json(args): Json<ServerGroupsSearchArgs>,
 ) -> Result<Json<Vec<ServerGroup>>> {
 	let mut conn = state.db.get().await?;
 	let groups = ServerGroup::search(&mut conn, &args.query).await?;

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -297,7 +297,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct ListArgs {
+pub struct ServerListArgs {
 	pub kind: Option<ServerKind>,
 	pub offset: u64,
 	pub limit: Option<u64>,
@@ -307,14 +307,14 @@ pub struct ListArgs {
 	post,
 	path = "/list_some",
 	tag = "servers",
-	request_body = ListArgs,
+	request_body = ServerListArgs,
 	responses(
 		(status = 200, body = Page<ServerInfo>),
 	),
 )]
 pub async fn list_some(
 	State(state): State<AppState>,
-	Json(args): Json<ListArgs>,
+	Json(args): Json<ServerListArgs>,
 ) -> Result<Json<Page<ServerInfo>>> {
 	let mut conn = state.db.get().await?;
 	let total = if let Some(kind) = args.kind {
@@ -603,7 +603,7 @@ pub async fn get_detail(
 }
 
 #[derive(Deserialize, ToSchema)]
-pub struct UpdateArgs {
+pub struct ServerUpdateArgs {
 	pub server_id: Uuid,
 	pub data: ServerDataUpdate,
 }
@@ -614,7 +614,7 @@ pub struct UpdateArgs {
 	operation_id = "server_update",
 	tag = "servers",
 	security(("tailscale-admin" = [])),
-	request_body = UpdateArgs,
+	request_body = ServerUpdateArgs,
 	responses(
 		(status = 200),
 		(status = 400, body = ProblemDetailsSchema),
@@ -623,7 +623,7 @@ pub struct UpdateArgs {
 pub async fn update(
 	State(state): State<AppState>,
 	_admin: TailscaleAdmin,
-	Json(args): Json<UpdateArgs>,
+	Json(args): Json<ServerUpdateArgs>,
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
 

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -116,7 +116,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CapabilitiesArgs"
+                "$ref": "#/components/schemas/BackupCapabilitiesArgs"
               }
             }
           },
@@ -164,7 +164,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CredentialsArgs"
+                "$ref": "#/components/schemas/BackupCredentialsArgs"
               }
             }
           },
@@ -443,7 +443,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CapabilitiesArgs"
+                "$ref": "#/components/schemas/RestoreCapabilitiesArgs"
               }
             }
           },
@@ -471,7 +471,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CredentialsArgs"
+                "$ref": "#/components/schemas/RestoreCredentialsArgs"
               }
             }
           },
@@ -1159,6 +1159,37 @@
           "type": "string"
         }
       },
+      "BackupCapabilitiesArgs": {
+        "type": "object",
+        "required": [
+          "types"
+        ],
+        "properties": {
+          "types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The backup types bestool can run on this server."
+          }
+        }
+      },
+      "BackupCredentialsArgs": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "purpose": {
+            "$ref": "#/components/schemas/BackupPurpose",
+            "description": "`backup` (default) grants write-without-delete; `restore` is downscoped\nread-only via a session policy."
+          },
+          "type": {
+            "type": "string",
+            "description": "The backup type these creds are for. Must be an enabled capability or\nhave a pending request of this `purpose` (an on-demand backup/restore)."
+          }
+        }
+      },
       "BackupPurpose": {
         "type": "string",
         "description": "Why a credential was issued / a run executed. A real capability gate\non the issued S3 creds, not just audit metadata: `Backup` grants\nwrite-without-delete, `Restore` grants read-only.",
@@ -1235,21 +1266,6 @@
           "nonce": {
             "type": "string",
             "description": "Base64 (standard) of the 32-byte challenge nonce."
-          }
-        }
-      },
-      "CapabilitiesArgs": {
-        "type": "object",
-        "required": [
-          "types"
-        ],
-        "properties": {
-          "types": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "The backup types bestool can run on this server."
           }
         }
       },
@@ -1339,22 +1355,6 @@
             "format": "int32",
             "description": "Always the literal `1`.",
             "minimum": 0
-          }
-        }
-      },
-      "CredentialsArgs": {
-        "type": "object",
-        "required": [
-          "type"
-        ],
-        "properties": {
-          "purpose": {
-            "$ref": "#/components/schemas/BackupPurpose",
-            "description": "`backup` (default) grants write-without-delete; `restore` is downscoped\nread-only via a session policy."
-          },
-          "type": {
-            "type": "string",
-            "description": "The backup type these creds are for. Must be an enabled capability or\nhave a pending request of this `purpose` (an on-demand backup/restore)."
           }
         }
       },
@@ -1729,6 +1729,21 @@
           }
         }
       },
+      "RestoreCapabilitiesArgs": {
+        "type": "object",
+        "required": [
+          "intents"
+        ],
+        "properties": {
+          "intents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntentDescriptor"
+            },
+            "description": "The intents this consumer can satisfy, each with its description, the\nCanopy semantics it opts into, and its parameter schema. Replaces the\nconsumer's advertised set wholesale."
+          }
+        }
+      },
       "RestoreCredentials": {
         "type": "object",
         "description": "Read-only credentials plus the repo password for one `(group, type)`. The\nAWS creds are the `credential_process` shape the consumer's proxy refreshes;\nthe password opens the kopia repo.",
@@ -1743,6 +1758,24 @@
           "repo_password": {
             "type": "string",
             "description": "The kopia repo passphrase, read from the group's k8s Secret."
+          }
+        }
+      },
+      "RestoreCredentialsArgs": {
+        "type": "object",
+        "required": [
+          "group",
+          "type"
+        ],
+        "properties": {
+          "group": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group whose repo to read."
+          },
+          "type": {
+            "type": "string",
+            "description": "The backup type to restore."
           }
         }
       },

--- a/crates/public-server/src/backup.rs
+++ b/crates/public-server/src/backup.rs
@@ -132,7 +132,7 @@ async fn require_issuable_capability(
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CapabilitiesArgs {
+pub struct BackupCapabilitiesArgs {
 	/// The backup types bestool can run on this server.
 	#[schema(value_type = Vec<String>)]
 	pub types: Vec<BackupType>,
@@ -144,7 +144,7 @@ pub struct CapabilitiesArgs {
 	operation_id = "register_backup_capabilities",
 	tag = "backup",
 	security(("server-device" = [])),
-	request_body = CapabilitiesArgs,
+	request_body = BackupCapabilitiesArgs,
 	responses(
 		(status = 204, description = "Capabilities registered."),
 		(status = 412, description = "Device is not bound to a live server.", body = ProblemDetailsSchema),
@@ -154,7 +154,7 @@ pub struct CapabilitiesArgs {
 async fn capabilities(
 	State(db): State<Db>,
 	device: ServerDevice,
-	Json(args): Json<CapabilitiesArgs>,
+	Json(args): Json<BackupCapabilitiesArgs>,
 ) -> Result<StatusCode> {
 	let mut conn = db.get().await?;
 	let device_id = device.0.0.id;
@@ -182,7 +182,7 @@ async fn capabilities(
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CredentialsArgs {
+pub struct BackupCredentialsArgs {
 	/// The backup type these creds are for. Must be an enabled capability or
 	/// have a pending request of this `purpose` (an on-demand backup/restore).
 	#[schema(value_type = String)]
@@ -289,7 +289,7 @@ pub fn backup_session_policy(bucket: &str, prefix: &str) -> String {
 	operation_id = "mint_backup_credentials",
 	tag = "backup",
 	security(("server-device" = [])),
-	request_body = CredentialsArgs,
+	request_body = BackupCredentialsArgs,
 	responses(
 		(status = 200, body = CredentialProcessOutput),
 		(status = 409, description = "Server ungrouped, no ready config, or type not enabled.", body = ProblemDetailsSchema),
@@ -301,7 +301,7 @@ async fn credentials(
 	State(db): State<Db>,
 	State(sts): State<Option<aws_sdk_sts::Client>>,
 	device: ServerDevice,
-	Json(args): Json<CredentialsArgs>,
+	Json(args): Json<BackupCredentialsArgs>,
 ) -> Result<Json<CredentialProcessOutput>> {
 	let mut conn = db.get().await?;
 	let device_id = device.0.0.id;

--- a/crates/public-server/src/restore.rs
+++ b/crates/public-server/src/restore.rs
@@ -57,7 +57,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CapabilitiesArgs {
+pub struct RestoreCapabilitiesArgs {
 	/// The intents this consumer can satisfy, each with its description, the
 	/// Canopy semantics it opts into, and its parameter schema. Replaces the
 	/// consumer's advertised set wholesale.
@@ -70,13 +70,13 @@ pub struct CapabilitiesArgs {
 	operation_id = "register_restore_capabilities",
 	tag = "restore",
 	security(("backup-restore-device" = [])),
-	request_body = CapabilitiesArgs,
+	request_body = RestoreCapabilitiesArgs,
 	responses((status = 204, description = "Capability set registered.")),
 )]
 async fn capabilities(
 	State(db): State<Db>,
 	device: BackupRestoreDevice,
-	Json(args): Json<CapabilitiesArgs>,
+	Json(args): Json<RestoreCapabilitiesArgs>,
 ) -> Result<StatusCode> {
 	let mut conn = db.get().await?;
 	let consumer_device_id = device.0.0.id;
@@ -258,7 +258,7 @@ async fn worklist(
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CredentialsArgs {
+pub struct RestoreCredentialsArgs {
 	/// The group whose repo to read.
 	pub group: Uuid,
 	/// The backup type to restore.
@@ -282,7 +282,7 @@ pub struct RestoreCredentials {
 	operation_id = "mint_restore_credentials",
 	tag = "restore",
 	security(("backup-restore-device" = [])),
-	request_body = CredentialsArgs,
+	request_body = RestoreCredentialsArgs,
 	responses(
 		(status = 200, body = RestoreCredentials),
 		(status = 403, description = "No enabled declaration authorizes this (group, type).", body = ProblemDetailsSchema),
@@ -295,7 +295,7 @@ async fn credentials(
 	State(sts): State<Option<aws_sdk_sts::Client>>,
 	State(kube): State<Option<BackupSecrets>>,
 	device: BackupRestoreDevice,
-	Json(args): Json<CredentialsArgs>,
+	Json(args): Json<RestoreCredentialsArgs>,
 ) -> Result<Json<RestoreCredentials>> {
 	let mut conn = db.get().await?;
 	let consumer_device_id = device.0.0.id;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -168,7 +168,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/BackupsGroupArgs"
               }
             }
           },
@@ -394,7 +394,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/BackupsGroupArgs"
               }
             }
           },
@@ -516,7 +516,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/BackupsGroupArgs"
               }
             }
           },
@@ -555,7 +555,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/BackupsGroupArgs"
               }
             }
           },
@@ -608,7 +608,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/BackupsGroupArgs"
               }
             }
           },
@@ -854,7 +854,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/BackupsGroupArgs"
               }
             }
           },
@@ -1083,7 +1083,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/BackupsGroupArgs"
               }
             }
           },
@@ -1411,7 +1411,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ListArgs"
+                "$ref": "#/components/schemas/BestoolListArgs"
               }
             }
           },
@@ -2213,7 +2213,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SearchArgs"
+                "$ref": "#/components/schemas/DeviceSearchArgs"
               }
             }
           },
@@ -2469,7 +2469,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateArgs"
+                "$ref": "#/components/schemas/HealthcheckUpdateArgs"
               }
             }
           },
@@ -2589,7 +2589,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AddNoteArgs"
+                "$ref": "#/components/schemas/IncidentAddNoteArgs"
               }
             }
           },
@@ -2634,7 +2634,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DeleteNoteArgs"
+                "$ref": "#/components/schemas/IncidentDeleteNoteArgs"
               }
             }
           },
@@ -2783,7 +2783,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ListForServerArgs"
+                "$ref": "#/components/schemas/IncidentListForServerArgs"
               }
             }
           },
@@ -2821,7 +2821,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ListNotesArgs"
+                "$ref": "#/components/schemas/IncidentListNotesArgs"
               }
             }
           },
@@ -2929,7 +2929,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AddNoteArgs"
+                "$ref": "#/components/schemas/IssueAddNoteArgs"
               }
             }
           },
@@ -2974,7 +2974,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/DeleteNoteArgs"
+                "$ref": "#/components/schemas/IssueDeleteNoteArgs"
               }
             }
           },
@@ -3003,7 +3003,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ListArgs"
+                "$ref": "#/components/schemas/IssueListArgs"
               }
             }
           },
@@ -3114,7 +3114,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ListForServerArgs"
+                "$ref": "#/components/schemas/IssueListForServerArgs"
               }
             }
           },
@@ -3152,7 +3152,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ListNotesArgs"
+                "$ref": "#/components/schemas/IssueListNotesArgs"
               }
             }
           },
@@ -3190,7 +3190,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ResolveArgs"
+                "$ref": "#/components/schemas/IssueResolveArgs"
               }
             }
           },
@@ -3546,7 +3546,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/RestoreReplicasGroupArgs"
               }
             }
           },
@@ -3612,7 +3612,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateArgs"
+                "$ref": "#/components/schemas/RestoreReplicasCreateArgs"
               }
             }
           },
@@ -3695,7 +3695,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GroupArgs"
+                "$ref": "#/components/schemas/RestoreReplicasGroupArgs"
               }
             }
           },
@@ -3733,7 +3733,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateArgs"
+                "$ref": "#/components/schemas/RestoreReplicasUpdateArgs"
               }
             }
           },
@@ -3854,7 +3854,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ResolveArgs"
+                "$ref": "#/components/schemas/SelfAlertsResolveArgs"
               }
             }
           },
@@ -3912,7 +3912,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateArgs"
+                "$ref": "#/components/schemas/ServerGroupsCreateArgs"
               }
             }
           },
@@ -4151,7 +4151,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SearchArgs"
+                "$ref": "#/components/schemas/ServerGroupsSearchArgs"
               }
             }
           },
@@ -4226,7 +4226,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateArgs"
+                "$ref": "#/components/schemas/ServerGroupsUpdateArgs"
               }
             }
           },
@@ -4647,7 +4647,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ListArgs"
+                "$ref": "#/components/schemas/ServerListArgs"
               }
             }
           },
@@ -4835,7 +4835,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateArgs"
+                "$ref": "#/components/schemas/ServerUpdateArgs"
               }
             }
           },
@@ -5884,22 +5884,6 @@
           }
         }
       },
-      "AddNoteArgs": {
-        "type": "object",
-        "required": [
-          "incident_id",
-          "body"
-        ],
-        "properties": {
-          "body": {
-            "type": "string"
-          },
-          "incident_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        }
-      },
       "ArtifactData": {
         "type": "object",
         "required": [
@@ -6508,6 +6492,39 @@
           }
         }
       },
+      "BackupsGroupArgs": {
+        "type": "object",
+        "required": [
+          "server_group_id"
+        ],
+        "properties": {
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "BestoolListArgs": {
+        "type": "object",
+        "required": [
+          "offset"
+        ],
+        "properties": {
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
       "BestoolSnippetDetail": {
         "type": "object",
         "required": [
@@ -6619,55 +6636,6 @@
             ],
             "format": "int64",
             "minimum": 0
-          }
-        }
-      },
-      "CreateArgs": {
-        "type": "object",
-        "required": [
-          "consumer_device_id",
-          "group_id",
-          "type",
-          "intent",
-          "name"
-        ],
-        "properties": {
-          "consumer_device_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "group_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "intent": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "overdue_after_seconds": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int64",
-            "description": "Overdue bound in whole seconds; `None` = no bound."
-          },
-          "params": {
-            "type": "object",
-            "description": "Operator-supplied parameter values, validated against the intent's schema."
-          },
-          "server_id": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "uuid",
-            "description": "`None` = all current servers in the group."
-          },
-          "type": {
-            "type": "string"
           }
         }
       },
@@ -6870,18 +6838,6 @@
           }
         }
       },
-      "DeleteNoteArgs": {
-        "type": "object",
-        "required": [
-          "note_id"
-        ],
-        "properties": {
-          "note_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        }
-      },
       "DeviceConnectionData": {
         "type": "object",
         "required": [
@@ -7055,6 +7011,17 @@
           "server",
           "backup-restore"
         ]
+      },
+      "DeviceSearchArgs": {
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        }
       },
       "EnrollmentStatus": {
         "type": "object",
@@ -7259,18 +7226,6 @@
         ],
         "properties": {
           "incident_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        }
-      },
-      "GroupArgs": {
-        "type": "object",
-        "required": [
-          "server_group_id"
-        ],
-        "properties": {
-          "server_group_id": {
             "type": "string",
             "format": "uuid"
           }
@@ -7545,6 +7500,28 @@
           }
         }
       },
+      "HealthcheckUpdateArgs": {
+        "type": "object",
+        "required": [
+          "check_name",
+          "severity"
+        ],
+        "properties": {
+          "check_name": {
+            "type": "string"
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional operator notes. `None` leaves the existing notes alone…\nwell, actually it overwrites with NULL — pass the current value\nto preserve. The UI sends the full current state."
+          },
+          "severity": {
+            "$ref": "#/components/schemas/Severity"
+          }
+        }
+      },
       "HistoryArgs": {
         "type": "object",
         "required": [
@@ -7590,6 +7567,22 @@
         ],
         "properties": {
           "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "IncidentAddNoteArgs": {
+        "type": "object",
+        "required": [
+          "incident_id",
+          "body"
+        ],
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "incident_id": {
             "type": "string",
             "format": "uuid"
           }
@@ -7694,6 +7687,18 @@
           }
         }
       },
+      "IncidentDeleteNoteArgs": {
+        "type": "object",
+        "required": [
+          "note_id"
+        ],
+        "properties": {
+          "note_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "IncidentIdArgs": {
         "type": "object",
         "required": [
@@ -7726,6 +7731,50 @@
               "null"
             ],
             "format": "date-time"
+          }
+        }
+      },
+      "IncidentListForServerArgs": {
+        "type": "object",
+        "required": [
+          "server_id"
+        ],
+        "properties": {
+          "include_closed": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "IncidentListNotesArgs": {
+        "type": "object",
+        "required": [
+          "incident_id"
+        ],
+        "properties": {
+          "incident_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
           }
         }
       },
@@ -7801,6 +7850,22 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "IssueAddNoteArgs": {
+        "type": "object",
+        "required": [
+          "issue_id",
+          "body"
+        ],
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "issue_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },
@@ -7950,6 +8015,18 @@
           }
         }
       },
+      "IssueDeleteNoteArgs": {
+        "type": "object",
+        "required": [
+          "note_id"
+        ],
+        "properties": {
+          "note_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "IssueIdArgs": {
         "type": "object",
         "required": [
@@ -7987,6 +8064,84 @@
           }
         }
       },
+      "IssueListArgs": {
+        "type": "object",
+        "properties": {
+          "activeOnly": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "serverGroupId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "severities": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Severity"
+            }
+          }
+        }
+      },
+      "IssueListForServerArgs": {
+        "type": "object",
+        "required": [
+          "server_id"
+        ],
+        "properties": {
+          "active_only": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "IssueListNotesArgs": {
+        "type": "object",
+        "required": [
+          "issue_id"
+        ],
+        "properties": {
+          "issue_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          }
+        }
+      },
       "IssueNoteData": {
         "type": "object",
         "required": [
@@ -8014,6 +8169,22 @@
           "issue_id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "IssueResolveArgs": {
+        "type": "object",
+        "required": [
+          "issue_id",
+          "reason"
+        ],
+        "properties": {
+          "issue_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "reason": {
+            "$ref": "#/components/schemas/ResolvedReason"
           }
         }
       },
@@ -8122,27 +8293,6 @@
           }
         }
       },
-      "ListArgs": {
-        "type": "object",
-        "required": [
-          "offset"
-        ],
-        "properties": {
-          "limit": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int64",
-            "minimum": 0
-          },
-          "offset": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
-          }
-        }
-      },
       "ListEventsArgs": {
         "type": "object",
         "required": [
@@ -8216,50 +8366,6 @@
           "server_group_id": {
             "type": "string",
             "format": "uuid"
-          }
-        }
-      },
-      "ListForServerArgs": {
-        "type": "object",
-        "required": [
-          "server_id"
-        ],
-        "properties": {
-          "include_closed": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "limit": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int64"
-          },
-          "server_id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        }
-      },
-      "ListNotesArgs": {
-        "type": "object",
-        "required": [
-          "incident_id"
-        ],
-        "properties": {
-          "incident_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "limit": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int64"
           }
         }
       },
@@ -9243,22 +9349,6 @@
           }
         }
       },
-      "ResolveArgs": {
-        "type": "object",
-        "required": [
-          "issue_id",
-          "reason"
-        ],
-        "properties": {
-          "issue_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "reason": {
-            "$ref": "#/components/schemas/ResolvedReason"
-          }
-        }
-      },
       "ResolveIncidentArgs": {
         "type": "object",
         "required": [
@@ -9441,6 +9531,97 @@
           }
         }
       },
+      "RestoreReplicasCreateArgs": {
+        "type": "object",
+        "required": [
+          "consumer_device_id",
+          "group_id",
+          "type",
+          "intent",
+          "name"
+        ],
+        "properties": {
+          "consumer_device_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "group_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "intent": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "overdue_after_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Overdue bound in whole seconds; `None` = no bound."
+          },
+          "params": {
+            "type": "object",
+            "description": "Operator-supplied parameter values, validated against the intent's schema."
+          },
+          "server_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "`None` = all current servers in the group."
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "RestoreReplicasGroupArgs": {
+        "type": "object",
+        "required": [
+          "server_group_id"
+        ],
+        "properties": {
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "RestoreReplicasUpdateArgs": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "overdue_after_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "params": {
+            "type": "object"
+          }
+        }
+      },
       "RetentionPolicy": {
         "type": "object",
         "description": "kopia `keep-*` retention policy. Org-minimum floors\n(`keep_daily ≥ 7, keep_weekly ≥ 4, keep_monthly ≥ 6`) are enforced by\n[`RetentionPolicy::validate_floor`] on create/update — unless the config\nopts out via its `allow_below_floor` flag (dangerous).",
@@ -9566,17 +9747,6 @@
           }
         }
       },
-      "SearchArgs": {
-        "type": "object",
-        "required": [
-          "query"
-        ],
-        "properties": {
-          "query": {
-            "type": "string"
-          }
-        }
-      },
       "SelfAlertView": {
         "type": "object",
         "required": [
@@ -9633,6 +9803,18 @@
               "null"
             ],
             "description": "Single-line headline."
+          }
+        }
+      },
+      "SelfAlertsResolveArgs": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },
@@ -10023,6 +10205,58 @@
           }
         }
       },
+      "ServerGroupsCreateArgs": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "slack_open_delay": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Optional initial value (seconds) for the group's Slack open\ncooldown. Omit to let the database default apply."
+          },
+          "tags": {
+            "$ref": "#/components/schemas/TagMap"
+          }
+        }
+      },
+      "ServerGroupsSearchArgs": {
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        }
+      },
+      "ServerGroupsUpdateArgs": {
+        "type": "object",
+        "required": [
+          "server_group_id",
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/PartialServerGroup"
+          },
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "ServerIdArgs": {
         "type": "object",
         "required": [
@@ -10291,6 +10525,37 @@
           }
         }
       },
+      "ServerListArgs": {
+        "type": "object",
+        "required": [
+          "offset"
+        ],
+        "properties": {
+          "kind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ServerKind"
+              }
+            ]
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
       "ServerRank": {
         "type": "string",
         "enum": [
@@ -10341,6 +10606,22 @@
           },
           "source": {
             "type": "string"
+          }
+        }
+      },
+      "ServerUpdateArgs": {
+        "type": "object",
+        "required": [
+          "server_id",
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ServerDataUpdate"
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },
@@ -10904,28 +11185,6 @@
           },
           "type": {
             "type": "string"
-          }
-        }
-      },
-      "UpdateArgs": {
-        "type": "object",
-        "required": [
-          "check_name",
-          "severity"
-        ],
-        "properties": {
-          "check_name": {
-            "type": "string"
-          },
-          "notes": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Optional operator notes. `None` leaves the existing notes alone…\nwell, actually it overwrites with NULL — pass the current value\nto preserve. The UI sends the full current state."
-          },
-          "severity": {
-            "$ref": "#/components/schemas/Severity"
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2450,11 +2450,6 @@ export interface components {
             /** Format: uuid */
             version_id: string;
         };
-        AddNoteArgs: {
-            body: string;
-            /** Format: uuid */
-            incident_id: string;
-        };
         ArtifactData: {
             artifact_type: string;
             download_url: string;
@@ -2673,6 +2668,16 @@ export interface components {
             recent_runs: components["schemas"]["BackupRun"][];
             stats?: null | components["schemas"]["BackupRepoStats"];
         };
+        BackupsGroupArgs: {
+            /** Format: uuid */
+            server_group_id: string;
+        };
+        BestoolListArgs: {
+            /** Format: int64 */
+            limit?: number | null;
+            /** Format: int64 */
+            offset: number;
+        };
         BestoolSnippetDetail: {
             description?: string | null;
             editor: string;
@@ -2707,27 +2712,6 @@ export interface components {
             device_id: string;
             /** Format: int64 */
             limit?: number | null;
-        };
-        CreateArgs: {
-            /** Format: uuid */
-            consumer_device_id: string;
-            /** Format: uuid */
-            group_id: string;
-            intent: string;
-            name: string;
-            /**
-             * Format: int64
-             * @description Overdue bound in whole seconds; `None` = no bound.
-             */
-            overdue_after_seconds?: number | null;
-            /** @description Operator-supplied parameter values, validated against the intent's schema. */
-            params?: Record<string, never>;
-            /**
-             * Format: uuid
-             * @description `None` = all current servers in the group.
-             */
-            server_id?: string | null;
-            type: string;
         };
         CreateArtifactArgs: {
             artifact_type: string;
@@ -2791,10 +2775,6 @@ export interface components {
         DeleteArgs: {
             email: string;
         };
-        DeleteNoteArgs: {
-            /** Format: uuid */
-            note_id: string;
-        };
         DeviceConnectionData: {
             /** Format: date-time */
             created_at: string;
@@ -2849,6 +2829,9 @@ export interface components {
         };
         /** @enum {string} */
         DeviceRole: "admin" | "releaser" | "server" | "backup-restore";
+        DeviceSearchArgs: {
+            query: string;
+        };
         EnrollmentStatus: {
             /**
              * Format: date-time
@@ -2937,10 +2920,6 @@ export interface components {
         GetIncidentArgs: {
             /** Format: uuid */
             incident_id: string;
-        };
-        GroupArgs: {
-            /** Format: uuid */
-            server_group_id: string;
         };
         GroupDetail: {
             /** @description The group's effective `billing.*` labels (product/deployment/stage). */
@@ -3076,6 +3055,16 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        HealthcheckUpdateArgs: {
+            check_name: string;
+            /**
+             * @description Optional operator notes. `None` leaves the existing notes alone…
+             *     well, actually it overwrites with NULL — pass the current value
+             *     to preserve. The UI sends the full current state.
+             */
+            notes?: string | null;
+            severity: components["schemas"]["Severity"];
+        };
         HistoryArgs: {
             /** Format: int64 */
             limit?: number | null;
@@ -3091,6 +3080,11 @@ export interface components {
         IdArgs: {
             /** Format: uuid */
             id: string;
+        };
+        IncidentAddNoteArgs: {
+            body: string;
+            /** Format: uuid */
+            incident_id: string;
         };
         IncidentData: {
             /** Format: date-time */
@@ -3136,6 +3130,10 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        IncidentDeleteNoteArgs: {
+            /** Format: uuid */
+            note_id: string;
+        };
         IncidentIdArgs: {
             /** Format: uuid */
             incident_id: string;
@@ -3146,6 +3144,19 @@ export interface components {
             joined_at: string;
             /** Format: date-time */
             left_at?: string | null;
+        };
+        IncidentListForServerArgs: {
+            include_closed?: boolean | null;
+            /** Format: int64 */
+            limit?: number | null;
+            /** Format: uuid */
+            server_id: string;
+        };
+        IncidentListNotesArgs: {
+            /** Format: uuid */
+            incident_id: string;
+            /** Format: int64 */
+            limit?: number | null;
         };
         IncidentNoteData: {
             author: string;
@@ -3170,6 +3181,11 @@ export interface components {
             intent: string;
             params?: components["schemas"]["BTreeMap"];
             semantics?: string[];
+        };
+        IssueAddNoteArgs: {
+            body: string;
+            /** Format: uuid */
+            issue_id: string;
         };
         IssueData: {
             active: boolean;
@@ -3229,6 +3245,10 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        IssueDeleteNoteArgs: {
+            /** Format: uuid */
+            note_id: string;
+        };
         IssueIdArgs: {
             /** Format: uuid */
             issue_id: string;
@@ -3245,6 +3265,27 @@ export interface components {
             /** Format: date-time */
             opened_at: string;
         };
+        IssueListArgs: {
+            activeOnly?: boolean | null;
+            /** Format: int64 */
+            limit?: number | null;
+            /** Format: uuid */
+            serverGroupId?: string | null;
+            severities?: components["schemas"]["Severity"][] | null;
+        };
+        IssueListForServerArgs: {
+            active_only?: boolean | null;
+            /** Format: int64 */
+            limit?: number | null;
+            /** Format: uuid */
+            server_id: string;
+        };
+        IssueListNotesArgs: {
+            /** Format: uuid */
+            issue_id: string;
+            /** Format: int64 */
+            limit?: number | null;
+        };
         IssueNoteData: {
             author: string;
             body: string;
@@ -3254,6 +3295,11 @@ export interface components {
             id: string;
             /** Format: uuid */
             issue_id: string;
+        };
+        IssueResolveArgs: {
+            /** Format: uuid */
+            issue_id: string;
+            reason: components["schemas"]["ResolvedReason"];
         };
         KeyIdArgs: {
             /** Format: uuid */
@@ -3291,12 +3337,6 @@ export interface components {
             /** Format: int64 */
             limit?: number | null;
         };
-        ListArgs: {
-            /** Format: int64 */
-            limit?: number | null;
-            /** Format: int64 */
-            offset: number;
-        };
         ListEventsArgs: {
             /** Format: uuid */
             issue_id: string;
@@ -3318,19 +3358,6 @@ export interface components {
             limit?: number | null;
             /** Format: uuid */
             server_group_id: string;
-        };
-        ListForServerArgs: {
-            include_closed?: boolean | null;
-            /** Format: int64 */
-            limit?: number | null;
-            /** Format: uuid */
-            server_id: string;
-        };
-        ListNotesArgs: {
-            /** Format: uuid */
-            incident_id: string;
-            /** Format: int64 */
-            limit?: number | null;
         };
         LiveVersionsBracket: {
             max: components["schemas"]["VersionStr"];
@@ -3746,11 +3773,6 @@ export interface components {
             server_id: string;
             type: string;
         };
-        ResolveArgs: {
-            /** Format: uuid */
-            issue_id: string;
-            reason: components["schemas"]["ResolvedReason"];
-        };
         ResolveIncidentArgs: {
             /** Format: uuid */
             incident_id: string;
@@ -3827,6 +3849,40 @@ export interface components {
             type: string;
             updated_at: string;
         };
+        RestoreReplicasCreateArgs: {
+            /** Format: uuid */
+            consumer_device_id: string;
+            /** Format: uuid */
+            group_id: string;
+            intent: string;
+            name: string;
+            /**
+             * Format: int64
+             * @description Overdue bound in whole seconds; `None` = no bound.
+             */
+            overdue_after_seconds?: number | null;
+            /** @description Operator-supplied parameter values, validated against the intent's schema. */
+            params?: Record<string, never>;
+            /**
+             * Format: uuid
+             * @description `None` = all current servers in the group.
+             */
+            server_id?: string | null;
+            type: string;
+        };
+        RestoreReplicasGroupArgs: {
+            /** Format: uuid */
+            server_group_id: string;
+        };
+        RestoreReplicasUpdateArgs: {
+            enabled: boolean;
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** Format: int64 */
+            overdue_after_seconds?: number | null;
+            params?: Record<string, never>;
+        };
         /**
          * @description kopia `keep-*` retention policy. Org-minimum floors
          *     (`keep_daily ≥ 7, keep_weekly ≥ 4, keep_monthly ≥ 6`) are enforced by
@@ -3880,9 +3936,6 @@ export interface components {
             retention?: null | components["schemas"]["RetentionPolicy"];
             type: string;
         };
-        SearchArgs: {
-            query: string;
-        };
         SelfAlertView: {
             active: boolean;
             /** Format: date-time */
@@ -3900,6 +3953,10 @@ export interface components {
             severity: components["schemas"]["Severity"];
             /** @description Single-line headline. */
             title?: string | null;
+        };
+        SelfAlertsResolveArgs: {
+            /** Format: uuid */
+            id: string;
         };
         ServerArgs: {
             /** Format: uuid */
@@ -4040,6 +4097,25 @@ export interface components {
             server_group_id: string;
             source: string;
         };
+        ServerGroupsCreateArgs: {
+            name: string;
+            notes?: string;
+            /**
+             * Format: int64
+             * @description Optional initial value (seconds) for the group's Slack open
+             *     cooldown. Omit to let the database default apply.
+             */
+            slack_open_delay?: number | null;
+            tags?: components["schemas"]["TagMap"];
+        };
+        ServerGroupsSearchArgs: {
+            query: string;
+        };
+        ServerGroupsUpdateArgs: {
+            data: components["schemas"]["PartialServerGroup"];
+            /** Format: uuid */
+            server_group_id: string;
+        };
         ServerIdArgs: {
             /** Format: uuid */
             server_id: string;
@@ -4142,6 +4218,13 @@ export interface components {
             /** Format: int64 */
             version_distance?: number | null;
         };
+        ServerListArgs: {
+            kind?: null | components["schemas"]["ServerKind"];
+            /** Format: int64 */
+            limit?: number | null;
+            /** Format: int64 */
+            offset: number;
+        };
         /** @enum {string} */
         ServerRank: "production" | "clone" | "demo" | "test" | "dev";
         ServerScopeArgs: {
@@ -4156,6 +4239,11 @@ export interface components {
             /** Format: uuid */
             server_id: string;
             source: string;
+        };
+        ServerUpdateArgs: {
+            data: components["schemas"]["ServerDataUpdate"];
+            /** Format: uuid */
+            server_id: string;
         };
         SetCapabilityArgs: {
             enabled: boolean;
@@ -4380,16 +4468,6 @@ export interface components {
             default_interval?: number | null;
             default_retention?: null | components["schemas"]["RetentionPolicy"];
             type: string;
-        };
-        UpdateArgs: {
-            check_name: string;
-            /**
-             * @description Optional operator notes. `None` leaves the existing notes alone…
-             *     well, actually it overwrites with NULL — pass the current value
-             *     to preserve. The UI sends the full current state.
-             */
-            notes?: string | null;
-            severity: components["schemas"]["Severity"];
         };
         UpdateArtifactArgs: {
             /** Format: uuid */
@@ -4635,7 +4713,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["BackupsGroupArgs"];
             };
         };
         responses: {
@@ -4788,7 +4866,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["BackupsGroupArgs"];
             };
         };
         responses: {
@@ -4874,7 +4952,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["BackupsGroupArgs"];
             };
         };
         responses: {
@@ -4903,7 +4981,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["BackupsGroupArgs"];
             };
         };
         responses: {
@@ -4934,7 +5012,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["BackupsGroupArgs"];
             };
         };
         responses: {
@@ -5096,7 +5174,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["BackupsGroupArgs"];
             };
         };
         responses: {
@@ -5261,7 +5339,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["BackupsGroupArgs"];
             };
         };
         responses: {
@@ -5502,7 +5580,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ListArgs"];
+                "application/json": components["schemas"]["BestoolListArgs"];
             };
         };
         responses: {
@@ -6072,7 +6150,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SearchArgs"];
+                "application/json": components["schemas"]["DeviceSearchArgs"];
             };
         };
         responses: {
@@ -6257,7 +6335,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["UpdateArgs"];
+                "application/json": components["schemas"]["HealthcheckUpdateArgs"];
             };
         };
         responses: {
@@ -6345,7 +6423,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["AddNoteArgs"];
+                "application/json": components["schemas"]["IncidentAddNoteArgs"];
             };
         };
         responses: {
@@ -6376,7 +6454,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["DeleteNoteArgs"];
+                "application/json": components["schemas"]["IncidentDeleteNoteArgs"];
             };
         };
         responses: {
@@ -6474,7 +6552,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ListForServerArgs"];
+                "application/json": components["schemas"]["IncidentListForServerArgs"];
             };
         };
         responses: {
@@ -6497,7 +6575,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ListNotesArgs"];
+                "application/json": components["schemas"]["IncidentListNotesArgs"];
             };
         };
         responses: {
@@ -6566,7 +6644,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["AddNoteArgs"];
+                "application/json": components["schemas"]["IssueAddNoteArgs"];
             };
         };
         responses: {
@@ -6597,7 +6675,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["DeleteNoteArgs"];
+                "application/json": components["schemas"]["IssueDeleteNoteArgs"];
             };
         };
         responses: {
@@ -6618,7 +6696,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ListArgs"];
+                "application/json": components["schemas"]["IssueListArgs"];
             };
         };
         responses: {
@@ -6687,7 +6765,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ListForServerArgs"];
+                "application/json": components["schemas"]["IssueListForServerArgs"];
             };
         };
         responses: {
@@ -6710,7 +6788,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ListNotesArgs"];
+                "application/json": components["schemas"]["IssueListNotesArgs"];
             };
         };
         responses: {
@@ -6733,7 +6811,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ResolveArgs"];
+                "application/json": components["schemas"]["IssueResolveArgs"];
             };
         };
         responses: {
@@ -6986,7 +7064,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["RestoreReplicasGroupArgs"];
             };
         };
         responses: {
@@ -7028,7 +7106,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["CreateArgs"];
+                "application/json": components["schemas"]["RestoreReplicasCreateArgs"];
             };
         };
         responses: {
@@ -7089,7 +7167,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["GroupArgs"];
+                "application/json": components["schemas"]["RestoreReplicasGroupArgs"];
             };
         };
         responses: {
@@ -7112,7 +7190,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["UpdateArgs"];
+                "application/json": components["schemas"]["RestoreReplicasUpdateArgs"];
             };
         };
         responses: {
@@ -7199,7 +7277,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ResolveArgs"];
+                "application/json": components["schemas"]["SelfAlertsResolveArgs"];
             };
         };
         responses: {
@@ -7245,7 +7323,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["CreateArgs"];
+                "application/json": components["schemas"]["ServerGroupsCreateArgs"];
             };
         };
         responses: {
@@ -7411,7 +7489,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SearchArgs"];
+                "application/json": components["schemas"]["ServerGroupsSearchArgs"];
             };
         };
         responses: {
@@ -7457,7 +7535,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["UpdateArgs"];
+                "application/json": components["schemas"]["ServerGroupsUpdateArgs"];
             };
         };
         responses: {
@@ -7763,7 +7841,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ListArgs"];
+                "application/json": components["schemas"]["ServerListArgs"];
             };
         };
         responses: {
@@ -7898,7 +7976,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["UpdateArgs"];
+                "application/json": components["schemas"]["ServerUpdateArgs"];
             };
         };
         responses: {


### PR DESCRIPTION
🤖 utoipa keys OpenAPI component schemas by the type's short name, so same-named `ToSchema` types in different modules silently overwrite each other in the generated spec. Several endpoints were documented with the wrong request body as a result.

**public-server** — `/restore-capabilities` and `/restore-credentials` shared `CapabilitiesArgs`/`CredentialsArgs` with the backup endpoints. The backup shapes won, so the restore request bodies were documented wrongly.

**private-server** — `CreateArgs`, `UpdateArgs`, `AddNoteArgs`, `ListArgs`, `ListForServerArgs`, `ListNotesArgs`, `ResolveArgs`, `SearchArgs`, `GroupArgs`, `DeleteNoteArgs` collided across the `fns/` modules. For example `issues/add_note` was documented with `incident_id`, `server_groups/create` got restore_replicas' body, and `healthchecks`, `restore_replicas`, `server_groups`, `servers` all shared one `UpdateArgs`. These feed `api-types.ts`, so the frontend had wrong request types for the collided endpoints.

Each colliding type is renamed with a module prefix matching the existing `operation_id` convention (e.g. `IssueAddNoteArgs`, `ServerGroupsCreateArgs`, `RestoreCapabilitiesArgs`). Both `openapi.json` specs and `api-types.ts` are regenerated. The wire format is unchanged — this only fixes the generated documentation/types.

A follow-up will add a build-time guard so a future collision fails loudly instead of silently overwriting.