### PR TITLE
feat: route read-only workloads through an optional RO database pool

### DIFF
--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -108,6 +108,7 @@ where
 	TestDb::run(async |conn, url| {
 		let public_state = public_server::state::AppState {
 			db: database::init_to(&url),
+			db_read: database::init_to(&url),
 			tera: public_server::state::AppState::init_tera().unwrap(),
 			server_versions_secret: Some("test-secret".to_string()),
 			tailnet_directory: None,
@@ -233,6 +234,7 @@ where
 
 		let public_state = public_server::state::AppState {
 			db: database::init_to(&url),
+			db_read: database::init_to(&url),
 			tera: public_server::state::AppState::init_tera().unwrap(),
 			server_versions_secret: Some("test-secret".to_string()),
 			tailnet_directory: None,
@@ -248,6 +250,7 @@ where
 		let private_router = router(
 			private_server::routes(private_server::state::AppState {
 				db: database::init_to(&url),
+				db_read: database::init_to(&url),
 				ro_pool: None,
 				tailnet_directory: Some(directory),
 				kube: Some(public_server::state::BackupSecrets::memory()),

--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -106,9 +106,13 @@ where
 	Fut: Future<Output = T>,
 {
 	TestDb::run(async |conn, url| {
+		// One pool per state, shared between the RW and RO handles — a second
+		// pool would double connections against the throwaway test cluster,
+		// and this mirrors production with RO_DATABASE_URL unset.
+		let public_db = database::init_to(&url);
 		let public_state = public_server::state::AppState {
-			db: database::init_to(&url),
-			db_read: database::init_to(&url),
+			db: public_db.clone(),
+			db_read: public_db,
 			tera: public_server::state::AppState::init_tera().unwrap(),
 			server_versions_secret: Some("test-secret".to_string()),
 			tailnet_directory: None,
@@ -232,9 +236,10 @@ where
 			},
 		)]);
 
+		let public_db = database::init_to(&url);
 		let public_state = public_server::state::AppState {
-			db: database::init_to(&url),
-			db_read: database::init_to(&url),
+			db: public_db.clone(),
+			db_read: public_db,
 			tera: public_server::state::AppState::init_tera().unwrap(),
 			server_versions_secret: Some("test-secret".to_string()),
 			tailnet_directory: None,
@@ -247,10 +252,11 @@ where
 				.merge(public_server::mcp::routes(public_state)),
 			ClientIpSource::RightmostForwarded,
 		);
+		let private_db = database::init_to(&url);
 		let private_router = router(
 			private_server::routes(private_server::state::AppState {
-				db: database::init_to(&url),
-				db_read: database::init_to(&url),
+				db: private_db.clone(),
+				db_read: private_db,
 				ro_pool: None,
 				tailnet_directory: Some(directory),
 				kube: Some(public_server::state::BackupSecrets::memory()),

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -62,14 +62,33 @@ pub fn init() -> Db {
 }
 
 pub fn init_to(url: &str) -> Db {
-	// Bound the pool. Every pod that links this crate (the two servers plus each
-	// job) runs its own pool against the same primary; mobc's defaults
-	// (max_open=10, idle and lifetimes uncapped) let the fleet's aggregate
-	// demand exceed the server's max_connections and pin backends indefinitely.
-	// Size per role via env, and recycle connections so a failover doesn't leave
-	// the pool holding dead backends.
-	let max_open = env_u64("DB_MAX_OPEN_CONNECTIONS", 5);
-	let max_idle = env_u64("DB_MAX_IDLE_CONNECTIONS", 2);
+	build_pool(url, "DB_MAX_OPEN_CONNECTIONS", "DB_MAX_IDLE_CONNECTIONS")
+}
+
+/// A second pool for workloads that only ever read, built against
+/// `RO_DATABASE_URL` when it's set. Routing reads off the primary pool keeps
+/// read traffic from starving writers of connections, and lets ops later
+/// point the var at an actual read replica without a code change. `None`
+/// when the var is unset — callers fall back to the primary pool.
+pub fn init_ro() -> Option<Db> {
+	std::env::var("RO_DATABASE_URL")
+		.ok()
+		.map(|url| init_ro_to(&url))
+}
+
+pub fn init_ro_to(url: &str) -> Db {
+	build_pool(url, "DB_RO_MAX_OPEN_CONNECTIONS", "DB_RO_MAX_IDLE_CONNECTIONS")
+}
+
+// Bound the pool. Every pod that links this crate (the two servers plus each
+// job) runs its own pool against the same backend; mobc's defaults
+// (max_open=10, idle and lifetimes uncapped) let the fleet's aggregate demand
+// exceed the server's max_connections and pin backends indefinitely. Size per
+// role via env, and recycle connections so a failover doesn't leave the pool
+// holding dead backends.
+fn build_pool(url: &str, max_open_key: &str, max_idle_key: &str) -> Db {
+	let max_open = env_u64(max_open_key, 5);
+	let max_idle = env_u64(max_idle_key, 2);
 	Pool::builder()
 		.max_open(max_open)
 		.max_idle(max_idle)

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -77,7 +77,11 @@ pub fn init_ro() -> Option<Db> {
 }
 
 pub fn init_ro_to(url: &str) -> Db {
-	build_pool(url, "DB_RO_MAX_OPEN_CONNECTIONS", "DB_RO_MAX_IDLE_CONNECTIONS")
+	build_pool(
+		url,
+		"DB_RO_MAX_OPEN_CONNECTIONS",
+		"DB_RO_MAX_IDLE_CONNECTIONS",
+	)
 }
 
 // Bound the pool. Every pod that links this crate (the two servers plus each

--- a/crates/private-server/src/fns/incidents.rs
+++ b/crates/private-server/src/fns/incidents.rs
@@ -194,7 +194,7 @@ pub async fn list_for_server(
 	_user: TailscaleUser,
 	Json(args): Json<IncidentListForServerArgs>,
 ) -> Result<Json<Vec<IncidentData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let incidents = Incident::list_for_server(
 		&mut conn,
 		args.server_id,
@@ -203,7 +203,7 @@ pub async fn list_for_server(
 	)
 	.await?;
 	Ok(Json(
-		enrich_incidents(&mut conn, &state.db, incidents).await?,
+		enrich_incidents(&mut conn, &state.db_read, incidents).await?,
 	))
 }
 
@@ -232,7 +232,7 @@ pub async fn list_for_group(
 	_user: TailscaleUser,
 	Json(args): Json<ListForGroupArgs>,
 ) -> Result<Json<Vec<IncidentData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let incidents = Incident::list_for_group(
 		&mut conn,
 		args.server_group_id,
@@ -241,7 +241,7 @@ pub async fn list_for_group(
 	)
 	.await?;
 	Ok(Json(
-		enrich_incidents(&mut conn, &state.db, incidents).await?,
+		enrich_incidents(&mut conn, &state.db_read, incidents).await?,
 	))
 }
 
@@ -266,10 +266,10 @@ pub async fn list_active(
 	_user: TailscaleUser,
 	Json(args): Json<ListActiveArgs>,
 ) -> Result<Json<Vec<IncidentData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let incidents = Incident::list_active(&mut conn, args.limit.unwrap_or(DEFAULT_LIMIT)).await?;
 	Ok(Json(
-		enrich_incidents(&mut conn, &state.db, incidents).await?,
+		enrich_incidents(&mut conn, &state.db_read, incidents).await?,
 	))
 }
 
@@ -294,7 +294,7 @@ pub async fn get_incident(
 	_user: TailscaleUser,
 	Json(args): Json<GetIncidentArgs>,
 ) -> Result<Json<IncidentWithIssues>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let (incident, rows) = Incident::get_with_issues(&mut conn, args.incident_id).await?;
 	let (links, raw_issues): (Vec<_>, Vec<_>) = rows.into_iter().unzip();
 	let issue_data = enrich_issues(&mut conn, raw_issues).await?;
@@ -303,7 +303,7 @@ pub async fn get_incident(
 		.zip(issue_data)
 		.map(|(link, issue)| IncidentIssueData::from((link, issue)))
 		.collect();
-	let incident = enrich_incident(&mut conn, &state.db, incident).await?;
+	let incident = enrich_incident(&mut conn, &state.db_read, incident).await?;
 	Ok(Json(IncidentWithIssues { incident, issues }))
 }
 
@@ -436,7 +436,7 @@ pub async fn list_notes(
 	_user: TailscaleUser,
 	Json(args): Json<IncidentListNotesArgs>,
 ) -> Result<Json<Vec<IncidentNoteData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let notes = IncidentNote::list_for_incident(
 		&mut conn,
 		args.incident_id,

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -315,7 +315,7 @@ pub async fn list(
 	_user: TailscaleUser,
 	Json(args): Json<IssueListArgs>,
 ) -> Result<Json<Vec<IssueData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let issues = Issue::list(
 		&mut conn,
 		IssueListFilters {
@@ -354,7 +354,7 @@ pub async fn list_for_device(
 	_user: TailscaleUser,
 	Json(args): Json<ListForDeviceArgs>,
 ) -> Result<Json<Vec<IssueData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let issues = Issue::list_for_device(
 		&mut conn,
 		args.device_id,
@@ -390,7 +390,7 @@ pub async fn list_for_server(
 	_user: TailscaleUser,
 	Json(args): Json<IssueListForServerArgs>,
 ) -> Result<Json<Vec<IssueData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let issues = Issue::list_for_server(
 		&mut conn,
 		args.server_id,
@@ -425,7 +425,7 @@ pub async fn list_events(
 	_user: TailscaleUser,
 	Json(args): Json<ListEventsArgs>,
 ) -> Result<Json<Page<EventData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let total = Event::count_for_issue(&mut conn, args.issue_id).await? as u64;
 	let events = Event::list_for_issue(
 		&mut conn,
@@ -665,7 +665,7 @@ pub async fn list_notes(
 	_user: TailscaleUser,
 	Json(args): Json<IssueListNotesArgs>,
 ) -> Result<Json<Vec<IssueNoteData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let notes = IssueNote::list_for_issue(
 		&mut conn,
 		args.issue_id,

--- a/crates/private-server/src/fns/restore_replicas.rs
+++ b/crates/private-server/src/fns/restore_replicas.rs
@@ -214,7 +214,7 @@ pub async fn for_group(
 	State(state): State<AppState>,
 	Json(args): Json<RestoreReplicasGroupArgs>,
 ) -> Result<Json<Vec<RestoreReplicaView>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let replicas = RestoreReplica::list_for_group(&mut conn, args.server_group_id).await?;
 	Ok(Json(to_views(&mut conn, replicas).await?))
 }
@@ -228,7 +228,7 @@ pub async fn for_group(
 	responses((status = 200, body = Vec<RestoreConsumerView>)),
 )]
 pub async fn consumers(State(state): State<AppState>) -> Result<Json<Vec<RestoreConsumerView>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let devices = Device::list_by_role(&mut conn, DeviceRole::BackupRestore).await?;
 	let mut out = Vec::with_capacity(devices.len());
 	for d in devices {
@@ -255,7 +255,7 @@ pub async fn checks(
 	State(state): State<AppState>,
 	Json(args): Json<RestoreReplicasGroupArgs>,
 ) -> Result<Json<Vec<BackupRestoreCheck>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let rows =
 		BackupRestoreCheck::list_recent_for_group(&mut conn, args.server_group_id, 50).await?;
 	Ok(Json(rows))

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -78,7 +78,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 	),
 )]
 pub async fn summary(State(state): State<AppState>) -> Result<Json<SummaryData>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 
 	let versions: BTreeSet<VersionStr> = Status::production_versions(&mut conn)
 		.await?
@@ -120,7 +120,7 @@ pub async fn summary(State(state): State<AppState>) -> Result<Json<SummaryData>>
 pub async fn server_grouped_ids(
 	State(state): State<AppState>,
 ) -> Result<Json<BTreeMap<ServerRank, Vec<Uuid>>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let groups = ServerGroup::list_all(&mut conn).await?;
 	if groups.is_empty() {
 		return Ok(Json(BTreeMap::new()));
@@ -164,7 +164,7 @@ pub async fn group_details(
 	State(state): State<AppState>,
 	Json(args): Json<GroupDetailsArgs>,
 ) -> Result<Json<ServerGroupCard>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let group = ServerGroup::get_by_id(&mut conn, args.server_group_id).await?;
 	let servers = group.list_servers(&mut conn).await?;
 
@@ -299,7 +299,7 @@ pub async fn snapshot(
 	_user: TailscaleUser,
 	Json(args): Json<SnapshotArgs>,
 ) -> Result<Json<Option<StatusSnapshotData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let status = match args.at {
 		Some(at) => Status::at_time(&mut conn, args.server_id, at).await?,
 		None => Status::latest_for_server(&mut conn, args.server_id).await?,

--- a/crates/private-server/src/fns/versions.rs
+++ b/crates/private-server/src/fns/versions.rs
@@ -151,7 +151,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 pub async fn get_grouped_versions(
 	State(state): State<AppState>,
 ) -> Result<Json<Vec<MinorVersionGroup>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let versions = Version::get_all_including_drafts(&mut conn).await?;
 
 	// One batched query to compute `ready` for every version returned.
@@ -250,7 +250,7 @@ pub async fn get_version_detail(
 	State(state): State<AppState>,
 	Json(args): Json<VersionStringArgs>,
 ) -> Result<Json<VersionDetail>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let version = VersionStr::from_str(&args.version)?;
 	let version_record = Version::get_by_version(&mut conn, version.clone()).await?;
 
@@ -334,7 +334,7 @@ pub async fn get_version_artifacts(
 	State(state): State<AppState>,
 	Json(args): Json<VersionStringArgs>,
 ) -> Result<Json<Vec<ArtifactData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let version = VersionStr::from_str(&args.version)?;
 	let version_record = Version::get_by_version(&mut conn, version).await?;
 	let artifacts_with_metadata =
@@ -550,7 +550,7 @@ pub async fn list_known_issues(
 	_user: TailscaleUser,
 	Json(args): Json<VersionIdArgs>,
 ) -> Result<Json<Vec<KnownIssueData>>> {
-	let mut conn = state.db.get().await?;
+	let mut conn = state.db_read.get().await?;
 	let v = Version::get_by_id(&mut conn, args.version_id).await?;
 	let rows = VersionKnownIssue::list_for_minor(&mut conn, v.major, v.minor).await?;
 	Ok(Json(rows.into_iter().map(KnownIssueData::from).collect()))

--- a/crates/private-server/src/lib.rs
+++ b/crates/private-server/src/lib.rs
@@ -24,7 +24,7 @@ pub fn routes(state: crate::state::AppState) -> commons_errors::Result<axum::rou
 	// non-public subtree so it inherits the tagged-device guard; gated on top
 	// by "any tailnet user" (see `mcp::require_tailnet_user`).
 	let mcp: Router<crate::state::AppState> = Router::new()
-		.fallback_service(canopy_mcp::service(state.db.clone()))
+		.fallback_service(canopy_mcp::service(state.db_read.clone()))
 		.layer(middleware::from_fn(mcp::require_tailnet_user));
 
 	let non_public = Router::new()

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -25,6 +25,13 @@ pub type RecoveryChallengeStore = Arc<Mutex<Option<RecoveryChallenge>>>;
 #[derive(Clone, Debug, FromRef)]
 pub struct AppState {
 	pub db: Db,
+	/// Pool for read-only workloads: the RO pool when `RO_DATABASE_URL` is
+	/// configured, otherwise a clone of `db`. Handlers that only ever read
+	/// (list/get endpoints, the read-only MCP query interface) use this
+	/// instead of `db` so that traffic can be routed to a read replica
+	/// without a code change on the ops side.
+	#[from_ref(skip)]
+	pub db_read: Db,
 	pub ro_pool: Option<PgPool>,
 	pub tailnet_directory: Option<TailnetDirectory>,
 	/// Secret store for the per-group repo-password Secrets (onboarding creates
@@ -83,8 +90,12 @@ impl AppState {
 		let aws = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
 		let sts = Some(aws_sdk_sts::Client::new(&aws));
 
+		let db = database::init();
+		let db_read = database::init_ro().unwrap_or_else(|| db.clone());
+
 		Ok(Self {
-			db: database::init(),
+			db,
+			db_read,
 			ro_pool,
 			tailnet_directory,
 			kube,
@@ -100,8 +111,10 @@ impl AppState {
 	/// / `BucketProber::fake`), which don't exist in release builds.
 	#[cfg(debug_assertions)]
 	pub async fn from_db_url(url: &str) -> Result<Self> {
+		let db = database::init_to(url);
 		Ok(Self {
-			db: database::init_to(url),
+			db_read: db.clone(),
+			db,
 			ro_pool: None,
 			tailnet_directory: None,
 			// In-memory secret store so onboarding (Secret creation) is exercised

--- a/crates/private-server/tests/device_admin_endpoints.rs
+++ b/crates/private-server/tests/device_admin_endpoints.rs
@@ -34,6 +34,7 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 	let router = router(
 		private_server::routes(private_server::state::AppState {
 			db: database::init_to(url),
+			db_read: database::init_to(url),
 			ro_pool: None,
 			tailnet_directory: Some(directory),
 			kube: None,

--- a/crates/private-server/tests/device_admin_endpoints.rs
+++ b/crates/private-server/tests/device_admin_endpoints.rs
@@ -31,10 +31,11 @@ fn test_directory() -> (std::net::IpAddr, String, TailnetDirectory) {
 }
 
 async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestServer {
+	let db = database::init_to(url);
 	let router = router(
 		private_server::routes(private_server::state::AppState {
-			db: database::init_to(url),
-			db_read: database::init_to(url),
+			db: db.clone(),
+			db_read: db,
 			ro_pool: None,
 			tailnet_directory: Some(directory),
 			kube: None,

--- a/crates/private-server/tests/tailnet_device_auth.rs
+++ b/crates/private-server/tests/tailnet_device_auth.rs
@@ -80,6 +80,7 @@ async fn unknown_tailnet_node_is_rejected_without_creating_a_row() {
 		let private_router = router(
 			private_server::routes(private_server::state::AppState {
 				db: database::init_to(&url),
+				db_read: database::init_to(&url),
 				ro_pool: None,
 				tailnet_directory: Some(directory),
 				kube: None,

--- a/crates/private-server/tests/tailnet_device_auth.rs
+++ b/crates/private-server/tests/tailnet_device_auth.rs
@@ -77,10 +77,11 @@ async fn unknown_tailnet_node_is_rejected_without_creating_a_row() {
 			},
 		)]);
 
+		let db = database::init_to(&url);
 		let private_router = router(
 			private_server::routes(private_server::state::AppState {
-				db: database::init_to(&url),
-				db_read: database::init_to(&url),
+				db: db.clone(),
+				db_read: db,
 				ro_pool: None,
 				tailnet_directory: Some(directory),
 				kube: None,

--- a/crates/public-server/src/mcp.rs
+++ b/crates/public-server/src/mcp.rs
@@ -35,7 +35,7 @@ pub fn routes(state: AppState) -> Router<()> {
 	Router::new().nest(
 		"/mcp",
 		Router::new()
-			.fallback_service(canopy_mcp::service(state.db.clone()))
+			.fallback_service(canopy_mcp::service(state.db_read.clone()))
 			.layer(middleware::from_fn_with_state(state, require_bearer_token)),
 	)
 }

--- a/crates/public-server/src/state.rs
+++ b/crates/public-server/src/state.rs
@@ -16,6 +16,12 @@ pub use commons_servers::backup_secrets::BackupSecrets;
 #[derive(Clone, Debug)]
 pub struct AppState {
 	pub db: Db,
+	/// Pool for read-only workloads: the RO pool when `RO_DATABASE_URL` is
+	/// configured, otherwise a clone of `db`. Used by the internet-facing
+	/// read-only MCP mount (`crate::mcp`); the device-facing endpoints under
+	/// `crate::routes` all write (status/event ingestion, credential
+	/// issuance) and stay on `db`.
+	pub db_read: Db,
 	#[cfg(feature = "ui")]
 	pub tera: Arc<Tera>,
 	#[cfg(feature = "ui")]
@@ -99,8 +105,10 @@ impl AppState {
 		db: Db,
 		tailnet_directory: Option<TailnetDirectory>,
 	) -> Result<Self> {
+		let db_read = database::init_ro().unwrap_or_else(|| db.clone());
 		Ok(Self {
 			db,
+			db_read,
 			#[cfg(feature = "ui")]
 			tera: Self::init_tera()?,
 			#[cfg(feature = "ui")]

--- a/crates/public-server/tests/backup.rs
+++ b/crates/public-server/tests/backup.rs
@@ -458,6 +458,7 @@ async fn report_no_live_server_is_412() {
 fn public_server_with_sts(url: &str, sts: aws_sdk_sts::Client) -> TestServer {
 	let state = public_server::state::AppState {
 		db: database::init_to(url),
+		db_read: database::init_to(url),
 		tera: public_server::state::AppState::init_tera().unwrap(),
 		server_versions_secret: Some("test-secret".to_string()),
 		tailnet_directory: None,

--- a/crates/public-server/tests/backup.rs
+++ b/crates/public-server/tests/backup.rs
@@ -456,9 +456,10 @@ async fn report_no_live_server_is_412() {
 /// client (and no kube), against the given DB url. Mirrors the harness wiring
 /// but lets the test inject the stubbed STS path.
 fn public_server_with_sts(url: &str, sts: aws_sdk_sts::Client) -> TestServer {
+	let db = database::init_to(url);
 	let state = public_server::state::AppState {
-		db: database::init_to(url),
-		db_read: database::init_to(url),
+		db: db.clone(),
+		db_read: db,
 		tera: public_server::state::AppState::init_tera().unwrap(),
 		server_versions_secret: Some("test-secret".to_string()),
 		tailnet_directory: None,

--- a/private-web/e2e/fixture.ts
+++ b/private-web/e2e/fixture.ts
@@ -186,6 +186,10 @@ export async function startStack(opts: StartOptions = {}): Promise<StackHandle> 
 			env: {
 				...process.env,
 				DATABASE_URL: databaseUrl,
+				// The outer environment (ramdisk-pg.sh, justfile) exports
+				// RO_DATABASE_URL pointing at its own cluster's base database;
+				// the read pool must target this stack's per-worker database.
+				RO_DATABASE_URL: databaseUrl,
 				BIND_ADDRESS: `127.0.0.1:${apiPort}`,
 				// No cluster in e2e: use the in-memory backup Secret store so
 				// onboarding (Secret creation) works against the real binary.


### PR DESCRIPTION
🤖 Adds a second diesel pool built from `RO_DATABASE_URL` (when set) and routes read-only workloads through it, so ops can point reads at a replica or read-only role without a code change. When the var is unset, `db_read` is a clone of the primary pool — behaviour is unchanged.

- `database::init_ro()` / `init_ro_to()` with their own `DB_RO_MAX_OPEN_CONNECTIONS` / `DB_RO_MAX_IDLE_CONNECTIONS` knobs (same defaults as the primary; note that setting `RO_DATABASE_URL` adds a pool's worth of connections per server pod).
- Both MCP mounts (tailnet `/api/mcp` and the internet-facing `/mcp`) now use the read pool — the MCP query interface is read-only by design. The bearer-auth middleware's token bump stays on the primary.
- Audited pure-read private-server handlers switched to `db_read`: statuses (summary, server_grouped_ids, group_details, snapshot), incidents/issues list+notes endpoints, versions reads, restore_replicas reads. Everything that writes — resolve/snooze/notes CRUD, the SQL playground, mcp_tokens admin — stays on `db`.
- The SQL playground's existing raw `ro_pool` is untouched.
- Test fixtures construct `db_read` from the per-test database URL rather than the env var, since the test harness's global `RO_DATABASE_URL` points at the cluster's unmigrated base database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)