### PR TITLE
feat: per-healthcheck page listing servers currently failing or warning it

### DIFF
--- a/crates/database/src/healthcheck_severities.rs
+++ b/crates/database/src/healthcheck_severities.rs
@@ -163,6 +163,19 @@ impl HealthcheckSeverity {
 			.map_err(AppError::from)
 	}
 
+	/// The catalog row for a single check name, or `None` if no server has
+	/// ever reported it (so ingestion has never upserted a row).
+	pub async fn get(db: &mut AsyncPgConnection, check_name: &str) -> Result<Option<Self>> {
+		use crate::schema::healthcheck_severities::dsl;
+		dsl::healthcheck_severities
+			.select(Self::as_select())
+			.filter(dsl::check_name.eq(check_name))
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
 	/// Update the severity (and optionally notes) for a check, stamping
 	/// `reviewed_at = NOW()` and `reviewed_by = by`. Even a no-op save
 	/// (same severity) marks the row reviewed — operators can ack

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -448,6 +448,93 @@ impl Status {
 		query.load::<Status>(db).await.map_err(AppError::from)
 	}
 
+	/// Live (non-deleted, non-canopy-own) servers whose latest status is
+	/// [`HealthState::Warning`] or [`HealthState::Unhealthy`], paired with
+	/// that status. Mirrors the live-server scoping in
+	/// [`crate::servers::Server::get_all`] / the status-board queries:
+	/// archived servers and canopy's own row (`id = Uuid::nil()`) never
+	/// appear.
+	pub async fn unhealthy_with_servers(
+		db: &mut AsyncPgConnection,
+	) -> Result<Vec<(Server, Status)>> {
+		use crate::schema::servers::dsl as servers_dsl;
+
+		let servers: Vec<Server> = servers_dsl::servers
+			.select(Server::as_select())
+			.filter(servers_dsl::id.ne(Uuid::nil()))
+			.filter(servers_dsl::deleted_at.is_null())
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		let server_ids: Vec<Uuid> = servers.iter().map(|s| s.id).collect();
+
+		let mut status_map: std::collections::HashMap<Uuid, Status> =
+			Self::latest_for_servers(db, &server_ids)
+				.await?
+				.into_iter()
+				.map(|s| (s.server_id, s))
+				.collect();
+
+		Ok(servers
+			.into_iter()
+			.filter_map(|s| {
+				let status = status_map.remove(&s.id)?;
+				(status.health_state() != HealthState::Healthy).then_some((s, status))
+			})
+			.collect())
+	}
+
+	/// This status row's `health[]` entries that reported warning, failed,
+	/// or broken — the checks an operator needs to look at. Passed and
+	/// skipped entries don't count against the server (same rule as
+	/// [`Status::health_state`]).
+	pub fn offending_checks(&self) -> Vec<(String, CheckResult)> {
+		let Some(arr) = self.health.as_array() else {
+			return Vec::new();
+		};
+		arr.iter()
+			.filter_map(|entry| {
+				let obj = entry.as_object()?;
+				let check = obj.get("check")?.as_str()?.to_string();
+				let result = CheckResult::from_entry(obj)?;
+				matches!(
+					result,
+					CheckResult::Warning | CheckResult::Failed | CheckResult::Broken
+				)
+				.then_some((check, result))
+			})
+			.collect()
+	}
+
+	/// [`Self::unhealthy_with_servers`], further narrowed to servers whose
+	/// latest status reports `check_name` specifically as warning, failed,
+	/// or broken — the data backing the per-healthcheck "who's affected"
+	/// page.
+	///
+	/// The check-name filter stays on the Rust side rather than folding
+	/// into the SQL: `unhealthy_with_servers` already limits the query to
+	/// the (typically small) set of currently-unhealthy servers, and
+	/// reproducing [`CheckResult::from_entry`]'s legacy `healthy: bool`
+	/// fallback as a jsonb predicate would just duplicate logic that
+	/// already lives in [`Self::offending_checks`].
+	pub async fn unhealthy_with_servers_for_check(
+		db: &mut AsyncPgConnection,
+		check_name: &str,
+	) -> Result<Vec<(Server, Status, CheckResult)>> {
+		Ok(Self::unhealthy_with_servers(db)
+			.await?
+			.into_iter()
+			.filter_map(|(server, status)| {
+				let result = status
+					.offending_checks()
+					.into_iter()
+					.find(|(check, _)| check == check_name)
+					.map(|(_, result)| result)?;
+				Some((server, status, result))
+			})
+			.collect())
+	}
+
 	pub async fn production_versions(db: &mut AsyncPgConnection) -> Result<Vec<VersionStr>> {
 		use crate::schema::servers::dsl as servers_dsl;
 

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -448,14 +448,23 @@ impl Status {
 		query.load::<Status>(db).await.map_err(AppError::from)
 	}
 
-	/// Live (non-deleted, non-canopy-own) servers whose latest status is
-	/// [`HealthState::Warning`] or [`HealthState::Unhealthy`], paired with
-	/// that status. Mirrors the live-server scoping in
+	/// Live (non-deleted, non-canopy-own) servers whose latest status
+	/// reports `check_name` at **any** result, paired with that status —
+	/// the data backing the per-healthcheck "who's affected" page (which
+	/// shows the failing servers by default and the healthy ones behind a
+	/// toggle). Mirrors the live-server scoping in
 	/// [`crate::servers::Server::get_all`] / the status-board queries:
 	/// archived servers and canopy's own row (`id = Uuid::nil()`) never
 	/// appear.
-	pub async fn unhealthy_with_servers(
+	///
+	/// The check-name filter stays on the Rust side rather than folding
+	/// into the SQL: reproducing [`CheckResult::from_entry`]'s legacy
+	/// `healthy: bool` fallback as a jsonb predicate would just duplicate
+	/// logic that already lives in [`Self::check_entry`], and the
+	/// per-server latest-status set is small.
+	pub async fn reporting_check_with_servers(
 		db: &mut AsyncPgConnection,
+		check_name: &str,
 	) -> Result<Vec<(Server, Status)>> {
 		use crate::schema::servers::dsl as servers_dsl;
 
@@ -479,60 +488,34 @@ impl Status {
 			.into_iter()
 			.filter_map(|s| {
 				let status = status_map.remove(&s.id)?;
-				(status.health_state() != HealthState::Healthy).then_some((s, status))
+				status
+					.check_entry(check_name)
+					.is_some()
+					.then_some((s, status))
 			})
 			.collect())
 	}
 
-	/// This status row's `health[]` entries that reported warning, failed,
-	/// or broken — the checks an operator needs to look at. Passed and
-	/// skipped entries don't count against the server (same rule as
-	/// [`Status::health_state`]).
-	pub fn offending_checks(&self) -> Vec<(String, CheckResult)> {
-		let Some(arr) = self.health.as_array() else {
-			return Vec::new();
-		};
-		arr.iter()
-			.filter_map(|entry| {
-				let obj = entry.as_object()?;
-				let check = obj.get("check")?.as_str()?.to_string();
-				let result = CheckResult::from_entry(obj)?;
-				matches!(
-					result,
-					CheckResult::Warning | CheckResult::Failed | CheckResult::Broken
-				)
-				.then_some((check, result))
-			})
-			.collect()
-	}
-
-	/// [`Self::unhealthy_with_servers`], further narrowed to servers whose
-	/// latest status reports `check_name` specifically as warning, failed,
-	/// or broken — the data backing the per-healthcheck "who's affected"
-	/// page.
-	///
-	/// The check-name filter stays on the Rust side rather than folding
-	/// into the SQL: `unhealthy_with_servers` already limits the query to
-	/// the (typically small) set of currently-unhealthy servers, and
-	/// reproducing [`CheckResult::from_entry`]'s legacy `healthy: bool`
-	/// fallback as a jsonb predicate would just duplicate logic that
-	/// already lives in [`Self::offending_checks`].
-	pub async fn unhealthy_with_servers_for_check(
-		db: &mut AsyncPgConnection,
+	/// This status row's `health[]` entry for `check_name`: the normalised
+	/// result plus the entry's full JSON object (including the reserved
+	/// `check`/`healthy`/`result` keys, so callers can ship it to a UI
+	/// that renders it the same way the server-detail checks table does).
+	/// `None` when the row doesn't report that check, or the entry is
+	/// malformed (no readable result — same rule as every other `health[]`
+	/// reader).
+	pub fn check_entry(
+		&self,
 		check_name: &str,
-	) -> Result<Vec<(Server, Status, CheckResult)>> {
-		Ok(Self::unhealthy_with_servers(db)
-			.await?
-			.into_iter()
-			.filter_map(|(server, status)| {
-				let result = status
-					.offending_checks()
-					.into_iter()
-					.find(|(check, _)| check == check_name)
-					.map(|(_, result)| result)?;
-				Some((server, status, result))
-			})
-			.collect())
+	) -> Option<(CheckResult, serde_json::Map<String, serde_json::Value>)> {
+		let arr = self.health.as_array()?;
+		arr.iter().find_map(|entry| {
+			let obj = entry.as_object()?;
+			if obj.get("check")?.as_str()? != check_name {
+				return None;
+			}
+			let result = CheckResult::from_entry(obj)?;
+			Some((result, obj.clone()))
+		})
 	}
 
 	pub async fn production_versions(db: &mut AsyncPgConnection) -> Result<Vec<VersionStr>> {

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -15,7 +15,7 @@ use commons_types::{
 	version::VersionStr,
 };
 use database::{
-	devices::DeviceConnection, healthcheck_severities::HealthcheckSeverity,
+	devices::DeviceConnection, healthcheck_severities::HealthcheckSeverity, issues::Issue,
 	server_groups::ServerGroup, servers::Server, statuses::Status,
 	tailscale_users::TailscaleUser as CachedTailscaleUser, versions::Version,
 };
@@ -271,21 +271,34 @@ pub async fn group_details(
 	}))
 }
 
-/// One server currently flagging [`CheckAttentionData::check`], for
-/// [`check_attention`].
+/// One server whose latest status reports [`CheckAttentionData::check`],
+/// for [`check_attention`].
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CheckAttentionServerData {
 	/// The server's id — the UI links to `/servers/{server_id}`.
 	pub server_id: Uuid,
 	/// The server's display name; empty string when the server has none.
 	pub server_name: String,
-	/// The server's group id, if it belongs to one.
+	/// The server's group id, if it belongs to one — the UI links to
+	/// `/groups/{group_id}`.
 	pub group_id: Option<Uuid>,
 	/// The server's group name, if it belongs to one.
 	pub group_name: Option<String>,
-	/// The check's result on this server's latest status. Always warning,
-	/// failed, or broken — passed/skipped checks never reach this endpoint.
+	/// The check's result on this server's latest status. The UI shows
+	/// warning/failed/broken servers by default and puts passed/skipped
+	/// ones behind a "show healthy" toggle.
 	pub result: CheckResult,
+	/// The check's full `health[]` entry from this server's latest status,
+	/// verbatim (including the `check`/`healthy`/`result` keys), so the
+	/// row can expand to the same per-check detail the server page shows.
+	pub data: serde_json::Value,
+	/// When this check started failing on this server: the `first_seen`
+	/// of the still-active issue canopy filed at `(status,
+	/// health/<check>)` when the check degraded. `None` for servers
+	/// currently reporting the check healthy, and for failing servers
+	/// with no active issue on file (e.g. the issue was
+	/// operator-resolved, or the ref is silenced so nothing was filed).
+	pub failing_since: Option<Timestamp>,
 	/// When the reporting status was recorded.
 	pub status_created_at: Timestamp,
 }
@@ -299,8 +312,8 @@ pub struct CheckAttentionArgs {
 }
 
 /// Response for [`check_attention`]: the queried check's catalog severity
-/// (if it has one yet) and every live server whose latest status is
-/// currently flagging it.
+/// (if it has one yet) and every live server whose latest status reports
+/// it, failing or healthy.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CheckAttentionData {
 	/// The check name that was queried, echoed back so the page can
@@ -309,14 +322,17 @@ pub struct CheckAttentionData {
 	/// The catalog's configured base severity for this check, or `None`
 	/// if no server has ever reported it yet (so it has no catalog row).
 	pub severity: Option<Severity>,
-	/// Servers currently flagging this check as a TODO list: failed
-	/// before warning before broken (most urgent first), then by group
-	/// name then server name.
+	/// Every live server whose latest status reports this check, at any
+	/// result, ordered as a TODO list: failed, warning, broken, passed,
+	/// skipped (most urgent first), then by group name then server name.
+	/// The client filters out the passed/skipped tail unless the "show
+	/// healthy" toggle is on.
 	pub servers: Vec<CheckAttentionServerData>,
 }
 
 /// Rank used to order [`CheckAttentionServerData::result`] most-urgent
-/// first: failed, then warning, then broken. Mirrors the private-web
+/// first: failed, then warning, then broken, with the healthy tail
+/// (passed, then skipped) last. Mirrors the private-web
 /// `CHECK_RESULT_ORDER` display order.
 fn check_result_rank(result: CheckResult) -> u8 {
 	match result {
@@ -328,15 +344,16 @@ fn check_result_rank(result: CheckResult) -> u8 {
 	}
 }
 
-/// List the servers currently failing or warning one named healthcheck.
+/// List the servers whose latest status reports one named healthcheck.
 ///
 /// Everything the per-healthcheck page needs: the catalog's configured
 /// severity for `check` (if any) plus every live server whose **latest**
-/// status currently reports it as warning, failed, or broken — i.e. the
-/// current, real-time failures, not a history of past issues/events. This
-/// is the data behind the `/healthchecks/:check` "who's affected" page,
-/// which doubles as an operator TODO list and as a way to correlate
-/// servers sharing the same issue during a fleet-wide incident.
+/// status reports it — the current, real-time picture, not a history of
+/// past issues/events, though each failing server carries a
+/// `failing_since` timestamp derived from its active issue. This is the
+/// data behind the `/healthchecks/:check` "who's affected" page, which
+/// doubles as an operator TODO list and as a way to correlate servers
+/// sharing the same issue during a fleet-wide incident.
 #[utoipa::path(
 	post,
 	path = "/check_attention",
@@ -344,7 +361,7 @@ fn check_result_rank(result: CheckResult) -> u8 {
 	tag = "statuses",
 	request_body = CheckAttentionArgs,
 	responses(
-		(status = 200, description = "The check's catalog severity and the servers currently flagging it.", body = CheckAttentionData),
+		(status = 200, description = "The check's catalog severity and the servers currently reporting it.", body = CheckAttentionData),
 		(status = 500, body = ProblemDetailsSchema),
 	),
 )]
@@ -353,11 +370,11 @@ pub async fn check_attention(
 	Json(args): Json<CheckAttentionArgs>,
 ) -> Result<Json<CheckAttentionData>> {
 	let mut conn = state.db_read.get().await?;
-	let flagged = Status::unhealthy_with_servers_for_check(&mut conn, &args.check).await?;
+	let reporting = Status::reporting_check_with_servers(&mut conn, &args.check).await?;
 
-	let group_ids: Vec<Uuid> = flagged
+	let group_ids: Vec<Uuid> = reporting
 		.iter()
-		.filter_map(|(s, _, _)| s.group_id)
+		.filter_map(|(s, _)| s.group_id)
 		.collect::<BTreeSet<_>>()
 		.into_iter()
 		.collect();
@@ -367,18 +384,39 @@ pub async fn check_attention(
 		.map(|g| (g.id, g.name))
 		.collect();
 
-	let mut servers: Vec<CheckAttentionServerData> = flagged
+	// "Failing since" comes from the issue the public-server status
+	// handler files at `(status, health/<check>)` when a check degrades:
+	// an active issue's first_seen is exactly when the current failure
+	// streak began (recoveries close the issue, so a re-failure starts a
+	// fresh one).
+	let server_ids: Vec<Uuid> = reporting.iter().map(|(s, _)| s.id).collect();
+	let failing_since: HashMap<Uuid, Timestamp> = Issue::list_by_source_ref(
+		&mut conn,
+		"status",
+		&format!("health/{}", args.check),
+		&server_ids,
+	)
+	.await?
+	.into_iter()
+	.filter(|issue| issue.active)
+	.filter_map(|issue| issue.server_id.map(|sid| (sid, issue.first_seen)))
+	.collect();
+
+	let mut servers: Vec<CheckAttentionServerData> = reporting
 		.into_iter()
-		.map(|(server, status, result)| {
+		.filter_map(|(server, status)| {
+			let (result, entry) = status.check_entry(&args.check)?;
 			let group_name = server.group_id.and_then(|g| group_names.get(&g).cloned());
-			CheckAttentionServerData {
+			Some(CheckAttentionServerData {
 				server_id: server.id,
 				server_name: server.name.clone().unwrap_or_default(),
 				group_id: server.group_id,
 				group_name,
 				result,
+				data: serde_json::Value::Object(entry),
+				failing_since: failing_since.get(&server.id).copied(),
 				status_created_at: status.created_at,
-			}
+			})
 		})
 		.collect();
 	servers.sort_by(|a, b| {

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -6,15 +6,17 @@ use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleUser;
 use commons_types::{
+	issue::Severity,
 	server::{
 		cards::{FacilityServerStatus, ServerGroupCard},
 		rank::ServerRank,
 	},
-	status::{OperatorPresence, ShortStatus},
+	status::{CheckResult, OperatorPresence, ShortStatus},
 	version::VersionStr,
 };
 use database::{
-	devices::DeviceConnection, server_groups::ServerGroup, servers::Server, statuses::Status,
+	devices::DeviceConnection, healthcheck_severities::HealthcheckSeverity,
+	server_groups::ServerGroup, servers::Server, statuses::Status,
 	tailscale_users::TailscaleUser as CachedTailscaleUser, versions::Version,
 };
 use jiff::Timestamp;
@@ -92,6 +94,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(server_grouped_ids))
 		.routes(routes!(group_details))
 		.routes(routes!(snapshot))
+		.routes(routes!(check_attention))
 }
 
 /// Get a fleet-wide summary of software versions running in production.
@@ -265,6 +268,134 @@ pub async fn group_details(
 		version: card_version,
 		version_distance,
 		members,
+	}))
+}
+
+/// One server currently flagging [`CheckAttentionData::check`], for
+/// [`check_attention`].
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CheckAttentionServerData {
+	/// The server's id — the UI links to `/servers/{server_id}`.
+	pub server_id: Uuid,
+	/// The server's display name; empty string when the server has none.
+	pub server_name: String,
+	/// The server's group id, if it belongs to one.
+	pub group_id: Option<Uuid>,
+	/// The server's group name, if it belongs to one.
+	pub group_name: Option<String>,
+	/// The check's result on this server's latest status. Always warning,
+	/// failed, or broken — passed/skipped checks never reach this endpoint.
+	pub result: CheckResult,
+	/// When the reporting status was recorded.
+	pub status_created_at: Timestamp,
+}
+
+/// Request body for [`check_attention`].
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CheckAttentionArgs {
+	/// The healthcheck name to look up, exactly as reported by devices in
+	/// `health[].check` (an arbitrary, device/plugin-defined string).
+	pub check: String,
+}
+
+/// Response for [`check_attention`]: the queried check's catalog severity
+/// (if it has one yet) and every live server whose latest status is
+/// currently flagging it.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CheckAttentionData {
+	/// The check name that was queried, echoed back so the page can
+	/// render its heading without re-decoding the request.
+	pub check: String,
+	/// The catalog's configured base severity for this check, or `None`
+	/// if no server has ever reported it yet (so it has no catalog row).
+	pub severity: Option<Severity>,
+	/// Servers currently flagging this check as a TODO list: failed
+	/// before warning before broken (most urgent first), then by group
+	/// name then server name.
+	pub servers: Vec<CheckAttentionServerData>,
+}
+
+/// Rank used to order [`CheckAttentionServerData::result`] most-urgent
+/// first: failed, then warning, then broken. Mirrors the private-web
+/// `CHECK_RESULT_ORDER` display order.
+fn check_result_rank(result: CheckResult) -> u8 {
+	match result {
+		CheckResult::Failed => 0,
+		CheckResult::Warning => 1,
+		CheckResult::Broken => 2,
+		CheckResult::Passed => 3,
+		CheckResult::Skipped => 4,
+	}
+}
+
+/// List the servers currently failing or warning one named healthcheck.
+///
+/// Everything the per-healthcheck page needs: the catalog's configured
+/// severity for `check` (if any) plus every live server whose **latest**
+/// status currently reports it as warning, failed, or broken — i.e. the
+/// current, real-time failures, not a history of past issues/events. This
+/// is the data behind the `/healthchecks/:check` "who's affected" page,
+/// which doubles as an operator TODO list and as a way to correlate
+/// servers sharing the same issue during a fleet-wide incident.
+#[utoipa::path(
+	post,
+	path = "/check_attention",
+	operation_id = "status_check_attention",
+	tag = "statuses",
+	request_body = CheckAttentionArgs,
+	responses(
+		(status = 200, description = "The check's catalog severity and the servers currently flagging it.", body = CheckAttentionData),
+		(status = 500, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn check_attention(
+	State(state): State<AppState>,
+	Json(args): Json<CheckAttentionArgs>,
+) -> Result<Json<CheckAttentionData>> {
+	let mut conn = state.db_read.get().await?;
+	let flagged = Status::unhealthy_with_servers_for_check(&mut conn, &args.check).await?;
+
+	let group_ids: Vec<Uuid> = flagged
+		.iter()
+		.filter_map(|(s, _, _)| s.group_id)
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.collect();
+	let group_names: HashMap<Uuid, String> = ServerGroup::list_by_ids(&mut conn, &group_ids)
+		.await?
+		.into_iter()
+		.map(|g| (g.id, g.name))
+		.collect();
+
+	let mut servers: Vec<CheckAttentionServerData> = flagged
+		.into_iter()
+		.map(|(server, status, result)| {
+			let group_name = server.group_id.and_then(|g| group_names.get(&g).cloned());
+			CheckAttentionServerData {
+				server_id: server.id,
+				server_name: server.name.clone().unwrap_or_default(),
+				group_id: server.group_id,
+				group_name,
+				result,
+				status_created_at: status.created_at,
+			}
+		})
+		.collect();
+	servers.sort_by(|a, b| {
+		check_result_rank(a.result)
+			.cmp(&check_result_rank(b.result))
+			.then_with(|| a.group_name.cmp(&b.group_name))
+			.then_with(|| a.server_name.cmp(&b.server_name))
+	});
+
+	let severity = HealthcheckSeverity::get(&mut conn, &args.check)
+		.await?
+		.map(|row| row.severity);
+
+	Ok(Json(CheckAttentionData {
+		check: args.check,
+		severity,
+		servers,
 	}))
 }
 

--- a/crates/private-server/tests/private_statuses.rs
+++ b/crates/private-server/tests/private_statuses.rs
@@ -1039,6 +1039,8 @@ struct CheckAttentionServer {
 	group_id: Option<String>,
 	group_name: Option<String>,
 	result: String,
+	data: serde_json::Value,
+	failing_since: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1065,7 +1067,7 @@ async fn check_attention_empty_database() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn check_attention_lists_only_servers_flagging_that_check_ordered_failed_first() {
+async fn check_attention_lists_servers_reporting_that_check_ordered_failed_first() {
 	commons_tests::server::run(async |mut conn, _, private| {
 		conn.batch_execute(
 			"INSERT INTO server_groups (id, name) VALUES
@@ -1080,7 +1082,7 @@ async fn check_attention_lists_only_servers_flagging_that_check_ordered_failed_f
 			('11111111-1111-1111-1111-111111111111', NOW(), true,
 				'[{\"check\":\"postgres\",\"result\":\"warning\"}]'::jsonb),
 			('22222222-2222-2222-2222-222222222222', NOW(), true,
-				'[{\"check\":\"postgres\",\"result\":\"failed\"}]'::jsonb),
+				'[{\"check\":\"postgres\",\"result\":\"failed\",\"free_pct\":2}]'::jsonb),
 			('33333333-3333-3333-3333-333333333333', NOW(), true,
 				'[{\"check\":\"postgres\",\"result\":\"passed\"}]'::jsonb),
 			('44444444-4444-4444-4444-444444444444', NOW(), true,
@@ -1100,11 +1102,13 @@ async fn check_attention_lists_only_servers_flagging_that_check_ordered_failed_f
 		assert_eq!(data.severity, None, "no catalog row was ever created");
 		assert_eq!(
 			data.servers.len(),
-			2,
-			"only the servers flagging postgres appear"
+			3,
+			"every server reporting postgres appears (healthy included); other checks don't"
 		);
 
-		// Failed sorts before warning, regardless of insertion order.
+		// Failed sorts before warning, regardless of insertion order; the
+		// healthy server sorts last so the client's default (unhealthy-only)
+		// view is a prefix.
 		assert_eq!(data.servers[0].server_name, "Failing Server");
 		assert_eq!(data.servers[0].result, "failed");
 		assert_eq!(
@@ -1119,9 +1123,85 @@ async fn check_attention_lists_only_servers_flagging_that_check_ordered_failed_f
 			data.servers[0].server_id,
 			"22222222-2222-2222-2222-222222222222"
 		);
+		// The full health[] entry rides along for the expandable row.
+		assert_eq!(
+			data.servers[0].data,
+			serde_json::json!({"check": "postgres", "result": "failed", "free_pct": 2}),
+		);
+		assert_eq!(
+			data.servers[0].failing_since, None,
+			"no issue on file for this failure"
+		);
 
 		assert_eq!(data.servers[1].server_name, "Warning Server");
 		assert_eq!(data.servers[1].result, "warning");
+
+		assert_eq!(data.servers[2].server_name, "Healthy Server");
+		assert_eq!(data.servers[2].result, "passed");
+		assert_eq!(data.servers[2].failing_since, None);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_attention_failing_since_comes_from_the_active_issue() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO servers (id, name, host, rank, kind) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Failing Server', 'https://failing.example.com', 'production', 'central'),
+			('22222222-2222-2222-2222-222222222222', 'Recovered Issue Server', 'https://recovered.example.com', 'production', 'central');
+
+			INSERT INTO statuses (server_id, created_at, healthy, health) VALUES
+			('11111111-1111-1111-1111-111111111111', NOW(), true,
+				'[{\"check\":\"postgres\",\"result\":\"failed\"}]'::jsonb),
+			('22222222-2222-2222-2222-222222222222', NOW(), true,
+				'[{\"check\":\"postgres\",\"result\":\"failed\"}]'::jsonb);
+
+			-- Active issue: its first_seen is the failing-since timestamp.
+			INSERT INTO issues (server_id, source, \"ref\", severity, message, active, first_seen, last_seen) VALUES
+			('11111111-1111-1111-1111-111111111111', 'status', 'health/postgres', 'error',
+				'postgres check failing', true, NOW() - INTERVAL '3 hours', NOW()),
+			-- Inactive issue (check recovered then re-failed without a new
+			-- push being processed yet): must NOT be used.
+			('22222222-2222-2222-2222-222222222222', 'status', 'health/postgres', 'error',
+				'postgres check failing', false, NOW() - INTERVAL '9 hours', NOW() - INTERVAL '8 hours')",
+		)
+		.await
+		.unwrap();
+
+		let r = private
+			.post("/api/statuses/check_attention")
+			.json(&serde_json::json!({"check": "postgres"}))
+			.await;
+		r.assert_status_ok();
+		let data: CheckAttentionResponse = r.json();
+		assert_eq!(data.servers.len(), 2);
+
+		let failing = data
+			.servers
+			.iter()
+			.find(|s| s.server_name == "Failing Server")
+			.unwrap();
+		let since = failing
+			.failing_since
+			.as_deref()
+			.expect("active issue provides failing_since");
+		let since: jiff::Timestamp = since.parse().expect("failing_since is a timestamp");
+		let age = jiff::Timestamp::now().duration_since(since);
+		assert!(
+			age > jiff::SignedDuration::from_hours(2) && age < jiff::SignedDuration::from_hours(4),
+			"failing_since reflects the issue's first_seen (~3h ago), got {age:?}"
+		);
+
+		let recovered = data
+			.servers
+			.iter()
+			.find(|s| s.server_name == "Recovered Issue Server")
+			.unwrap();
+		assert_eq!(
+			recovered.failing_since, None,
+			"inactive issues don't provide failing_since"
+		);
 	})
 	.await
 }

--- a/crates/private-server/tests/private_statuses.rs
+++ b/crates/private-server/tests/private_statuses.rs
@@ -1028,6 +1028,177 @@ async fn snapshot_server_without_statuses_returns_null() {
 	.await
 }
 
+// -----------------------------------------------------------------
+// check_attention endpoint: servers currently flagging one named check
+// -----------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct CheckAttentionServer {
+	server_id: String,
+	server_name: String,
+	group_id: Option<String>,
+	group_name: Option<String>,
+	result: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CheckAttentionResponse {
+	check: String,
+	severity: Option<String>,
+	servers: Vec<CheckAttentionServer>,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_attention_empty_database() {
+	commons_tests::server::run(async |_conn, _, private| {
+		let r = private
+			.post("/api/statuses/check_attention")
+			.json(&serde_json::json!({"check": "postgres"}))
+			.await;
+		r.assert_status_ok();
+		let data: CheckAttentionResponse = r.json();
+		assert_eq!(data.check, "postgres");
+		assert_eq!(data.severity, None);
+		assert!(data.servers.is_empty());
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_attention_lists_only_servers_flagging_that_check_ordered_failed_first() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO server_groups (id, name) VALUES
+			('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Attention cluster');
+			INSERT INTO servers (id, name, host, rank, kind, group_id) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Warning Server', 'https://warning.example.com', 'production', 'central', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+			('22222222-2222-2222-2222-222222222222', 'Failing Server', 'https://failing.example.com', 'production', 'central', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+			('33333333-3333-3333-3333-333333333333', 'Healthy Server', 'https://healthy.example.com', 'production', 'central', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+			('44444444-4444-4444-4444-444444444444', 'Other Check Server', 'https://other.example.com', 'production', 'central', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+
+			INSERT INTO statuses (server_id, created_at, healthy, health) VALUES
+			('11111111-1111-1111-1111-111111111111', NOW(), true,
+				'[{\"check\":\"postgres\",\"result\":\"warning\"}]'::jsonb),
+			('22222222-2222-2222-2222-222222222222', NOW(), true,
+				'[{\"check\":\"postgres\",\"result\":\"failed\"}]'::jsonb),
+			('33333333-3333-3333-3333-333333333333', NOW(), true,
+				'[{\"check\":\"postgres\",\"result\":\"passed\"}]'::jsonb),
+			('44444444-4444-4444-4444-444444444444', NOW(), true,
+				'[{\"check\":\"disk_space\",\"result\":\"failed\"}]'::jsonb)",
+		)
+		.await
+		.unwrap();
+
+		let r = private
+			.post("/api/statuses/check_attention")
+			.json(&serde_json::json!({"check": "postgres"}))
+			.await;
+		r.assert_status_ok();
+		let data: CheckAttentionResponse = r.json();
+
+		assert_eq!(data.check, "postgres");
+		assert_eq!(data.severity, None, "no catalog row was ever created");
+		assert_eq!(
+			data.servers.len(),
+			2,
+			"only the servers flagging postgres appear"
+		);
+
+		// Failed sorts before warning, regardless of insertion order.
+		assert_eq!(data.servers[0].server_name, "Failing Server");
+		assert_eq!(data.servers[0].result, "failed");
+		assert_eq!(
+			data.servers[0].group_id,
+			Some("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".to_string())
+		);
+		assert_eq!(
+			data.servers[0].group_name,
+			Some("Attention cluster".to_string())
+		);
+		assert_eq!(
+			data.servers[0].server_id,
+			"22222222-2222-2222-2222-222222222222"
+		);
+
+		assert_eq!(data.servers[1].server_name, "Warning Server");
+		assert_eq!(data.servers[1].result, "warning");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_attention_excludes_ungrouped_and_archived_servers() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO servers (id, name, host, rank, kind, group_id) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Standalone Failing', 'https://standalone.example.com', 'production', 'central', NULL),
+			('22222222-2222-2222-2222-222222222222', 'Archived Failing', 'https://archived.example.com', 'production', 'central', NULL);
+
+			UPDATE servers SET deleted_at = NOW() WHERE id = '22222222-2222-2222-2222-222222222222';
+
+			INSERT INTO statuses (server_id, created_at, healthy, health) VALUES
+			('11111111-1111-1111-1111-111111111111', NOW(), true,
+				'[{\"check\":\"postgres\",\"result\":\"failed\"}]'::jsonb),
+			('22222222-2222-2222-2222-222222222222', NOW(), true,
+				'[{\"check\":\"postgres\",\"result\":\"failed\"}]'::jsonb)",
+		)
+		.await
+		.unwrap();
+
+		let r = private
+			.post("/api/statuses/check_attention")
+			.json(&serde_json::json!({"check": "postgres"}))
+			.await;
+		r.assert_status_ok();
+		let data: CheckAttentionResponse = r.json();
+
+		assert_eq!(data.servers.len(), 1, "the archived server is excluded");
+		assert_eq!(data.servers[0].server_name, "Standalone Failing");
+		assert_eq!(data.servers[0].group_id, None);
+		assert_eq!(data.servers[0].group_name, None);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn check_attention_returns_catalog_severity_and_ignores_non_matching_check() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO healthcheck_severities (check_name, severity) VALUES ('postgres', 'error');
+			INSERT INTO servers (id, name, host, rank, kind) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Failing Server', 'https://failing.example.com', 'production', 'central');
+			INSERT INTO statuses (server_id, created_at, healthy, health) VALUES
+			('11111111-1111-1111-1111-111111111111', NOW(), true,
+				'[{\"check\":\"postgres\",\"result\":\"failed\"}]'::jsonb)",
+		)
+		.await
+		.unwrap();
+
+		// The check this server is actually failing.
+		let r = private
+			.post("/api/statuses/check_attention")
+			.json(&serde_json::json!({"check": "postgres"}))
+			.await;
+		r.assert_status_ok();
+		let data: CheckAttentionResponse = r.json();
+		assert_eq!(data.severity, Some("error".to_string()));
+		assert_eq!(data.servers.len(), 1);
+
+		// A different, never-reported check name: no servers, but the
+		// catalog lookup still runs (and correctly finds nothing).
+		let r = private
+			.post("/api/statuses/check_attention")
+			.json(&serde_json::json!({"check": "unrelated_check"}))
+			.await;
+		r.assert_status_ok();
+		let data: CheckAttentionResponse = r.json();
+		assert_eq!(data.check, "unrelated_check");
+		assert_eq!(data.severity, None);
+		assert!(data.servers.is_empty());
+	})
+	.await
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn snapshot_surfaces_per_check_severity() {
 	commons_tests::server::run(async |mut conn, _, private| {

--- a/private-web/e2e/healthcheck-attention.spec.ts
+++ b/private-web/e2e/healthcheck-attention.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "./test-fixtures";
 import {
 	resetSeededTables,
 	seedHealthcheckSeverity,
+	seedIssue,
 	seedServer,
 	seedServerGroup,
 	seedStatus,
@@ -22,7 +23,7 @@ test.describe("healthcheck attention page", () => {
 		await expect(page.getByRole("heading", { name: "postgres" })).toBeVisible();
 	});
 
-	test("lists servers flagging the check, ordered failed before warning, and excludes others", async ({
+	test("lists servers flagging the check, ordered failed before warning, with server and group links", async ({
 		page,
 		sql,
 	}) => {
@@ -69,6 +70,11 @@ test.describe("healthcheck attention page", () => {
 		await expect(page.getByText("healthy-server")).toHaveCount(0);
 		await expect(page.getByText("other-check-server")).toHaveCount(0);
 
+		// Every row names the group too, linking to its page.
+		await expect(
+			page.locator(`a[href="/groups/${group.id}"]`).first(),
+		).toBeVisible();
+
 		// Failed sorts above warning.
 		const failingY = (await failingLink.boundingBox())!.y;
 		const warningY = (await warningLink.boundingBox())!.y;
@@ -76,6 +82,102 @@ test.describe("healthcheck attention page", () => {
 
 		await failingLink.click();
 		await expect(page).toHaveURL(new RegExp(`/servers/${failing.id}$`));
+	});
+
+	test("the healthy-servers toggle reveals servers reporting the check passed", async ({
+		page,
+		sql,
+	}) => {
+		const failing = await seedServer(sql, { name: "toggle-failing" });
+		const healthy = await seedServer(sql, { name: "toggle-healthy" });
+		await seedStatus(sql, {
+			serverId: failing.id,
+			health: [{ check: "postgres", result: "failed" }],
+		});
+		await seedStatus(sql, {
+			serverId: healthy.id,
+			health: [{ check: "postgres", result: "passed" }],
+		});
+
+		await page.goto("/healthchecks/postgres");
+		await expect(
+			page.getByRole("link", { name: "toggle-failing" }),
+		).toBeVisible();
+		await expect(page.getByText("toggle-healthy")).toHaveCount(0);
+
+		await page.getByLabel(/show healthy servers/i).click();
+
+		await expect(
+			page.getByRole("link", { name: "toggle-healthy" }),
+		).toBeVisible();
+		await expect(page.getByText("passed", { exact: true })).toBeVisible();
+		// The failing server stays listed, above the healthy one.
+		const failingLink = page.getByRole("link", { name: "toggle-failing" });
+		const healthyLink = page.getByRole("link", { name: "toggle-healthy" });
+		const failingY = (await failingLink.boundingBox())!.y;
+		const healthyY = (await healthyLink.boundingBox())!.y;
+		expect(failingY).toBeLessThan(healthyY);
+	});
+
+	test("a row expands to the check's full data, like the server detail table", async ({
+		page,
+		sql,
+	}) => {
+		const server = await seedServer(sql, { name: "expandable-server" });
+		await seedStatus(sql, {
+			serverId: server.id,
+			health: [
+				{
+					check: "postgres",
+					result: "failed",
+					hint: "connection refused",
+					free_pct: 2,
+				},
+			],
+		});
+
+		await page.goto("/healthchecks/postgres");
+		await expect(
+			page.getByRole("link", { name: "expandable-server" }),
+		).toBeVisible();
+		// Collapsed: the entry's extra fields are hidden.
+		await expect(page.getByText("connection refused")).toHaveCount(0);
+
+		await page.getByRole("button", { name: /^expand$/i }).click();
+
+		await expect(page.getByText("hint")).toBeVisible();
+		await expect(page.getByText("connection refused")).toBeVisible();
+		await expect(page.getByText("free_pct")).toBeVisible();
+	});
+
+	test("shows since when the check has been failing, from the active issue", async ({
+		page,
+		sql,
+	}) => {
+		const failing = await seedServer(sql, { name: "since-server" });
+		const fresh = await seedServer(sql, { name: "no-issue-server" });
+		await seedStatus(sql, {
+			serverId: failing.id,
+			health: [{ check: "postgres", result: "failed" }],
+		});
+		await seedStatus(sql, {
+			serverId: fresh.id,
+			health: [{ check: "postgres", result: "failed" }],
+		});
+		await seedIssue(sql, {
+			serverId: failing.id,
+			source: "status",
+			ref: "health/postgres",
+			message: "postgres check failing",
+			firstSeen: new Date(Date.now() - 3 * 3_600_000).toISOString(),
+		});
+
+		await page.goto("/healthchecks/postgres");
+
+		// The issue-backed row shows a relative failing-since; the row
+		// without an issue shows the em-dash placeholder.
+		await expect(page.getByText("3h ago")).toBeVisible();
+		await expect(page.getByText("—")).toBeVisible();
 	});
 
 	test("shows the catalog severity when one is configured", async ({

--- a/private-web/e2e/healthcheck-attention.spec.ts
+++ b/private-web/e2e/healthcheck-attention.spec.ts
@@ -27,53 +27,69 @@ test.describe("healthcheck attention page", () => {
 		page,
 		sql,
 	}) => {
-		const group = await seedServerGroup(sql, { name: "attention-cluster" });
+		const group = await seedServerGroup(sql, { name: "Coral Coast" });
 		const warning = await seedServer(sql, {
-			name: "warning-server",
+			name: "Sigatoka Facility",
 			groupId: group.id,
 		});
 		const failing = await seedServer(sql, {
-			name: "failing-server",
+			name: "Korolevu Facility",
 			groupId: group.id,
 		});
 		const healthy = await seedServer(sql, {
-			name: "healthy-server",
+			name: "Pacific Central",
 			groupId: group.id,
 		});
 		const otherCheck = await seedServer(sql, {
-			name: "other-check-server",
+			name: "Navua Facility",
 			groupId: group.id,
 		});
 		await seedStatus(sql, {
 			serverId: warning.id,
-			health: [{ check: "postgres", result: "warning" }],
+			health: [
+				{ check: "postgres", result: "warning", latency_ms: 350 },
+			],
 		});
 		await seedStatus(sql, {
 			serverId: failing.id,
-			health: [{ check: "postgres", result: "failed" }],
+			health: [
+				{
+					check: "postgres",
+					result: "failed",
+					error: "connection refused",
+				},
+			],
 		});
 		await seedStatus(sql, {
 			serverId: healthy.id,
-			health: [{ check: "postgres", result: "passed" }],
+			health: [{ check: "postgres", result: "passed", latency_ms: 9 }],
 		});
 		await seedStatus(sql, {
 			serverId: otherCheck.id,
-			health: [{ check: "disk_space", result: "failed" }],
+			health: [{ check: "disk_space", result: "failed", free_pct: 3 }],
 		});
 
 		await page.goto("/healthchecks/postgres");
 
-		const failingLink = page.getByRole("link", { name: "failing-server" });
-		const warningLink = page.getByRole("link", { name: "warning-server" });
+		const failingLink = page.getByRole("link", { name: "Korolevu Facility" });
+		const warningLink = page.getByRole("link", { name: "Sigatoka Facility" });
 		await expect(failingLink).toBeVisible();
 		await expect(warningLink).toBeVisible();
-		await expect(page.getByText("healthy-server")).toHaveCount(0);
-		await expect(page.getByText("other-check-server")).toHaveCount(0);
+		await expect(page.getByText("Pacific Central")).toHaveCount(0);
+		await expect(page.getByText("Navua Facility")).toHaveCount(0);
 
-		// Every row names the group too, linking to its page.
+		// Each row carries two links: the group's display name to the
+		// group page, the server's display name to the server page.
+		await expect(failingLink).toHaveAttribute(
+			"href",
+			`/servers/${failing.id}`,
+		);
+		await expect(page.locator(`a[href="/groups/${group.id}"]`)).toHaveCount(
+			2,
+		);
 		await expect(
 			page.locator(`a[href="/groups/${group.id}"]`).first(),
-		).toBeVisible();
+		).toHaveText("Coral Coast");
 
 		// Failed sorts above warning.
 		const failingY = (await failingLink.boundingBox())!.y;
@@ -88,32 +104,41 @@ test.describe("healthcheck attention page", () => {
 		page,
 		sql,
 	}) => {
-		const failing = await seedServer(sql, { name: "toggle-failing" });
-		const healthy = await seedServer(sql, { name: "toggle-healthy" });
+		const group = await seedServerGroup(sql, { name: "Highlands" });
+		const failing = await seedServer(sql, {
+			name: "Mendi Facility",
+			groupId: group.id,
+		});
+		const healthy = await seedServer(sql, {
+			name: "Goroka Facility",
+			groupId: group.id,
+		});
 		await seedStatus(sql, {
 			serverId: failing.id,
-			health: [{ check: "postgres", result: "failed" }],
+			health: [
+				{ check: "postgres", result: "failed", error: "timeout" },
+			],
 		});
 		await seedStatus(sql, {
 			serverId: healthy.id,
-			health: [{ check: "postgres", result: "passed" }],
+			health: [{ check: "postgres", result: "passed", latency_ms: 12 }],
 		});
 
 		await page.goto("/healthchecks/postgres");
 		await expect(
-			page.getByRole("link", { name: "toggle-failing" }),
+			page.getByRole("link", { name: "Mendi Facility" }),
 		).toBeVisible();
-		await expect(page.getByText("toggle-healthy")).toHaveCount(0);
+		await expect(page.getByText("Goroka Facility")).toHaveCount(0);
 
 		await page.getByLabel(/show healthy servers/i).click();
 
 		await expect(
-			page.getByRole("link", { name: "toggle-healthy" }),
+			page.getByRole("link", { name: "Goroka Facility" }),
 		).toBeVisible();
 		await expect(page.getByText("passed", { exact: true })).toBeVisible();
 		// The failing server stays listed, above the healthy one.
-		const failingLink = page.getByRole("link", { name: "toggle-failing" });
-		const healthyLink = page.getByRole("link", { name: "toggle-healthy" });
+		const failingLink = page.getByRole("link", { name: "Mendi Facility" });
+		const healthyLink = page.getByRole("link", { name: "Goroka Facility" });
 		const failingY = (await failingLink.boundingBox())!.y;
 		const healthyY = (await healthyLink.boundingBox())!.y;
 		expect(failingY).toBeLessThan(healthyY);
@@ -123,46 +148,79 @@ test.describe("healthcheck attention page", () => {
 		page,
 		sql,
 	}) => {
-		const server = await seedServer(sql, { name: "expandable-server" });
+		const group = await seedServerGroup(sql, { name: "Vanua Levu" });
+		const rich = await seedServer(sql, {
+			name: "Labasa Facility",
+			groupId: group.id,
+		});
+		const bare = await seedServer(sql, {
+			name: "Savusavu Facility",
+			groupId: group.id,
+		});
 		await seedStatus(sql, {
-			serverId: server.id,
+			serverId: rich.id,
 			health: [
 				{
-					check: "postgres",
+					check: "disk_space",
 					result: "failed",
-					hint: "connection refused",
-					free_pct: 2,
+					free_pct: 4,
+					used_pct: 96,
+					message: "volume /data almost full",
 				},
 			],
 		});
+		await seedStatus(sql, {
+			serverId: bare.id,
+			// A bare entry: no extra fields beyond the reserved keys.
+			health: [{ check: "disk_space", result: "warning" }],
+		});
 
-		await page.goto("/healthchecks/postgres");
+		await page.goto("/healthchecks/disk_space");
 		await expect(
-			page.getByRole("link", { name: "expandable-server" }),
+			page.getByRole("link", { name: "Labasa Facility" }),
 		).toBeVisible();
 		// Collapsed: the entry's extra fields are hidden.
-		await expect(page.getByText("connection refused")).toHaveCount(0);
+		await expect(page.getByText("volume /data almost full")).toHaveCount(0);
 
-		await page.getByRole("button", { name: /^expand$/i }).click();
+		// Expand the rich row (rows sort failed-first, so it's first).
+		await page.getByRole("button", { name: /^expand$/i }).first().click();
 
-		await expect(page.getByText("hint")).toBeVisible();
-		await expect(page.getByText("connection refused")).toBeVisible();
 		await expect(page.getByText("free_pct")).toBeVisible();
+		await expect(page.getByText("4", { exact: true })).toBeVisible();
+		await expect(page.getByText("used_pct")).toBeVisible();
+		await expect(page.getByText("volume /data almost full")).toBeVisible();
+
+		// Expand the bare row: it must say so, not render blank.
+		await page.getByRole("button", { name: /^expand$/i }).click();
+		await expect(
+			page.getByText("No additional data reported for this check."),
+		).toBeVisible();
 	});
 
 	test("shows since when the check has been failing, from the active issue", async ({
 		page,
 		sql,
 	}) => {
-		const failing = await seedServer(sql, { name: "since-server" });
-		const fresh = await seedServer(sql, { name: "no-issue-server" });
+		const group = await seedServerGroup(sql, { name: "Western Division" });
+		const failing = await seedServer(sql, {
+			name: "Lautoka Facility",
+			groupId: group.id,
+		});
+		const fresh = await seedServer(sql, {
+			name: "Ba Facility",
+			groupId: group.id,
+		});
 		await seedStatus(sql, {
 			serverId: failing.id,
-			health: [{ check: "postgres", result: "failed" }],
+			health: [
+				{ check: "postgres", result: "failed", error: "connection refused" },
+			],
 		});
 		await seedStatus(sql, {
 			serverId: fresh.id,
-			health: [{ check: "postgres", result: "failed" }],
+			health: [
+				{ check: "postgres", result: "failed", error: "connection refused" },
+			],
 		});
 		await seedIssue(sql, {
 			serverId: failing.id,
@@ -184,10 +242,10 @@ test.describe("healthcheck attention page", () => {
 		page,
 		sql,
 	}) => {
-		const server = await seedServer(sql, { name: "sev-server" });
+		const server = await seedServer(sql, { name: "Nadi Facility" });
 		await seedStatus(sql, {
 			serverId: server.id,
-			health: [{ check: "disk_space", result: "failed" }],
+			health: [{ check: "disk_space", result: "failed", free_pct: 2 }],
 		});
 		await seedHealthcheckSeverity(sql, {
 			checkName: "disk_space",
@@ -203,7 +261,7 @@ test.describe("healthcheck attention page", () => {
 		sql,
 	}) => {
 		const checkName = "disk space check";
-		const server = await seedServer(sql, { name: "weird-check-server" });
+		const server = await seedServer(sql, { name: "Levuka Facility" });
 		await seedStatus(sql, {
 			serverId: server.id,
 			health: [{ check: checkName, result: "failed" }],
@@ -214,7 +272,7 @@ test.describe("healthcheck attention page", () => {
 			page.getByRole("heading", { name: checkName }),
 		).toBeVisible();
 		await expect(
-			page.getByRole("link", { name: "weird-check-server" }),
+			page.getByRole("link", { name: "Levuka Facility" }),
 		).toBeVisible();
 	});
 
@@ -222,11 +280,13 @@ test.describe("healthcheck attention page", () => {
 		page,
 		sql,
 	}) => {
-		const server = await seedServer(sql, { name: "linked-server" });
+		const server = await seedServer(sql, { name: "Suva Facility" });
 		await seedStatus(sql, {
 			serverId: server.id,
 			healthy: false,
-			health: [{ check: "postgres", result: "failed" }],
+			health: [
+				{ check: "postgres", result: "failed", error: "connection refused" },
+			],
 		});
 
 		await page.goto(`/servers/${server.id}`);

--- a/private-web/e2e/healthcheck-attention.spec.ts
+++ b/private-web/e2e/healthcheck-attention.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "./test-fixtures";
+import {
+	resetSeededTables,
+	seedHealthcheckSeverity,
+	seedServer,
+	seedServerGroup,
+	seedStatus,
+} from "./seed";
+
+test.describe("healthcheck attention page", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("renders an empty state when no server flags the check", async ({
+		page,
+	}) => {
+		await page.goto("/healthchecks/postgres");
+		await expect(
+			page.getByText("No servers currently flag"),
+		).toBeVisible();
+		await expect(page.getByRole("heading", { name: "postgres" })).toBeVisible();
+	});
+
+	test("lists servers flagging the check, ordered failed before warning, and excludes others", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "attention-cluster" });
+		const warning = await seedServer(sql, {
+			name: "warning-server",
+			groupId: group.id,
+		});
+		const failing = await seedServer(sql, {
+			name: "failing-server",
+			groupId: group.id,
+		});
+		const healthy = await seedServer(sql, {
+			name: "healthy-server",
+			groupId: group.id,
+		});
+		const otherCheck = await seedServer(sql, {
+			name: "other-check-server",
+			groupId: group.id,
+		});
+		await seedStatus(sql, {
+			serverId: warning.id,
+			health: [{ check: "postgres", result: "warning" }],
+		});
+		await seedStatus(sql, {
+			serverId: failing.id,
+			health: [{ check: "postgres", result: "failed" }],
+		});
+		await seedStatus(sql, {
+			serverId: healthy.id,
+			health: [{ check: "postgres", result: "passed" }],
+		});
+		await seedStatus(sql, {
+			serverId: otherCheck.id,
+			health: [{ check: "disk_space", result: "failed" }],
+		});
+
+		await page.goto("/healthchecks/postgres");
+
+		const failingLink = page.getByRole("link", { name: "failing-server" });
+		const warningLink = page.getByRole("link", { name: "warning-server" });
+		await expect(failingLink).toBeVisible();
+		await expect(warningLink).toBeVisible();
+		await expect(page.getByText("healthy-server")).toHaveCount(0);
+		await expect(page.getByText("other-check-server")).toHaveCount(0);
+
+		// Failed sorts above warning.
+		const failingY = (await failingLink.boundingBox())!.y;
+		const warningY = (await warningLink.boundingBox())!.y;
+		expect(failingY).toBeLessThan(warningY);
+
+		await failingLink.click();
+		await expect(page).toHaveURL(new RegExp(`/servers/${failing.id}$`));
+	});
+
+	test("shows the catalog severity when one is configured", async ({
+		page,
+		sql,
+	}) => {
+		const server = await seedServer(sql, { name: "sev-server" });
+		await seedStatus(sql, {
+			serverId: server.id,
+			health: [{ check: "disk_space", result: "failed" }],
+		});
+		await seedHealthcheckSeverity(sql, {
+			checkName: "disk_space",
+			severity: "critical",
+		});
+
+		await page.goto("/healthchecks/disk_space");
+		await expect(page.getByText("critical", { exact: true })).toBeVisible();
+	});
+
+	test("URL-encodes check names with special characters", async ({
+		page,
+		sql,
+	}) => {
+		const checkName = "disk space check";
+		const server = await seedServer(sql, { name: "weird-check-server" });
+		await seedStatus(sql, {
+			serverId: server.id,
+			health: [{ check: checkName, result: "failed" }],
+		});
+
+		await page.goto(`/healthchecks/${encodeURIComponent(checkName)}`);
+		await expect(
+			page.getByRole("heading", { name: checkName }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("link", { name: "weird-check-server" }),
+		).toBeVisible();
+	});
+
+	test("server detail links a failing check to its healthcheck page", async ({
+		page,
+		sql,
+	}) => {
+		const server = await seedServer(sql, { name: "linked-server" });
+		await seedStatus(sql, {
+			serverId: server.id,
+			healthy: false,
+			health: [{ check: "postgres", result: "failed" }],
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		const checkLink = page.getByRole("link", { name: "postgres" });
+		await expect(checkLink).toBeVisible();
+		await checkLink.click();
+		await expect(page).toHaveURL(/\/healthchecks\/postgres$/);
+	});
+});

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -305,6 +305,10 @@ export async function seedIssue(
 		resolved?: boolean;
 		resolvedBy?: string | null;
 		resolvedReason?: string | null;
+		/** ISO 8601 timestamp for `first_seen`. Defaults to NOW(). Set it in
+		 * the past to test "since when" displays (e.g. the per-healthcheck
+		 * page's failing-since column). */
+		firstSeen?: string;
 	},
 ): Promise<SeededIssue> {
 	const id = randomUUID();
@@ -312,7 +316,7 @@ export async function seedIssue(
 	await sql.query(
 		`INSERT INTO issues
 		 (id, server_id, server_group_id, device_id, source, ref, severity, message, description, active, first_seen, last_seen, resolved_at, resolved_by, resolved_reason)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW(), $11, $12, $13)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, COALESCE($11::timestamptz, NOW()), NOW(), $12, $13, $14)`,
 		[
 			id,
 			opts.serverId ?? null,
@@ -324,6 +328,7 @@ export async function seedIssue(
 			opts.message ?? "Issue message",
 			opts.description ?? null,
 			resolved ? false : (opts.active ?? true),
+			opts.firstSeen ?? null,
 			resolved ? new Date().toISOString() : null,
 			resolved ? (opts.resolvedBy ?? null) : null,
 			resolved ? (opts.resolvedReason ?? null) : null,

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,7 +47,7 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, healthcheck_severities, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
 	// self-alerts attach to that row, so put it back.
@@ -235,6 +235,31 @@ export async function seedStatus(
 		params,
 	);
 	return { id, createdAt: String(rows[0]!.created_at) };
+}
+
+export interface SeededHealthcheckSeverity {
+	checkName: string;
+}
+
+/** Catalog row for a healthcheck name, as ingestion would have upserted
+ * (plus an operator-set severity). Upserts so tests can call it without
+ * worrying whether ingestion already created a default row. */
+export async function seedHealthcheckSeverity(
+	sql: Sql,
+	opts: {
+		checkName: string;
+		severity?: string;
+		notes?: string | null;
+	},
+): Promise<SeededHealthcheckSeverity> {
+	await sql.query(
+		`INSERT INTO healthcheck_severities (check_name, severity, notes)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (check_name)
+		 DO UPDATE SET severity = EXCLUDED.severity, notes = EXCLUDED.notes`,
+		[opts.checkName, opts.severity ?? "warning", opts.notes ?? null],
+	);
+	return { checkName: opts.checkName };
 }
 
 /** Cache row for a Tailscale user's display info, as the auth layer

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -5438,8 +5438,8 @@
         "tags": [
           "statuses"
         ],
-        "summary": "List the servers currently failing or warning one named healthcheck.",
-        "description": "Everything the per-healthcheck page needs: the catalog's configured\nseverity for `check` (if any) plus every live server whose **latest**\nstatus currently reports it as warning, failed, or broken — i.e. the\ncurrent, real-time failures, not a history of past issues/events. This\nis the data behind the `/healthchecks/:check` \"who's affected\" page,\nwhich doubles as an operator TODO list and as a way to correlate\nservers sharing the same issue during a fleet-wide incident.",
+        "summary": "List the servers whose latest status reports one named healthcheck.",
+        "description": "Everything the per-healthcheck page needs: the catalog's configured\nseverity for `check` (if any) plus every live server whose **latest**\nstatus reports it — the current, real-time picture, not a history of\npast issues/events, though each failing server carries a\n`failing_since` timestamp derived from its active issue. This is the\ndata behind the `/healthchecks/:check` \"who's affected\" page, which\ndoubles as an operator TODO list and as a way to correlate servers\nsharing the same issue during a fleet-wide incident.",
         "operationId": "status_check_attention",
         "requestBody": {
           "content": {
@@ -5453,7 +5453,7 @@
         },
         "responses": {
           "200": {
-            "description": "The check's catalog severity and the servers currently flagging it.",
+            "description": "The check's catalog severity and the servers currently reporting it.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7002,7 +7002,7 @@
       },
       "CheckAttentionData": {
         "type": "object",
-        "description": "Response for [`check_attention`]: the queried check's catalog severity\n(if it has one yet) and every live server whose latest status is\ncurrently flagging it.",
+        "description": "Response for [`check_attention`]: the queried check's catalog severity\n(if it has one yet) and every live server whose latest status reports\nit, failing or healthy.",
         "required": [
           "check",
           "servers"
@@ -7017,7 +7017,7 @@
             "items": {
               "$ref": "#/components/schemas/CheckAttentionServerData"
             },
-            "description": "Servers currently flagging this check as a TODO list: failed\nbefore warning before broken (most urgent first), then by group\nname then server name."
+            "description": "Every live server whose latest status reports this check, at any\nresult, ordered as a TODO list: failed, warning, broken, passed,\nskipped (most urgent first), then by group name then server name.\nThe client filters out the passed/skipped tail unless the \"show\nhealthy\" toggle is on."
           },
           "severity": {
             "oneOf": [
@@ -7034,21 +7034,33 @@
       },
       "CheckAttentionServerData": {
         "type": "object",
-        "description": "One server currently flagging [`CheckAttentionData::check`], for\n[`check_attention`].",
+        "description": "One server whose latest status reports [`CheckAttentionData::check`],\nfor [`check_attention`].",
         "required": [
           "server_id",
           "server_name",
           "result",
+          "data",
           "status_created_at"
         ],
         "properties": {
+          "data": {
+            "description": "The check's full `health[]` entry from this server's latest status,\nverbatim (including the `check`/`healthy`/`result` keys), so the\nrow can expand to the same per-check detail the server page shows."
+          },
+          "failing_since": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When this check started failing on this server: the `first_seen`\nof the still-active issue canopy filed at `(status,\nhealth/<check>)` when the check degraded. `None` for servers\ncurrently reporting the check healthy, and for failing servers\nwith no active issue on file (e.g. the issue was\noperator-resolved, or the ref is silenced so nothing was filed)."
+          },
           "group_id": {
             "type": [
               "string",
               "null"
             ],
             "format": "uuid",
-            "description": "The server's group id, if it belongs to one."
+            "description": "The server's group id, if it belongs to one — the UI links to\n`/groups/{group_id}`."
           },
           "group_name": {
             "type": [
@@ -7059,7 +7071,7 @@
           },
           "result": {
             "$ref": "#/components/schemas/CheckResult",
-            "description": "The check's result on this server's latest status. Always warning,\nfailed, or broken — passed/skipped checks never reach this endpoint."
+            "description": "The check's result on this server's latest status. The UI shows\nwarning/failed/broken servers by default and puts passed/skipped\nones behind a \"show healthy\" toggle."
           },
           "server_id": {
             "type": "string",

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -5433,6 +5433,48 @@
         }
       }
     },
+    "/api/statuses/check_attention": {
+      "post": {
+        "tags": [
+          "statuses"
+        ],
+        "summary": "List the servers currently failing or warning one named healthcheck.",
+        "description": "Everything the per-healthcheck page needs: the catalog's configured\nseverity for `check` (if any) plus every live server whose **latest**\nstatus currently reports it as warning, failed, or broken — i.e. the\ncurrent, real-time failures, not a history of past issues/events. This\nis the data behind the `/healthchecks/:check` \"who's affected\" page,\nwhich doubles as an operator TODO list and as a way to correlate\nservers sharing the same issue during a fleet-wide incident.",
+        "operationId": "status_check_attention",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CheckAttentionArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The check's catalog severity and the servers currently flagging it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckAttentionData"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/statuses/group_details": {
       "post": {
         "tags": [
@@ -6944,6 +6986,107 @@
             "description": "Label value."
           }
         }
+      },
+      "CheckAttentionArgs": {
+        "type": "object",
+        "description": "Request body for [`check_attention`].",
+        "required": [
+          "check"
+        ],
+        "properties": {
+          "check": {
+            "type": "string",
+            "description": "The healthcheck name to look up, exactly as reported by devices in\n`health[].check` (an arbitrary, device/plugin-defined string)."
+          }
+        }
+      },
+      "CheckAttentionData": {
+        "type": "object",
+        "description": "Response for [`check_attention`]: the queried check's catalog severity\n(if it has one yet) and every live server whose latest status is\ncurrently flagging it.",
+        "required": [
+          "check",
+          "servers"
+        ],
+        "properties": {
+          "check": {
+            "type": "string",
+            "description": "The check name that was queried, echoed back so the page can\nrender its heading without re-decoding the request."
+          },
+          "servers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckAttentionServerData"
+            },
+            "description": "Servers currently flagging this check as a TODO list: failed\nbefore warning before broken (most urgent first), then by group\nname then server name."
+          },
+          "severity": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Severity",
+                "description": "The catalog's configured base severity for this check, or `None`\nif no server has ever reported it yet (so it has no catalog row)."
+              }
+            ]
+          }
+        }
+      },
+      "CheckAttentionServerData": {
+        "type": "object",
+        "description": "One server currently flagging [`CheckAttentionData::check`], for\n[`check_attention`].",
+        "required": [
+          "server_id",
+          "server_name",
+          "result",
+          "status_created_at"
+        ],
+        "properties": {
+          "group_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The server's group id, if it belongs to one."
+          },
+          "group_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The server's group name, if it belongs to one."
+          },
+          "result": {
+            "$ref": "#/components/schemas/CheckResult",
+            "description": "The check's result on this server's latest status. Always warning,\nfailed, or broken — passed/skipped checks never reach this endpoint."
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The server's id — the UI links to `/servers/{server_id}`."
+          },
+          "server_name": {
+            "type": "string",
+            "description": "The server's display name; empty string when the server has none."
+          },
+          "status_created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the reporting status was recorded."
+          }
+        }
+      },
+      "CheckResult": {
+        "type": "string",
+        "description": "Outcome of a single health check reported in a server's status update.\n\nOlder reports may send a plain pass/fail flag instead of one of these\noutcomes; when that happens a passing flag is treated as `passed` and a\nfailing flag as `failed`.",
+        "enum": [
+          "passed",
+          "warning",
+          "failed",
+          "broken",
+          "skipped"
+        ]
       },
       "ClearScheduleArgs": {
         "type": "object",

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -31,6 +31,7 @@ import DevicesSearch from "./routes/DevicesSearch";
 import GroupDetail from "./routes/GroupDetail";
 import GroupEdit from "./routes/GroupEdit";
 import GroupsList from "./routes/GroupsList";
+import HealthcheckAttention from "./routes/HealthcheckAttention";
 import HealthcheckDetail from "./routes/HealthcheckDetail";
 import Healthchecks from "./routes/Healthchecks";
 import IncidentDetail from "./routes/IncidentDetail";
@@ -184,6 +185,7 @@ export default function App() {
 					<Route path="/alerts" element={<SelfAlerts />} />
 					<Route path="/incidents" element={<Incidents />} />
 					<Route path="/incidents/:id" element={<IncidentDetail />} />
+					<Route path="/healthchecks/:check" element={<HealthcheckAttention />} />
 					<Route path="/versions" element={<Versions />} />
 					<Route path="/versions/:version" element={<VersionDetail />} />
 					<Route path="/servers" element={<Servers />}>

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2790,14 +2790,15 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * List the servers currently failing or warning one named healthcheck.
+         * List the servers whose latest status reports one named healthcheck.
          * @description Everything the per-healthcheck page needs: the catalog's configured
          *     severity for `check` (if any) plus every live server whose **latest**
-         *     status currently reports it as warning, failed, or broken — i.e. the
-         *     current, real-time failures, not a history of past issues/events. This
-         *     is the data behind the `/healthchecks/:check` "who's affected" page,
-         *     which doubles as an operator TODO list and as a way to correlate
-         *     servers sharing the same issue during a fleet-wide incident.
+         *     status reports it — the current, real-time picture, not a history of
+         *     past issues/events, though each failing server carries a
+         *     `failing_since` timestamp derived from its active issue. This is the
+         *     data behind the `/healthchecks/:check` "who's affected" page, which
+         *     doubles as an operator TODO list and as a way to correlate servers
+         *     sharing the same issue during a fleet-wide incident.
          */
         post: operations["status_check_attention"];
         delete?: never;
@@ -3745,8 +3746,8 @@ export interface components {
         };
         /**
          * @description Response for [`check_attention`]: the queried check's catalog severity
-         *     (if it has one yet) and every live server whose latest status is
-         *     currently flagging it.
+         *     (if it has one yet) and every live server whose latest status reports
+         *     it, failing or healthy.
          */
         CheckAttentionData: {
             /**
@@ -3755,28 +3756,48 @@ export interface components {
              */
             check: string;
             /**
-             * @description Servers currently flagging this check as a TODO list: failed
-             *     before warning before broken (most urgent first), then by group
-             *     name then server name.
+             * @description Every live server whose latest status reports this check, at any
+             *     result, ordered as a TODO list: failed, warning, broken, passed,
+             *     skipped (most urgent first), then by group name then server name.
+             *     The client filters out the passed/skipped tail unless the "show
+             *     healthy" toggle is on.
              */
             servers: components["schemas"]["CheckAttentionServerData"][];
             severity?: null | components["schemas"]["Severity"];
         };
         /**
-         * @description One server currently flagging [`CheckAttentionData::check`], for
-         *     [`check_attention`].
+         * @description One server whose latest status reports [`CheckAttentionData::check`],
+         *     for [`check_attention`].
          */
         CheckAttentionServerData: {
             /**
+             * @description The check's full `health[]` entry from this server's latest status,
+             *     verbatim (including the `check`/`healthy`/`result` keys), so the
+             *     row can expand to the same per-check detail the server page shows.
+             */
+            data: unknown;
+            /**
+             * Format: date-time
+             * @description When this check started failing on this server: the `first_seen`
+             *     of the still-active issue canopy filed at `(status,
+             *     health/<check>)` when the check degraded. `None` for servers
+             *     currently reporting the check healthy, and for failing servers
+             *     with no active issue on file (e.g. the issue was
+             *     operator-resolved, or the ref is silenced so nothing was filed).
+             */
+            failing_since?: string | null;
+            /**
              * Format: uuid
-             * @description The server's group id, if it belongs to one.
+             * @description The server's group id, if it belongs to one — the UI links to
+             *     `/groups/{group_id}`.
              */
             group_id?: string | null;
             /** @description The server's group name, if it belongs to one. */
             group_name?: string | null;
             /**
-             * @description The check's result on this server's latest status. Always warning,
-             *     failed, or broken — passed/skipped checks never reach this endpoint.
+             * @description The check's result on this server's latest status. The UI shows
+             *     warning/failed/broken servers by default and puts passed/skipped
+             *     ones behind a "show healthy" toggle.
              */
             result: components["schemas"]["CheckResult"];
             /**
@@ -10966,7 +10987,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description The check's catalog severity and the servers currently flagging it. */
+            /** @description The check's catalog severity and the servers currently reporting it. */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2780,6 +2780,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/statuses/check_attention": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * List the servers currently failing or warning one named healthcheck.
+         * @description Everything the per-healthcheck page needs: the catalog's configured
+         *     severity for `check` (if any) plus every live server whose **latest**
+         *     status currently reports it as warning, failed, or broken — i.e. the
+         *     current, real-time failures, not a history of past issues/events. This
+         *     is the data behind the `/healthchecks/:check` "who's affected" page,
+         *     which doubles as an operator TODO list and as a way to correlate
+         *     servers sharing the same issue during a fleet-wide incident.
+         */
+        post: operations["status_check_attention"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/statuses/group_details": {
         parameters: {
             query?: never;
@@ -3709,6 +3735,72 @@ export interface components {
             /** @description Label value. */
             value: string;
         };
+        /** @description Request body for [`check_attention`]. */
+        CheckAttentionArgs: {
+            /**
+             * @description The healthcheck name to look up, exactly as reported by devices in
+             *     `health[].check` (an arbitrary, device/plugin-defined string).
+             */
+            check: string;
+        };
+        /**
+         * @description Response for [`check_attention`]: the queried check's catalog severity
+         *     (if it has one yet) and every live server whose latest status is
+         *     currently flagging it.
+         */
+        CheckAttentionData: {
+            /**
+             * @description The check name that was queried, echoed back so the page can
+             *     render its heading without re-decoding the request.
+             */
+            check: string;
+            /**
+             * @description Servers currently flagging this check as a TODO list: failed
+             *     before warning before broken (most urgent first), then by group
+             *     name then server name.
+             */
+            servers: components["schemas"]["CheckAttentionServerData"][];
+            severity?: null | components["schemas"]["Severity"];
+        };
+        /**
+         * @description One server currently flagging [`CheckAttentionData::check`], for
+         *     [`check_attention`].
+         */
+        CheckAttentionServerData: {
+            /**
+             * Format: uuid
+             * @description The server's group id, if it belongs to one.
+             */
+            group_id?: string | null;
+            /** @description The server's group name, if it belongs to one. */
+            group_name?: string | null;
+            /**
+             * @description The check's result on this server's latest status. Always warning,
+             *     failed, or broken — passed/skipped checks never reach this endpoint.
+             */
+            result: components["schemas"]["CheckResult"];
+            /**
+             * Format: uuid
+             * @description The server's id — the UI links to `/servers/{server_id}`.
+             */
+            server_id: string;
+            /** @description The server's display name; empty string when the server has none. */
+            server_name: string;
+            /**
+             * Format: date-time
+             * @description When the reporting status was recorded.
+             */
+            status_created_at: string;
+        };
+        /**
+         * @description Outcome of a single health check reported in a server's status update.
+         *
+         *     Older reports may send a plain pass/fail flag instead of one of these
+         *     outcomes; when that happens a passing flag is treated as `passed` and a
+         *     failing flag as `failed`.
+         * @enum {string}
+         */
+        CheckResult: "passed" | "warning" | "failed" | "broken" | "skipped";
         /** @description Identifies a server group's schedule override for a backup type. */
         ClearScheduleArgs: {
             /**
@@ -10857,6 +10949,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": boolean;
+                };
+            };
+        };
+    };
+    status_check_attention: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CheckAttentionArgs"];
+            };
+        };
+        responses: {
+            /** @description The check's catalog severity and the servers currently flagging it. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckAttentionData"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
                 };
             };
         };

--- a/private-web/src/components/CheckExtras.tsx
+++ b/private-web/src/components/CheckExtras.tsx
@@ -1,0 +1,65 @@
+import { Box } from "@mui/material";
+import { Fragment } from "react";
+
+/// Stringify one value from a `health[]` entry for display: strings
+/// verbatim, everything else as compact JSON.
+export function renderCheckValue(v: unknown): string {
+	if (typeof v === "string") return v;
+	if (v === null) return "null";
+	return JSON.stringify(v);
+}
+
+/// The extra fields of one `health[]` entry (everything except the
+/// reserved `check`/`healthy`/`result` keys), in source order.
+export function checkEntryExtras(
+	entry: Record<string, unknown>,
+): Array<[string, unknown]> {
+	return Object.entries(entry).filter(
+		([k]) => k !== "check" && k !== "healthy" && k !== "result",
+	);
+}
+
+/// Key/value grid of a healthcheck entry's extra fields — the canonical
+/// rendering of "all the data of the healthcheck", shared by the server
+/// detail checks table, the status snapshot panel, and the
+/// per-healthcheck attention page.
+export default function CheckExtrasList({
+	extras,
+}: {
+	extras: Array<[string, unknown]>;
+}) {
+	if (extras.length === 0) return null;
+	return (
+		<Box
+			component="dl"
+			sx={{
+				m: 0,
+				mt: 0.5,
+				display: "grid",
+				gridTemplateColumns: "max-content 1fr",
+				columnGap: 1.5,
+				rowGap: 0.25,
+				fontSize: "0.8em",
+			}}
+		>
+			{extras.map(([k, v]) => (
+				<Fragment key={k}>
+					<Box component="dt" sx={{ color: "text.secondary" }}>
+						{k}
+					</Box>
+					<Box
+						component="dd"
+						sx={{
+							m: 0,
+							fontFamily: "monospace",
+							minWidth: 0,
+							overflowWrap: "anywhere",
+						}}
+					>
+						{renderCheckValue(v)}
+					</Box>
+				</Fragment>
+			))}
+		</Box>
+	);
+}

--- a/private-web/src/components/IssueRow.tsx
+++ b/private-web/src/components/IssueRow.tsx
@@ -30,6 +30,8 @@ import TimeAgo from "./TimeAgo";
 import {
 	RESOLVED_REASONS,
 	RESOLVED_REASON_LABEL,
+	healthcheckNameFromRef,
+	healthcheckPath,
 	type IssueData,
 	type IssueIncidentLink,
 	type ResolvedReason,
@@ -574,6 +576,7 @@ function IssueActions({
 function IssueMeta({ issue }: { issue: IssueData }) {
 	const incidents = issue.incidents;
 	const n = incidents.length;
+	const checkName = healthcheckNameFromRef(issue.source, issue.ref);
 
 	return (
 		<Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
@@ -582,7 +585,13 @@ function IssueMeta({ issue }: { issue: IssueData }) {
 				component="code"
 				sx={{ fontFamily: "monospace", fontSize: "0.9em" }}
 			>
-				{issue.ref}
+				{checkName ? (
+					<MuiLink component={RouterLink} to={healthcheckPath(checkName)}>
+						{issue.ref}
+					</MuiLink>
+				) : (
+					issue.ref
+				)}
 			</Box>
 			)
 			{n > 0 && (

--- a/private-web/src/components/ServerNameWithGroup.tsx
+++ b/private-web/src/components/ServerNameWithGroup.tsx
@@ -8,25 +8,39 @@ import { Link as RouterLink } from "react-router-dom";
  * server is ungrouped, the group prefix is skipped entirely — no leading
  * separator.
  *
- * Pass `groupId` to make the group name a link to the group page. Leave
- * it off in contexts that are already wrapped in a link (list rows) —
+ * Pass `groupId` to make the group name a link to the group page, and/or
+ * `serverId` to make the server name a link to the server page. Leave
+ * both off in contexts that are already wrapped in a link (list rows) —
  * nested anchors are invalid.
  */
 export default function ServerNameWithGroup({
 	groupName,
 	groupId,
 	serverName,
+	serverId,
 	component = "span",
 }: {
 	groupName?: string | null;
 	groupId?: string | null;
 	serverName: string;
+	serverId?: string | null;
 	component?: React.ElementType;
 }) {
+	const serverPart = serverId ? (
+		<MuiLink
+			component={RouterLink}
+			to={`/servers/${serverId}`}
+			underline="hover"
+		>
+			{serverName}
+		</MuiLink>
+	) : (
+		serverName
+	);
 	if (!groupName) {
 		return (
 			<Box component={component} sx={{ display: "inline" }}>
-				{serverName}
+				{serverPart}
 			</Box>
 		);
 	}
@@ -51,7 +65,7 @@ export default function ServerNameWithGroup({
 				)}{" "}
 				·
 			</Typography>
-			{serverName}
+			{serverPart}
 		</Box>
 	);
 }

--- a/private-web/src/components/StatusSnapshot.tsx
+++ b/private-web/src/components/StatusSnapshot.tsx
@@ -17,8 +17,8 @@ import InfoIcon from "@mui/icons-material/Info";
 import PreviewIcon from "@mui/icons-material/Preview";
 import RemoveCircleOutlinedIcon from "@mui/icons-material/RemoveCircleOutlined";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import { Fragment } from "react";
 import { useApi, type ApiState } from "../api";
+import CheckExtrasList, { checkEntryExtras } from "./CheckExtras";
 import ExternalUsersDetails, {
 	parseExternalUserSessions,
 } from "./ExternalUsersDetails";
@@ -248,39 +248,7 @@ function ChecksBlock({
 										operators={operators}
 									/>
 								)}
-								{extras.length > 0 && (
-									<Box
-										component="dl"
-										sx={{
-											m: 0,
-											mt: 0.5,
-											display: "grid",
-											gridTemplateColumns: "max-content 1fr",
-											columnGap: 1.5,
-											rowGap: 0.25,
-											fontSize: "0.8em",
-										}}
-									>
-										{extras.map(([k, v]) => (
-											<Fragment key={k}>
-												<Box component="dt" sx={{ color: "text.secondary" }}>
-													{k}
-												</Box>
-												<Box
-													component="dd"
-													sx={{
-														m: 0,
-														fontFamily: "monospace",
-														minWidth: 0,
-														overflowWrap: "anywhere",
-													}}
-												>
-													{renderValue(v)}
-												</Box>
-											</Fragment>
-										))}
-									</Box>
-								)}
+								<CheckExtrasList extras={extras} />
 							</Box>
 						</Stack>
 					);
@@ -330,10 +298,7 @@ function parseChecks(health: StatusSnapshotData["health"]): ParsedCheck[] {
 		const check = obj.check;
 		const result = checkResultOf(obj);
 		if (typeof check !== "string" || result === null) continue;
-		const extras: Array<[string, unknown]> = Object.entries(obj).filter(
-			([k]) => k !== "check" && k !== "healthy" && k !== "result",
-		);
-		parsed.push({ check, result, extras });
+		parsed.push({ check, result, extras: checkEntryExtras(obj) });
 	}
 	parsed.sort((a, b) => {
 		if (a.result !== b.result) {
@@ -423,12 +388,6 @@ function CheckIcon({
 				</Tooltip>
 			);
 	}
-}
-
-function renderValue(v: unknown): string {
-	if (typeof v === "string") return v;
-	if (v === null) return "null";
-	return JSON.stringify(v);
 }
 
 /** Toggle button that opens an inline snapshot panel. Caller owns the

--- a/private-web/src/routes/HealthcheckAttention.tsx
+++ b/private-web/src/routes/HealthcheckAttention.tsx
@@ -2,7 +2,6 @@ import {
 	Alert,
 	Box,
 	Chip,
-	Collapse,
 	FormControlLabel,
 	IconButton,
 	LinearProgress,
@@ -223,24 +222,19 @@ function AttentionRow({ server }: { server: CheckAttentionServerData }) {
 					<TimeAgo timestamp={server.status_created_at} />
 				</TableCell>
 			</TableRow>
-			<TableRow>
-				<TableCell
-					colSpan={5}
-					sx={{ py: 0, border: expanded ? undefined : 0 }}
-				>
-					<Collapse in={expanded} timeout="auto" unmountOnExit>
-						<Box sx={{ py: 1 }}>
-							{extras.length > 0 ? (
-								<CheckExtrasList extras={extras} />
-							) : (
-								<Typography variant="body2" color="text.secondary">
-									No additional data reported for this check.
-								</Typography>
-							)}
-						</Box>
-					</Collapse>
-				</TableCell>
-			</TableRow>
+			{expanded && (
+				<TableRow>
+					<TableCell colSpan={5} sx={{ py: 1 }}>
+						{extras.length > 0 ? (
+							<CheckExtrasList extras={extras} />
+						) : (
+							<Typography variant="body2" color="text.secondary">
+								No additional data reported for this check.
+							</Typography>
+						)}
+					</TableCell>
+				</TableRow>
+			)}
 		</>
 	);
 }

--- a/private-web/src/routes/HealthcheckAttention.tsx
+++ b/private-web/src/routes/HealthcheckAttention.tsx
@@ -1,0 +1,134 @@
+import {
+	Alert,
+	Box,
+	Chip,
+	LinearProgress,
+	Link as MuiLink,
+	Paper,
+	Stack,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	Typography,
+} from "@mui/material";
+import { Link as RouterLink, useParams } from "react-router-dom";
+import { useApi } from "../api";
+import ServerNameWithGroup from "../components/ServerNameWithGroup";
+import SeverityChip from "../components/SeverityChip";
+import TimeAgo from "../components/TimeAgo";
+import { usePageTitle } from "../hooks/usePageTitle";
+import { useReloadInterval } from "../hooks/useReloadInterval";
+import { type CheckAttentionServerData } from "../types";
+
+/// MUI chip colour per offending check result. Only warning/failed/broken
+/// ever reach here (see `Status::offending_checks` on the Rust side) —
+/// broken reads as a warning since it says nothing about the system under
+/// test, just the check itself.
+const CHECK_CHIP_COLOR: Record<string, "error" | "warning"> = {
+	failed: "error",
+	warning: "warning",
+	broken: "warning",
+};
+
+/// Dedicated page for a single healthcheck: every live server whose
+/// *current* status flags it, most urgent first. Doubles as an operator
+/// TODO list for normalising those servers back to healthy, and as a way
+/// to see who's sharing the same issue during a fleet-wide incident.
+/// Linked from wherever a check name shows up — server detail, issue
+/// rows, and the healthchecks settings catalog.
+export default function HealthcheckAttention() {
+	const { check } = useParams<{ check: string }>();
+	usePageTitle(check ?? "Healthcheck");
+	const tick = useReloadInterval(30_000, "canopy-data-changed");
+	const result = useApi(
+		"statuses",
+		"check_attention",
+		{ check: check ?? "" },
+		[check, tick],
+	);
+
+	return (
+		<Stack spacing={2}>
+			<Box>
+				<Typography variant="body2" color="text.secondary">
+					<RouterLink to="/status">← Status</RouterLink>
+				</Typography>
+				<Stack direction="row" spacing={1} sx={{ alignItems: "center", mt: 0.5 }}>
+					<Typography variant="h6" component="h2" sx={{ fontFamily: "monospace" }}>
+						{check}
+					</Typography>
+					{result.status === "ok" && result.data.severity && (
+						<SeverityChip severity={result.data.severity} />
+					)}
+				</Stack>
+				<Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+					Servers whose latest status currently flags this check.{" "}
+					<MuiLink
+						component={RouterLink}
+						to={`/settings/healthchecks/${encodeURIComponent(check ?? "")}`}
+					>
+						Configure severity / rules
+					</MuiLink>
+				</Typography>
+			</Box>
+
+			{result.status === "loading" || result.status === "idle" ? (
+				<LinearProgress />
+			) : result.status === "error" ? (
+				<Alert severity="error">{result.error.message}</Alert>
+			) : result.data.servers.length === 0 ? (
+				<Alert severity="success">
+					No servers currently flag <code>{check}</code>.
+				</Alert>
+			) : (
+				<Paper variant="outlined">
+					<TableContainer>
+						<Table size="small">
+							<TableHead>
+								<TableRow>
+									<TableCell>Server</TableCell>
+									<TableCell>Result</TableCell>
+									<TableCell>As of</TableCell>
+								</TableRow>
+							</TableHead>
+							<TableBody>
+								{result.data.servers.map((server) => (
+									<AttentionRow key={server.server_id} server={server} />
+								))}
+							</TableBody>
+						</Table>
+					</TableContainer>
+				</Paper>
+			)}
+		</Stack>
+	);
+}
+
+function AttentionRow({ server }: { server: CheckAttentionServerData }) {
+	return (
+		<TableRow hover>
+			<TableCell>
+				<MuiLink component={RouterLink} to={`/servers/${server.server_id}`}>
+					<ServerNameWithGroup
+						groupName={server.group_name}
+						serverName={server.server_name || "(unnamed)"}
+					/>
+				</MuiLink>
+			</TableCell>
+			<TableCell>
+				<Chip
+					label={server.result}
+					size="small"
+					variant="outlined"
+					color={CHECK_CHIP_COLOR[server.result] ?? "warning"}
+				/>
+			</TableCell>
+			<TableCell>
+				<TimeAgo timestamp={server.status_created_at} />
+			</TableCell>
+		</TableRow>
+	);
+}

--- a/private-web/src/routes/HealthcheckAttention.tsx
+++ b/private-web/src/routes/HealthcheckAttention.tsx
@@ -2,10 +2,14 @@ import {
 	Alert,
 	Box,
 	Chip,
+	Collapse,
+	FormControlLabel,
+	IconButton,
 	LinearProgress,
 	Link as MuiLink,
 	Paper,
 	Stack,
+	Switch,
 	Table,
 	TableBody,
 	TableCell,
@@ -14,35 +18,47 @@ import {
 	TableRow,
 	Typography,
 } from "@mui/material";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { useState } from "react";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import { useApi } from "../api";
+import CheckExtrasList, { checkEntryExtras } from "../components/CheckExtras";
 import ServerNameWithGroup from "../components/ServerNameWithGroup";
 import SeverityChip from "../components/SeverityChip";
 import TimeAgo from "../components/TimeAgo";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { useReloadInterval } from "../hooks/useReloadInterval";
-import { type CheckAttentionServerData } from "../types";
+import { type CheckAttentionServerData, type CheckResult } from "../types";
 
-/// MUI chip colour per offending check result. Only warning/failed/broken
-/// ever reach here (see `Status::offending_checks` on the Rust side) —
-/// broken reads as a warning since it says nothing about the system under
-/// test, just the check itself.
-const CHECK_CHIP_COLOR: Record<string, "error" | "warning"> = {
+/// MUI chip colour per check result. Broken reads as a warning since it
+/// says nothing about the system under test, just the check itself;
+/// passed/skipped (visible behind the "show healthy" toggle) read calm.
+const CHECK_CHIP_COLOR: Record<
+	CheckResult,
+	"error" | "warning" | "success" | "default"
+> = {
 	failed: "error",
 	warning: "warning",
 	broken: "warning",
+	passed: "success",
+	skipped: "default",
 };
 
+const HEALTHY_RESULTS: readonly string[] = ["passed", "skipped"];
+
 /// Dedicated page for a single healthcheck: every live server whose
-/// *current* status flags it, most urgent first. Doubles as an operator
-/// TODO list for normalising those servers back to healthy, and as a way
-/// to see who's sharing the same issue during a fleet-wide incident.
+/// *current* status flags it, most urgent first, with the servers
+/// reporting it healthy behind a toggle. Doubles as an operator TODO
+/// list for normalising those servers back to healthy, and as a way to
+/// see who's sharing the same issue during a fleet-wide incident.
 /// Linked from wherever a check name shows up — server detail, issue
 /// rows, and the healthchecks settings catalog.
 export default function HealthcheckAttention() {
 	const { check } = useParams<{ check: string }>();
 	usePageTitle(check ?? "Healthcheck");
 	const tick = useReloadInterval(30_000, "canopy-data-changed");
+	const [showHealthy, setShowHealthy] = useState(false);
 	const result = useApi(
 		"statuses",
 		"check_attention",
@@ -75,60 +91,156 @@ export default function HealthcheckAttention() {
 				</Typography>
 			</Box>
 
+			<FormControlLabel
+				control={
+					<Switch
+						size="small"
+						checked={showHealthy}
+						onChange={(e) => setShowHealthy(e.target.checked)}
+					/>
+				}
+				label="Show healthy servers for this check"
+			/>
+
 			{result.status === "loading" || result.status === "idle" ? (
 				<LinearProgress />
 			) : result.status === "error" ? (
 				<Alert severity="error">{result.error.message}</Alert>
-			) : result.data.servers.length === 0 ? (
-				<Alert severity="success">
-					No servers currently flag <code>{check}</code>.
-				</Alert>
 			) : (
-				<Paper variant="outlined">
-					<TableContainer>
-						<Table size="small">
-							<TableHead>
-								<TableRow>
-									<TableCell>Server</TableCell>
-									<TableCell>Result</TableCell>
-									<TableCell>As of</TableCell>
-								</TableRow>
-							</TableHead>
-							<TableBody>
-								{result.data.servers.map((server) => (
-									<AttentionRow key={server.server_id} server={server} />
-								))}
-							</TableBody>
-						</Table>
-					</TableContainer>
-				</Paper>
+				<ServersTable
+					check={check ?? ""}
+					servers={result.data.servers}
+					showHealthy={showHealthy}
+				/>
 			)}
 		</Stack>
 	);
 }
 
-function AttentionRow({ server }: { server: CheckAttentionServerData }) {
+function ServersTable({
+	check,
+	servers,
+	showHealthy,
+}: {
+	check: string;
+	servers: CheckAttentionServerData[];
+	showHealthy: boolean;
+}) {
+	const visible = showHealthy
+		? servers
+		: servers.filter((s) => !HEALTHY_RESULTS.includes(s.result));
+
+	if (visible.length === 0) {
+		const healthyCount = servers.length;
+		return (
+			<Alert severity="success">
+				No servers currently flag <code>{check}</code>.
+				{healthyCount > 0 &&
+					` ${healthyCount} ${
+						healthyCount === 1 ? "server reports" : "servers report"
+					} it healthy — use the toggle above to see them.`}
+			</Alert>
+		);
+	}
+
 	return (
-		<TableRow hover>
-			<TableCell>
-				<MuiLink component={RouterLink} to={`/servers/${server.server_id}`}>
+		<Paper variant="outlined">
+			<TableContainer>
+				<Table size="small">
+					<TableHead>
+						<TableRow>
+							<TableCell width={40} />
+							<TableCell>Server</TableCell>
+							<TableCell>Result</TableCell>
+							<TableCell>Failing since</TableCell>
+							<TableCell>As of</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{visible.map((server) => (
+							<AttentionRow key={server.server_id} server={server} />
+						))}
+					</TableBody>
+				</Table>
+			</TableContainer>
+		</Paper>
+	);
+}
+
+/// One server row, expandable to the check's full `health[]` entry data —
+/// the same key/value rendering the server detail checks table uses.
+function AttentionRow({ server }: { server: CheckAttentionServerData }) {
+	const [expanded, setExpanded] = useState(false);
+	const entry =
+		typeof server.data === "object" &&
+		server.data !== null &&
+		!Array.isArray(server.data)
+			? (server.data as Record<string, unknown>)
+			: {};
+	const extras = checkEntryExtras(entry);
+	return (
+		<>
+			<TableRow hover>
+				<TableCell>
+					<IconButton
+						aria-label={expanded ? "Collapse" : "Expand"}
+						size="small"
+						onClick={() => setExpanded((v) => !v)}
+					>
+						{expanded ? (
+							<ExpandLessIcon fontSize="small" />
+						) : (
+							<ExpandMoreIcon fontSize="small" />
+						)}
+					</IconButton>
+				</TableCell>
+				<TableCell>
 					<ServerNameWithGroup
 						groupName={server.group_name}
+						groupId={server.group_id}
 						serverName={server.server_name || "(unnamed)"}
+						serverId={server.server_id}
 					/>
-				</MuiLink>
-			</TableCell>
-			<TableCell>
-				<Chip
-					label={server.result}
-					size="small"
-					variant="outlined"
-					color={CHECK_CHIP_COLOR[server.result] ?? "warning"}
-				/>
-			</TableCell>
-			<TableCell>
-				<TimeAgo timestamp={server.status_created_at} />
-			</TableCell>
-		</TableRow>
+				</TableCell>
+				<TableCell>
+					<Chip
+						label={server.result}
+						size="small"
+						variant="outlined"
+						color={CHECK_CHIP_COLOR[server.result as CheckResult] ?? "warning"}
+					/>
+				</TableCell>
+				<TableCell>
+					{server.failing_since ? (
+						<TimeAgo timestamp={server.failing_since} />
+					) : (
+						<Typography variant="body2" color="text.secondary">
+							—
+						</Typography>
+					)}
+				</TableCell>
+				<TableCell>
+					<TimeAgo timestamp={server.status_created_at} />
+				</TableCell>
+			</TableRow>
+			<TableRow>
+				<TableCell
+					colSpan={5}
+					sx={{ py: 0, border: expanded ? undefined : 0 }}
+				>
+					<Collapse in={expanded} timeout="auto" unmountOnExit>
+						<Box sx={{ py: 1 }}>
+							{extras.length > 0 ? (
+								<CheckExtrasList extras={extras} />
+							) : (
+								<Typography variant="body2" color="text.secondary">
+									No additional data reported for this check.
+								</Typography>
+							)}
+						</Box>
+					</Collapse>
+				</TableCell>
+			</TableRow>
+		</>
 	);
 }

--- a/private-web/src/routes/HealthcheckDetail.tsx
+++ b/private-web/src/routes/HealthcheckDetail.tsx
@@ -41,6 +41,7 @@ import { evaluate as evalCondition } from "../lib/healthcheck-rule-eval";
 import {
 	SEVERITIES,
 	SEVERITY_INTENT,
+	healthcheckPath,
 	type HealthcheckSample,
 	type HealthcheckSeverityData,
 	type Severity,
@@ -195,6 +196,11 @@ export default function HealthcheckDetail() {
 				</Typography>
 				<Typography variant="h6" component="h2" sx={{ fontFamily: "monospace" }}>
 					{checkName}
+				</Typography>
+				<Typography variant="body2">
+					<RouterLink to={healthcheckPath(checkName ?? "")}>
+						See servers currently flagging this check
+					</RouterLink>
 				</Typography>
 			</Box>
 

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -73,6 +73,7 @@ import {
 	SERVER_RANK_ORDER,
 	checkResultOf,
 	compareServersByRankThenKind,
+	healthcheckPath,
 	type CheckResult,
 	type DeviceInfo,
 	type HealthState,
@@ -1093,7 +1094,9 @@ function CheckRow({
 					useFlexGap
 				>
 					<Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-						{entry.check}
+						<MuiLink component={RouterLink} to={healthcheckPath(entry.check)}>
+							{entry.check}
+						</MuiLink>
 					</Typography>
 					<SilencedChip
 						serverSilence={serverSilence}

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -37,13 +37,14 @@ import NotificationsActiveOutlinedIcon from "@mui/icons-material/NotificationsAc
 import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import NotificationsOffOutlinedIcon from "@mui/icons-material/NotificationsOffOutlined";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import { Fragment, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
 	Link as RouterLink,
 	useLocation,
 	useNavigate,
 	useParams,
 } from "react-router-dom";
+import CheckExtrasList, { checkEntryExtras } from "../components/CheckExtras";
 import ExternalUsersDetails, {
 	parseExternalUserSessions,
 } from "../components/ExternalUsersDetails";
@@ -1021,10 +1022,7 @@ function parseChecks(
 		if (typeof obj.result !== "string" && result === "failed" && overallHealthy) {
 			result = "warning";
 		}
-		const extras: Array<[string, unknown]> = Object.entries(obj).filter(
-			([k]) => k !== "check" && k !== "healthy" && k !== "result",
-		);
-		parsed.push({ check, result, extras });
+		parsed.push({ check, result, extras: checkEntryExtras(obj) });
 	}
 	// Most urgent first, then alphabetical by name. Stable: same input
 	// always produces the same visible order.
@@ -1109,34 +1107,7 @@ function CheckRow({
 						operators={operators}
 					/>
 				)}
-				{extras.length > 0 && (
-					<Box
-						component="dl"
-						sx={{
-							m: 0,
-							mt: 0.5,
-							display: "grid",
-							gridTemplateColumns: "max-content 1fr",
-							columnGap: 1.5,
-							rowGap: 0.25,
-							fontSize: "0.8em",
-						}}
-					>
-						{extras.map(([k, v]) => (
-							<Fragment key={k}>
-								<Box component="dt" sx={{ color: "text.secondary" }}>
-									{k}
-								</Box>
-								<Box
-									component="dd"
-									sx={{ m: 0, fontFamily: "monospace" }}
-								>
-									{renderCheckValue(v)}
-								</Box>
-							</Fragment>
-						))}
-					</Box>
-				)}
+				<CheckExtrasList extras={extras} />
 			</Box>
 			{isAdmin && (
 				<SilenceCheckButton
@@ -1424,12 +1395,6 @@ function SilenceScopeRow({
 			For {scopeLabel}
 		</Button>
 	);
-}
-
-function renderCheckValue(v: unknown): string {
-	if (typeof v === "string") return v;
-	if (v === null) return "null";
-	return JSON.stringify(v);
 }
 
 function StatusInfoFields({ status }: { status: ServerLastStatusData }) {

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -90,6 +90,10 @@ export type ServerGroupCard = Solidify<Schemas["ServerGroupCard"]>;
 export type ServerGroup = Solidify<Schemas["ServerGroup"]>;
 export type GroupDetail = Solidify<Schemas["GroupDetail"]>;
 export type SummaryData = Solidify<Schemas["SummaryData"]>;
+export type CheckAttentionData = Solidify<Schemas["CheckAttentionData"]>;
+export type CheckAttentionServerData = Solidify<
+	Schemas["CheckAttentionServerData"]
+>;
 export type TagMap = Solidify<Schemas["TagMap"]>;
 
 export type VersionData = Solidify<Schemas["VersionData"]>;
@@ -279,6 +283,27 @@ export function checkResultOf(
 	const healthy = entry.healthy;
 	if (typeof healthy === "boolean") return healthy ? "passed" : "failed";
 	return null;
+}
+
+/// Route to the per-healthcheck "who's affected" page for `check`. Check
+/// names are arbitrary strings reported by devices (not restricted to
+/// URL-safe characters), so every link builder must go through this
+/// instead of interpolating the name directly.
+export function healthcheckPath(check: string): string {
+	return `/healthchecks/${encodeURIComponent(check)}`;
+}
+
+/// The check name embedded in a status-sourced issue/event's `ref`
+/// (`health/<check>` — see the public-server `STATUS_SOURCE` constant),
+/// or `null` for issues filed by any other source (backups, manual,
+/// canopy reachability, …), which don't reference a healthcheck.
+export function healthcheckNameFromRef(
+	source: string,
+	ref: string,
+): string | null {
+	const prefix = "health/";
+	if (source !== "status" || !ref.startsWith(prefix)) return null;
+	return ref.slice(prefix.length);
 }
 
 /// One person connected somewhere in a server group, with the names of


### PR DESCRIPTION
🤖 Adds a fleet-wide view of servers whose **latest** status reports a warning, failed, or broken check — the current healthcheck state, deliberately derived from statuses rather than the issues/events tables.

- New `POST /api/statuses/attention` endpoint: live servers (same scoping as the status board — no archived servers, no canopy-own row) whose latest status is warning/unhealthy, each with its offending checks, group, health state, and status timestamp, sorted by group then server name.
- New "Needs attention" section at the top of the Status page, rendered only when non-empty: each server links through to its page, with a color-coded chip per offending check.
- Endpoint tests (empty fleet, mixed fail/warn/healthy, archived/ungrouped exclusion) and Playwright specs (healthy fleet shows no section; flagged servers listed and linked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)