### PR TITLE
feat: record and display the recovery vault's last write time

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -17,6 +17,7 @@ pub mod issues;
 pub mod mcp_tokens;
 pub mod notes;
 pub mod pg_duration;
+pub mod recovery_vault;
 pub mod restore;
 pub mod schema;
 pub mod self_alerts;
@@ -47,6 +48,7 @@ pub use commons_types::backup::{
 	RunOutcome,
 };
 pub use devices::{Device, DeviceConnection, DeviceKey, DeviceWithInfo};
+pub use recovery_vault::RecoveryVaultWrite;
 pub use restore::{
 	BackupRestoreCheck, NewBackupRestoreCheck, NewRestoreReplica, RestoreConsumerCapability,
 	RestoreReplica,

--- a/crates/database/src/recovery_vault.rs
+++ b/crates/database/src/recovery_vault.rs
@@ -1,0 +1,51 @@
+//! Records of successful recovery vault writes.
+//!
+//! The backups pod encrypts and PUTs a fresh `state.age` snapshot to the vault
+//! bucket every [`crate::backups`]-adjacent tick (see
+//! `crates/jobs/src/backup/recovery_snapshot.rs`). The private server can't
+//! cheaply check the vault bucket itself (the S3 config is jobs-pod-only env),
+//! so the writer records each success here and the recovery vault settings
+//! page reads it back.
+
+use commons_errors::{AppError, Result};
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::Timestamp;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::recovery_vault_writes)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct RecoveryVaultWrite {
+	pub id: Uuid,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp)]
+	pub written_at: Timestamp,
+	pub bytes: i64,
+}
+
+impl RecoveryVaultWrite {
+	/// Record a successful vault write of `bytes` ciphertext bytes.
+	pub async fn record(db: &mut AsyncPgConnection, bytes: i64) -> Result<Self> {
+		use crate::schema::recovery_vault_writes::dsl;
+
+		diesel::insert_into(dsl::recovery_vault_writes)
+			.values(dsl::bytes.eq(bytes))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// The most recent vault write, if any.
+	pub async fn latest(db: &mut AsyncPgConnection) -> Result<Option<Self>> {
+		use crate::schema::recovery_vault_writes::dsl;
+
+		dsl::recovery_vault_writes
+			.order(dsl::written_at.desc())
+			.select(Self::as_select())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+}

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -331,6 +331,14 @@ diesel::table! {
 }
 
 diesel::table! {
+	recovery_vault_writes (id) {
+		id -> Uuid,
+		written_at -> Timestamptz,
+		bytes -> Int8,
+	}
+}
+
+diesel::table! {
 	restore_consumer_capabilities (consumer_device_id, intent) {
 		consumer_device_id -> Uuid,
 		intent -> Text,
@@ -643,6 +651,7 @@ diesel::allow_tables_to_appear_in_same_query!(
 	issue_notes,
 	issues,
 	mcp_tokens,
+	recovery_vault_writes,
 	restore_consumer_capabilities,
 	restore_replicas,
 	server_backup_capabilities,

--- a/crates/database/tests/recovery_vault.rs
+++ b/crates/database/tests/recovery_vault.rs
@@ -1,0 +1,39 @@
+//! Recovery vault write bookkeeping: `record` inserts one row per successful
+//! vault write, `latest` reports the most recent one (or `None` before the
+//! first write).
+
+use database::RecoveryVaultWrite;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn record_and_latest() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		assert!(
+			RecoveryVaultWrite::latest(&mut conn)
+				.await
+				.expect("latest")
+				.is_none(),
+			"no writes yet"
+		);
+
+		let first = RecoveryVaultWrite::record(&mut conn, 1_000)
+			.await
+			.expect("record first");
+		let latest = RecoveryVaultWrite::latest(&mut conn)
+			.await
+			.expect("latest")
+			.expect("a write exists");
+		assert_eq!(latest.id, first.id);
+		assert_eq!(latest.bytes, 1_000);
+
+		let second = RecoveryVaultWrite::record(&mut conn, 2_048)
+			.await
+			.expect("record second");
+		let latest = RecoveryVaultWrite::latest(&mut conn)
+			.await
+			.expect("latest")
+			.expect("a write exists");
+		assert_eq!(latest.id, second.id, "latest is the most recent write");
+		assert_eq!(latest.bytes, 2_048);
+	})
+	.await
+}

--- a/crates/jobs/src/backup/recovery_snapshot.rs
+++ b/crates/jobs/src/backup/recovery_snapshot.rs
@@ -231,6 +231,9 @@ async fn tick(worker: &Worker, config: &RecoveryVaultConfig) -> Result<()> {
 		bytes,
 		"recovery-snapshot: wrote encrypted vault object"
 	);
+	if let Err(e) = database::RecoveryVaultWrite::record(&mut db, bytes as i64).await {
+		warn!("recovery-snapshot: failed to record write bookkeeping: {e:#}");
+	}
 	Ok(())
 }
 

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -24,8 +24,9 @@ use database::pg_duration::PgDuration;
 use database::{
 	BackupMaintenanceRun, BackupRecoveryVerification, BackupRepoStats, BackupRequest, BackupRun,
 	BackupTypeDefault, NewBackupTypeDefault, NewServerGroupBackupConfig,
-	NewServerGroupBackupSchedule, RetentionPolicy, ServerBackupCapability, ServerGroupBackupConfig,
-	ServerGroupBackupSchedule, server_groups::ServerGroup, servers::Server,
+	NewServerGroupBackupSchedule, RecoveryVaultWrite, RetentionPolicy, ServerBackupCapability,
+	ServerGroupBackupConfig, ServerGroupBackupSchedule, server_groups::ServerGroup,
+	servers::Server,
 };
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -1503,6 +1504,10 @@ pub struct RecoveryStatusResponse {
 	pub due: bool,
 	/// Human-readable reason for the `due` value.
 	pub reason: String,
+	/// When the vault object was last successfully written by the backups pod.
+	pub last_write_at: Option<Timestamp>,
+	/// Size (bytes) of the ciphertext from the last successful write.
+	pub last_write_bytes: Option<i64>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -1578,6 +1583,7 @@ pub async fn recovery_status(
 	let mut conn = state.db.get().await?;
 	let latest = BackupRecoveryVerification::latest(&mut conn).await?;
 	let (due, reason) = recovery_due(latest.as_ref(), &recipients, Timestamp::now());
+	let last_write = RecoveryVaultWrite::latest(&mut conn).await?;
 	Ok(Json(RecoveryStatusResponse {
 		configured: state.recovery_recipients.is_some(),
 		recipients,
@@ -1585,6 +1591,8 @@ pub async fn recovery_status(
 		last_verified_recipients: latest.map(|v| v.recipient_list()).unwrap_or_default(),
 		due,
 		reason,
+		last_write_at: last_write.as_ref().map(|w| w.written_at),
+		last_write_bytes: last_write.map(|w| w.bytes),
 	}))
 }
 

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -950,6 +950,37 @@ async fn recovery_ceremony_roundtrip() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn recovery_status_reports_last_write() {
+	use database::RecoveryVaultWrite;
+
+	commons_tests::server::run(async move |mut conn, _public, private| {
+		// No writes yet → null.
+		let resp = private
+			.post("/api/backups/recovery_status")
+			.json(&serde_json::json!({}))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert!(body["last_write_at"].is_null());
+		assert!(body["last_write_bytes"].is_null());
+
+		RecoveryVaultWrite::record(&mut conn, 12_345)
+			.await
+			.expect("record vault write");
+
+		let resp = private
+			.post("/api/backups/recovery_status")
+			.json(&serde_json::json!({}))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert!(!body["last_write_at"].is_null());
+		assert_eq!(body["last_write_bytes"], 12_345);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn recovery_verify_rejects_wrong_and_missing() {
 	let identity = age::x25519::Identity::generate();
 	unsafe {

--- a/migrations/2026-07-03-142753-0000_recovery_vault_writes/down.sql
+++ b/migrations/2026-07-03-142753-0000_recovery_vault_writes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE recovery_vault_writes;

--- a/migrations/2026-07-03-142753-0000_recovery_vault_writes/up.sql
+++ b/migrations/2026-07-03-142753-0000_recovery_vault_writes/up.sql
@@ -1,0 +1,9 @@
+-- Records of successful recovery vault writes: each time the backups pod
+-- encrypts and PUTs a fresh state.age snapshot to the vault bucket, we record
+-- when and how large the ciphertext was. Surfaced in the recovery vault
+-- settings page so operators can see the vault is actually being kept fresh.
+CREATE TABLE recovery_vault_writes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    written_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    bytes BIGINT NOT NULL
+);

--- a/private-web/e2e/recovery-vault.spec.ts
+++ b/private-web/e2e/recovery-vault.spec.ts
@@ -1,3 +1,4 @@
+import { resetSeededTables, seedRecoveryVaultWrite } from "./seed";
 import { expect, test } from "./test-fixtures";
 
 // The fixture configures CANOPY_RECOVERY_VAULT_KEYS with a throwaway age public
@@ -32,5 +33,21 @@ test.describe("Recovery vault ceremony", () => {
 		await page.getByLabel("Decrypted answer").fill("not-the-nonce");
 		await page.getByRole("button", { name: /submit answer/i }).click();
 		await expect(page.getByText(/does not match/i)).toBeVisible();
+	});
+
+	test("shows the last vault write, and 'never' before the first", async ({
+		page,
+		sql,
+	}) => {
+		await resetSeededTables(sql);
+
+		await page.goto("/settings/recovery");
+		await expect(page.getByText(/last vault write:\s*never/i)).toBeVisible();
+
+		await seedRecoveryVaultWrite(sql, { bytes: 2048, writtenAgoSecs: 3600 });
+		await page.reload();
+		await expect(page.getByText(/last vault write:/i)).toContainText(
+			"1h ago (2,048 bytes)",
+		);
 	});
 });

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,7 +47,7 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
 	// self-alerts attach to that row, so put it back.
@@ -719,5 +719,18 @@ export async function seedRestoreCheck(
 			opts.healthDetails === undefined ? null : JSON.stringify(opts.healthDetails),
 			opts.observedAt ?? null,
 		],
+	);
+}
+
+/** Seed a `recovery_vault_writes` row. `writtenAgoSecs` backdates the write;
+ * omit for NOW(). */
+export async function seedRecoveryVaultWrite(
+	sql: Sql,
+	opts: { bytes?: number; writtenAgoSecs?: number } = {},
+): Promise<void> {
+	await sql.query(
+		`INSERT INTO recovery_vault_writes (written_at, bytes)
+		 VALUES (NOW() - make_interval(secs => $1), $2)`,
+		[opts.writtenAgoSecs ?? 0, opts.bytes ?? 4096],
 	);
 }

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -9266,6 +9266,22 @@
             },
             "description": "The recipient set the last verification covered."
           },
+          "last_write_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When the vault object was last successfully written by the backups pod."
+          },
+          "last_write_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Size (bytes) of the ciphertext from the last successful write."
+          },
           "reason": {
             "type": "string",
             "description": "Human-readable reason for the `due` value."

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3745,6 +3745,16 @@ export interface components {
             last_verified_at?: string | null;
             /** @description The recipient set the last verification covered. */
             last_verified_recipients: string[];
+            /**
+             * Format: date-time
+             * @description When the vault object was last successfully written by the backups pod.
+             */
+            last_write_at?: string | null;
+            /**
+             * Format: int64
+             * @description Size (bytes) of the ciphertext from the last successful write.
+             */
+            last_write_bytes?: number | null;
             /** @description Human-readable reason for the `due` value. */
             reason: string;
             /** @description The live recipient fingerprints (`age1…`). */

--- a/private-web/src/routes/RecoveryVault.tsx
+++ b/private-web/src/routes/RecoveryVault.tsx
@@ -15,6 +15,7 @@ import {
 } from "@mui/material";
 import { useState } from "react";
 import { useApi, useApiAction } from "../api";
+import TimeAgo from "../components/TimeAgo";
 import { usePageTitle } from "../hooks/usePageTitle";
 
 /// Decode the base64 age ciphertext and download it as a `.age` file the
@@ -104,6 +105,18 @@ export default function RecoveryVault() {
 						{s.last_verified_at
 							? new Date(s.last_verified_at).toLocaleString()
 							: "never"}
+					</Typography>
+					<Typography variant="body2">
+						Last vault write:{" "}
+						{s.last_write_at ? (
+							<>
+								<TimeAgo timestamp={s.last_write_at} />
+								{s.last_write_bytes != null &&
+									` (${s.last_write_bytes.toLocaleString()} bytes)`}
+							</>
+						) : (
+							"never"
+						)}
 					</Typography>
 
 					<Typography variant="subtitle2">Recipients</Typography>


### PR DESCRIPTION
🤖 The recovery snapshot job PUTs an encrypted vault object on schedule, but success was only ever logged — operators had no way to see whether the vault is actually being kept fresh. The private server can't cheaply probe the vault bucket itself (its S3 config is jobs-pod-only), so successful writes are now recorded in the database.

- New `recovery_vault_writes` table (migration + scrubbed schema): one row per successful vault PUT, with timestamp and ciphertext size.
- The recovery snapshot job records each successful write; bookkeeping failure is warn-and-continue, never failing the snapshot itself.
- `recovery_status` now returns `last_write_at` / `last_write_bytes`, and the recovery vault settings page shows a "Last vault write" row — always rendered, with an explicit "never" state when no write has been recorded.
- DB tests for the model, an endpoint test for the new fields, and a Playwright spec covering both the "never" and recorded states (new `seedRecoveryVaultWrite` helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)