### PR TITLE
fix(database): sensible message for servers that have never reported

### DIFF
--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -243,13 +243,15 @@ impl Status {
 		let mut filed = 0usize;
 		for server in &monitored {
 			let threshold = server.alert_when_down_for.0;
-			let elapsed = match status_map.get(&server.id) {
-				Some(s) => now.duration_since(s.created_at).abs(),
-				// No status ever recorded: treat as infinite downtime so the
-				// threshold always trips. Caps at i64::MAX seconds for arithmetic.
-				None => SignedDuration::MAX,
+			// No status ever recorded ⇒ `None`, which always trips the
+			// threshold below.
+			let elapsed: Option<SignedDuration> = status_map
+				.get(&server.id)
+				.map(|s| now.duration_since(s.created_at).abs());
+			let down = match elapsed {
+				Some(e) => e >= threshold,
+				None => true,
 			};
-			let down = elapsed >= threshold;
 			let existing = issue_map.get(&server.id).copied();
 
 			let event = match (down, existing) {
@@ -269,12 +271,19 @@ impl Status {
 					r#ref: REACHABILITY_REF.into(),
 					severity: Some(Severity::Error),
 					description: None,
-					message: format!(
-						"Server {} has not reported for {} (threshold {})",
-						server_label(server),
-						format_secs(elapsed.as_secs()),
-						format_secs(threshold.as_secs()),
-					),
+					message: match elapsed {
+						Some(e) => format!(
+							"Server {} has not reported for {} (threshold {})",
+							server_label(server),
+							format_secs(e.as_secs()),
+							format_secs(threshold.as_secs()),
+						),
+						None => format!(
+							"Server {} has never reported (threshold {})",
+							server_label(server),
+							format_secs(threshold.as_secs()),
+						),
+					},
 					active: Some(true),
 					occurred_at: Some(now),
 				},

--- a/crates/database/tests/reachability_sweep.rs
+++ b/crates/database/tests/reachability_sweep.rs
@@ -104,9 +104,18 @@ async fn sweep_files_when_no_status_ever() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
 		// No status row at all → infinite downtime → always crosses threshold.
 		let id = insert_server(&mut conn, "http://gone.invalid/", 600).await;
-		Status::sweep_reachability(&mut conn).await.expect("sweep");
+		let filed = Status::sweep_reachability(&mut conn).await.expect("sweep");
+		assert_eq!(filed, 1);
 		let issue = issue_for(&mut conn, id).await.expect("issue exists");
 		assert_eq!(issue.severity, Severity::Error);
+		assert!(issue.active);
+		assert!(
+			issue.message.contains("has never reported"),
+			"expected a never-reported message, got: {}",
+			issue.message
+		);
+		assert!(issue.message.contains("(threshold 10m)"));
+		assert!(!issue.message.contains("106751991167300d"));
 	})
 	.await
 }


### PR DESCRIPTION
🤖 A server with no status rows at all got flagged with "Server X has not reported for 106751991167300d (threshold 10m)" — the reachability sweep used `SignedDuration::MAX` as a never-reported sentinel and fed it straight into the duration formatter.

The sweep now tracks elapsed time as an `Option`, and the never-reported case files "Server X has never reported (threshold 10m)" instead. Alerting behaviour is unchanged: never-reported still always trips the threshold.

The existing never-reported sweep test now asserts the message wording (and the absence of the old garbage string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)