### PR TITLE
fix(private-web): split snapshot size and uploaded bytes into separate columns

### DIFF
--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -360,12 +360,13 @@ test.describe("backups ready: stats + backup-now", () => {
 
 		await page.goto(`/groups/${group.id}/backups`);
 		const runs = page.getByRole("table").last();
-		// Shown exactly (from inspection), not the "~" approximate S3 proxy.
 		await expect(runs.getByText("4.0 KiB")).toBeVisible();
-		await expect(runs.getByText("~4.0 KiB")).toHaveCount(0);
+		// No S3 traffic reported and no snapshot id → Uploaded and Snapshot cells
+		// both fall back to "—".
+		await expect(runs.getByRole("cell", { name: "—" })).toHaveCount(2);
 	});
 
-	test("failed run shows expandable error detail and no upload size", async ({
+	test("failed run shows expandable error detail, no snapshot size, and no upload", async ({
 		page,
 		sql,
 	}) => {
@@ -394,9 +395,9 @@ test.describe("backups ready: stats + backup-now", () => {
 		const runs = page.getByRole("table").last();
 		await expect(runs.getByText("err-srv")).toBeVisible();
 		await expect(runs.getByText("failure")).toBeVisible();
-		// A failed run uploaded nothing and has no snapshot → "—" cells (Uploaded
-		// + Snapshot), not "unknown".
-		await expect(runs.getByRole("cell", { name: "—" }).first()).toBeVisible();
+		// A failed run has no size, no upload, and no snapshot → three "—" cells
+		// (Snapshot size, Uploaded, Snapshot), not "unknown".
+		await expect(runs.getByRole("cell", { name: "—" })).toHaveCount(3);
 
 		// Error detail is hidden until the row is expanded.
 		await expect(page.getByText(/disk quota exceeded/i)).toBeHidden();
@@ -404,7 +405,7 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(page.getByText(/disk quota exceeded/i)).toBeVisible();
 	});
 
-	test("run with S3 traffic but no upload size shows ~payload and expandable traffic detail", async ({
+	test("run with S3 traffic but no reported size shows uploaded bytes, no snapshot size, and expandable traffic detail", async ({
 		page,
 		sql,
 	}) => {
@@ -420,15 +421,16 @@ test.describe("backups ready: stats + backup-now", () => {
 			status: "ready",
 			intervalSeconds: 3600,
 		});
-		// No explicit upload size, but the proxy tallied S3 traffic → the Uploaded
-		// column falls back to the payload-sent figure, marked approximate.
+		// No explicit size (device-reported or inspected), but the proxy tallied
+		// S3 traffic → the Uploaded column shows the payload-sent figure directly,
+		// while Snapshot size stays empty.
 		await seedBackupRun(sql, {
 			deviceId: device.id,
 			groupId: group.id,
 			serverId: server.id,
 			outcome: "success",
 			bytesUploaded: null,
-			s3SentPayloadBytes: 2048, // 2.0 KiB → the Uploaded approximation
+			s3SentPayloadBytes: 2048, // 2.0 KiB → shown in the Uploaded column
 			s3SentRawBytes: 3072, // 3.0 KiB
 			s3ReceivedPayloadBytes: 512, // 512 B
 			s3ReceivedRawBytes: 1024, // 1.0 KiB
@@ -437,8 +439,9 @@ test.describe("backups ready: stats + backup-now", () => {
 		await page.goto(`/groups/${group.id}/backups`);
 		const runs = page.getByRole("table").last();
 		await expect(runs.getByText("s3-srv")).toBeVisible();
-		// Uploaded falls back to the payload-sent figure, prefixed "~".
-		await expect(runs.getByText("~2.0 KiB")).toBeVisible();
+		await expect(runs.getByText("2.0 KiB")).toBeVisible();
+		// Snapshot size has nothing to show, nor does the (unseeded) snapshot id.
+		await expect(runs.getByRole("cell", { name: "—" })).toHaveCount(2);
 
 		// The S3 traffic breakdown is hidden until the row is expanded.
 		await expect(page.getByText(/s3 traffic/i)).toBeHidden();
@@ -446,6 +449,43 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(page.getByText(/s3 traffic/i)).toBeVisible();
 		await expect(page.getByText(/2\.0 KiB payload \/ 3\.0 KiB raw/i)).toBeVisible();
 		await expect(page.getByText(/512 B payload \/ 1\.0 KiB raw/i)).toBeVisible();
+	});
+
+	test("run with both a snapshot size and S3 traffic shows them as distinct columns", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "both-sizes-group" });
+		const device = await seedDevice(sql);
+		const server = await seedServer(sql, {
+			name: "both-sizes-srv",
+			groupId: group.id,
+			deviceId: device.id,
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+			intervalSeconds: 3600,
+		});
+		// The full snapshot is much larger than what kopia actually had to send,
+		// since it dedupes against data the server already has.
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			outcome: "success",
+			bytesUploaded: 1048576, // 1.0 MiB snapshot size
+			s3SentPayloadBytes: 2048, // 2.0 KiB actually sent
+			s3SentRawBytes: 3072,
+			s3ReceivedPayloadBytes: 512,
+			s3ReceivedRawBytes: 1024,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const runs = page.getByRole("table").last();
+		await expect(runs.getByText("both-sizes-srv")).toBeVisible();
+		await expect(runs.getByText("1.0 MiB")).toBeVisible();
+		await expect(runs.getByText("2.0 KiB")).toBeVisible();
 	});
 
 	test("backup-now writes a request row; cancel deletes it", async ({

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -676,21 +676,18 @@ function RunRow({ run, members }: { run: BackupRun; members: ServerInfo[] }) {
 	const hasError = Boolean(run.error);
 	const hasS3 = hasS3Traffic(run);
 	const expandable = hasError || hasS3;
-	// bestool reports an explicit upload size for some backup types; when it's
-	// absent, canopy's own repo inspection fills in the snapshot's logical size
-	// (exact, but from a different source), and failing that the S3 payload-sent
-	// tally is the closest proxy (marked approximate).
+	// The snapshot's logical tree size, from whichever source reported it:
+	// bestool's own accounting, or (failing that) canopy's repo inspection.
+	// Both describe the same quantity — kopia doesn't re-upload bits the
+	// server already has, so this is usually larger than what actually went
+	// over the wire.
 	const fromInspect =
 		run.bytes_uploaded == null && run.snapshot_logical_bytes != null;
-	const uploadedApprox =
-		run.bytes_uploaded == null &&
-		run.snapshot_logical_bytes == null &&
-		run.s3_sent_payload_bytes != null;
-	const uploaded =
-		run.bytes_uploaded ??
-		run.snapshot_logical_bytes ??
-		run.s3_sent_payload_bytes ??
-		null;
+	const snapshotSize = run.bytes_uploaded ?? run.snapshot_logical_bytes ?? null;
+	// Bytes actually sent over the wire, from the SigV4 proxy's tally — the
+	// only genuine "uploaded" figure. Absent for backup types the proxy
+	// doesn't front, or before the first inspection.
+	const uploaded = run.s3_sent_payload_bytes ?? null;
 	return (
 		<>
 			<TableRow sx={expandable ? { "& > *": { borderBottom: "unset" } } : undefined}>
@@ -719,18 +716,23 @@ function RunRow({ run, members }: { run: BackupRun; members: ServerInfo[] }) {
 					/>
 				</TableCell>
 				<TableCell>
-					{uploaded == null ? (
+					{snapshotSize == null ? (
 						"—"
-					) : uploadedApprox ? (
-						<Tooltip title="Approximate: from S3 payload sent (no explicit upload size reported)">
-							<span>~{formatBytes(uploaded)}</span>
-						</Tooltip>
 					) : fromInspect ? (
 						<Tooltip title="From repo inspection (the device reported no size)">
-							<span>{formatBytes(uploaded)}</span>
+							<span>{formatBytes(snapshotSize)}</span>
 						</Tooltip>
 					) : (
-						formatBytes(uploaded)
+						formatBytes(snapshotSize)
+					)}
+				</TableCell>
+				<TableCell>
+					{uploaded == null ? (
+						"—"
+					) : (
+						<Tooltip title="Bytes sent to S3 (SigV4 proxy tally)">
+							<span>{formatBytes(uploaded)}</span>
+						</Tooltip>
 					)}
 				</TableCell>
 				<TableCell>
@@ -739,7 +741,7 @@ function RunRow({ run, members }: { run: BackupRun; members: ServerInfo[] }) {
 			</TableRow>
 			{expandable && (
 				<TableRow>
-					<TableCell colSpan={8} sx={{ py: 0, border: 0 }}>
+					<TableCell colSpan={9} sx={{ py: 0, border: 0 }}>
 						<Collapse in={open} timeout="auto" unmountOnExit>
 							{hasError && (
 								<Alert severity="error" variant="outlined" sx={{ my: 1 }}>
@@ -867,6 +869,7 @@ function RecentRunsPanel({
 								<TableCell>Type</TableCell>
 								<TableCell>Purpose</TableCell>
 								<TableCell>Outcome</TableCell>
+								<TableCell>Snapshot size</TableCell>
 								<TableCell>Uploaded</TableCell>
 								<TableCell>Snapshot</TableCell>
 							</TableRow>


### PR DESCRIPTION
🤖 The recent-runs "Uploaded" column conflated two metrics: `bytes_uploaded` and `snapshot_logical_bytes` are both the snapshot's logical tree size (device-reported vs inspection-derived — the reconcile alert expects them to agree), while the bytes actually sent over the wire live in the SigV4 proxy tally and are usually smaller, since kopia doesn't re-upload data the repo already has.

The table now shows two headline columns:
- **Snapshot size**: `bytes_uploaded ?? snapshot_logical_bytes`, keeping the "from repo inspection" provenance tooltip.
- **Uploaded**: `s3_sent_payload_bytes` only — the genuine wire figure — with an explanatory tooltip; em-dash when the proxy didn't front that run.

The collapsible S3 traffic detail row is unchanged. Playwright specs updated for the new columns plus a new spec asserting the two values render distinctly.

Note for later: the per-server capability page's `LatestSnapshot` shows `latest_snapshot_bytes`, fed from `bytes_uploaded` with the same "how much it uploaded" doc wording — same confusion, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)