### PR TITLE
feat(openapi): vendor utoipa-axum fork that panics on schema-name collisions

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -18,3 +18,8 @@ Except as otherwise noted (below and/or in individual files), the project is
 licensed under the GNU General Public License, Version 3.0 <LICENSE-GPL> or
 <https://www.gnu.org/licenses/gpl-3.0-standalone.html> or any later version of
 this license, at your option.
+
+The vendored fork of utoipa-axum at <vendor/canopy-utoipa-axum>, originally by
+Juha Kukkonen and contributors <https://github.com/juhaku/utoipa>, is instead
+licensed under the MIT license <vendor/canopy-utoipa-axum/LICENSE-MIT> or the
+Apache License 2.0 <vendor/canopy-utoipa-axum/LICENSE-APACHE>, at your option.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "canopy-utoipa-axum"
+version = "0.2.0"
+dependencies = [
+ "axum",
+ "paste",
+ "serde",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
 name = "cbor-diag"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4679,6 +4691,7 @@ dependencies = [
  "base64 0.22.1",
  "bestool-postgres",
  "canopy-mcp",
+ "canopy-utoipa-axum",
  "chbs",
  "clap",
  "commons-errors",
@@ -4703,7 +4716,6 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "utoipa",
- "utoipa-axum",
  "utoipa-swagger-ui",
  "uuid",
 ]
@@ -4774,6 +4786,7 @@ dependencies = [
  "axum-test",
  "base64 0.22.1",
  "canopy-mcp",
+ "canopy-utoipa-axum",
  "clap",
  "commons-errors",
  "commons-servers",
@@ -4804,7 +4817,6 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "utoipa",
- "utoipa-axum",
  "utoipa-swagger-ui",
  "uuid",
 ]
@@ -6778,19 +6790,6 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa-gen",
-]
-
-[[package]]
-name = "utoipa-axum"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
-dependencies = [
- "axum",
- "paste",
- "tower-layer",
- "tower-service",
- "utoipa",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 	"crates/jobs",
 	"crates/private-server",
 	"crates/public-server",
+	"vendor/canopy-utoipa-axum",
 ]
 
 [workspace.dependencies]
@@ -58,7 +59,10 @@ timesimp = "1.0.0"
 tokio = "1.52.3"
 tracing = "0.1.44"
 utoipa = { version = "5", features = ["jiff_0_2", "uuid", "axum_extras"] }
-utoipa-axum = "0.2"
+# Vendored fork of utoipa-axum under vendor/canopy-utoipa-axum — panics on
+# OpenAPI schema-name collisions instead of silently overwriting. See that
+# crate's Cargo.toml header.
+canopy-utoipa-axum = { path = "vendor/canopy-utoipa-axum" }
 utoipa-swagger-ui = { version = "9", default-features = false, features = ["axum", "vendored"] }
 
 [profile.release]

--- a/crates/private-server/Cargo.toml
+++ b/crates/private-server/Cargo.toml
@@ -40,7 +40,7 @@ tokio-postgres = { version = "0.7.17", features = ["with-jiff-0_2", "with-serde_
 tower-http = { version = "0.7.0", features = ["fs"] }
 tracing.workspace = true
 utoipa.workspace = true
-utoipa-axum.workspace = true
+canopy-utoipa-axum.workspace = true
 utoipa-swagger-ui.workspace = true
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
 chbs = "0.1.1"

--- a/crates/private-server/src/bin/private-openapi-dump.rs
+++ b/crates/private-server/src/bin/private-openapi-dump.rs
@@ -5,9 +5,9 @@
 //! No database or network is required — the spec is fully derived from compile-
 //! time annotations.
 
+use canopy_utoipa_axum::router::OpenApiRouter;
 use private_server::{fns, openapi::ApiDoc};
 use utoipa::OpenApi;
-use utoipa_axum::router::OpenApiRouter;
 
 fn main() {
 	let (_router, openapi) = OpenApiRouter::with_openapi(ApiDoc::openapi())

--- a/crates/private-server/src/fns.rs
+++ b/crates/private-server/src/fns.rs
@@ -1,5 +1,5 @@
+use canopy_utoipa_axum::router::OpenApiRouter;
 use serde::{Deserialize, Serialize};
-use utoipa_axum::router::OpenApiRouter;
 
 pub mod admins;
 pub mod backups;

--- a/crates/private-server/src/fns/admins.rs
+++ b/crates/private-server/src/fns/admins.rs
@@ -1,10 +1,10 @@
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use serde::Deserialize;
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -12,6 +12,7 @@
 
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use commons_types::{
@@ -30,7 +31,6 @@ use database::{
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::{AppState, RecoveryChallenge};
 

--- a/crates/private-server/src/fns/bestool.rs
+++ b/crates/private-server/src/fns/bestool.rs
@@ -1,10 +1,10 @@
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleUser;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use crate::fns::Page;

--- a/crates/private-server/src/fns/commons.rs
+++ b/crates/private-server/src/fns/commons.rs
@@ -1,7 +1,7 @@
 use axum::Json;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::device_auth::keygen;
 use commons_servers::tailnet_directory::DirectoryEntry;
@@ -12,7 +13,6 @@ use database::servers::Server;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::fns::Page;
 use crate::fns::servers::{ServerInfo, decorate_with_status, fill_display_hosts, server_to_info};

--- a/crates/private-server/src/fns/healthchecks.rs
+++ b/crates/private-server/src/fns/healthchecks.rs
@@ -5,6 +5,7 @@
 
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use commons_types::issue::Severity;
@@ -16,7 +17,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/private-server/src/fns/incidents.rs
+++ b/crates/private-server/src/fns/incidents.rs
@@ -1,5 +1,6 @@
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::{TailscaleAdmin, TailscaleUser};
 use commons_types::{Uuid, issue::ResolvedReason};
@@ -10,7 +11,6 @@ use database::tailscale_users::TailscaleUser as CachedTailscaleUser;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::fns::issues::{IssueData, enrich_issues, lookup_user};
 use crate::state::AppState;

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -1,5 +1,6 @@
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::{TailscaleAdmin, TailscaleUser};
 use commons_types::{
@@ -15,7 +16,6 @@ use database::tailscale_users::TailscaleUser as CachedTailscaleUser;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::fns::Page;
 use crate::state::AppState;

--- a/crates/private-server/src/fns/mcp_tokens.rs
+++ b/crates/private-server/src/fns/mcp_tokens.rs
@@ -7,6 +7,7 @@
 
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use commons_types::Uuid;
@@ -14,7 +15,6 @@ use database::mcp_tokens::McpToken;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/private-server/src/fns/restore_replicas.rs
+++ b/crates/private-server/src/fns/restore_replicas.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use commons_types::device::DeviceRole;
@@ -27,7 +28,6 @@ use database::{
 use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/private-server/src/fns/self_alerts.rs
+++ b/crates/private-server/src/fns/self_alerts.rs
@@ -5,6 +5,7 @@
 
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::{TailscaleAdmin, TailscaleUser};
 use commons_types::Uuid;
@@ -13,7 +14,6 @@ use database::issues::Issue;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/private-server/src/fns/server_groups.rs
+++ b/crates/private-server/src/fns/server_groups.rs
@@ -1,12 +1,12 @@
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::{backup_jobs::BillingLabels, tailscale_auth::TailscaleAdmin};
 use commons_types::{Uuid, server::TagMap};
 use database::server_groups::{NewServerGroup, PartialServerGroup, ServerGroup};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -1,6 +1,7 @@
 use axum::Json;
 use axum::extract::State;
 use base64::Engine;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use commons_types::{
@@ -25,7 +26,6 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::fns::Page;
 use crate::state::AppState;

--- a/crates/private-server/src/fns/silenced_refs.rs
+++ b/crates/private-server/src/fns/silenced_refs.rs
@@ -1,12 +1,12 @@
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use commons_types::Uuid;
 use database::silenced_refs::{ServerGroupSilencedRef, ServerSilencedRef};
 use serde::Deserialize;
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/private-server/src/fns/sql.rs
+++ b/crates/private-server/src/fns/sql.rs
@@ -5,6 +5,7 @@ use axum::extract::State;
 use bestool_postgres::error::format_db_error;
 use bestool_postgres::stringify::postgres_to_json_value;
 use bestool_postgres::text_cast::{CellRef, TextCaster};
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleUser;
 use database::sql_playground_history::SqlPlaygroundHistory;
@@ -12,7 +13,6 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use crate::fns::Page;

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleUser;
 use commons_types::{
@@ -19,7 +20,6 @@ use database::{
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use crate::state::AppState;

--- a/crates/private-server/src/fns/versions.rs
+++ b/crates/private-server/src/fns/versions.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use axum::Json;
 use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::{TailscaleAdmin, TailscaleUser};
 use commons_types::version::{VersionStatus, VersionStr};
@@ -10,7 +11,6 @@ use database::{artifacts::Artifact, version_known_issues::VersionKnownIssue, ver
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use crate::state::AppState;

--- a/crates/private-server/src/lib.rs
+++ b/crates/private-server/src/lib.rs
@@ -8,8 +8,8 @@ pub mod state;
 pub fn routes(state: crate::state::AppState) -> commons_errors::Result<axum::routing::Router<()>> {
 	use axum::middleware;
 	use axum::routing::Router;
+	use canopy_utoipa_axum::router::OpenApiRouter;
 	use utoipa::OpenApi;
-	use utoipa_axum::router::OpenApiRouter;
 	use utoipa_swagger_ui::SwaggerUi;
 
 	let (api_router, api_spec) = OpenApiRouter::with_openapi(openapi::ApiDoc::openapi())

--- a/crates/private-server/tests/openapi_spec.rs
+++ b/crates/private-server/tests/openapi_spec.rs
@@ -1,8 +1,8 @@
 //! Smoke test: the OpenAPI spec generates and exposes one path per migrated module.
 
+use canopy_utoipa_axum::router::OpenApiRouter;
 use private_server::openapi::ApiDoc;
 use utoipa::OpenApi;
-use utoipa_axum::router::OpenApiRouter;
 
 fn build_spec() -> serde_json::Value {
 	let (_router, openapi) = OpenApiRouter::with_openapi(ApiDoc::openapi())

--- a/crates/public-server/Cargo.toml
+++ b/crates/public-server/Cargo.toml
@@ -51,7 +51,7 @@ tower-http = { version = "0.7.0", optional = true, features = [
 	"trace",
 ] }
 utoipa.workspace = true
-utoipa-axum.workspace = true
+canopy-utoipa-axum.workspace = true
 utoipa-swagger-ui = { workspace = true, optional = true }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
 serde_json = "1.0.150"

--- a/crates/public-server/src/artifacts.rs
+++ b/crates/public-server/src/artifacts.rs
@@ -2,6 +2,7 @@ use axum::{
 	Json,
 	extract::{Path, State},
 };
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::device_auth::ReleaserDevice;
 use commons_types::version::{VersionStatus, VersionStr};
@@ -12,7 +13,6 @@ use database::{
 };
 use diesel::SelectableHelper as _;
 use diesel_async::RunQueryDsl as _;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/public-server/src/backup.rs
+++ b/crates/public-server/src/backup.rs
@@ -19,6 +19,7 @@
 
 use aws_sdk_sts::operation::RequestId as _;
 use axum::{Json, extract::State, http::StatusCode};
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::device_auth::ServerDevice;
 use commons_types::backup::{BackupConfigStatus, BackupPurpose, BackupType, RunOutcome};
@@ -34,7 +35,6 @@ use database::{
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use crate::state::{AppState, BackupSecrets};

--- a/crates/public-server/src/bestool.rs
+++ b/crates/public-server/src/bestool.rs
@@ -1,10 +1,10 @@
 use axum::{Json, extract::State};
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use database::Db;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/public-server/src/bin/public-openapi-dump.rs
+++ b/crates/public-server/src/bin/public-openapi-dump.rs
@@ -4,9 +4,9 @@
 //! No database or network is required — the spec is fully derived from
 //! compile-time annotations.
 
+use canopy_utoipa_axum::router::OpenApiRouter;
 use public_server::openapi::ApiDoc;
 use utoipa::OpenApi;
-use utoipa_axum::router::OpenApiRouter;
 
 fn main() {
 	let (_router, openapi) = OpenApiRouter::with_openapi(ApiDoc::openapi())

--- a/crates/public-server/src/events.rs
+++ b/crates/public-server/src/events.rs
@@ -1,4 +1,5 @@
 use axum::{Json, extract::State};
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::device_auth::ServerDevice;
 use database::{
@@ -6,7 +7,6 @@ use database::{
 	issues::{Issue, NewEvent},
 	servers::Server,
 };
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/public-server/src/lib.rs
+++ b/crates/public-server/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "ui")]
 use axum::extract::State;
-use utoipa_axum::router::OpenApiRouter;
+use canopy_utoipa_axum::router::OpenApiRouter;
 
 use crate::state::AppState;
 

--- a/crates/public-server/src/main.rs
+++ b/crates/public-server/src/main.rs
@@ -2,12 +2,12 @@ use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 
 use axum::Router;
 use axum_client_ip::ClientIpSource;
+use canopy_utoipa_axum::router::OpenApiRouter;
 use clap::Parser;
 use commons_servers::{router, serve};
 use lloggs::{LoggingArgs, PreArgs};
 use public_server::state::AppState;
 use utoipa::OpenApi as _;
-use utoipa_axum::router::OpenApiRouter;
 use utoipa_swagger_ui::SwaggerUi;
 
 #[derive(Debug, Parser)]

--- a/crates/public-server/src/restore.rs
+++ b/crates/public-server/src/restore.rs
@@ -15,6 +15,7 @@
 
 use aws_sdk_sts::operation::RequestId as _;
 use axum::{Json, extract::State, http::StatusCode};
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::device_auth::BackupRestoreDevice;
 use commons_types::backup::{
@@ -33,7 +34,6 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use crate::{

--- a/crates/public-server/src/servers.rs
+++ b/crates/public-server/src/servers.rs
@@ -8,6 +8,7 @@ use commons_servers::device_auth::{mtls, pop};
 use commons_servers::tailnet_directory::TailnetDirectory;
 
 use crate::ratelimit::RateLimiter;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_types::server::{kind::ServerKind, rank::ServerRank};
 use database::{
 	Db,
@@ -20,7 +21,6 @@ use database::{
 use diesel_async::AsyncConnection;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use crate::state::AppState;

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -5,6 +5,7 @@ use axum::{
 	Json,
 	extract::{Path, State},
 };
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::{
 	backup_jobs::backups_due_now_for_server, device_auth::ServerDevice, headers::VersionHeader,
@@ -25,7 +26,6 @@ use database::{
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
 use crate::state::AppState;

--- a/crates/public-server/src/tags.rs
+++ b/crates/public-server/src/tags.rs
@@ -1,9 +1,9 @@
 use axum::{Json, extract::State};
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::device_auth::ServerDevice;
 use commons_types::server::TagMap;
 use database::{Db, servers::Server};
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/public-server/src/versions.rs
+++ b/crates/public-server/src/versions.rs
@@ -12,6 +12,7 @@ use axum::{
 	response::IntoResponse,
 	routing::{Router, get},
 };
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::device_auth::{AdminDevice, ReleaserDevice};
 use commons_types::version::{VersionRange, VersionStr};
@@ -34,7 +35,6 @@ use qrcode::{QrCode, render::svg};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "ui")]
 use tera::{Context, Tera};
-use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::state::AppState;
 

--- a/crates/public-server/tests/openapi_spec.rs
+++ b/crates/public-server/tests/openapi_spec.rs
@@ -1,9 +1,9 @@
 //! Smoke test: the public-server OpenAPI spec generates and exposes the
 //! handlers we expect. Mirrors the equivalent test in `private-server`.
 
+use canopy_utoipa_axum::router::OpenApiRouter;
 use public_server::openapi::ApiDoc;
 use utoipa::OpenApi;
-use utoipa_axum::router::OpenApiRouter;
 
 fn build_spec() -> serde_json::Value {
 	let (_router, openapi) = OpenApiRouter::with_openapi(ApiDoc::openapi())

--- a/vendor/canopy-utoipa-axum/CHANGELOG.md
+++ b/vendor/canopy-utoipa-axum/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog - utoipa-axum
+
+## 0.2.0 - Thu 16 2025
+
+* Re-release of what was released in 0.1.4 (https://github.com/juhaku/utoipa/pull/1295)
+
+## 0.1.4 - Jan 6 2025
+
+### Changed
+
+* Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
+* Added mutable getter for the openapi instance of a OpenApiRouter (https://github.com/juhaku/utoipa/pull/1262)
+* utoipa-axum: Add basic path params test (https://github.com/juhaku/utoipa/pull/1268)
+
+## 0.1.3 - Dec 19 2024
+
+### Changed
+
+* Allow trailing comma in `routes!()` macro (https://github.com/juhaku/utoipa/pull/1238)
+
+### Fixed
+
+* Fix axum path nesting (https://github.com/juhaku/utoipa/pull/1231)
+* Fix diverging axum route and openapi spec (https://github.com/juhaku/utoipa/pull/1199)
+
+## 0.1.2 - Oct 29 2024
+
+### Changed
+
+* Merge paths if they already are added to the paths map in utoipa-axum (https://github.com/juhaku/utoipa/pull/1171)
+
+## 0.1.1 - Oct 16 2024
+
+### Changed
+
+* Use OpenApiRouter::default for empty OpenApi (https://github.com/juhaku/utoipa/pull/1133)
+
+## 0.1.0 - Oct 14 2024
+
+### Added
+
+* Add auto collect schemas for utoipa-axum (https://github.com/juhaku/utoipa/pull/1072)
+* Add typos to CI (https://github.com/juhaku/utoipa/pull/1036)
+* Add paths support for routes! macro (https://github.com/juhaku/utoipa/pull/1023)
+* Add macros feature flag (https://github.com/juhaku/utoipa/pull/1015)
+* Add `utoipa-axum` binding example and update docs (https://github.com/juhaku/utoipa/pull/1007)
+* Add support to define multiple operation methods (https://github.com/juhaku/utoipa/pull/1006)
+* Add utoipa axum bindings (https://github.com/juhaku/utoipa/pull/1004)
+
+### Fixed
+
+* Fix `routes!` macro call (https://github.com/juhaku/utoipa/pull/1108)
+* Fix testing without explicit features (https://github.com/juhaku/utoipa/pull/1041)
+* Fix building utoipa-axum & utoipa-swagger-ui (https://github.com/juhaku/utoipa/pull/1038)
+* Fix utoipa-axum project description
+* Fix some typos
+
+### Changed
+
+* Fix typos
+* Remove commit commit id from changelogs (https://github.com/juhaku/utoipa/pull/1077)
+* Update to rc version
+* Chore change the operations implementation. (https://github.com/juhaku/utoipa/pull/1026)
+* Update utoipa-axum version
+* Enhance `utoipa-axum` bindings (https://github.com/juhaku/utoipa/pull/1017)
+* Update next beta versions
+

--- a/vendor/canopy-utoipa-axum/Cargo.toml
+++ b/vendor/canopy-utoipa-axum/Cargo.toml
@@ -1,0 +1,37 @@
+# Vendored fork of utoipa-axum 0.2.0 (MIT OR Apache-2.0, upstream
+# https://github.com/juhaku/utoipa). The only functional change is in
+# `src/router.rs`: `routes()`, `nest()`, and `merge()` now panic when two
+# distinct types would register the same OpenAPI component schema name with
+# different definitions, instead of silently overwriting one with the other.
+# See the `// CANOPY FORK:` comments in router.rs. Keep this in sync with
+# upstream when bumping the version.
+[package]
+name = "canopy-utoipa-axum"
+description = "Utoipa's axum bindings (canopy fork: panics on schema-name collisions)"
+version = "0.2.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/juhaku/utoipa"
+authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
+
+[features]
+debug = []
+
+# default-features can't be overridden through workspace inheritance, and the
+# servers already pull axum/utoipa with their default features on, so feature
+# unification lands in the same place regardless. We only add the `macros`
+# feature utoipa-axum's generated code needs.
+[dependencies]
+axum = { workspace = true }
+utoipa = { workspace = true, features = ["macros"] }
+tower-service = "0.3"
+tower-layer = "0.3.2"
+paste = "1.0"
+
+[dev-dependencies]
+axum = { workspace = true, features = ["json"] }
+utoipa = { workspace = true, features = ["macros"] }
+serde = { workspace = true, features = ["derive"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/vendor/canopy-utoipa-axum/Cargo.toml
+++ b/vendor/canopy-utoipa-axum/Cargo.toml
@@ -15,7 +15,9 @@ repository = "https://github.com/juhaku/utoipa"
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
 
 [features]
-debug = []
+# The derive(Debug) on OpenApiRouter needs utoipa's own debug feature for
+# OpenApi's Debug impl; without forwarding, --all-features builds fail.
+debug = ["utoipa/debug"]
 
 # default-features can't be overridden through workspace inheritance, and the
 # servers already pull axum/utoipa with their default features on, so feature

--- a/vendor/canopy-utoipa-axum/LICENSE-APACHE
+++ b/vendor/canopy-utoipa-axum/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/canopy-utoipa-axum/LICENSE-MIT
+++ b/vendor/canopy-utoipa-axum/LICENSE-MIT
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright © 2021
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/canopy-utoipa-axum/README.md
+++ b/vendor/canopy-utoipa-axum/README.md
@@ -1,0 +1,52 @@
+# utoipa-axum - Bindings for Axum and utoipa
+
+[![Utoipa build](https://github.com/juhaku/utoipa/actions/workflows/build.yaml/badge.svg)](https://github.com/juhaku/utoipa/actions/workflows/build.yaml)
+[![crates.io](https://img.shields.io/crates/v/utoipa-axum.svg?label=crates.io&color=orange&logo=rust)](https://crates.io/crates/utoipa-axum)
+[![docs.rs](https://img.shields.io/static/v1?label=docs.rs&message=utoipa-axum&color=blue&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K)](https://docs.rs/utoipa-axum/latest/)
+![rustc](https://img.shields.io/static/v1?label=rustc&message=1.75&color=orange&logo=rust)
+
+Utoipa axum brings `utoipa` and `axum` closer together by the way of providing an ergonomic API that is extending on
+the `axum` API. It gives a natural way to register handlers known to `axum` and also simultaneously generates OpenAPI
+specification from the handlers.
+
+## Crate features
+
+- **`debug`**: Implement debug traits for types.
+
+## Install
+
+Add dependency declaration to `Cargo.toml`.
+
+```toml
+[dependencies]
+utoipa-axum = "0.2"
+```
+
+## Examples
+
+Use `OpenApiRouter` to collect handlers with `#[utoipa::path]` macro to compose service and form OpenAPI spec.
+
+```rust
+use utoipa_axum::{routes, PathItemExt, router::OpenApiRouter};
+
+#[derive(utoipa::ToSchema)]
+struct User {
+    id: i32,
+}
+
+#[utoipa::path(get, path = "/user", responses((status = OK, body = User)))]
+async fn get_user() -> Json<User> {
+    Json(User { id: 1 })
+}
+
+let (router, api) = OpenApiRouter::new()
+    .routes(routes!(get_user))
+    .split_for_parts();
+```
+
+## License
+
+Licensed under either of [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT) license at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this crate
+by you, shall be dual licensed, without any additional terms or conditions.

--- a/vendor/canopy-utoipa-axum/rustfmt.toml
+++ b/vendor/canopy-utoipa-axum/rustfmt.toml
@@ -1,0 +1,4 @@
+# This is a lightly-patched fork of the upstream utoipa-axum crate. rustfmt
+# resolves the nearest config per file, so this overrides the workspace's
+# `hard_tabs = true` and keeps the fork in upstream's default (4-space) style,
+# so diffs against upstream stay small. Our changes are marked `// CANOPY FORK:`.

--- a/vendor/canopy-utoipa-axum/src/lib.rs
+++ b/vendor/canopy-utoipa-axum/src/lib.rs
@@ -1,0 +1,197 @@
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![warn(missing_docs)]
+#![warn(rustdoc::broken_intra_doc_links)]
+
+//! Utoipa axum brings `utoipa` and `axum` closer together by the way of providing an ergonomic API that is extending on
+//! the `axum` API. It gives a natural way to register handlers known to `axum` and also simultaneously generates OpenAPI
+//! specification from the handlers.
+//!
+//! ## Crate features
+//!
+//! - **`debug`**: Implement debug traits for types.
+//!
+//! ## Install
+//!
+//! Add dependency declaration to `Cargo.toml`.
+//!
+//! ```toml
+//! [dependencies]
+//! utoipa-axum = "0.2"
+//! ```
+//!
+//! ## Examples
+//!
+//! _**Use [`OpenApiRouter`][router] to collect handlers with _`#[utoipa::path]`_ macro to compose service and form OpenAPI spec.**_
+//!
+//! ```rust
+//! # use axum::Json;
+//! # use utoipa::openapi::OpenApi;
+//! # use canopy_utoipa_axum::{routes, PathItemExt, router::OpenApiRouter};
+//!  #[derive(utoipa::ToSchema, serde::Serialize)]
+//!  struct User {
+//!      id: i32,
+//!  }
+//!
+//!  #[utoipa::path(get, path = "/user", responses((status = OK, body = User)))]
+//!  async fn get_user() -> Json<User> {
+//!     Json(User { id: 1 })
+//!  }
+//!  
+//!  let (router, api): (axum::Router, OpenApi) = OpenApiRouter::new()
+//!      .routes(routes!(get_user))
+//!      .split_for_parts();
+//! ```
+//!
+//! [router]: router/struct.OpenApiRouter.html
+
+pub mod router;
+
+use axum::routing::MethodFilter;
+use utoipa::openapi::HttpMethod;
+
+/// Extends [`utoipa::openapi::path::PathItem`] by providing conversion methods to convert this
+/// path item type to a [`axum::routing::MethodFilter`].
+pub trait PathItemExt {
+    /// Convert this path item type to a [`axum::routing::MethodFilter`].
+    ///
+    /// Method filter is used with handler registration on [`axum::routing::MethodRouter`].
+    fn to_method_filter(&self) -> MethodFilter;
+}
+
+impl PathItemExt for HttpMethod {
+    fn to_method_filter(&self) -> MethodFilter {
+        match self {
+            HttpMethod::Get => MethodFilter::GET,
+            HttpMethod::Put => MethodFilter::PUT,
+            HttpMethod::Post => MethodFilter::POST,
+            HttpMethod::Head => MethodFilter::HEAD,
+            HttpMethod::Patch => MethodFilter::PATCH,
+            HttpMethod::Trace => MethodFilter::TRACE,
+            HttpMethod::Delete => MethodFilter::DELETE,
+            HttpMethod::Options => MethodFilter::OPTIONS,
+        }
+    }
+}
+
+/// re-export paste so users do not need to add the dependency.
+#[doc(hidden)]
+pub use paste::paste;
+
+/// Collect axum handlers annotated with [`utoipa::path`] to [`router::UtoipaMethodRouter`].
+///
+/// [`routes`] macro will return [`router::UtoipaMethodRouter`] which contains an
+/// [`axum::routing::MethodRouter`] and currently registered paths. The output of this macro is
+/// meant to be used together with [`router::OpenApiRouter`] which combines the paths and axum
+/// routers to a single entity.
+///
+/// Only handlers collected with [`routes`] macro will get registered to the OpenApi.
+///
+/// # Panics
+///
+/// Routes registered via [`routes`] macro or via `axum::routing::*` operations are bound to same
+/// rules where only one one HTTP method can can be registered once per call. This means that the
+/// following will produce runtime panic from axum code.
+///
+/// ```rust,no_run
+/// # use canopy_utoipa_axum::{routes, router::UtoipaMethodRouter};
+/// # use utoipa::path;
+///  #[utoipa::path(get, path = "/search")]
+///  async fn search_user() {}
+///
+///  #[utoipa::path(get, path = "")]
+///  async fn get_user() {}
+///
+///  let _: UtoipaMethodRouter = routes!(get_user, search_user);
+/// ```
+/// Since the _`axum`_ does not support method filter for `CONNECT` requests, using this macro with
+/// handler having request method type `CONNECT` `#[utoipa::path(connect, path = "")]` will panic at
+/// runtime.
+///
+/// # Examples
+///
+/// _**Create new `OpenApiRouter` with `get_user` and `post_user` paths.**_
+/// ```rust
+/// # use canopy_utoipa_axum::{routes, router::{OpenApiRouter, UtoipaMethodRouter}};
+/// # use utoipa::path;
+///  #[utoipa::path(get, path = "")]
+///  async fn get_user() {}
+///
+///  #[utoipa::path(post, path = "")]
+///  async fn post_user() {}
+///
+///  let _: OpenApiRouter = OpenApiRouter::new().routes(routes!(get_user, post_user));
+/// ```
+#[macro_export]
+macro_rules! routes {
+    ( $handler:path $(, $tail:path)* $(,)? ) => {
+        {
+            use $crate::PathItemExt;
+            let mut paths = utoipa::openapi::path::Paths::new();
+            let mut schemas = Vec::<(String, utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>)>::new();
+            let (path, item, types) = $crate::routes!(@resolve_types $handler : schemas);
+            #[allow(unused_mut)]
+            let mut method_router = types.iter().by_ref().fold(axum::routing::MethodRouter::new(), |router, path_type| {
+                router.on(path_type.to_method_filter(), $handler)
+            });
+            paths.add_path_operation(&path, types, item);
+            $( method_router = $crate::routes!( schemas: method_router: paths: $tail ); )*
+            (schemas, paths, method_router)
+        }
+    };
+    ( $schemas:tt: $router:ident: $paths:ident: $handler:path $(, $tail:tt)* ) => {
+        {
+            let (path, item, types) = $crate::routes!(@resolve_types $handler : $schemas);
+            let router = types.iter().by_ref().fold($router, |router, path_type| {
+                router.on(path_type.to_method_filter(), $handler)
+            });
+            $paths.add_path_operation(&path, types, item);
+            router
+        }
+    };
+    ( @resolve_types $handler:path : $schemas:tt ) => {
+        {
+            $crate::paste! {
+                let path = $crate::routes!( @path [path()] of $handler );
+                let mut operation = $crate::routes!( @path [operation()] of $handler );
+                let types = $crate::routes!( @path [methods()] of $handler );
+                let tags = $crate::routes!( @path [tags()] of $handler );
+                $crate::routes!( @path [schemas(&mut $schemas)] of $handler );
+                if !tags.is_empty() {
+                    let operation_tags = operation.tags.get_or_insert(Vec::new());
+                    operation_tags.extend(tags.iter().map(ToString::to_string));
+                }
+                (path, operation, types)
+            }
+        }
+    };
+    ( @path $op:tt of $part:ident $( :: $tt:tt )* ) => {
+        $crate::routes!( $op : [ $part $( $tt )*] )
+    };
+    ( $op:tt : [ $first:tt $( $rest:tt )* ] $( $rev:tt )* ) => {
+        $crate::routes!( $op : [ $( $rest )* ] $first $( $rev)* )
+    };
+    ( $op:tt : [] $first:tt $( $rest:tt )* ) => {
+        $crate::routes!( @inverse $op : $first $( $rest )* )
+    };
+    ( @inverse $op:tt : $tt:tt $( $rest:tt )* ) => {
+        $crate::routes!( @rev $op : $tt [$($rest)*] )
+    };
+    ( @rev $op:tt : $tt:tt [ $first:tt $( $rest:tt)* ] $( $reversed:tt )* ) => {
+        $crate::routes!( @rev $op : $tt [ $( $rest )* ] $first $( $reversed )* )
+    };
+    ( @rev [$op:ident $( $args:tt )* ] : $handler:tt [] $($tt:tt)* ) => {
+        {
+            #[allow(unused_imports)]
+            use utoipa::{Path, __dev::{Tags, SchemaReferences}};
+            $crate::paste! {
+                $( $tt :: )* [<__path_ $handler>]::$op $( $args )*
+            }
+        }
+    };
+    ( ) => {};
+}
+
+// CANOPY FORK: upstream's inline `#[cfg(test)] mod tests` (insta snapshot
+// tests of the routes! macro) was removed to avoid vendoring its heavy
+// dev-dependencies. The fork's own behaviour is covered by
+// `tests/schema_collision.rs`.

--- a/vendor/canopy-utoipa-axum/src/router.rs
+++ b/vendor/canopy-utoipa-axum/src/router.rs
@@ -1,0 +1,466 @@
+//! Implements Router for composing handlers and collecting OpenAPI information.
+use std::convert::Infallible;
+
+use axum::extract::Request;
+use axum::handler::Handler;
+use axum::response::IntoResponse;
+use axum::routing::{MethodRouter, Route, RouterAsService};
+use axum::Router;
+use tower_layer::Layer;
+use tower_service::Service;
+
+// CANOPY FORK: guard against silent OpenAPI component-schema name collisions.
+//
+// utoipa keys `components.schemas` by the type's short name, so two distinct
+// `ToSchema` types that share a name (e.g. a `CreateArgs` in two different
+// modules) silently overwrite each other when their routers are combined —
+// producing a spec that documents one endpoint with another endpoint's body.
+// Upstream just inserts into the schema map; we panic instead so a collision
+// surfaces loudly at router-build time (spec generation, tests, or server
+// startup) rather than shipping a wrong spec. Identical definitions under the
+// same name are harmless (the common case of a shared arg shape) and do not
+// panic.
+fn assert_schema_not_conflicting(
+    existing: &utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+    incoming: &utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+    name: &str,
+) {
+    assert!(
+        existing == incoming,
+        "OpenAPI component schema name collision: two different types both register \
+         the schema `{name}` with different definitions. utoipa keys component \
+         schemas by the type's short name, so same-named `ToSchema` types in \
+         different modules silently overwrite each other. Rename one (e.g. give it \
+         a module-qualified name) or set `#[schema(as = \"...\")]`."
+    );
+}
+
+// CANOPY FORK: check an incoming OpenApi's schemas against ours before delegating
+// a `nest`/`merge` to utoipa core (which would silently overwrite on collision).
+fn assert_no_schema_conflicts(ours: &utoipa::openapi::OpenApi, theirs: &utoipa::openapi::OpenApi) {
+    let (Some(ours), Some(theirs)) = (ours.components.as_ref(), theirs.components.as_ref()) else {
+        return;
+    };
+    for (name, schema) in &theirs.schemas {
+        if let Some(existing) = ours.schemas.get(name) {
+            assert_schema_not_conflicting(existing, schema, name);
+        }
+    }
+}
+
+/// Wrapper type for [`utoipa::openapi::path::Paths`] and [`axum::routing::MethodRouter`].
+///
+/// This is used with [`OpenApiRouter::routes`] method to register current _`paths`_ to the
+/// [`utoipa::openapi::OpenApi`] of [`OpenApiRouter`] instance.
+///
+/// See [`routes`][routes] for usage.
+///
+/// [routes]: ../macro.routes.html
+pub type UtoipaMethodRouter<S = (), E = Infallible> = (
+    Vec<(
+        String,
+        utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+    )>,
+    utoipa::openapi::path::Paths,
+    axum::routing::MethodRouter<S, E>,
+);
+
+/// Extension trait for [`UtoipaMethodRouter`] to expose typically used methods of
+/// [`axum::routing::MethodRouter`] and to extend [`UtoipaMethodRouter`] with useful convenience
+/// methods.
+pub trait UtoipaMethodRouterExt<S, E>
+where
+    S: Send + Sync + Clone + 'static,
+{
+    /// Pass through method for [`axum::routing::MethodRouter::layer`].
+    ///
+    /// This method is provided as convenience for defining layers to [`axum::routing::MethodRouter`]
+    /// routes.
+    fn layer<L, NewError>(self, layer: L) -> UtoipaMethodRouter<S, NewError>
+    where
+        L: Layer<Route<E>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
+        <L::Service as Service<Request>>::Response: IntoResponse + 'static,
+        <L::Service as Service<Request>>::Error: Into<NewError> + 'static,
+        <L::Service as Service<Request>>::Future: Send + 'static,
+        E: 'static,
+        S: 'static,
+        NewError: 'static;
+
+    /// Pass through method for [`axum::routing::MethodRouter::with_state`].
+    ///
+    /// Allows quick state definition for underlying [`axum::routing::MethodRouter`].
+    fn with_state<S2>(self, state: S) -> UtoipaMethodRouter<S2, E>;
+
+    /// Convenience method that allows custom mapping for [`axum::routing::MethodRouter`] via
+    /// methods that not exposed directly through [`UtoipaMethodRouterExt`].
+    ///
+    /// This method could be used to add layers, route layers or fallback handlers for the method
+    /// router.
+    /// ```rust
+    /// # use canopy_utoipa_axum::{routes, router::{UtoipaMethodRouter, UtoipaMethodRouterExt}};
+    /// # #[utoipa::path(get, path = "")]
+    /// # async fn search_user() {}
+    /// let _: UtoipaMethodRouter = routes!(search_user).map(|method_router| {
+    ///     // .. implementation here
+    ///     method_router
+    /// });
+    /// ```
+    fn map<NewError>(
+        self,
+        op: impl FnOnce(MethodRouter<S, E>) -> MethodRouter<S, NewError>,
+    ) -> UtoipaMethodRouter<S, NewError>;
+}
+
+impl<S, E> UtoipaMethodRouterExt<S, E> for UtoipaMethodRouter<S, E>
+where
+    S: Send + Sync + Clone + 'static,
+{
+    fn layer<L, NewError>(self, layer: L) -> UtoipaMethodRouter<S, NewError>
+    where
+        L: Layer<Route<E>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
+        <L::Service as Service<Request>>::Response: IntoResponse + 'static,
+        <L::Service as Service<Request>>::Error: Into<NewError> + 'static,
+        <L::Service as Service<Request>>::Future: Send + 'static,
+        E: 'static,
+        S: 'static,
+        NewError: 'static,
+    {
+        (self.0, self.1, self.2.layer(layer))
+    }
+
+    fn with_state<S2>(self, state: S) -> UtoipaMethodRouter<S2, E> {
+        (self.0, self.1, self.2.with_state(state))
+    }
+
+    fn map<NewError>(
+        self,
+        op: impl FnOnce(MethodRouter<S, E>) -> MethodRouter<S, NewError>,
+    ) -> UtoipaMethodRouter<S, NewError> {
+        (self.0, self.1, op(self.2))
+    }
+}
+
+/// A wrapper struct for [`axum::Router`] and [`utoipa::openapi::OpenApi`] for composing handlers
+/// and services with collecting OpenAPI information from the handlers.
+///
+/// This struct provides pass through implementation for most of the [`axum::Router`] methods and
+/// extends capabilities for few to collect the OpenAPI information. Methods that are not
+/// implemented can be easily called after converting this router to [`axum::Router`] by
+/// [`Into::into`].
+///
+/// # Examples
+///
+/// _**Create new [`OpenApiRouter`] with default values populated from cargo environment variables.**_
+/// ```rust
+/// # use canopy_utoipa_axum::router::OpenApiRouter;
+/// let _: OpenApiRouter = OpenApiRouter::new();
+/// ```
+///
+/// _**Instantiate a new [`OpenApiRouter`] with new empty [`utoipa::openapi::OpenApi`].**_
+/// ```rust
+/// # use canopy_utoipa_axum::router::OpenApiRouter;
+/// let _: OpenApiRouter = OpenApiRouter::default();
+/// ```
+#[derive(Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct OpenApiRouter<S = ()>(Router<S>, utoipa::openapi::OpenApi);
+
+impl<S> OpenApiRouter<S>
+where
+    S: Send + Sync + Clone + 'static,
+{
+    /// Instantiate a new [`OpenApiRouter`] with default values populated from cargo environment
+    /// variables. This creates an `OpenApi` similar of creating a new `OpenApi` via
+    /// `#[derive(OpenApi)]`
+    ///
+    /// If you want to create [`OpenApiRouter`] with completely empty [`utoipa::openapi::OpenApi`]
+    /// instance, use [`OpenApiRouter::default()`].
+    pub fn new() -> OpenApiRouter<S> {
+        use utoipa::OpenApi;
+        #[derive(OpenApi)]
+        struct Api;
+
+        Self::with_openapi(Api::openapi())
+    }
+
+    /// Instantiates a new [`OpenApiRouter`] with given _`openapi`_ instance.
+    ///
+    /// This function allows using existing [`utoipa::openapi::OpenApi`] as source for this router.
+    ///
+    /// # Examples
+    ///
+    /// _**Use derived [`utoipa::openapi::OpenApi`] as source for [`OpenApiRouter`].**_
+    /// ```rust
+    /// # use utoipa::OpenApi;
+    /// # use canopy_utoipa_axum::router::OpenApiRouter;
+    /// #[derive(utoipa::ToSchema)]
+    /// struct Todo {
+    ///     id: i32,
+    /// }
+    /// #[derive(utoipa::OpenApi)]
+    /// #[openapi(components(schemas(Todo)))]
+    /// struct Api;
+    ///
+    /// let mut router: OpenApiRouter = OpenApiRouter::with_openapi(Api::openapi());
+    /// ```
+    pub fn with_openapi(openapi: utoipa::openapi::OpenApi) -> Self {
+        Self(Router::new(), openapi)
+    }
+
+    /// Pass through method for [`axum::Router::as_service`].
+    pub fn as_service<B>(&mut self) -> RouterAsService<'_, B, S> {
+        self.0.as_service()
+    }
+
+    /// Pass through method for [`axum::Router::fallback`].
+    pub fn fallback<H, T>(self, handler: H) -> Self
+    where
+        H: Handler<T, S>,
+        T: 'static,
+    {
+        Self(self.0.fallback(handler), self.1)
+    }
+
+    /// Pass through method for [`axum::Router::fallback_service`].
+    pub fn fallback_service<T>(self, service: T) -> Self
+    where
+        T: Service<Request, Error = Infallible> + Clone + Send + Sync + 'static,
+        T::Response: IntoResponse,
+        T::Future: Send + 'static,
+    {
+        Self(self.0.fallback_service(service), self.1)
+    }
+
+    /// Pass through method for [`axum::Router::layer`].
+    pub fn layer<L>(self, layer: L) -> Self
+    where
+        L: Layer<Route> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
+        <L::Service as Service<Request>>::Response: IntoResponse + 'static,
+        <L::Service as Service<Request>>::Error: Into<Infallible> + 'static,
+        <L::Service as Service<Request>>::Future: Send + 'static,
+    {
+        Self(self.0.layer(layer), self.1)
+    }
+
+    /// Register [`UtoipaMethodRouter`] content created with [`routes`][routes] macro to `self`.
+    ///
+    /// Paths of the [`UtoipaMethodRouter`] will be extended to [`utoipa::openapi::OpenApi`] and
+    /// [`axum::routing::MethodRouter`] will be added to the [`axum::Router`].
+    ///
+    /// [routes]: ../macro.routes.html
+    pub fn routes(mut self, (schemas, mut paths, method_router): UtoipaMethodRouter<S>) -> Self {
+        let router = if paths.paths.len() == 1 {
+            let first_entry = &paths.paths.first_entry();
+            let path = first_entry.as_ref().map(|path| path.key());
+            let Some(path) = path else {
+                unreachable!("Whoopsie, I thought there was one Path entry");
+            };
+            let path = if path.is_empty() { "/" } else { path };
+
+            self.0.route(path, method_router)
+        } else {
+            paths.paths.iter().fold(self.0, |this, (path, _)| {
+                let path = if path.is_empty() { "/" } else { path };
+                this.route(path, method_router.clone())
+            })
+        };
+
+        // add or merge current paths to the OpenApi
+        for (path, item) in paths.paths {
+            if let Some(it) = self.1.paths.paths.get_mut(&path) {
+                it.merge_operations(item);
+            } else {
+                self.1.paths.paths.insert(path, item);
+            }
+        }
+
+        let components = self
+            .1
+            .components
+            .get_or_insert(utoipa::openapi::Components::new());
+        // CANOPY FORK: was `components.schemas.extend(schemas)`; insert one at a
+        // time so a name that already maps to a different schema panics instead
+        // of being silently overwritten.
+        for (name, schema) in schemas {
+            if let Some(existing) = components.schemas.get(&name) {
+                assert_schema_not_conflicting(existing, &schema, &name);
+            }
+            components.schemas.insert(name, schema);
+        }
+
+        Self(router, self.1)
+    }
+
+    /// Pass through method for [`axum::Router<S>::route`].
+    pub fn route(self, path: &str, method_router: MethodRouter<S>) -> Self {
+        Self(self.0.route(path, method_router), self.1)
+    }
+
+    /// Pass through method for [`axum::Router::route_layer`].
+    pub fn route_layer<L>(self, layer: L) -> Self
+    where
+        L: Layer<Route> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
+        <L::Service as Service<Request>>::Response: IntoResponse + 'static,
+        <L::Service as Service<Request>>::Error: Into<Infallible> + 'static,
+        <L::Service as Service<Request>>::Future: Send + 'static,
+    {
+        Self(self.0.route_layer(layer), self.1)
+    }
+
+    /// Pass through method for [`axum::Router<S>::route_service`].
+    pub fn route_service<T>(self, path: &str, service: T) -> Self
+    where
+        T: Service<Request, Error = Infallible> + Clone + Send + Sync + 'static,
+        T::Response: IntoResponse,
+        T::Future: Send + 'static,
+    {
+        Self(self.0.route_service(path, service), self.1)
+    }
+
+    /// Nest `router` to `self` under given `path`. Router routes will be nested with
+    /// [`axum::Router::nest`].
+    ///
+    /// This method expects [`OpenApiRouter`] instance in order to nest OpenApi paths and router
+    /// routes. If you wish to use [`axum::Router::nest`] you need to first convert this instance
+    /// to [`axum::Router`] _(`let _: Router = OpenApiRouter::new().into()`)_.
+    ///
+    /// # Examples
+    ///
+    /// _**Nest two routers.**_
+    /// ```rust
+    /// # use canopy_utoipa_axum::{routes, PathItemExt, router::OpenApiRouter};
+    /// #[utoipa::path(get, path = "/search")]
+    /// async fn search() {}
+    ///
+    /// let search_router = OpenApiRouter::new()
+    ///     .routes(canopy_utoipa_axum::routes!(search));
+    ///
+    /// let router: OpenApiRouter = OpenApiRouter::new()
+    ///     .nest("/api", search_router);
+    /// ```
+    pub fn nest(self, path: &str, router: OpenApiRouter<S>) -> Self {
+        // from axum::routing::path_router::path_for_nested_route
+        // method is private, so we need to replicate it here
+        fn path_for_nested_route(prefix: &str, path: &str) -> String {
+            let path = if path.is_empty() { "/" } else { path };
+            debug_assert!(prefix.starts_with('/'));
+
+            if prefix.ends_with('/') {
+                format!("{prefix}{}", path.trim_start_matches('/'))
+            } else if path == "/" {
+                prefix.into()
+            } else {
+                format!("{prefix}{path}")
+            }
+        }
+
+        // CANOPY FORK: utoipa core's nest silently overwrites colliding schema
+        // names; check before delegating so a real collision panics.
+        assert_no_schema_conflicts(&self.1, &router.1);
+        let api = self.1.nest_with_path_composer(
+            path_for_nested_route(path, "/"),
+            router.1,
+            path_for_nested_route,
+        );
+        let router = self.0.nest(path, router.0);
+
+        Self(router, api)
+    }
+
+    /// Pass through method for [`axum::Router::nest_service`]. _**This does nothing for OpenApi paths.**_
+    pub fn nest_service<T>(self, path: &str, service: T) -> Self
+    where
+        T: Service<Request, Error = Infallible> + Clone + Send + Sync + 'static,
+        T::Response: IntoResponse,
+        T::Future: Send + 'static,
+    {
+        Self(self.0.nest_service(path, service), self.1)
+    }
+
+    /// Merge [`utoipa::openapi::path::Paths`] from `router` to `self` and merge [`Router`] routes
+    /// and fallback with [`axum::Router::merge`].
+    ///
+    /// This method expects [`OpenApiRouter`] instance in order to merge OpenApi paths and router
+    /// routes. If you wish to use [`axum::Router::merge`] you need to first convert this instance
+    /// to [`axum::Router`] _(`let _: Router = OpenApiRouter::new().into()`)_.
+    ///
+    /// # Examples
+    ///
+    /// _**Merge two routers.**_
+    /// ```rust
+    /// # use canopy_utoipa_axum::{routes, PathItemExt, router::OpenApiRouter};
+    /// #[utoipa::path(get, path = "/search")]
+    /// async fn search() {}
+    ///
+    /// let search_router = OpenApiRouter::new()
+    ///     .routes(canopy_utoipa_axum::routes!(search));
+    ///
+    /// let router: OpenApiRouter = OpenApiRouter::new()
+    ///     .merge(search_router);
+    /// ```
+    pub fn merge(mut self, router: OpenApiRouter<S>) -> Self {
+        // CANOPY FORK: utoipa core's merge silently overwrites colliding schema
+        // names; check before delegating so a real collision panics.
+        assert_no_schema_conflicts(&self.1, &router.1);
+        self.1.merge(router.1);
+
+        Self(self.0.merge(router.0), self.1)
+    }
+
+    /// Pass through method for [`axum::Router::with_state`].
+    pub fn with_state<S2>(self, state: S) -> OpenApiRouter<S2> {
+        OpenApiRouter(self.0.with_state(state), self.1)
+    }
+
+    /// Consume `self` returning the [`utoipa::openapi::OpenApi`] instance of the
+    /// [`OpenApiRouter`].
+    pub fn into_openapi(self) -> utoipa::openapi::OpenApi {
+        self.1
+    }
+
+    /// Take the [`utoipa::openapi::OpenApi`] instance without consuming the [`OpenApiRouter`].
+    pub fn to_openapi(&mut self) -> utoipa::openapi::OpenApi {
+        std::mem::take(&mut self.1)
+    }
+
+    /// Get reference to the [`utoipa::openapi::OpenApi`] instance of the router.
+    pub fn get_openapi(&self) -> &utoipa::openapi::OpenApi {
+        &self.1
+    }
+
+    /// Get mutable reference to the [`utoipa::openapi::OpenApi`] instance of the router.
+    pub fn get_openapi_mut(&mut self) -> &mut utoipa::openapi::OpenApi {
+        &mut self.1
+    }
+
+    /// Split the content of the [`OpenApiRouter`] to parts. Method will return a tuple of
+    /// inner [`axum::Router`] and [`utoipa::openapi::OpenApi`].
+    pub fn split_for_parts(self) -> (axum::Router<S>, utoipa::openapi::OpenApi) {
+        (self.0, self.1)
+    }
+}
+
+impl<S> Default for OpenApiRouter<S>
+where
+    S: Send + Sync + Clone + 'static,
+{
+    fn default() -> Self {
+        Self::with_openapi(utoipa::openapi::OpenApiBuilder::new().build())
+    }
+}
+
+impl<S> From<OpenApiRouter<S>> for Router<S> {
+    fn from(value: OpenApiRouter<S>) -> Self {
+        value.0
+    }
+}
+
+impl<S> From<Router<S>> for OpenApiRouter<S> {
+    fn from(value: Router<S>) -> Self {
+        OpenApiRouter(value, utoipa::openapi::OpenApiBuilder::new().build())
+    }
+}

--- a/vendor/canopy-utoipa-axum/tests/schema_collision.rs
+++ b/vendor/canopy-utoipa-axum/tests/schema_collision.rs
@@ -1,0 +1,68 @@
+//! CANOPY FORK tests: the collision guard added in `router.rs` must panic when
+//! two different types register the same OpenAPI component schema name, and
+//! must stay quiet when the definitions are identical.
+
+use axum::Json;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+// Two distinct request bodies both forced to the component name `Dup` via
+// `#[schema(as = ...)]` — exactly the situation that arises naturally when two
+// modules define same-named `ToSchema` structs.
+#[derive(Deserialize, ToSchema)]
+#[schema(as = Dup)]
+struct AlphaArgs {
+    #[allow(dead_code)]
+    alpha: i32,
+}
+
+#[derive(Deserialize, ToSchema)]
+#[schema(as = Dup)]
+struct BetaArgs {
+    #[allow(dead_code)]
+    beta: String,
+}
+
+#[utoipa::path(post, path = "/alpha", request_body = AlphaArgs)]
+async fn alpha(_: Json<AlphaArgs>) {}
+
+#[utoipa::path(post, path = "/beta", request_body = BetaArgs)]
+async fn beta(_: Json<BetaArgs>) {}
+
+// A second handler reusing the *same* type produces the same schema under the
+// same name — the harmless shared-shape case that must not panic.
+#[utoipa::path(post, path = "/alpha2", request_body = AlphaArgs)]
+async fn alpha2(_: Json<AlphaArgs>) {}
+
+#[test]
+#[should_panic(expected = "schema name collision")]
+fn routes_on_one_router_panics_on_conflict() {
+    let _: OpenApiRouter = OpenApiRouter::new()
+        .routes(routes!(alpha))
+        .routes(routes!(beta));
+}
+
+#[test]
+#[should_panic(expected = "schema name collision")]
+fn nest_panics_on_conflict() {
+    let _: OpenApiRouter = OpenApiRouter::new()
+        .nest("/a", OpenApiRouter::new().routes(routes!(alpha)))
+        .nest("/b", OpenApiRouter::new().routes(routes!(beta)));
+}
+
+#[test]
+#[should_panic(expected = "schema name collision")]
+fn merge_panics_on_conflict() {
+    let _: OpenApiRouter = OpenApiRouter::new()
+        .merge(OpenApiRouter::new().routes(routes!(alpha)))
+        .merge(OpenApiRouter::new().routes(routes!(beta)));
+}
+
+#[test]
+fn identical_schema_under_same_name_is_fine() {
+    // Same type registered twice: same name, same definition — no panic.
+    let _: OpenApiRouter = OpenApiRouter::new()
+        .routes(routes!(alpha))
+        .nest("/again", OpenApiRouter::new().routes(routes!(alpha2)));
+}


### PR DESCRIPTION
🤖 Follow-up to #316. That PR fixed the schema-name collisions by hand; this one makes the class of bug fail loudly instead of shipping a silently-wrong spec.

## The problem

utoipa keys OpenAPI component schemas by the type's short name, so two distinct `ToSchema` types that share a name (a `CreateArgs` in two modules, say) silently overwrite each other when their routers are combined. Nothing in upstream utoipa/utoipa-axum detects this, and once the spec is a JSON object the collision is invisible (the map already collapsed), so a post-hoc check on the generated spec can't catch it either.

## The guard

utoipa-axum is tiny (two source files, ~3 releases in two years), so it's vendored as `canopy-utoipa-axum` under `vendor/`. The only functional change (marked `// CANOPY FORK:` in `src/router.rs`) is that `routes()`, `nest()`, and `merge()` now **panic** when a component schema name would be registered with a definition that differs from the one already present, instead of silently overwriting it. Identical definitions under the same name — a genuinely shared argument shape — are still fine.

The panic fires at router-build time, which is spec generation (`just gen-openapi`), the `openapi_spec` tests, and server startup — so a future collision can't reach a committed spec unnoticed.

`vendor/canopy-utoipa-axum/tests/schema_collision.rs` covers all three combine paths and the identical-schema no-panic case. A nested `rustfmt.toml` keeps the fork in upstream's formatting so future syncs stay small.

The rest of the diff repoints the workspace dependency and renames imports `utoipa_axum` -> `canopy_utoipa_axum` across the two server crates.