### PR TITLE
feat(e2e): screenshot every test and publish them as a PR artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,17 @@ jobs:
             private-web/test-results
           retention-days: 7
           if-no-files-found: ignore
+      - name: Upload Playwright screenshots
+        # Every test (pass or fail) takes an end-of-test screenshot (see
+        # playwright.config.ts `use.screenshot`), so this always uploads,
+        # not just on failure, to make visual review of a PR's UI trivial.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-screenshots
+          path: private-web/test-results/**/*.png
+          retention-days: 5
+          if-no-files-found: ignore
 
   # Dummy job to have a stable name for PR requirements
   tests-pass:

--- a/private-web/playwright.config.ts
+++ b/private-web/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
 	expect: { timeout: 10_000 },
 	use: {
 		trace: "retain-on-failure",
-		screenshot: "only-on-failure",
+		screenshot: { mode: "on", fullPage: true },
 		video: "retain-on-failure",
 	},
 	projects: [


### PR DESCRIPTION
🤖 From review feedback on #318: seeing how a UI change actually renders required running the suite locally. Playwright now takes a full-page screenshot at the end of every test — passes included, not just failures — and CI uploads the PNGs as a `playwright-screenshots` artifact on every run (5-day retention, `if: always()`).

The existing failure-only diagnostics bundle (HTML report + videos + traces, 7-day retention) is untouched; this is a separate screenshots-only artifact so green runs don't upload videos/traces.

Screenshot file naming is Playwright's default (per-test slug directories with `test-finished-1.png` / `test-failed-1.png`) — opaque but browsable; no custom flattening tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)