### PR TITLE
feat(jobs): inspect promptly after successful backup maintenance

### DIFF
--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -1292,6 +1292,31 @@ impl BackupMaintenanceRun {
 			.map_err(AppError::from)
 	}
 
+	/// When the group's maintenance last completed *successfully*, or `None` if
+	/// it never has. Drives prompt post-maintenance inspection: maintenance
+	/// (retention pruning, compaction) changes what's actually in the repo, so
+	/// the stats/snapshot inventory should freshen soon after — mirroring
+	/// [`BackupRun::latest_backup_at_for_group`]'s "freshen after a backup"
+	/// role. A failed run doesn't change repo contents and is already surfaced
+	/// via the separate `MAINTENANCE_ERROR` alert, so only successes count
+	/// here (matching the success-only convention there).
+	pub async fn latest_successful_finished_at_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<Option<Timestamp>> {
+		use crate::schema::backup_maintenance_runs::dsl;
+
+		let row: Option<Self> = dsl::backup_maintenance_runs
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::outcome.eq(RunOutcome::Success))
+			.order_by(dsl::finished_at.desc())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)?;
+		Ok(row.and_then(|r| r.finished_at))
+	}
+
 	/// Whether a run row still exists and is open (`outcome IS NULL`). Used by
 	/// the scheduler's crash-detection to mark a run failed when its Job
 	/// finished without ever reporting.

--- a/crates/database/tests/backups.rs
+++ b/crates/database/tests/backups.rs
@@ -782,6 +782,90 @@ async fn maintenance_list_filtered_narrows_by_every_field() {
 	.await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn maintenance_latest_successful_finished_at() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+
+		// No runs at all → None.
+		assert_eq!(
+			BackupMaintenanceRun::latest_successful_finished_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap(),
+			None
+		);
+
+		// A failed run doesn't count.
+		let failed = BackupMaintenanceRun::start(&mut conn, group_id, MaintenanceKind::Quick)
+			.await
+			.unwrap();
+		BackupMaintenanceRun::finish(
+			&mut conn,
+			failed,
+			RunOutcome::Failure,
+			Some("boom".into()),
+			None,
+		)
+		.await
+		.unwrap();
+		assert_eq!(
+			BackupMaintenanceRun::latest_successful_finished_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap(),
+			None
+		);
+
+		// A successful run is picked up.
+		let ok = BackupMaintenanceRun::start(&mut conn, group_id, MaintenanceKind::Full)
+			.await
+			.unwrap();
+		BackupMaintenanceRun::finish(&mut conn, ok, RunOutcome::Success, None, Some(2048))
+			.await
+			.unwrap();
+		let first_success =
+			BackupMaintenanceRun::latest_successful_finished_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap();
+		assert!(first_success.is_some());
+
+		// A later failure doesn't regress the "latest success" answer.
+		tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+		let failed_after = BackupMaintenanceRun::start(&mut conn, group_id, MaintenanceKind::Quick)
+			.await
+			.unwrap();
+		BackupMaintenanceRun::finish(
+			&mut conn,
+			failed_after,
+			RunOutcome::Failure,
+			Some("boom".into()),
+			None,
+		)
+		.await
+		.unwrap();
+		assert_eq!(
+			BackupMaintenanceRun::latest_successful_finished_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap(),
+			first_success
+		);
+
+		// A newer success overtakes it.
+		tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+		let ok2 = BackupMaintenanceRun::start(&mut conn, group_id, MaintenanceKind::Full)
+			.await
+			.unwrap();
+		BackupMaintenanceRun::finish(&mut conn, ok2, RunOutcome::Success, None, Some(4096))
+			.await
+			.unwrap();
+		let second_success =
+			BackupMaintenanceRun::latest_successful_finished_at_for_group(&mut conn, group_id)
+				.await
+				.unwrap();
+		assert!(second_success > first_success);
+	})
+	.await;
+}
+
 // --- repo snapshots ---------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/jobs/src/backup/inspection.rs
+++ b/crates/jobs/src/backup/inspection.rs
@@ -10,15 +10,20 @@
 //!
 //! A group is due when **a backup has landed since its last inspection** (so the
 //! stats panel freshens shortly after a backup — including a manual "back up
-//! now" — rather than waiting), or otherwise on its **hash-jittered cadence**:
-//! the group's effective backup interval (min across enabled types'
-//! schedule/default `expected_interval`), floored to weekly, so corruption/drift
-//! is still caught on quiet repos.
+//! now" — rather than waiting), **a maintenance run has completed successfully
+//! since its last inspection** (maintenance prunes/compacts the repo, so the
+//! inventory should freshen after it too), or otherwise on its
+//! **hash-jittered cadence**: the group's effective backup interval (min
+//! across enabled types' schedule/default `expected_interval`), floored to
+//! weekly, so corruption/drift is still caught on quiet repos.
 
 use std::time::Duration;
 
 use commons_servers::backup_jobs::{effective_interval_for_group, slot_is_due};
-use database::{BackupConfigStatus, BackupRepoSnapshot, BackupRun, ServerGroupBackupConfig};
+use database::{
+	BackupConfigStatus, BackupMaintenanceRun, BackupRepoSnapshot, BackupRun,
+	ServerGroupBackupConfig,
+};
 use jiff::Timestamp;
 use tokio::{
 	task::{self, JoinHandle},
@@ -53,6 +58,25 @@ fn backup_since_inspect(
 ) -> bool {
 	match (latest_backup, last_inspected) {
 		(Some(backup), Some(inspected)) => backup > inspected,
+		(Some(_), None) => true,
+		(None, _) => false,
+	}
+}
+
+/// Whether a maintenance run has completed successfully since the repo was
+/// last inspected — the signal to inspect promptly after maintenance (pruning
+/// and compaction change what's actually stored, so the inventory should
+/// freshen). `latest_maint` is the group's newest successful maintenance
+/// completion; `last_inspected` is the newest inspection. Never-inspected with
+/// a completed maintenance run present → due. A failed run doesn't count: it
+/// hasn't changed repo contents, and it's already surfaced via the separate
+/// maintenance-error alert.
+fn maintenance_since_inspect(
+	latest_maint: Option<Timestamp>,
+	last_inspected: Option<Timestamp>,
+) -> bool {
+	match (latest_maint, last_inspected) {
+		(Some(maint), Some(inspected)) => maint > inspected,
 		(Some(_), None) => true,
 		(None, _) => false,
 	}
@@ -138,6 +162,15 @@ async fn tick(worker: &Worker) -> Result<(), String> {
 			.map_err(|e| e.to_string())?;
 		let due_after_backup = backup_since_inspect(latest_backup, last_inspected);
 
+		// ...or a maintenance run has completed successfully since the last
+		// inspection (pruning/compaction changes the repo, so freshen the
+		// inventory the same way a landed backup does)...
+		let latest_maint =
+			BackupMaintenanceRun::latest_successful_finished_at_for_group(&mut db, c.group_id)
+				.await
+				.map_err(|e| e.to_string())?;
+		let due_after_maint = maintenance_since_inspect(latest_maint, last_inspected);
+
 		// ...otherwise fall back to the per-group cadence: the group's effective
 		// backup interval, floored to weekly (also the floor when no enabled type
 		// has an interval), so corruption/drift is still caught on quiet repos.
@@ -146,7 +179,7 @@ async fn tick(worker: &Worker) -> Result<(), String> {
 			.map_err(|e| e.to_string())?
 			.map_or(INSPECT_FLOOR, |i| i.max(INSPECT_FLOOR));
 		let into = secs_into(now, window);
-		if !due_after_backup && !slot_is_due(c.group_id, window, TICK, into) {
+		if !due_after_backup && !due_after_maint && !slot_is_due(c.group_id, window, TICK, into) {
 			continue;
 		}
 		spawn_inspect(worker, c.clone());
@@ -185,5 +218,21 @@ mod tests {
 		// No successful backup yet → nothing to inspect for.
 		assert!(!backup_since_inspect(None, None));
 		assert!(!backup_since_inspect(None, Some(t0)));
+	}
+
+	#[test]
+	fn maintenance_since_inspect_decisions() {
+		let t0: Timestamp = "2026-06-01T00:00:00Z".parse().unwrap();
+		let t1: Timestamp = "2026-06-01T01:00:00Z".parse().unwrap();
+		// Maintenance completed newer than last inspection → due.
+		assert!(maintenance_since_inspect(Some(t1), Some(t0)));
+		// Inspection at/after the latest maintenance completion → not due.
+		assert!(!maintenance_since_inspect(Some(t0), Some(t1)));
+		assert!(!maintenance_since_inspect(Some(t0), Some(t0)));
+		// Maintenance completed but never inspected → due.
+		assert!(maintenance_since_inspect(Some(t0), None));
+		// No successful maintenance run yet → nothing to inspect for.
+		assert!(!maintenance_since_inspect(None, None));
+		assert!(!maintenance_since_inspect(None, Some(t0)));
 	}
 }

--- a/crates/jobs/src/backup/inspection.rs
+++ b/crates/jobs/src/backup/inspection.rs
@@ -8,14 +8,18 @@
 //! Inspection is read-only, but it still goes through the in-flight set
 //! ([`super::worker`]) so it doesn't overlap a maintenance run on the same repo.
 //!
-//! A group is due when **a backup has landed since its last inspection** (so the
-//! stats panel freshens shortly after a backup — including a manual "back up
-//! now" — rather than waiting), **a maintenance run has completed successfully
-//! since its last inspection** (maintenance prunes/compacts the repo, so the
-//! inventory should freshen after it too), or otherwise on its
-//! **hash-jittered cadence**: the group's effective backup interval (min
-//! across enabled types' schedule/default `expected_interval`), floored to
-//! weekly, so corruption/drift is still caught on quiet repos.
+//! A group is due when any of these hold:
+//!
+//! - **a backup has landed since its last inspection** — so the stats panel
+//!   freshens shortly after a backup (including a manual "back up now")
+//!   rather than waiting;
+//! - **a maintenance run has completed successfully since its last
+//!   inspection** — maintenance prunes/compacts the repo, so the inventory
+//!   should freshen after it too;
+//! - otherwise, its **hash-jittered cadence** has come around: the group's
+//!   effective backup interval (min across enabled types' schedule/default
+//!   `expected_interval`), floored to weekly, so corruption/drift is still
+//!   caught on quiet repos.
 
 use std::time::Duration;
 


### PR DESCRIPTION
🤖 Maintenance prunes and compacts the repo, but the inspection inventory only freshened after a backup landed or on the weekly-floored cadence. Inspection due-ness now also triggers when a maintenance run has completed successfully since the last inspection, mirroring the existing post-backup trigger: the next inspection tick (≤60s after the maintenance guard is released) picks it up, so there's no chaining through the completion path and the per-group in-flight guard is respected. Like the post-backup trigger, it bypasses the weekly floor.

Failed maintenance runs deliberately don't trigger inspection: they haven't changed repo contents, they're already surfaced via the maintenance-error alert, and counting them would re-trigger on every failed retry.

Adds `BackupMaintenanceRun::latest_successful_finished_at_for_group` with a DB test, plus unit tests for the due-ness decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)