### PR TITLE
fix(private-web): uniform dot-grid cells so wrapped status dots align

### DIFF
--- a/private-web/e2e/status.spec.ts
+++ b/private-web/e2e/status.spec.ts
@@ -74,79 +74,69 @@ test.describe("status page", () => {
 		).toBeVisible();
 	});
 
-	test("dot strip renders a wide group's members with rank separators", async ({
+	test("dot strips wrap and align across a spread of group sizes", async ({
 		page,
 		sql,
 	}) => {
+		test.setTimeout(120_000);
 		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
-		const group = await seedServerGroup(sql, { name: "wide-fleet" });
 		const device = await seedDevice(sql);
 
-		// Twelve members across three ranks, with a spread of health states so
-		// the strip shows plain, ringed, and never-reported dots. Enough dots
-		// that the strip wraps at typical card widths (the screenshots artifact
-		// shows the resulting grid).
-		const members: Array<{
-			rank: "production" | "clone" | "dev";
-			kind: "central" | "facility";
-			health?: unknown[];
-			healthy?: boolean;
-			reported?: boolean;
-		}> = [
-			{ rank: "production", kind: "central" },
-			{ rank: "production", kind: "facility" },
-			{
-				rank: "production",
-				kind: "facility",
-				health: [{ check: "postgres", result: "failed" }],
-				healthy: false,
-			},
-			{
-				rank: "production",
-				kind: "facility",
-				health: [{ check: "disk_space", result: "warning" }],
-			},
-			{ rank: "production", kind: "facility" },
-			{ rank: "production", kind: "facility", reported: false },
-			{ rank: "clone", kind: "central" },
-			{
-				rank: "clone",
-				kind: "facility",
-				health: [{ check: "postgres", result: "failed" }],
-				healthy: false,
-			},
-			{ rank: "clone", kind: "facility" },
-			{ rank: "dev", kind: "central" },
-			{ rank: "dev", kind: "facility" },
-			{ rank: "dev", kind: "facility", reported: false },
-		];
-		for (const [i, m] of members.entries()) {
-			const server = await seedServer(sql, {
-				name: `wf-${m.rank}-${i}`,
-				kind: m.kind,
-				rank: m.rank,
-				groupId: group.id,
-			});
-			if (m.reported !== false) {
+		// Groups of increasing size so the strip renders unwrapped, wrapped
+		// once, and wrapped many times (the screenshots artifact shows the
+		// grids). Each group spans three ranks, so two triangle separators
+		// appear per strip; health states cycle so plain, failed-ringed,
+		// warning-ringed, and never-reported dots all show up.
+		const splits: Record<number, [number, number, number]> = {
+			5: [3, 1, 1],
+			10: [6, 2, 2],
+			20: [12, 5, 3],
+			30: [18, 8, 4],
+			50: [30, 13, 7],
+		};
+		const groups: Array<{ id: string; size: number }> = [];
+		for (const [size, split] of Object.entries(splits)) {
+			const n = Number(size);
+			const group = await seedServerGroup(sql, { name: `fleet-of-${n}` });
+			groups.push({ id: group.id, size: n });
+			const ranks = (["production", "clone", "dev"] as const).flatMap(
+				(rank, ri) => Array(split[ri]).fill(rank) as ("production" | "clone" | "dev")[],
+			);
+			for (const [i, rank] of ranks.entries()) {
+				const server = await seedServer(sql, {
+					name: `f${n}-${i}`,
+					kind: i === 0 ? "central" : "facility",
+					rank,
+					groupId: group.id,
+				});
+				if (i % 7 === 6) continue; // never reported: grey dot
+				const health =
+					i % 4 === 3
+						? [{ check: "postgres", result: "failed" }]
+						: i % 5 === 4
+							? [{ check: "disk_space", result: "warning" }]
+							: [];
 				await seedStatus(sql, {
 					serverId: server.id,
 					deviceId: device.id,
-					healthy: m.healthy ?? true,
-					health: m.health ?? [],
+					healthy: i % 4 !== 3,
+					health,
 				});
 			}
 		}
 
 		await page.goto("/status");
 
-		// The group may surface under more than one rank bucket; every card
-		// shows the full strip, so scope to the first.
-		const card = page.locator(`a[href="/groups/${group.id}"]`).first();
-		const strip = card.getByTestId("dot-strip");
-		await expect(strip).toBeVisible();
-		// Two rank boundaries (production→clone, clone→dev).
-		await expect(strip.getByTestId("rank-separator")).toHaveCount(2);
-		// Every child cell is a dot or separator: 12 members + 2 separators.
-		await expect(strip.locator("> *")).toHaveCount(14);
+		for (const { id, size } of groups) {
+			// A group may surface under more than one rank bucket; every card
+			// shows the full strip, so scope to the first.
+			const card = page.locator(`a[href="/groups/${id}"]`).first();
+			const strip = card.getByTestId("dot-strip");
+			await expect(strip).toBeVisible();
+			// Two rank boundaries (production→clone, clone→dev).
+			await expect(strip.getByTestId("rank-separator")).toHaveCount(2);
+			// Every child cell is a dot or a separator.
+			await expect(strip.locator("> *")).toHaveCount(size + 2);
+		}
 	});
 });

--- a/private-web/e2e/status.spec.ts
+++ b/private-web/e2e/status.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "./test-fixtures";
 import {
 	resetSeededTables,
+	seedDevice,
 	seedServer,
 	seedServerGroup,
+	seedStatus,
 	seedVersion,
 } from "./seed";
 
@@ -70,5 +72,81 @@ test.describe("status page", () => {
 		await expect(
 			page.locator(`a[href="/groups/${prodGroup.id}"]`),
 		).toBeVisible();
+	});
+
+	test("dot strip renders a wide group's members with rank separators", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const group = await seedServerGroup(sql, { name: "wide-fleet" });
+		const device = await seedDevice(sql);
+
+		// Twelve members across three ranks, with a spread of health states so
+		// the strip shows plain, ringed, and never-reported dots. Enough dots
+		// that the strip wraps at typical card widths (the screenshots artifact
+		// shows the resulting grid).
+		const members: Array<{
+			rank: "production" | "clone" | "dev";
+			kind: "central" | "facility";
+			health?: unknown[];
+			healthy?: boolean;
+			reported?: boolean;
+		}> = [
+			{ rank: "production", kind: "central" },
+			{ rank: "production", kind: "facility" },
+			{
+				rank: "production",
+				kind: "facility",
+				health: [{ check: "postgres", result: "failed" }],
+				healthy: false,
+			},
+			{
+				rank: "production",
+				kind: "facility",
+				health: [{ check: "disk_space", result: "warning" }],
+			},
+			{ rank: "production", kind: "facility" },
+			{ rank: "production", kind: "facility", reported: false },
+			{ rank: "clone", kind: "central" },
+			{
+				rank: "clone",
+				kind: "facility",
+				health: [{ check: "postgres", result: "failed" }],
+				healthy: false,
+			},
+			{ rank: "clone", kind: "facility" },
+			{ rank: "dev", kind: "central" },
+			{ rank: "dev", kind: "facility" },
+			{ rank: "dev", kind: "facility", reported: false },
+		];
+		for (const [i, m] of members.entries()) {
+			const server = await seedServer(sql, {
+				name: `wf-${m.rank}-${i}`,
+				kind: m.kind,
+				rank: m.rank,
+				groupId: group.id,
+			});
+			if (m.reported !== false) {
+				await seedStatus(sql, {
+					serverId: server.id,
+					deviceId: device.id,
+					healthy: m.healthy ?? true,
+					health: m.health ?? [],
+				});
+			}
+		}
+
+		await page.goto("/status");
+
+		// The group may surface under more than one rank bucket; every card
+		// shows the full strip, so scope to the first.
+		const card = page.locator(`a[href="/groups/${group.id}"]`).first();
+		const strip = card.getByTestId("dot-strip");
+		await expect(strip).toBeVisible();
+		// Two rank boundaries (production→clone, clone→dev).
+		await expect(strip.getByTestId("rank-separator")).toHaveCount(2);
+		// Every child cell is a dot or separator: 12 members + 2 separators.
+		await expect(strip.locator("> *")).toHaveCount(14);
 	});
 });

--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -365,6 +365,7 @@ export function RankedDotStrip({ members }: { members: FacilityServerStatus[] })
 					key={`sep-${rank}`}
 					component="span"
 					aria-hidden
+					data-testid="rank-separator"
 					sx={{ ...dotCellSx, color: "text.primary" }}
 				>
 					{/* Hollow play-button triangle, dot-sized; MUI's
@@ -409,6 +410,7 @@ export function RankedDotStrip({ members }: { members: FacilityServerStatus[] })
 		<Stack
 			direction="row"
 			spacing={0}
+			data-testid="dot-strip"
 			sx={{ flexWrap: "wrap", alignItems: "center", gap: "0.5em" }}
 		>
 			{cells}

--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -339,65 +339,68 @@ function OperatorCountChip({
 /// (centrals first within a rank). A thin grey vertical bar separates
 /// adjacent ranks, so operators can see at a glance how the group
 /// breaks down without naming each dot.
+// Every child of the strip — dot or rank separator — sits in an identical
+// fixed-size cell, so wrapped rows always align to the same column grid no
+// matter where the line breaks fall. Spacing comes from the container's
+// `gap`, not per-dot margins (StatusDot's inline right-margin is neutralised).
+const dotCellSx = {
+	display: "inline-flex",
+	width: "1em",
+	height: "1em",
+	alignItems: "center",
+	justifyContent: "center",
+	flex: "none",
+	"& > span": { marginRight: 0 },
+} as const;
+
 export function RankedDotStrip({ members }: { members: FacilityServerStatus[] }) {
 	const sorted = [...members].sort(compareServersByRankThenKind);
-	const chunks: Array<{ rank: string; entries: FacilityServerStatus[] }> = [];
+	const cells: React.ReactNode[] = [];
+	let prevRank: string | null = null;
 	for (const m of sorted) {
-		const key = m.rank ?? "_unranked";
-		const last = chunks[chunks.length - 1];
-		if (last && last.rank === key) last.entries.push(m);
-		else chunks.push({ rank: key, entries: [m] });
+		const rank = m.rank ?? "_unranked";
+		if (prevRank != null && rank !== prevRank) {
+			cells.push(
+				<Box
+					key={`sep-${rank}`}
+					component="span"
+					aria-hidden
+					sx={dotCellSx}
+				>
+					<Box
+						component="span"
+						sx={{ width: "1px", height: "0.9em", bgcolor: "text.disabled" }}
+					/>
+				</Box>,
+			);
+		}
+		prevRank = rank;
+		cells.push(
+			<Tooltip
+				key={m.id}
+				title={`${m.name || "(unnamed)"}${
+					m.rank ? ` · ${m.rank}` : ""
+				} · ${m.kind}`}
+			>
+				<Box component="span" sx={dotCellSx}>
+					<StatusDot
+						up={m.up}
+						health={m.health}
+						title={`${m.name}: ${m.up}${
+							m.health !== "healthy" ? ` (${m.health})` : ""
+						}`}
+					/>
+				</Box>
+			</Tooltip>,
+		);
 	}
 	return (
 		<Stack
 			direction="row"
 			spacing={0}
-			sx={{ flexWrap: "wrap", alignItems: "center", rowGap: "0.5em" }}
+			sx={{ flexWrap: "wrap", alignItems: "center", gap: "0.5em" }}
 		>
-			{chunks.map((chunk, idx) => (
-				<Box
-					key={chunk.rank}
-					component="span"
-					sx={{
-						display: "inline-flex",
-						flexWrap: "wrap",
-						alignItems: "center",
-						rowGap: "0.5em",
-					}}
-				>
-					{idx > 0 && (
-						<Box
-							component="span"
-							aria-hidden
-							sx={{
-								display: "inline-block",
-								width: "1px",
-								height: "0.9em",
-								mx: "0.25em",
-								bgcolor: "text.disabled",
-							}}
-						/>
-					)}
-					{chunk.entries.map((m) => (
-						<Tooltip
-							key={m.id}
-							title={`${m.name || "(unnamed)"}${
-								m.rank ? ` · ${m.rank}` : ""
-							} · ${m.kind}`}
-						>
-							<Box component="span" sx={{ display: "inline-flex" }}>
-								<StatusDot
-									up={m.up}
-									health={m.health}
-									title={`${m.name}: ${m.up}${
-										m.health !== "healthy" ? ` (${m.health})` : ""
-									}`}
-								/>
-							</Box>
-						</Tooltip>
-					))}
-				</Box>
-			))}
+			{cells}
 		</Stack>
 	);
 }

--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -336,9 +336,9 @@ function OperatorCountChip({
 }
 
 /// Strip of StatusDots for a group's members, sorted by rank then kind
-/// (centrals first within a rank). A thin grey vertical bar separates
-/// adjacent ranks, so operators can see at a glance how the group
-/// breaks down without naming each dot.
+/// (centrals first within a rank). A hollow right-pointing triangle
+/// separates adjacent ranks, so operators can see at a glance how the
+/// group breaks down without naming each dot.
 // Every child of the strip — dot or rank separator — sits in an identical
 // fixed-size cell, so wrapped rows always align to the same column grid no
 // matter where the line breaks fall. Spacing comes from the container's
@@ -365,12 +365,23 @@ export function RankedDotStrip({ members }: { members: FacilityServerStatus[] })
 					key={`sep-${rank}`}
 					component="span"
 					aria-hidden
-					sx={dotCellSx}
+					sx={{ ...dotCellSx, color: "text.primary" }}
 				>
-					<Box
-						component="span"
-						sx={{ width: "1px", height: "0.9em", bgcolor: "text.disabled" }}
-					/>
+					{/* Hollow play-button triangle, dot-sized; MUI's
+					    PlayArrowOutlined renders too small in a 1em cell and
+					    has sharp corners, hence the inline SVG. */}
+					<svg
+						width="1em"
+						height="1em"
+						viewBox="0 0 16 16"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth={2}
+						strokeLinejoin="round"
+						strokeLinecap="round"
+					>
+						<path d="M4.5 3.2 12.8 8 4.5 12.8Z" />
+					</svg>
 				</Box>,
 			);
 		}


### PR DESCRIPTION
🤖 Follow-up to #318, which fixed the missing row spacing but introduced two new problems visible on groups whose dots span multiple lines: a rank that wraps internally expands its inline-flex chunk to the full row width, orphaning the next rank (and its separator) onto a fresh line even when there's room; and the separator's footprint still didn't match a dot's, so wrapped rows didn't align column-wise.

The strip is now a single wrapping flex container of identical fixed-size cells — every dot and every rank separator occupies the same 1em cell, spaced by container `gap` instead of per-dot margins. Line breaks can fall anywhere (including mid-rank) and every row lands on the same column grid; separators read as rank boundaries wherever they fall.

Verified the cell/wrap behaviour against a static mock at the reported card widths before porting: wraps mid-rank and after separators all stay grid-aligned with no orphaned lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)