### PR TITLE
fix(private-web): status dot strip wrap spacing and separator width

### DIFF
--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -349,12 +349,21 @@ export function RankedDotStrip({ members }: { members: FacilityServerStatus[] })
 		else chunks.push({ rank: key, entries: [m] });
 	}
 	return (
-		<Stack direction="row" spacing={0} sx={{ flexWrap: "wrap", alignItems: "center" }}>
+		<Stack
+			direction="row"
+			spacing={0}
+			sx={{ flexWrap: "wrap", alignItems: "center", rowGap: "0.5em" }}
+		>
 			{chunks.map((chunk, idx) => (
 				<Box
 					key={chunk.rank}
 					component="span"
-					sx={{ display: "inline-flex", alignItems: "center" }}
+					sx={{
+						display: "inline-flex",
+						flexWrap: "wrap",
+						alignItems: "center",
+						rowGap: "0.5em",
+					}}
 				>
 					{idx > 0 && (
 						<Box
@@ -364,7 +373,7 @@ export function RankedDotStrip({ members }: { members: FacilityServerStatus[] })
 								display: "inline-block",
 								width: "1px",
 								height: "0.9em",
-								mx: 0.5,
+								mx: "0.25em",
 								bgcolor: "text.disabled",
 							}}
 						/>


### PR DESCRIPTION
🤖 When a group has many servers, the indicator dots on the status card wrap onto multiple lines with no vertical spacing between rows, and the rank separator bar used a fixed-pixel margin (`mx: 0.5` → 4px) that didn't match the em-based rhythm of the dots, throwing off alignment.

- Add `rowGap: 0.5em` (matching the dots' horizontal spacing) to the dot strip and to each rank chunk.
- Let a single rank's dots wrap internally instead of overflowing as one long line.
- Make the separator margins em-based (`0.25em` per side) so its effective width scales with the dots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)