### PR TITLE
feat: group S3 transfer totals for the month, with egress cost tooltip

### DIFF
--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -1083,6 +1083,46 @@ impl BackupRun {
 			.map_err(AppError::from)
 	}
 
+	/// Total S3 bytes sent/received (raw — the full wire size including SigV4
+	/// chunk framing, not the decoded payload) across the group's device backup
+	/// runs reported so far this calendar month (UTC boundary). Returns
+	/// `(sent, received)`, `0` for a side with no tallied runs.
+	///
+	/// This only covers what bestool's proxy tallies on `backup_runs` during
+	/// device backups — repo maintenance and inspection traffic against the
+	/// bucket isn't tallied anywhere, so the total undercounts the bucket's
+	/// actual monthly S3 traffic.
+	pub async fn s3_traffic_this_month_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<(i64, i64)> {
+		#[derive(diesel::QueryableByName)]
+		struct Totals {
+			#[diesel(sql_type = diesel::sql_types::Int8)]
+			sent: i64,
+			#[diesel(sql_type = diesel::sql_types::Int8)]
+			received: i64,
+		}
+
+		// SUM() over bigint columns promotes to numeric in Postgres, so the
+		// query casts back to bigint explicitly; COALESCE turns "no rows"/
+		// "all NULL" into 0 rather than surfacing NULL.
+		let totals: Totals = diesel::sql_query(
+			"SELECT \
+				COALESCE(SUM(s3_sent_raw_bytes), 0)::bigint AS sent, \
+				COALESCE(SUM(s3_received_raw_bytes), 0)::bigint AS received \
+			FROM backup_runs \
+			WHERE group_id = $1 \
+				AND reported_at >= date_trunc('month', now(), 'UTC')",
+		)
+		.bind::<diesel::sql_types::Uuid, _>(group_id)
+		.get_result(db)
+		.await
+		.map_err(AppError::from)?;
+
+		Ok((totals.sent, totals.received))
+	}
+
 	/// Fill `snapshot_logical_bytes` from repo inspection for runs matched by
 	/// snapshot id, only where it is still unset — write-once, since a snapshot
 	/// is immutable. `sizes` maps a snapshot id to its observed logical size.

--- a/crates/database/tests/backups.rs
+++ b/crates/database/tests/backups.rs
@@ -453,6 +453,126 @@ async fn latest_success_ignores_restore_and_failure() {
 	.await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn s3_traffic_this_month_sums_raw_bytes_within_the_month_window() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let other_group_id = insert_group(&mut conn, "other").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let device_id = insert_device(&mut conn).await;
+
+		async fn insert_run_with_s3(
+			conn: &mut AsyncPgConnection,
+			group_id: Uuid,
+			device_id: Uuid,
+			server_id: Uuid,
+			sent: Option<i64>,
+			received: Option<i64>,
+			age: Option<SignedDuration>,
+		) -> Uuid {
+			let id = Uuid::new_v4();
+			BackupRun::record(
+				conn,
+				NewBackupRun {
+					id,
+					device_id,
+					group_id,
+					server_id: Some(server_id),
+					r#type: BackupType::TamanuPostgres,
+					purpose: BackupPurpose::Backup,
+					outcome: RunOutcome::Success,
+					error: None,
+					bytes_uploaded: Some(1),
+					snapshot_id: None,
+					s3_sent_raw_bytes: sent,
+					s3_sent_payload_bytes: sent,
+					s3_received_raw_bytes: received,
+					s3_received_payload_bytes: received,
+				},
+			)
+			.await
+			.unwrap();
+			if let Some(age) = age {
+				sql_query(
+					"UPDATE backup_runs SET reported_at = NOW() - ($2 || ' seconds')::INTERVAL \
+					 WHERE id = $1",
+				)
+				.bind::<sql_types::Uuid, _>(id)
+				.bind::<sql_types::Text, _>(age.as_secs().to_string())
+				.execute(conn)
+				.await
+				.expect("backdate reported_at");
+			}
+			id
+		}
+
+		// Two runs this month → summed.
+		insert_run_with_s3(
+			&mut conn,
+			group_id,
+			device_id,
+			server_id,
+			Some(100),
+			Some(10),
+			None,
+		)
+		.await;
+		insert_run_with_s3(
+			&mut conn,
+			group_id,
+			device_id,
+			server_id,
+			Some(200),
+			Some(20),
+			None,
+		)
+		.await;
+		// A run with no S3 tally at all (e.g. a backup type the proxy didn't
+		// instrument) contributes nothing, not an error.
+		insert_run_with_s3(&mut conn, group_id, device_id, server_id, None, None, None).await;
+		// A run reported last month is out of the window (40 days always crosses
+		// a calendar-month boundary, regardless of today's date).
+		insert_run_with_s3(
+			&mut conn,
+			group_id,
+			device_id,
+			server_id,
+			Some(9_999),
+			Some(9_999),
+			Some(SignedDuration::from_hours(24 * 40)),
+		)
+		.await;
+		// A run in another group must not leak into this group's total.
+		let other_server_id = insert_server(&mut conn, other_group_id).await;
+		insert_run_with_s3(
+			&mut conn,
+			other_group_id,
+			device_id,
+			other_server_id,
+			Some(5_000),
+			Some(5_000),
+			None,
+		)
+		.await;
+
+		let (sent, received) = BackupRun::s3_traffic_this_month_for_group(&mut conn, group_id)
+			.await
+			.unwrap();
+		assert_eq!(sent, 300);
+		assert_eq!(received, 30);
+
+		// A group with no runs at all gets zeros, not an error.
+		let empty_group_id = insert_group(&mut conn, "empty").await;
+		let (sent, received) =
+			BackupRun::s3_traffic_this_month_for_group(&mut conn, empty_group_id)
+				.await
+				.unwrap();
+		assert_eq!(sent, 0);
+		assert_eq!(received, 0);
+	})
+	.await;
+}
+
 // --- issuances --------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -270,6 +270,13 @@ pub struct BackupStatsView {
 	/// enabled state), so the "back up now" panel can offer the right types per
 	/// server and grey out servers that have declared none.
 	pub capabilities: Vec<ServerBackupCapabilityView>,
+	/// Total S3 bytes sent to (uploads) and received from (downloads) the
+	/// bucket by the group's device backup runs so far this calendar month
+	/// (UTC), raw wire bytes. Repo maintenance/inspection traffic isn't
+	/// tallied anywhere, so this undercounts the bucket's actual monthly S3
+	/// traffic.
+	pub s3_month_sent_bytes: i64,
+	pub s3_month_received_bytes: i64,
 }
 
 /// One `(server, type)` backup capability and whether the operator has it
@@ -1302,6 +1309,8 @@ pub async fn stats(
 		BackupRun::list_for_group(&mut conn, args.server_group_id, RECENT_LIMIT).await?;
 	let recent_maintenance =
 		BackupMaintenanceRun::list_for_group(&mut conn, args.server_group_id, RECENT_LIMIT).await?;
+	let (s3_month_sent_bytes, s3_month_received_bytes) =
+		BackupRun::s3_traffic_this_month_for_group(&mut conn, args.server_group_id).await?;
 
 	// Pending requests + declared capabilities across the group's member servers.
 	let members = group.list_servers(&mut conn).await?;
@@ -1377,6 +1386,8 @@ pub async fn stats(
 		recent_maintenance,
 		pending_requests,
 		capabilities,
+		s3_month_sent_bytes,
+		s3_month_received_bytes,
 	}))
 }
 

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -296,6 +296,71 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(runs.getByText("stats-srv")).toBeVisible();
 	});
 
+	test("monthly S3 traffic totals this month's runs with an egress-cost tooltip", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "s3-traffic-group" });
+		const device = await seedDevice(sql);
+		const server = await seedServer(sql, {
+			name: "s3-traffic-srv",
+			groupId: group.id,
+			deviceId: device.id,
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+			region: "ap-southeast-2",
+			intervalSeconds: 3600,
+		});
+		// Two runs this month → summed (300 sent / 30 received, raw bytes).
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			s3SentRawBytes: 100,
+			s3SentPayloadBytes: 90,
+			s3ReceivedRawBytes: 10,
+			s3ReceivedPayloadBytes: 9,
+		});
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			s3SentRawBytes: 200,
+			s3SentPayloadBytes: 180,
+			s3ReceivedRawBytes: 20,
+			s3ReceivedPayloadBytes: 18,
+		});
+		// Backdated 40 days → always outside the calendar month, must not count.
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			s3SentRawBytes: 9999,
+			s3ReceivedRawBytes: 9999,
+			reportedAgoSecs: 40 * 24 * 3600,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const stat = page.getByText(/S3 traffic \(this month\)/i);
+		await expect(stat).toBeVisible();
+		// Raw-byte totals for the in-month runs only (9999s excluded).
+		await expect(stat).toContainText("300 B sent / 30 B received");
+		// The undercount caveat is visible without hovering.
+		await expect(
+			page.getByText(/device backup traffic only/i),
+		).toBeVisible();
+
+		// The tooltip prices egress by the config's region.
+		await stat.hover();
+		const tooltip = page.getByRole("tooltip");
+		await expect(tooltip).toContainText("Uploads are free");
+		await expect(tooltip).toContainText("$0.114/GB in ap-southeast-2");
+		await expect(tooltip).toContainText("estimated $0.00");
+		await expect(tooltip).not.toContainText("assumed");
+	});
+
 	test("recent run shows a truncated, copyable snapshot id", async ({
 		page,
 		sql,

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -343,7 +343,9 @@ test.describe("backups ready: stats + backup-now", () => {
 		});
 
 		await page.goto(`/groups/${group.id}/backups`);
-		const stat = page.getByText(/S3 traffic \(this month\)/i);
+		// getByText resolves to the innermost <strong> label; the values live in
+		// its parent Typography, so assert (and hover) on that.
+		const stat = page.getByText(/S3 traffic \(this month\)/i).locator("..");
 		await expect(stat).toBeVisible();
 		// Raw-byte totals for the in-month runs only (9999s excluded).
 		await expect(stat).toContainText("300 B sent / 30 B received");
@@ -505,12 +507,14 @@ test.describe("backups ready: stats + backup-now", () => {
 		// Uploaded falls back to the payload-sent figure, prefixed "~".
 		await expect(runs.getByText("~2.0 KiB")).toBeVisible();
 
-		// The S3 traffic breakdown is hidden until the row is expanded.
-		await expect(page.getByText(/s3 traffic/i)).toBeHidden();
+		// The S3 traffic breakdown is hidden until the row is expanded. Scoped to
+		// the runs table: the repo-stats panel has its own always-visible
+		// "S3 traffic (this month)" stat that would otherwise match.
+		await expect(runs.getByText(/s3 traffic/i)).toBeHidden();
 		await runs.getByRole("button", { name: /show details/i }).click();
-		await expect(page.getByText(/s3 traffic/i)).toBeVisible();
-		await expect(page.getByText(/2\.0 KiB payload \/ 3\.0 KiB raw/i)).toBeVisible();
-		await expect(page.getByText(/512 B payload \/ 1\.0 KiB raw/i)).toBeVisible();
+		await expect(runs.getByText(/s3 traffic/i)).toBeVisible();
+		await expect(runs.getByText(/2\.0 KiB payload \/ 3\.0 KiB raw/i)).toBeVisible();
+		await expect(runs.getByText(/512 B payload \/ 1\.0 KiB raw/i)).toBeVisible();
 	});
 
 	test("backup-now writes a request row; cancel deletes it", async ({

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -420,6 +420,8 @@ export async function seedBackupRun(
 		s3SentPayloadBytes?: number | null;
 		s3ReceivedRawBytes?: number | null;
 		s3ReceivedPayloadBytes?: number | null;
+		/** Backdate `reported_at` by this many seconds (default: now). */
+		reportedAgoSecs?: number;
 	},
 ): Promise<{ id: string }> {
 	const id = randomUUID();
@@ -427,8 +429,9 @@ export async function seedBackupRun(
 		`INSERT INTO backup_runs
 		 (id, device_id, group_id, server_id, type, purpose, outcome, error, bytes_uploaded, snapshot_id,
 		  s3_sent_raw_bytes, s3_sent_payload_bytes, s3_received_raw_bytes, s3_received_payload_bytes,
-		  snapshot_logical_bytes)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+		  snapshot_logical_bytes, reported_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+		  NOW() - make_interval(secs => $16))`,
 		[
 			id,
 			opts.deviceId,
@@ -445,6 +448,7 @@ export async function seedBackupRun(
 			opts.s3ReceivedRawBytes ?? null,
 			opts.s3ReceivedPayloadBytes ?? null,
 			opts.snapshotLogicalBytes ?? null,
+			opts.reportedAgoSecs ?? 0,
 		],
 	);
 	return { id };

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6452,7 +6452,9 @@
           "recent_runs",
           "recent_maintenance",
           "pending_requests",
-          "capabilities"
+          "capabilities",
+          "s3_month_sent_bytes",
+          "s3_month_received_bytes"
         ],
         "properties": {
           "capabilities": {
@@ -6479,6 +6481,15 @@
             "items": {
               "$ref": "#/components/schemas/BackupRun"
             }
+          },
+          "s3_month_received_bytes": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "s3_month_sent_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total S3 bytes sent to (uploads) and received from (downloads) the\nbucket by the group's device backup runs so far this calendar month\n(UTC), raw wire bytes. Repo maintenance/inspection traffic isn't\ntallied anywhere, so this undercounts the bucket's actual monthly S3\ntraffic."
           },
           "stats": {
             "oneOf": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2666,6 +2666,17 @@ export interface components {
             pending_requests: components["schemas"]["PendingRequestRow"][];
             recent_maintenance: components["schemas"]["BackupMaintenanceRun"][];
             recent_runs: components["schemas"]["BackupRun"][];
+            /** Format: int64 */
+            s3_month_received_bytes: number;
+            /**
+             * Format: int64
+             * @description Total S3 bytes sent to (uploads) and received from (downloads) the
+             *     bucket by the group's device backup runs so far this calendar month
+             *     (UTC), raw wire bytes. Repo maintenance/inspection traffic isn't
+             *     tallied anywhere, so this undercounts the bucket's actual monthly S3
+             *     traffic.
+             */
+            s3_month_sent_bytes: number;
             stats?: null | components["schemas"]["BackupRepoStats"];
         };
         BackupsGroupArgs: {

--- a/private-web/src/lib/s3Pricing.ts
+++ b/private-web/src/lib/s3Pricing.ts
@@ -1,0 +1,35 @@
+/// AWS S3 data-transfer-OUT-to-internet price, USD per GB (decimal GB, AWS's
+/// billing unit), first tier (up to 10 TB/month). Data transfer IN (uploads)
+/// is free in every region. Source: AWS's published price list
+/// (`AWSDataTransfer` service, https://aws.amazon.com/s3/pricing/), fetched
+/// 2026-07-04 — re-check before relying on this for real budgeting.
+export const S3_EGRESS_USD_PER_GB: Record<string, number> = {
+	"us-east-1": 0.09,
+	"us-west-2": 0.09,
+	"eu-west-1": 0.09,
+	"ap-southeast-1": 0.12,
+	"ap-southeast-2": 0.114,
+	"ap-southeast-3": 0.132,
+	"ap-southeast-4": 0.114,
+	"ap-northeast-1": 0.114,
+};
+
+/// Region assumed when a group's backup config has none set. The fleet is
+/// predominantly Pacific/Australia, so this is a best-guess, not a promise —
+/// the actual region a `null` config resolves to is an operator/deployment
+/// concern outside this config row.
+export const DEFAULT_S3_REGION = "ap-southeast-2";
+
+/// Egress rate to use for a group's cost estimate: the region's own rate if
+/// known, else `DEFAULT_S3_REGION`'s. `assumed` is true when `region` itself
+/// was `null` (config default) rather than an explicit, just-unlisted region.
+export function s3EgressRateForRegion(region: string | null): {
+	rate: number;
+	region: string;
+	assumed: boolean;
+} {
+	const effective = region ?? DEFAULT_S3_REGION;
+	const rate =
+		S3_EGRESS_USD_PER_GB[effective] ?? S3_EGRESS_USD_PER_GB[DEFAULT_S3_REGION];
+	return { rate, region: effective, assumed: region == null };
+}

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -39,6 +39,7 @@ import { useReloadInterval } from "../hooks/useReloadInterval";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { humanSeconds } from "../lib/humanDuration";
 import { formatBytes } from "../lib/formatBytes";
+import { s3EgressRateForRegion } from "../lib/s3Pricing";
 import { usePageTitle } from "../hooks/usePageTitle";
 import TimeAgo from "../components/TimeAgo";
 import { LatestSnapshot, SnapshotId } from "../components/SnapshotId";
@@ -197,7 +198,7 @@ export default function BackupPanel() {
 					}}
 				>
 					<ConfigSummary config={data} />
-					<RepoStatsPanel groupId={id} />
+					<RepoStatsPanel groupId={id} region={data.region} />
 				</Box>
 			) : (
 				<ConfigSummary config={data} />
@@ -786,7 +787,13 @@ function S3TrafficDetail({ run }: { run: BackupRun }) {
 
 /// Repository stats (top, beside the config summary). Read-only snapshot of the
 /// kopia repo's size/counts as of the last inspection.
-function RepoStatsPanel({ groupId }: { groupId: string }) {
+function RepoStatsPanel({
+	groupId,
+	region,
+}: {
+	groupId: string;
+	region: string | null;
+}) {
 	const stats = useApi(
 		"backups",
 		"stats",
@@ -802,32 +809,78 @@ function RepoStatsPanel({ groupId }: { groupId: string }) {
 				<LinearProgress />
 			) : stats.status === "error" ? (
 				<Alert severity="error">{stats.error.message}</Alert>
-			) : stats.data.stats == null ? (
-				<Typography color="text.secondary">
-					No stats yet (awaiting first inspection).
-				</Typography>
 			) : (
 				<Stack spacing={0.5}>
-					<Stat label="Snapshots" value={stats.data.stats.snapshot_count} />
-					<Stat label="Sources" value={stats.data.stats.source_count} />
-					<Stat
-						label="Logical bytes"
-						value={formatBytes(stats.data.stats.logical_bytes)}
+					{stats.data.stats == null ? (
+						<Typography color="text.secondary">
+							No stats yet (awaiting first inspection).
+						</Typography>
+					) : (
+						<>
+							<Stat label="Snapshots" value={stats.data.stats.snapshot_count} />
+							<Stat label="Sources" value={stats.data.stats.source_count} />
+							<Stat
+								label="Logical bytes"
+								value={formatBytes(stats.data.stats.logical_bytes)}
+							/>
+							<Stat
+								label="Physical bytes"
+								value={formatBytes(stats.data.stats.physical_bytes)}
+							/>
+							<Stat
+								label="Bucket bytes"
+								value={formatBytes(stats.data.stats.bucket_bytes)}
+							/>
+							<Typography variant="caption" color="text.secondary">
+								Observed <TimeAgo timestamp={stats.data.stats.observed_at} />
+							</Typography>
+						</>
+					)}
+					<S3MonthlyTrafficStat
+						sentBytes={stats.data.s3_month_sent_bytes}
+						receivedBytes={stats.data.s3_month_received_bytes}
+						region={region}
 					/>
-					<Stat
-						label="Physical bytes"
-						value={formatBytes(stats.data.stats.physical_bytes)}
-					/>
-					<Stat
-						label="Bucket bytes"
-						value={formatBytes(stats.data.stats.bucket_bytes)}
-					/>
-					<Typography variant="caption" color="text.secondary">
-						Observed <TimeAgo timestamp={stats.data.stats.observed_at} />
-					</Typography>
 				</Stack>
 			)}
 		</Paper>
+	);
+}
+
+/// This calendar month's S3 traffic tallied across the group's device backup
+/// runs, with a tooltip estimating the egress cost. Uploads (sent) are data
+/// transfer IN, which AWS never charges for; downloads (received) are egress
+/// to the internet, billed per GB by region.
+function S3MonthlyTrafficStat({
+	sentBytes,
+	receivedBytes,
+	region,
+}: {
+	sentBytes: number;
+	receivedBytes: number;
+	region: string | null;
+}) {
+	const { rate, region: priceRegion, assumed } = s3EgressRateForRegion(region);
+	const estimatedCost = (receivedBytes / 1_000_000_000) * rate;
+	const tooltip =
+		`Uploads are free (data transfer in). Downloads are billed as internet ` +
+		`egress: ~$${rate.toFixed(3)}/GB in ${priceRegion}` +
+		(assumed ? " (assumed — no region set on this config)" : "") +
+		`, so this month's downloads are an estimated $${estimatedCost.toFixed(2)}. ` +
+		`Excludes AWS's 100 GB/month free egress allowance and per-request costs.`;
+	return (
+		<Stack spacing={0}>
+			<Tooltip title={tooltip}>
+				<Typography variant="body2" sx={{ cursor: "help", width: "fit-content" }}>
+					<strong>S3 traffic (this month):</strong> {formatBytes(sentBytes)} sent /{" "}
+					{formatBytes(receivedBytes)} received
+				</Typography>
+			</Tooltip>
+			<Typography variant="caption" color="text.secondary">
+				* device backup traffic only — repository maintenance/inspection traffic
+				isn't tallied
+			</Typography>
+		</Stack>
 	);
 }
 


### PR DESCRIPTION
🤖 The backup panel's stats now include the group's total S3 traffic for the current calendar month (UTC), with a tooltip estimating the egress cost.

- `BackupRun::s3_traffic_this_month_for_group`: single SQL aggregate over `backup_runs` raw sent/received byte tallies, month-windowed on `reported_at`.
- `BackupStatsView` gains `s3_month_sent_bytes` / `s3_month_received_bytes`; spec + wire types regenerated.
- UI: "S3 traffic (this month)" stat with sent/received totals. The tooltip explains uploads are free (data transfer in) and estimates download egress cost from a per-region rate table (AWS Price List API rates as of 2026-07-04, first ≤10 TB tier, ignoring the 100 GB free allowance and per-request costs).
- **Known undercount, stated in the UI caption and field docs**: only device backup runs are tallied (by bestool's SigV4 proxy). Kopia maintenance/inspection traffic against the bucket isn't tallied anywhere, so this is a floor, not the bucket's true monthly traffic. Instrumenting those runs would be a separate change.
- DB test for the aggregate (month window, null columns, cross-group isolation) and a Playwright spec for the rendered totals + tooltip.

Conflicts with #319 (both add `s3Pricing.ts` and thread `region` into `RepoStatsPanel`) — whichever merges second needs a small reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)