### PR TITLE
feat(private-web): edit dialog for restore replicas

### DIFF
--- a/private-web/e2e/restore-replicas.spec.ts
+++ b/private-web/e2e/restore-replicas.spec.ts
@@ -333,6 +333,102 @@ test.describe("restore replicas", () => {
 		expect(rows[0]!.params.minimum_uptime).toBe(3600);
 	});
 
+	test("editing a declaration through the dialog updates name, overdue bound, and enabled", async ({
+		page,
+		sql,
+	}) => {
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		await seedRestoreConsumerCapability(sql, {
+			deviceId: consumer.id,
+			intents: ["verify"],
+		});
+		const groupId = await groupWithBackups(sql, "edit-group");
+		const replica = await seedRestoreReplica(sql, {
+			consumerDeviceId: consumer.id,
+			groupId,
+			intent: "verify",
+			name: "before-edit",
+			overdueAfterSeconds: 3600,
+			enabled: true,
+		});
+
+		await page.goto(`/groups/${groupId}/backups`);
+		await page.getByRole("button", { name: "edit before-edit" }).click();
+
+		const dialog = page.getByRole("dialog");
+		await expect(dialog.getByLabel("Name")).toHaveValue("before-edit");
+		await expect(dialog.getByLabel("Overdue after (hours, optional)")).toHaveValue(
+			"1",
+		);
+
+		await dialog.getByLabel("Name").fill("after-edit");
+		await dialog.getByLabel("Overdue after (hours, optional)").fill("4");
+		await dialog.getByLabel("Enabled").click();
+		await dialog.getByRole("button", { name: /^save$/i }).click();
+
+		await expect(page.getByRole("row", { name: /after-edit/ })).toBeVisible();
+		await expect(page.getByRole("row", { name: /before-edit/ })).toHaveCount(0);
+
+		const rows = await sql.query<{
+			name: string;
+			overdue_after_secs: string;
+			enabled: boolean;
+		}>(
+			`SELECT name, enabled, EXTRACT(EPOCH FROM overdue_after)::text AS overdue_after_secs
+			 FROM restore_replicas WHERE id = $1`,
+			[replica.id],
+		);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]!.name).toBe("after-edit");
+		expect(rows[0]!.enabled).toBe(false);
+		expect(Number(rows[0]!.overdue_after_secs)).toBe(4 * 3600);
+	});
+
+	test("editing a declaration's parameters persists the typed values", async ({
+		page,
+		sql,
+	}) => {
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		await seedRestoreConsumerCapability(sql, {
+			deviceId: consumer.id,
+			intents: [
+				{
+					intent: "analytics",
+					description: "Keeps a queryable replica running.",
+					semantics: ["check", "url"],
+					params: {
+						minimum_uptime: { type: "duration", default: 7200 },
+						anonymisation: { type: "boolean", default: true },
+					},
+				},
+			],
+		});
+		const groupId = await groupWithBackups(sql, "edit-param-group");
+		await seedRestoreReplica(sql, {
+			consumerDeviceId: consumer.id,
+			groupId,
+			intent: "analytics",
+			name: "param-edit",
+			params: { minimum_uptime: 3600, anonymisation: true },
+		});
+
+		await page.goto(`/groups/${groupId}/backups`);
+		await page.getByRole("button", { name: "edit param-edit" }).click();
+
+		const dialog = page.getByRole("dialog");
+		const uptime = dialog.getByLabel("minimum_uptime (seconds)");
+		await expect(uptime).toHaveValue("3600");
+		await uptime.fill("1800");
+		await dialog.getByRole("button", { name: /^save$/i }).click();
+
+		await expect(page.getByRole("row", { name: /param-edit/ })).toBeVisible();
+		const rows = await sql.query<{ params: { minimum_uptime?: number } }>(
+			"SELECT params FROM restore_replicas WHERE name = 'param-edit'",
+		);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]!.params.minimum_uptime).toBe(1800);
+	});
+
 	test("a restore check surfaces a replica url as a link", async ({
 		page,
 		sql,

--- a/private-web/src/components/RestoreReplicasSection.tsx
+++ b/private-web/src/components/RestoreReplicasSection.tsx
@@ -1,5 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
@@ -14,6 +15,7 @@ import {
 	DialogContent,
 	DialogTitle,
 	FormControl,
+	FormControlLabel,
 	IconButton,
 	InputLabel,
 	Link,
@@ -39,6 +41,7 @@ import type {
 	IntentDescriptor,
 	ParamSpec,
 	RestoreConsumerView,
+	RestoreReplicaView,
 } from "../types";
 
 function kebabCase(s: string): string {
@@ -102,6 +105,9 @@ export default function RestoreReplicasSection({
 	);
 
 	const [createOpen, setCreateOpen] = useState(false);
+	const [editingReplica, setEditingReplica] = useState<RestoreReplicaView | null>(
+		null,
+	);
 	const [error, setError] = useState<string | null>(null);
 
 	const onDelete = async (id: string) => {
@@ -237,6 +243,12 @@ export default function RestoreReplicasSection({
 									{isAdmin && (
 										<TableCell align="right">
 											<IconButton
+												aria-label={`edit ${r.name}`}
+												onClick={() => setEditingReplica(r)}
+											>
+												<EditIcon />
+											</IconButton>
+											<IconButton
 												edge="end"
 												aria-label={`delete ${r.name}`}
 												onClick={() => onDelete(r.id)}
@@ -291,6 +303,18 @@ export default function RestoreReplicasSection({
 						reload();
 					}}
 					consumers={consumers.status === "ok" ? consumers.data : []}
+				/>
+			)}
+
+			{editingReplica && (
+				<EditReplicaDialog
+					replica={editingReplica}
+					consumers={consumers.status === "ok" ? consumers.data : []}
+					onClose={() => setEditingReplica(null)}
+					onUpdated={() => {
+						setEditingReplica(null);
+						reload();
+					}}
 				/>
 			)}
 		</Box>
@@ -361,6 +385,83 @@ function ParamField({
 			onChange={(e) => onChange(e.target.value)}
 		/>
 	);
+}
+
+/** The "Parameters" heading plus one typed input per entry in `paramSchema`,
+ * shared between the declare and edit dialogs. Renders nothing for an intent
+ * with no parameters (or one Canopy has no schema for, e.g. a gap). */
+function ParamFieldsEditor({
+	paramSchema,
+	values,
+	onChange,
+}: {
+	paramSchema: Record<string, ParamSpec>;
+	values: Record<string, string>;
+	onChange: (key: string, value: string) => void;
+}) {
+	const entries = Object.entries(paramSchema);
+	if (entries.length === 0) return null;
+	return (
+		<>
+			<Typography variant="subtitle2">Parameters</Typography>
+			{entries.map(([key, spec]) => (
+				<ParamField
+					key={key}
+					name={key}
+					spec={spec}
+					value={values[key] ?? ""}
+					onChange={(v) => onChange(key, v)}
+				/>
+			))}
+		</>
+	);
+}
+
+/** Convert the typed form fields into the wire params object, omitting any the
+ * operator left unset (the consumer resolves those to their default or null).
+ * Returns an error message string if a numeric field doesn't parse. */
+function paramValuesToWire(
+	paramSchema: Record<string, ParamSpec>,
+	paramValues: Record<string, string>,
+): Record<string, unknown> | string {
+	const out: Record<string, unknown> = {};
+	for (const [key, spec] of Object.entries(paramSchema)) {
+		const raw = paramValues[key];
+		if (raw == null || raw === "") continue;
+		if (spec.type === "boolean") {
+			out[key] = raw === "true";
+		} else if (
+			spec.type === "integer" ||
+			spec.type === "bytes" ||
+			spec.type === "duration"
+		) {
+			const n = Number(raw);
+			if (!Number.isFinite(n)) return `Parameter "${key}" must be a number`;
+			out[key] = n;
+		} else {
+			out[key] = raw;
+		}
+	}
+	return out;
+}
+
+/** Stringify a replica's stored parameter values for the edit form's typed
+ * inputs, keyed by the intent's current schema. Values for keys the schema no
+ * longer describes are dropped — there'd be no field to show them in. */
+function wireParamsToValues(
+	paramSchema: Record<string, ParamSpec>,
+	params: unknown,
+): Record<string, string> {
+	const source = (
+		params && typeof params === "object" ? params : {}
+	) as Record<string, unknown>;
+	const out: Record<string, string> = {};
+	for (const [key, spec] of Object.entries(paramSchema)) {
+		const raw = source[key];
+		if (raw == null) continue;
+		out[key] = spec.type === "boolean" ? String(Boolean(raw)) : String(raw);
+	}
+	return out;
 }
 
 function CreateReplicaDialog({
@@ -442,30 +543,6 @@ function CreateReplicaDialog({
 		if (!nameEdited) setName(suggestedName);
 	}, [suggestedName, nameEdited]);
 
-	// Convert the typed form fields into the wire params object, omitting any the
-	// operator left unset (the consumer resolves those to their default or null).
-	const buildParams = (): Record<string, unknown> | string => {
-		const out: Record<string, unknown> = {};
-		for (const [key, spec] of Object.entries(paramSchema)) {
-			const raw = paramValues[key];
-			if (raw == null || raw === "") continue;
-			if (spec.type === "boolean") {
-				out[key] = raw === "true";
-			} else if (
-				spec.type === "integer" ||
-				spec.type === "bytes" ||
-				spec.type === "duration"
-			) {
-				const n = Number(raw);
-				if (!Number.isFinite(n)) return `Parameter "${key}" must be a number`;
-				out[key] = n;
-			} else {
-				out[key] = raw;
-			}
-		}
-		return out;
-	};
-
 	const onSubmit = async () => {
 		if (!consumerId) return setError("Pick a consumer");
 		if (!intent) return setError("Pick an intent the consumer advertises");
@@ -476,7 +553,7 @@ function CreateReplicaDialog({
 		if (overdue_after_seconds != null && !Number.isFinite(overdue_after_seconds)) {
 			return setError("Overdue bound must be a number of hours");
 		}
-		const params = buildParams();
+		const params = paramValuesToWire(paramSchema, paramValues);
 		if (typeof params === "string") return setError(params);
 		setPending(true);
 		setError(null);
@@ -598,20 +675,13 @@ function CreateReplicaDialog({
 						onChange={(e) => setOverdueHours(e.target.value)}
 					/>
 
-					{Object.keys(paramSchema).length > 0 && (
-						<Typography variant="subtitle2">Parameters</Typography>
-					)}
-					{Object.entries(paramSchema).map(([key, spec]) => (
-						<ParamField
-							key={key}
-							name={key}
-							spec={spec}
-							value={paramValues[key] ?? ""}
-							onChange={(v) =>
-								setParamValues((prev) => ({ ...prev, [key]: v }))
-							}
-						/>
-					))}
+					<ParamFieldsEditor
+						paramSchema={paramSchema}
+						values={paramValues}
+						onChange={(key, v) =>
+							setParamValues((prev) => ({ ...prev, [key]: v }))
+						}
+					/>
 
 					{error && <Alert severity="error">{error}</Alert>}
 				</Stack>
@@ -622,6 +692,132 @@ function CreateReplicaDialog({
 				</Button>
 				<Button variant="contained" onClick={onSubmit} disabled={pending}>
 					{pending ? "Declaring…" : "Declare"}
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}
+
+/** Edit a declared replica's non-structural fields (name, overdue bound,
+ * parameters, enabled). Scope — consumer, group/server, type, intent — is
+ * immutable, so this dialog doesn't offer it. Parameter fields come from the
+ * consumer's current schema for the replica's intent, if it still advertises
+ * one; for a gap declaration there's no schema to render fields for, so the
+ * stored parameter values are carried through unchanged. */
+function EditReplicaDialog({
+	replica,
+	consumers,
+	onClose,
+	onUpdated,
+}: {
+	replica: RestoreReplicaView;
+	consumers: RestoreConsumerView[];
+	onClose: () => void;
+	onUpdated: () => void;
+}) {
+	const selectedConsumer = consumers.find(
+		(c) => c.device_id === replica.consumer_device_id,
+	);
+	const selectedDescriptor = selectedConsumer?.intents.find(
+		(d) => d.intent === replica.intent,
+	);
+	const paramSchema: Record<string, ParamSpec> =
+		(selectedDescriptor?.params as Record<string, ParamSpec> | undefined) ?? {};
+
+	const [name, setName] = useState(replica.name);
+	const [overdueHours, setOverdueHours] = useState(
+		replica.overdue_after_seconds != null
+			? String(replica.overdue_after_seconds / 3600)
+			: "",
+	);
+	const [enabled, setEnabled] = useState(replica.enabled);
+	const [paramValues, setParamValues] = useState<Record<string, string>>(() =>
+		wireParamsToValues(paramSchema, replica.params),
+	);
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const onSubmit = async () => {
+		if (!name.trim()) return setError("Name cannot be empty");
+		const hours = overdueHours.trim();
+		const overdue_after_seconds =
+			hours === "" ? null : Math.round(Number(hours) * 3600);
+		if (overdue_after_seconds != null && !Number.isFinite(overdue_after_seconds)) {
+			return setError("Overdue bound must be a number of hours");
+		}
+		let params: unknown = replica.params;
+		if (Object.keys(paramSchema).length > 0) {
+			const built = paramValuesToWire(paramSchema, paramValues);
+			if (typeof built === "string") return setError(built);
+			params = built;
+		}
+		setPending(true);
+		setError(null);
+		try {
+			await callApi("restore_replicas", "update", {
+				id: replica.id,
+				name: name.trim(),
+				overdue_after_seconds,
+				params,
+				enabled,
+			});
+			onUpdated();
+		} catch (err) {
+			setError(formatError(err));
+			setPending(false);
+		}
+	};
+
+	return (
+		<Dialog open onClose={() => !pending && onClose()} fullWidth maxWidth="sm">
+			<DialogTitle>Edit restore replica</DialogTitle>
+			<DialogContent>
+				<Stack spacing={2} sx={{ mt: 1 }}>
+					<TextField
+						size="small"
+						fullWidth
+						label="Name"
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+					/>
+
+					<TextField
+						size="small"
+						fullWidth
+						type="number"
+						label="Overdue after (hours, optional)"
+						placeholder="no bound"
+						value={overdueHours}
+						onChange={(e) => setOverdueHours(e.target.value)}
+					/>
+
+					<FormControlLabel
+						control={
+							<Switch
+								checked={enabled}
+								onChange={(e) => setEnabled(e.target.checked)}
+							/>
+						}
+						label="Enabled"
+					/>
+
+					<ParamFieldsEditor
+						paramSchema={paramSchema}
+						values={paramValues}
+						onChange={(key, v) =>
+							setParamValues((prev) => ({ ...prev, [key]: v }))
+						}
+					/>
+
+					{error && <Alert severity="error">{error}</Alert>}
+				</Stack>
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onClose} disabled={pending}>
+					Cancel
+				</Button>
+				<Button variant="contained" onClick={onSubmit} disabled={pending}>
+					{pending ? "Saving…" : "Save"}
 				</Button>
 			</DialogActions>
 		</Dialog>


### PR DESCRIPTION
🤖 Restore replicas can now be edited in place instead of delete + recreate. The backend `restore_replicas/update` endpoint already existed (name, overdue bound, params, enabled — scope fields stay immutable by design); this adds the missing UI.

- Edit button on each replica row (admin only) opens a dialog pre-filled from the row, submitting via the existing update endpoint.
- Param-field rendering is now shared between the create and edit dialogs (`ParamFieldsEditor`, `paramValuesToWire`, `wireParamsToValues`) instead of duplicated.
- When a consumer no longer advertises the replica's intent (a "gap"), there's no param schema, so the dialog passes stored params through unchanged; name/overdue/enabled remain editable.
- Note: saving re-derives params from the current schema, so stored keys the schema no longer describes are dropped — same as what create would produce today.
- Playwright coverage: pre-fill + name/overdue/enabled persistence (checked in-page and in the DB), and editing a typed param value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)