### PR TITLE
feat(mcp): backup run/maintenance history, restore replicas, and org defaults

### DIFF
--- a/crates/canopy-mcp/src/lib.rs
+++ b/crates/canopy-mcp/src/lib.rs
@@ -18,7 +18,10 @@ use std::collections::HashMap;
 
 use commons_types::{
 	Uuid,
-	backup::{BackupConfigStatus, BackupPlacement, BackupRepoMode, RunOutcome},
+	backup::{
+		BackupConfigStatus, BackupPlacement, BackupRepoMode, BackupType, IntentDescriptor,
+		MaintenanceKind, RestoreIntent, RunOutcome,
+	},
 	issue::Severity,
 	server::{kind::ServerKind, rank::ServerRank},
 	status::{HealthState, ShortStatus},
@@ -27,11 +30,14 @@ use commons_types::{
 use database::{
 	backup::staleness::{StalenessVerdict, scan_rows},
 	backups::{
-		BackupMaintenanceRun, BackupRepoSnapshot, BackupRepoStats, BackupRun,
+		BackupMaintenanceRun, BackupMaintenanceRunFilters, BackupRepoSnapshot, BackupRepoStats,
+		BackupRun, BackupRunFilters, BackupTypeDefault, MaintenanceOutcomeFilter, RetentionPolicy,
 		ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
 	},
+	devices::Device,
 	diesel_async::AsyncPgConnection,
 	issues::{Event, Incident, Issue, IssueListFilters},
+	restore::{BackupRestoreCheck, RestoreConsumerCapability, RestoreReplica},
 	server_groups::ServerGroup,
 	servers::Server,
 	slack_outbox::SlackOutbox,
@@ -58,6 +64,9 @@ const STUCK_MAINTENANCE_AFTER: SignedDuration = SignedDuration::from_hours(6);
 const FAILED_RUN_WINDOW: SignedDuration = SignedDuration::from_hours(24);
 /// Default cap on `find_servers` results.
 const DEFAULT_SERVER_LIMIT: u64 = 200;
+/// Default / max rows for `list_backup_runs` and `list_maintenance_runs`.
+const DEFAULT_RUN_LIMIT: i64 = 50;
+const MAX_RUN_LIMIT: i64 = 200;
 
 #[derive(Clone)]
 pub struct CanopyMcp {
@@ -165,6 +174,52 @@ pub struct FindIssuesArgs {
 pub struct IssueIdArgs {
 	/// The issue's id.
 	pub issue_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListBackupRunsArgs {
+	/// Restrict to one group's id.
+	pub group_id: Option<String>,
+	/// Restrict to one server's id.
+	pub server_id: Option<String>,
+	/// Filter by backup type, e.g. `tamanu-postgres`.
+	pub r#type: Option<String>,
+	/// Filter by outcome: `success` or `failure`.
+	pub outcome: Option<String>,
+	/// Only runs reported within this many days.
+	pub since_days: Option<u32>,
+	/// Max runs to return (default 50, capped at 200).
+	pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListMaintenanceRunsArgs {
+	/// Restrict to one group's id.
+	pub group_id: Option<String>,
+	/// Filter by maintenance kind: `quick` or `full`.
+	pub kind: Option<String>,
+	/// Filter by outcome: `success`, `failure`, or `running` (still in flight).
+	pub outcome: Option<String>,
+	/// Only runs started within this many days.
+	pub since_days: Option<u32>,
+	/// Max runs to return (default 50, capped at 200).
+	pub limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindRestoreReplicasArgs {
+	/// Restrict to one group's id.
+	pub group_id: Option<String>,
+	/// Restrict to one restore consumer device's id.
+	pub consumer_device_id: Option<String>,
+	/// Only enabled declarations. Defaults to false (all).
+	pub enabled_only: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RestoreReplicaIdArgs {
+	/// The replica declaration's id.
+	pub replica_id: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -515,6 +570,146 @@ struct IssueDetail {
 	snoozed_until: Option<Timestamp>,
 	recent_events: Vec<EventOut>,
 	incidents: Vec<IncidentRefOut>,
+}
+
+#[derive(Serialize)]
+struct BackupRunOut {
+	id: Uuid,
+	group_id: Uuid,
+	group_name: Option<String>,
+	server_id: Option<Uuid>,
+	server_name: Option<String>,
+	device_id: Uuid,
+	r#type: String,
+	purpose: String,
+	outcome: RunOutcome,
+	error: Option<String>,
+	bytes_uploaded: Option<i64>,
+	snapshot_id: Option<String>,
+	reported_at: Timestamp,
+	/// S3 traffic tallied by bestool's proxy for this run.
+	s3_sent_raw_bytes: Option<i64>,
+	s3_sent_payload_bytes: Option<i64>,
+	s3_received_raw_bytes: Option<i64>,
+	s3_received_payload_bytes: Option<i64>,
+	/// Logical size of this run's snapshot, as observed by canopy's own repo
+	/// inspection (distinct from `bytes_uploaded`, the device's own figure).
+	snapshot_logical_bytes: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct BackupRunsList {
+	count: usize,
+	truncated: bool,
+	runs: Vec<BackupRunOut>,
+}
+
+#[derive(Serialize)]
+struct MaintenanceRunOut {
+	id: i64,
+	group_id: Uuid,
+	group_name: Option<String>,
+	kind: MaintenanceKind,
+	started_at: Timestamp,
+	finished_at: Option<Timestamp>,
+	/// `None` while the run is still in flight.
+	outcome: Option<RunOutcome>,
+	error: Option<String>,
+	bytes_reclaimed: Option<i64>,
+}
+
+#[derive(Serialize)]
+struct MaintenanceRunsList {
+	count: usize,
+	truncated: bool,
+	runs: Vec<MaintenanceRunOut>,
+}
+
+#[derive(Serialize)]
+struct RestoreReplicaOut {
+	id: Uuid,
+	consumer_device_id: Uuid,
+	consumer_name: Option<String>,
+	group_id: Uuid,
+	group_name: Option<String>,
+	/// `None` = declared against every current server in the group.
+	server_id: Option<Uuid>,
+	server_name: Option<String>,
+	r#type: String,
+	intent: String,
+	name: String,
+	overdue_after_seconds: Option<i64>,
+	enabled: bool,
+	/// The consumer no longer advertises this intent, so Canopy is not
+	/// dispatching this declaration. Mirrors the `gap` flag the operator UI
+	/// shows for the same reason (see `restore_replicas::to_views`).
+	gap: bool,
+	/// Timestamp of the latest healthy restore-verification report for this
+	/// exact `(server, type, intent)`. Only populated for server-scoped
+	/// declarations; a group-wide declaration (`server_id: null`) covers many
+	/// servers so has no single answer here — use `get_restore_replica` or
+	/// `find_backup_problems` for a specific server.
+	last_healthy_at: Option<Timestamp>,
+	created_at: Timestamp,
+	updated_at: Timestamp,
+}
+
+#[derive(Serialize)]
+struct RestoreReplicaList {
+	count: usize,
+	replicas: Vec<RestoreReplicaOut>,
+}
+
+#[derive(Serialize)]
+struct RestoreCheckOut {
+	id: i64,
+	server_id: Option<Uuid>,
+	server_name: Option<String>,
+	snapshot_id: Option<String>,
+	outcome: RunOutcome,
+	replica_healthy: bool,
+	error: Option<String>,
+	postgres_version: Option<String>,
+	observed_at: Timestamp,
+	reported_at: Timestamp,
+	health_details: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct RestoreReplicaDetail {
+	#[serde(flatten)]
+	replica: RestoreReplicaOut,
+	/// The consumer's advertised descriptor for this intent (description,
+	/// semantics, parameter schema): `None` when `gap` is true, since the
+	/// consumer doesn't currently advertise it.
+	intent_descriptor: Option<IntentDescriptor>,
+	/// Recent health reports for this replica, newest first.
+	recent_checks: Vec<RestoreCheckOut>,
+}
+
+#[derive(Serialize)]
+struct BackupDefaultOut {
+	r#type: String,
+	/// Seconds between scheduled runs; `null` = manual-only.
+	default_interval_seconds: Option<i64>,
+	default_retention: Option<RetentionPolicyOut>,
+	auto_enable: bool,
+	/// Whether this default opts out of the org retention floor (dangerous).
+	allow_below_floor: bool,
+}
+
+#[derive(Serialize)]
+struct RetentionPolicyOut {
+	keep_latest: i32,
+	keep_daily: i32,
+	keep_weekly: i32,
+	keep_monthly: i32,
+	keep_annual: i32,
+}
+
+#[derive(Serialize)]
+struct BackupDefaultsList {
+	defaults: Vec<BackupDefaultOut>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1348,6 +1543,283 @@ impl CanopyMcp {
 			incidents,
 		})
 	}
+
+	#[tool(
+		description = "List backup-run history across the fleet (or narrowed by group/server/type/outcome), \
+		               newest first. Each run carries its outcome, error (if failed), and its size / S3 \
+		               traffic figures. Use this to inspect what actually happened; use \
+		               find_backup_problems for the current alerting state."
+	)]
+	async fn list_backup_runs(
+		&self,
+		Parameters(args): Parameters<ListBackupRunsArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let group_id = parse_opt_uuid(&args.group_id, "group_id")?;
+		let server_id = parse_opt_uuid(&args.server_id, "server_id")?;
+		let r#type = args.r#type.as_deref().map(BackupType::from);
+		let outcome = parse_opt::<RunOutcome>(&args.outcome, "outcome")?;
+		let since = args.since_days.map(since_from_days);
+		let limit = args
+			.limit
+			.unwrap_or(DEFAULT_RUN_LIMIT)
+			.clamp(1, MAX_RUN_LIMIT);
+
+		let runs = BackupRun::list_filtered(
+			&mut conn,
+			BackupRunFilters {
+				group_id,
+				server_id,
+				r#type,
+				outcome,
+				since,
+			},
+			limit,
+		)
+		.await
+		.map_err(mcp_err)?;
+
+		let group_names = group_names(&mut conn, &unique(runs.iter().map(|r| r.group_id))).await?;
+		let server_names =
+			Server::names_by_ids(&mut conn, &unique(runs.iter().filter_map(|r| r.server_id)))
+				.await
+				.map_err(mcp_err)?;
+
+		let count = runs.len();
+		let truncated = count as i64 == limit;
+		let out = runs
+			.into_iter()
+			.map(|r| BackupRunOut {
+				id: r.id,
+				group_id: r.group_id,
+				group_name: group_names.get(&r.group_id).cloned(),
+				server_id: r.server_id,
+				server_name: r
+					.server_id
+					.and_then(|s| server_names.get(&s))
+					.and_then(|(n, _)| n.clone()),
+				device_id: r.device_id,
+				r#type: r.r#type.to_string(),
+				purpose: r.purpose.to_string(),
+				outcome: r.outcome,
+				error: r.error,
+				bytes_uploaded: r.bytes_uploaded,
+				snapshot_id: r.snapshot_id,
+				reported_at: r.reported_at,
+				s3_sent_raw_bytes: r.s3_sent_raw_bytes,
+				s3_sent_payload_bytes: r.s3_sent_payload_bytes,
+				s3_received_raw_bytes: r.s3_received_raw_bytes,
+				s3_received_payload_bytes: r.s3_received_payload_bytes,
+				snapshot_logical_bytes: r.snapshot_logical_bytes,
+			})
+			.collect();
+
+		ok_json(&BackupRunsList {
+			count,
+			truncated,
+			runs: out,
+		})
+	}
+
+	#[tool(
+		description = "List repo-maintenance run history across the fleet (or narrowed by group/kind/outcome), \
+		               newest first: kopia maintenance jobs, distinct from backup runs. Use \
+		               outcome=\"running\" to find jobs currently in flight."
+	)]
+	async fn list_maintenance_runs(
+		&self,
+		Parameters(args): Parameters<ListMaintenanceRunsArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let group_id = parse_opt_uuid(&args.group_id, "group_id")?;
+		let kind = parse_opt::<MaintenanceKind>(&args.kind, "kind")?;
+		let outcome = match args.outcome.as_deref() {
+			Some("running") => Some(MaintenanceOutcomeFilter::Running),
+			Some(s) => Some(MaintenanceOutcomeFilter::Outcome(
+				s.parse::<RunOutcome>()
+					.map_err(|_| McpError::invalid_params(format!("invalid outcome: {s}"), None))?,
+			)),
+			None => None,
+		};
+		let since = args.since_days.map(since_from_days);
+		let limit = args
+			.limit
+			.unwrap_or(DEFAULT_RUN_LIMIT)
+			.clamp(1, MAX_RUN_LIMIT);
+
+		let runs = BackupMaintenanceRun::list_filtered(
+			&mut conn,
+			BackupMaintenanceRunFilters {
+				group_id,
+				kind,
+				outcome,
+				since,
+			},
+			limit,
+		)
+		.await
+		.map_err(mcp_err)?;
+
+		let group_names = group_names(&mut conn, &unique(runs.iter().map(|r| r.group_id))).await?;
+
+		let count = runs.len();
+		let truncated = count as i64 == limit;
+		let out = runs
+			.into_iter()
+			.map(|r| MaintenanceRunOut {
+				id: r.id,
+				group_id: r.group_id,
+				group_name: group_names.get(&r.group_id).cloned(),
+				kind: r.kind,
+				started_at: r.started_at,
+				finished_at: r.finished_at,
+				outcome: r.outcome,
+				error: r.error,
+				bytes_reclaimed: r.bytes_reclaimed,
+			})
+			.collect();
+
+		ok_json(&MaintenanceRunsList {
+			count,
+			truncated,
+			runs: out,
+		})
+	}
+
+	#[tool(
+		description = "List managed-restore replica declarations (fleet-wide, or narrowed by group/consumer), \
+		               with the consumer's display name and whether the consumer currently advertises the \
+		               declared intent (`gap: true` means Canopy is not dispatching it — the declaration is \
+		               unsatisfiable until the consumer registers that intent again). Server-scoped \
+		               declarations also carry the latest healthy restore-verification timestamp for that \
+		               exact (server, type, intent); use get_restore_replica for the recent-checks history \
+		               and the consumer's full intent descriptor."
+	)]
+	async fn find_restore_replicas(
+		&self,
+		Parameters(args): Parameters<FindRestoreReplicasArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let group = parse_opt_uuid(&args.group_id, "group_id")?;
+		let consumer = parse_opt_uuid(&args.consumer_device_id, "consumer_device_id")?;
+		let enabled_only = args.enabled_only.unwrap_or(false);
+
+		let mut replicas = match group {
+			Some(g) => RestoreReplica::list_for_group(&mut conn, g)
+				.await
+				.map_err(mcp_err)?,
+			None => RestoreReplica::list_all(&mut conn).await.map_err(mcp_err)?,
+		};
+		replicas.retain(|r| {
+			consumer.is_none_or(|c| r.consumer_device_id == c) && (!enabled_only || r.enabled)
+		});
+
+		let replicas = self.restore_replica_outs(&mut conn, replicas).await?;
+		ok_json(&RestoreReplicaList {
+			count: replicas.len(),
+			replicas,
+		})
+	}
+
+	#[tool(
+		description = "Full detail for one managed-restore replica declaration: its config, the consumer's \
+		               full descriptor for the intent (parameters, semantics — `None` when the declaration \
+		               is a gap), and its recent restore-verification health reports."
+	)]
+	async fn get_restore_replica(
+		&self,
+		Parameters(args): Parameters<RestoreReplicaIdArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let id = parse_uuid(&args.replica_id, "replica_id")?;
+		let Ok(replica) = RestoreReplica::get(&mut conn, id).await else {
+			return Ok(not_found(format!("no restore replica with id {id}")));
+		};
+
+		let intent_descriptor =
+			RestoreConsumerCapability::list_for_consumer(&mut conn, replica.consumer_device_id)
+				.await
+				.map_err(mcp_err)?
+				.into_iter()
+				.find(|d| d.intent == replica.intent);
+
+		let relevant: Vec<BackupRestoreCheck> =
+			BackupRestoreCheck::list_recent_for_group(&mut conn, replica.group_id, 50)
+				.await
+				.map_err(mcp_err)?
+				.into_iter()
+				.filter(|c| c.replica_id == Some(replica.id))
+				.collect();
+		let check_server_names = Server::names_by_ids(
+			&mut conn,
+			&unique(relevant.iter().filter_map(|c| c.server_id)),
+		)
+		.await
+		.map_err(mcp_err)?;
+		let recent_checks = relevant
+			.into_iter()
+			.map(|c| RestoreCheckOut {
+				id: c.id,
+				server_id: c.server_id,
+				server_name: c
+					.server_id
+					.and_then(|s| check_server_names.get(&s))
+					.and_then(|(n, _)| n.clone()),
+				snapshot_id: c.snapshot_id,
+				outcome: c.outcome,
+				replica_healthy: c.replica_healthy,
+				error: c.error,
+				postgres_version: c.postgres_version,
+				observed_at: c.observed_at,
+				reported_at: c.reported_at,
+				health_details: c.health_details,
+			})
+			.collect();
+
+		let replica = self
+			.restore_replica_outs(&mut conn, vec![replica])
+			.await?
+			.into_iter()
+			.next()
+			.expect("exactly one replica");
+
+		ok_json(&RestoreReplicaDetail {
+			replica,
+			intent_descriptor,
+			recent_checks,
+		})
+	}
+
+	#[tool(
+		description = "Canopy-wide default schedule/retention per backup type — what a group inherits for a \
+		               type unless it sets its own schedule override (see get_group's `backups.schedules`)."
+	)]
+	async fn get_backup_defaults(
+		&self,
+		Parameters(_): Parameters<EmptyArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let rows = BackupTypeDefault::list(&mut conn).await.map_err(mcp_err)?;
+		let defaults = rows
+			.into_iter()
+			.map(|d| BackupDefaultOut {
+				r#type: d.r#type.to_string(),
+				default_interval_seconds: d.default_interval.map(|pg| pg.0.as_secs()),
+				default_retention: RetentionPolicy::from_json(&d.default_retention).map(|r| {
+					RetentionPolicyOut {
+						keep_latest: r.keep_latest,
+						keep_daily: r.keep_daily,
+						keep_weekly: r.keep_weekly,
+						keep_monthly: r.keep_monthly,
+						keep_annual: r.keep_annual,
+					}
+				}),
+				auto_enable: d.auto_enable,
+				allow_below_floor: d.allow_below_floor,
+			})
+			.collect();
+		ok_json(&BackupDefaultsList { defaults })
+	}
 }
 
 impl CanopyMcp {
@@ -1372,6 +1844,90 @@ impl CanopyMcp {
 			}
 		}
 		Ok(adoption)
+	}
+
+	/// Enrich replica rows with consumer/group/server display names, the `gap`
+	/// flag (the consumer no longer advertises the declared intent — mirrors
+	/// the operator UI's `restore_replicas::to_views`), and, for server-scoped
+	/// declarations, the latest healthy restore-verification timestamp for that
+	/// exact `(server, type, intent)` (from
+	/// `BackupRestoreCheck::latest_healthy_by_key_for_group`). Does not compute
+	/// an overdue verdict — that logic lives solely in
+	/// `database::restore::sweep_overdue`, which alone owns the once-vs-check
+	/// semantics distinction.
+	async fn restore_replica_outs(
+		&self,
+		conn: &mut AsyncPgConnection,
+		replicas: Vec<RestoreReplica>,
+	) -> Result<Vec<RestoreReplicaOut>, McpError> {
+		let consumer_ids = unique(replicas.iter().map(|r| r.consumer_device_id));
+		let consumer_names = Device::tailscale_names_by_ids(conn, &consumer_ids)
+			.await
+			.map_err(mcp_err)?;
+		let group_ids = unique(replicas.iter().map(|r| r.group_id));
+		let g_names = group_names(conn, &group_ids).await?;
+		let server_names =
+			Server::names_by_ids(conn, &unique(replicas.iter().filter_map(|r| r.server_id)))
+				.await
+				.map_err(mcp_err)?;
+
+		let mut caps: HashMap<Uuid, std::collections::HashSet<RestoreIntent>> = HashMap::new();
+		for id in &consumer_ids {
+			let set = RestoreConsumerCapability::list_for_consumer(conn, *id)
+				.await
+				.map_err(mcp_err)?
+				.into_iter()
+				.map(|d| d.intent)
+				.collect();
+			caps.insert(*id, set);
+		}
+
+		let mut healthy_by_group: HashMap<
+			Uuid,
+			HashMap<(Uuid, BackupType, RestoreIntent), Timestamp>,
+		> = HashMap::new();
+		for gid in &group_ids {
+			let map = BackupRestoreCheck::latest_healthy_by_key_for_group(conn, *gid)
+				.await
+				.map_err(mcp_err)?;
+			healthy_by_group.insert(*gid, map);
+		}
+
+		Ok(replicas
+			.into_iter()
+			.map(|r| {
+				let gap = !caps
+					.get(&r.consumer_device_id)
+					.is_some_and(|s| s.contains(&r.intent));
+				let last_healthy_at = r.server_id.and_then(|sid| {
+					healthy_by_group
+						.get(&r.group_id)
+						.and_then(|m| m.get(&(sid, r.r#type.clone(), r.intent.clone())))
+						.copied()
+				});
+				RestoreReplicaOut {
+					id: r.id,
+					consumer_device_id: r.consumer_device_id,
+					consumer_name: consumer_names.get(&r.consumer_device_id).cloned(),
+					group_id: r.group_id,
+					group_name: g_names.get(&r.group_id).cloned(),
+					server_id: r.server_id,
+					server_name: r
+						.server_id
+						.and_then(|s| server_names.get(&s))
+						.and_then(|(n, _)| n.clone()),
+					r#type: r.r#type.to_string(),
+					intent: r.intent.to_string(),
+					name: r.name,
+					overdue_after_seconds: r.overdue_after.map(|f| f.0.as_secs()),
+					enabled: r.enabled,
+					gap,
+					last_healthy_at,
+					created_at: r.created_at,
+					updated_at: r.updated_at,
+				}
+			})
+			.collect())
 	}
 }
 

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -903,6 +903,18 @@ pub struct NewBackupRun {
 	pub s3_received_payload_bytes: Option<i64>,
 }
 
+/// Multi-field filter for the fleet-wide backup-run history query. Each field
+/// is opt-in: `Default` matches every run.
+#[derive(Debug, Clone, Default)]
+pub struct BackupRunFilters {
+	pub group_id: Option<Uuid>,
+	pub server_id: Option<Uuid>,
+	pub r#type: Option<BackupType>,
+	pub outcome: Option<RunOutcome>,
+	/// When `Some`, restrict to runs reported at or after this time.
+	pub since: Option<Timestamp>,
+}
+
 impl BackupRun {
 	/// Record a reported run. A duplicate `id` (the client-minted run-uuid)
 	/// fails its own insert; that PK violation is surfaced as
@@ -1039,6 +1051,38 @@ impl BackupRun {
 			.map_err(AppError::from)
 	}
 
+	/// Fleet-wide run history, newest first, narrowed by whichever filters are
+	/// set. Backs the MCP `list_backup_runs` tool.
+	pub async fn list_filtered(
+		db: &mut AsyncPgConnection,
+		filters: BackupRunFilters,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::backup_runs::dsl;
+
+		let mut q = dsl::backup_runs.into_boxed();
+		if let Some(gid) = filters.group_id {
+			q = q.filter(dsl::group_id.eq(gid));
+		}
+		if let Some(sid) = filters.server_id {
+			q = q.filter(dsl::server_id.eq(sid));
+		}
+		if let Some(ty) = &filters.r#type {
+			q = q.filter(dsl::type_.eq(ty.as_str()));
+		}
+		if let Some(outcome) = filters.outcome {
+			q = q.filter(dsl::outcome.eq(outcome));
+		}
+		if let Some(since) = filters.since {
+			q = q.filter(dsl::reported_at.ge(jiff_diesel::Timestamp::from(since)));
+		}
+		q.order(dsl::reported_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
 	/// Fill `snapshot_logical_bytes` from repo inspection for runs matched by
 	/// snapshot id, only where it is still unset — write-once, since a snapshot
 	/// is immutable. `sizes` maps a snapshot id to its observed logical size.
@@ -1118,6 +1162,25 @@ pub struct BackupMaintenanceRun {
 	pub bytes_reclaimed: Option<i64>,
 }
 
+/// Filter value for [`BackupMaintenanceRunFilters::outcome`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaintenanceOutcomeFilter {
+	/// Still running (`outcome IS NULL`).
+	Running,
+	Outcome(RunOutcome),
+}
+
+/// Multi-field filter for the fleet-wide maintenance-run history query. Each
+/// field is opt-in: `Default` matches every run.
+#[derive(Debug, Clone, Default)]
+pub struct BackupMaintenanceRunFilters {
+	pub group_id: Option<Uuid>,
+	pub kind: Option<MaintenanceKind>,
+	pub outcome: Option<MaintenanceOutcomeFilter>,
+	/// When `Some`, restrict to runs started at or after this time.
+	pub since: Option<Timestamp>,
+}
+
 impl BackupMaintenanceRun {
 	/// Open a maintenance-run row at Job start; returns the new id for the
 	/// matching [`finish`](Self::finish).
@@ -1169,6 +1232,41 @@ impl BackupMaintenanceRun {
 		dsl::backup_maintenance_runs
 			.filter(dsl::group_id.eq(group_id))
 			.order(dsl::started_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Fleet-wide maintenance-run history, newest first, narrowed by whichever
+	/// filters are set. Backs the MCP `list_maintenance_runs` tool.
+	pub async fn list_filtered(
+		db: &mut AsyncPgConnection,
+		filters: BackupMaintenanceRunFilters,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::backup_maintenance_runs::dsl;
+
+		let mut q = dsl::backup_maintenance_runs.into_boxed();
+		if let Some(gid) = filters.group_id {
+			q = q.filter(dsl::group_id.eq(gid));
+		}
+		if let Some(kind) = filters.kind {
+			q = q.filter(dsl::kind.eq(kind));
+		}
+		match filters.outcome {
+			Some(MaintenanceOutcomeFilter::Running) => {
+				q = q.filter(dsl::outcome.is_null());
+			}
+			Some(MaintenanceOutcomeFilter::Outcome(o)) => {
+				q = q.filter(dsl::outcome.eq(Some(o)));
+			}
+			None => {}
+		}
+		if let Some(since) = filters.since {
+			q = q.filter(dsl::started_at.ge(jiff_diesel::Timestamp::from(since)));
+		}
+		q.order(dsl::started_at.desc())
 			.limit(limit)
 			.load(db)
 			.await

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -36,8 +36,9 @@ pub mod versions;
 pub mod views;
 
 pub use backups::{
-	BackupCredentialIssuance, BackupMaintenanceRun, BackupRecoveryVerification, BackupRepoSnapshot,
-	BackupRepoStats, BackupRequest, BackupRun, BackupTypeDefault, NewBackupCredentialIssuance,
+	BackupCredentialIssuance, BackupMaintenanceRun, BackupMaintenanceRunFilters,
+	BackupRecoveryVerification, BackupRepoSnapshot, BackupRepoStats, BackupRequest, BackupRun,
+	BackupRunFilters, BackupTypeDefault, MaintenanceOutcomeFilter, NewBackupCredentialIssuance,
 	NewBackupRun, NewBackupTypeDefault, NewServerGroupBackupConfig, NewServerGroupBackupSchedule,
 	RetentionPolicy, ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
 };

--- a/crates/database/tests/backups.rs
+++ b/crates/database/tests/backups.rs
@@ -6,11 +6,12 @@ use commons_tests::db::TestDb;
 use database::diesel_async::AsyncPgConnection;
 use database::pg_duration::PgDuration;
 use database::{
-	BackupConfigStatus, BackupCredentialIssuance, BackupPurpose, BackupRepoSnapshot,
-	BackupRepoStats, BackupRequest, BackupRun, BackupType, BackupTypeDefault, MaintenanceKind,
-	NewBackupCredentialIssuance, NewBackupRun, NewBackupTypeDefault, NewServerGroupBackupConfig,
-	NewServerGroupBackupSchedule, RunOutcome, ServerBackupCapability, ServerGroupBackupConfig,
-	ServerGroupBackupSchedule, backups::BackupMaintenanceRun,
+	BackupConfigStatus, BackupCredentialIssuance, BackupMaintenanceRunFilters, BackupPurpose,
+	BackupRepoSnapshot, BackupRepoStats, BackupRequest, BackupRun, BackupRunFilters, BackupType,
+	BackupTypeDefault, MaintenanceKind, MaintenanceOutcomeFilter, NewBackupCredentialIssuance,
+	NewBackupRun, NewBackupTypeDefault, NewServerGroupBackupConfig, NewServerGroupBackupSchedule,
+	RunOutcome, ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
+	backups::BackupMaintenanceRun,
 };
 use diesel::{sql_query, sql_types};
 use diesel_async::RunQueryDsl;
@@ -494,6 +495,147 @@ async fn issuance_snapshots_bucket_and_orders_newest_first() {
 	.await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn list_filtered_narrows_by_every_field() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_a = insert_group(&mut conn, "a").await;
+		let group_b = insert_group(&mut conn, "b").await;
+		let server_a = insert_server(&mut conn, group_a).await;
+		let server_b = insert_server(&mut conn, group_b).await;
+		let device = insert_device(&mut conn).await;
+
+		let pg_run = new_run(
+			Uuid::new_v4(),
+			device,
+			group_a,
+			Some(server_a),
+			BackupPurpose::Backup,
+			RunOutcome::Success,
+		);
+		BackupRun::record(&mut conn, pg_run).await.expect("pg run");
+
+		let files_run_id = Uuid::new_v4();
+		let mut files_run = new_run(
+			files_run_id,
+			device,
+			group_a,
+			Some(server_a),
+			BackupPurpose::Backup,
+			RunOutcome::Failure,
+		);
+		files_run.r#type = BackupType::from("files");
+		BackupRun::record(&mut conn, files_run)
+			.await
+			.expect("files run");
+
+		let other_group_run = new_run(
+			Uuid::new_v4(),
+			device,
+			group_b,
+			Some(server_b),
+			BackupPurpose::Backup,
+			RunOutcome::Success,
+		);
+		BackupRun::record(&mut conn, other_group_run)
+			.await
+			.expect("other group run");
+
+		// No filters: all three.
+		let all = BackupRun::list_filtered(&mut conn, BackupRunFilters::default(), 10)
+			.await
+			.unwrap();
+		assert_eq!(all.len(), 3);
+
+		// group_id.
+		let for_a = BackupRun::list_filtered(
+			&mut conn,
+			BackupRunFilters {
+				group_id: Some(group_a),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(for_a.len(), 2);
+
+		// server_id.
+		let for_server_b = BackupRun::list_filtered(
+			&mut conn,
+			BackupRunFilters {
+				server_id: Some(server_b),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(for_server_b.len(), 1);
+		assert_eq!(for_server_b[0].server_id, Some(server_b));
+
+		// type.
+		let files_only = BackupRun::list_filtered(
+			&mut conn,
+			BackupRunFilters {
+				r#type: Some(BackupType::from("files")),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(files_only.len(), 1);
+		assert_eq!(files_only[0].id, files_run_id);
+
+		// outcome.
+		let failures = BackupRun::list_filtered(
+			&mut conn,
+			BackupRunFilters {
+				outcome: Some(RunOutcome::Failure),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(failures.len(), 1);
+		assert_eq!(failures[0].id, files_run_id);
+
+		// since: a future cutoff excludes everything already recorded.
+		let none = BackupRun::list_filtered(
+			&mut conn,
+			BackupRunFilters {
+				since: Some(Timestamp::now() + SignedDuration::from_hours(1)),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert!(none.is_empty());
+
+		// since: a past cutoff keeps everything.
+		let all_again = BackupRun::list_filtered(
+			&mut conn,
+			BackupRunFilters {
+				since: Some(Timestamp::now() - SignedDuration::from_hours(1)),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(all_again.len(), 3);
+
+		// limit caps the result set.
+		let limited = BackupRun::list_filtered(&mut conn, BackupRunFilters::default(), 1)
+			.await
+			.unwrap();
+		assert_eq!(limited.len(), 1);
+	})
+	.await;
+}
+
 // --- maintenance runs -------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]
@@ -521,6 +663,121 @@ async fn maintenance_start_finish_bracket() {
 		assert_eq!(done.outcome, Some(RunOutcome::Success));
 		assert_eq!(done.bytes_reclaimed, Some(1024));
 		assert!(done.finished_at.is_some());
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn maintenance_list_filtered_narrows_by_every_field() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_a = insert_group(&mut conn, "a").await;
+		let group_b = insert_group(&mut conn, "b").await;
+
+		let running_id = BackupMaintenanceRun::start(&mut conn, group_a, MaintenanceKind::Quick)
+			.await
+			.unwrap();
+
+		let failed_id = BackupMaintenanceRun::start(&mut conn, group_a, MaintenanceKind::Full)
+			.await
+			.unwrap();
+		BackupMaintenanceRun::finish(
+			&mut conn,
+			failed_id,
+			RunOutcome::Failure,
+			Some("boom".into()),
+			None,
+		)
+		.await
+		.unwrap();
+
+		let other_group_id =
+			BackupMaintenanceRun::start(&mut conn, group_b, MaintenanceKind::Quick)
+				.await
+				.unwrap();
+		BackupMaintenanceRun::finish(
+			&mut conn,
+			other_group_id,
+			RunOutcome::Success,
+			None,
+			Some(512),
+		)
+		.await
+		.unwrap();
+
+		// No filters: all three.
+		let all = BackupMaintenanceRun::list_filtered(
+			&mut conn,
+			BackupMaintenanceRunFilters::default(),
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(all.len(), 3);
+
+		// group_id.
+		let for_a = BackupMaintenanceRun::list_filtered(
+			&mut conn,
+			BackupMaintenanceRunFilters {
+				group_id: Some(group_a),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(for_a.len(), 2);
+
+		// kind.
+		let full_only = BackupMaintenanceRun::list_filtered(
+			&mut conn,
+			BackupMaintenanceRunFilters {
+				kind: Some(MaintenanceKind::Full),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(full_only.len(), 1);
+		assert_eq!(full_only[0].id, failed_id);
+
+		// outcome=running.
+		let running = BackupMaintenanceRun::list_filtered(
+			&mut conn,
+			BackupMaintenanceRunFilters {
+				outcome: Some(MaintenanceOutcomeFilter::Running),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(running.len(), 1);
+		assert_eq!(running[0].id, running_id);
+
+		// outcome=failure.
+		let failed = BackupMaintenanceRun::list_filtered(
+			&mut conn,
+			BackupMaintenanceRunFilters {
+				outcome: Some(MaintenanceOutcomeFilter::Outcome(RunOutcome::Failure)),
+				..Default::default()
+			},
+			10,
+		)
+		.await
+		.unwrap();
+		assert_eq!(failed.len(), 1);
+		assert_eq!(failed[0].id, failed_id);
+
+		// limit caps the result set.
+		let limited = BackupMaintenanceRun::list_filtered(
+			&mut conn,
+			BackupMaintenanceRunFilters::default(),
+			1,
+		)
+		.await
+		.unwrap();
+		assert_eq!(limited.len(), 1);
 	})
 	.await;
 }

--- a/crates/private-server/tests/mcp.rs
+++ b/crates/private-server/tests/mcp.rs
@@ -120,6 +120,11 @@ async fn initialize_and_list_tools() {
 			"get_incident",
 			"find_issues",
 			"get_issue",
+			"list_backup_runs",
+			"list_maintenance_runs",
+			"find_restore_replicas",
+			"get_restore_replica",
+			"get_backup_defaults",
 		] {
 			assert!(body.contains(tool), "tools/list missing {tool}: {body}");
 		}
@@ -494,6 +499,282 @@ async fn backup_problems_scan_runs() {
 		let p = call_tool!(private, "find_backup_problems", serde_json::json!({}));
 		assert!(p["count"].is_number());
 		assert!(p["problems"].is_array());
+	})
+	.await
+}
+
+// --- backup runs, maintenance runs, restore replicas, backup defaults -------
+
+const RGROUP: &str = "bbbbbbbb-0000-0000-0000-000000000001";
+const RSERVER: &str = "bbbbbbbb-0000-0000-0000-000000000002";
+const RDEVICE: &str = "bbbbbbbb-0000-0000-0000-000000000003";
+const RUN_OK: &str = "bbbbbbbb-0000-0000-0000-0000000000a1";
+const RUN_FAIL: &str = "bbbbbbbb-0000-0000-0000-0000000000a2";
+const CONSUMER: &str = "bbbbbbbb-0000-0000-0000-000000000004";
+const REPLICA_GROUP_WIDE: &str = "bbbbbbbb-0000-0000-0000-0000000000b1";
+const REPLICA_SERVER_SCOPED: &str = "bbbbbbbb-0000-0000-0000-0000000000b2";
+const REPLICA_GAP: &str = "bbbbbbbb-0000-0000-0000-0000000000b3";
+
+/// A group + server + device, two backup runs (one success, one failure), and
+/// two maintenance runs (one finished, one still running).
+async fn seed_backup_runs(conn: &mut impl SimpleAsyncConnection) {
+	conn.batch_execute(&format!(
+		"INSERT INTO server_groups (id, name) VALUES ('{RGROUP}', 'Backup Group'); \
+		 INSERT INTO servers (id, host, name, kind, group_id) VALUES \
+			('{RSERVER}', 'https://backup-target', 'Backup Target', 'central', '{RGROUP}'); \
+		 INSERT INTO devices (id, role) VALUES ('{RDEVICE}', 'server'); \
+		 INSERT INTO backup_runs \
+			(id, device_id, group_id, server_id, type, purpose, outcome, snapshot_id, bytes_uploaded, s3_sent_raw_bytes, snapshot_logical_bytes, reported_at) \
+			VALUES \
+			('{RUN_OK}', '{RDEVICE}', '{RGROUP}', '{RSERVER}', 'tamanu-postgres', 'backup', 'success', 'snap-1', 1000, 1200, 900, NOW() - interval '1 hour'), \
+			('{RUN_FAIL}', '{RDEVICE}', '{RGROUP}', '{RSERVER}', 'tamanu-postgres', 'backup', 'failure', NULL, NULL, NULL, NULL, NOW() - interval '10 minutes'); \
+		 INSERT INTO backup_maintenance_runs (group_id, kind, started_at, finished_at, outcome, bytes_reclaimed) VALUES \
+			('{RGROUP}', 'quick', NOW() - interval '2 hours', NOW() - interval '110 minutes', 'success', 2048), \
+			('{RGROUP}', 'full', NOW() - interval '30 minutes', NULL, NULL, NULL);"
+	))
+	.await
+	.expect("seed backup runs");
+}
+
+/// A restore consumer advertising only `verify`, and three declarations: a
+/// group-wide `verify` (supported, no single server to report health for), a
+/// server-scoped `verify` (supported, with a healthy check on record), and a
+/// server-scoped `analytics` (unsupported — a gap, since the consumer only
+/// advertises `verify`).
+async fn seed_restore_replicas(conn: &mut impl SimpleAsyncConnection) {
+	conn.batch_execute(&format!(
+		"INSERT INTO devices (id, role) VALUES ('{CONSUMER}', 'backup-restore'); \
+		 INSERT INTO restore_consumer_capabilities (consumer_device_id, intent, semantics) VALUES \
+			('{CONSUMER}', 'verify', '[\"check\"]'::jsonb); \
+		 INSERT INTO restore_replicas (id, consumer_device_id, group_id, server_id, type, intent, name) VALUES \
+			('{REPLICA_GROUP_WIDE}', '{CONSUMER}', '{RGROUP}', NULL, 'tamanu-postgres', 'verify', 'group-wide'), \
+			('{REPLICA_SERVER_SCOPED}', '{CONSUMER}', '{RGROUP}', '{RSERVER}', 'tamanu-postgres', 'verify', 'server-scoped'), \
+			('{REPLICA_GAP}', '{CONSUMER}', '{RGROUP}', '{RSERVER}', 'tamanu-postgres', 'analytics', 'server-scoped-gap'); \
+		 INSERT INTO backup_restore_checks \
+			(replica_id, consumer_device_id, group_id, server_id, type, intent, snapshot_id, outcome, replica_healthy, observed_at) \
+			VALUES \
+			('{REPLICA_SERVER_SCOPED}', '{CONSUMER}', '{RGROUP}', '{RSERVER}', 'tamanu-postgres', 'verify', 'snap-1', 'success', true, NOW() - interval '30 minutes');"
+	))
+	.await
+	.expect("seed restore replicas");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_backup_runs_filters() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed_backup_runs(&mut conn).await;
+
+		let all = call_tool!(private, "list_backup_runs", serde_json::json!({}));
+		assert_eq!(all["count"], 2);
+		let run = all["runs"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|r| r["id"] == RUN_OK)
+			.expect("seeded run present");
+		assert_eq!(run["group_name"], "Backup Group");
+		assert_eq!(run["server_name"], "Backup Target");
+		assert_eq!(run["outcome"], "success");
+		assert_eq!(run["s3_sent_raw_bytes"], 1200);
+		assert_eq!(run["snapshot_logical_bytes"], 900);
+
+		let failures = call_tool!(
+			private,
+			"list_backup_runs",
+			serde_json::json!({ "outcome": "failure" })
+		);
+		let ids: Vec<&str> = failures["runs"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.map(|r| r["id"].as_str().unwrap())
+			.collect();
+		assert_eq!(ids, vec![RUN_FAIL]);
+
+		let by_type = call_tool!(
+			private,
+			"list_backup_runs",
+			serde_json::json!({ "type": "tamanu-postgres" })
+		);
+		assert_eq!(by_type["count"], 2);
+
+		let by_other_type = call_tool!(
+			private,
+			"list_backup_runs",
+			serde_json::json!({ "type": "files" })
+		);
+		assert_eq!(by_other_type["count"], 0);
+
+		let by_server = call_tool!(
+			private,
+			"list_backup_runs",
+			serde_json::json!({ "server_id": RSERVER })
+		);
+		assert_eq!(by_server["count"], 2);
+
+		let limited = call_tool!(
+			private,
+			"list_backup_runs",
+			serde_json::json!({ "limit": 1 })
+		);
+		assert_eq!(limited["count"], 1);
+		assert_eq!(limited["truncated"], true);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_maintenance_runs_filters() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed_backup_runs(&mut conn).await;
+
+		let all = call_tool!(private, "list_maintenance_runs", serde_json::json!({}));
+		assert_eq!(all["count"], 2);
+		let finished = all["runs"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|r| r["kind"] == "quick")
+			.expect("finished run present");
+		assert_eq!(finished["group_name"], "Backup Group");
+		assert_eq!(finished["outcome"], "success");
+		assert_eq!(finished["bytes_reclaimed"], 2048);
+
+		let running = call_tool!(
+			private,
+			"list_maintenance_runs",
+			serde_json::json!({ "outcome": "running" })
+		);
+		let kinds: Vec<&str> = running["runs"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.map(|r| r["kind"].as_str().unwrap())
+			.collect();
+		assert_eq!(kinds, vec!["full"]);
+		assert!(running["runs"][0]["finished_at"].is_null());
+
+		let by_kind = call_tool!(
+			private,
+			"list_maintenance_runs",
+			serde_json::json!({ "kind": "full" })
+		);
+		assert_eq!(by_kind["count"], 1);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn find_restore_replicas_reports_gap_and_health() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed_backup_runs(&mut conn).await;
+		seed_restore_replicas(&mut conn).await;
+
+		let all = call_tool!(
+			private,
+			"find_restore_replicas",
+			serde_json::json!({ "group_id": RGROUP })
+		);
+		assert_eq!(all["count"], 3);
+		let replicas = all["replicas"].as_array().unwrap();
+
+		let group_wide = replicas
+			.iter()
+			.find(|r| r["id"] == REPLICA_GROUP_WIDE)
+			.unwrap();
+		assert_eq!(group_wide["gap"], false);
+		assert!(
+			group_wide["last_healthy_at"].is_null(),
+			"group-wide declarations have no single server to report health for"
+		);
+
+		let server_scoped = replicas
+			.iter()
+			.find(|r| r["id"] == REPLICA_SERVER_SCOPED)
+			.unwrap();
+		assert_eq!(server_scoped["gap"], false);
+		assert_eq!(server_scoped["server_name"], "Backup Target");
+		assert!(!server_scoped["last_healthy_at"].is_null());
+
+		let gap = replicas.iter().find(|r| r["id"] == REPLICA_GAP).unwrap();
+		assert_eq!(
+			gap["gap"], true,
+			"consumer only advertises verify, not analytics"
+		);
+
+		// Empty for an unrelated group.
+		let none = call_tool!(
+			private,
+			"find_restore_replicas",
+			serde_json::json!({ "group_id": "cccccccc-0000-0000-0000-000000000000" })
+		);
+		assert_eq!(none["count"], 0);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_restore_replica_detail_and_gap() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed_backup_runs(&mut conn).await;
+		seed_restore_replicas(&mut conn).await;
+
+		let detail = call_tool!(
+			private,
+			"get_restore_replica",
+			serde_json::json!({ "replica_id": REPLICA_SERVER_SCOPED })
+		);
+		assert_eq!(detail["gap"], false);
+		assert_eq!(detail["intent_descriptor"]["intent"], "verify");
+		assert_eq!(detail["intent_descriptor"]["semantics"][0], "check");
+		let checks = detail["recent_checks"].as_array().unwrap();
+		assert_eq!(checks.len(), 1);
+		assert_eq!(checks[0]["outcome"], "success");
+		assert_eq!(checks[0]["replica_healthy"], true);
+		assert_eq!(checks[0]["snapshot_id"], "snap-1");
+
+		let gap_detail = call_tool!(
+			private,
+			"get_restore_replica",
+			serde_json::json!({ "replica_id": REPLICA_GAP })
+		);
+		assert_eq!(gap_detail["gap"], true);
+		assert!(gap_detail["intent_descriptor"].is_null());
+		assert!(gap_detail["recent_checks"].as_array().unwrap().is_empty());
+
+		// Unknown id → tool error, not a protocol error.
+		let missing = private
+			.post("/api/mcp")
+			.add_header("accept", ACCEPT)
+			.add_header("mcp-protocol-version", PROTO)
+			.json(&serde_json::json!({
+				"jsonrpc": "2.0", "id": 4, "method": "tools/call",
+				"params": {
+					"name": "get_restore_replica",
+					"arguments": { "replica_id": "44444444-4444-4444-4444-444444444444" }
+				}
+			}))
+			.await;
+		let env = parse_envelope(&missing.text());
+		assert_eq!(env["result"]["isError"], serde_json::json!(true));
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn backup_defaults_lists_seeded_org_default() {
+	commons_tests::server::run(async |_conn, _public, private| {
+		// The `tamanu-postgres` default is seeded by a migration, so it's present
+		// even with no other setup.
+		let d = call_tool!(private, "get_backup_defaults", serde_json::json!({}));
+		let defaults = d["defaults"].as_array().unwrap();
+		let tpg = defaults
+			.iter()
+			.find(|d| d["type"] == "tamanu-postgres")
+			.expect("seeded default present");
+		assert_eq!(tpg["default_interval_seconds"], 6 * 60 * 60);
+		assert_eq!(tpg["default_retention"]["keep_daily"], 7);
+		assert_eq!(tpg["auto_enable"], false);
 	})
 	.await
 }


### PR DESCRIPTION
🤖 Adds five read-only MCP tools covering the backup data that wasn't reachable before (get_group caps at 10 runs / 5 maintenance rows; find_backup_problems only surfaces its narrow problem framing):

- `list_backup_runs` — filterable history (group, server, type, outcome, since_days, limit ≤ 200) including per-run S3 traffic and snapshot sizes.
- `list_maintenance_runs` — same shape, with kind and success/failure/running outcome filters.
- `find_restore_replicas` / `get_restore_replica` — replica declarations with consumer capability gaps and recent restore-check health. Deliberately exposes the raw signals (`gap`, `last_healthy_at`, `overdue_after`) rather than re-deriving an overdue verdict — that logic lives solely in `database::restore::sweep_overdue`.
- `get_backup_defaults` — org-wide per-type retention defaults.

Backing filters (`BackupRun::list_filtered`, `BackupMaintenanceRun::list_filtered`) live in the database crate. Tests: filter-narrowing DB tests for both, plus MCP integration tests for each new tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)