### PR TITLE
fix: recover restore-verification alerts when a replica is deleted

### DIFF
--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -13,7 +13,7 @@ use diesel::{
 	prelude::*,
 	result::{DatabaseErrorKind, Error as DieselError},
 };
-use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use jiff::Timestamp;
 use serde::Serialize;
 use uuid::Uuid;
@@ -244,15 +244,32 @@ impl RestoreReplica {
 		Ok(result)
 	}
 
+	/// Delete a declaration and recover any active restore-verification alert
+	/// keyed to its `(server, type, intent)` scope — the overdue sweep only
+	/// walks current declarations, so an alert left behind by a deleted one
+	/// would otherwise never clear. Runs in a single transaction so a failure
+	/// partway can't leave the row deleted with its alerts unrecovered.
 	pub async fn delete(db: &mut AsyncPgConnection, id: Uuid) -> Result<()> {
-		use crate::schema::restore_replicas::dsl;
-		let n = diesel::delete(dsl::restore_replicas.filter(dsl::id.eq(id)))
-			.execute(db)
+		db.transaction::<_, AppError, _>(async |conn| {
+			use crate::schema::restore_replicas::dsl;
+			let existing = Self::get(conn, id).await?;
+			let n = diesel::delete(dsl::restore_replicas.filter(dsl::id.eq(id)))
+				.execute(conn)
+				.await?;
+			if n == 0 {
+				return Err(AppError::DatabaseQuery(DieselError::NotFound));
+			}
+			recover_old_scope_alerts(
+				conn,
+				existing.group_id,
+				existing.server_id,
+				&existing.r#type,
+				&existing.intent,
+			)
 			.await?;
-		if n == 0 {
-			return Err(AppError::DatabaseQuery(DieselError::NotFound));
-		}
-		Ok(())
+			Ok(())
+		})
+		.await
 	}
 
 	/// Whether an enabled declaration covers `(consumer, group, type)` — the
@@ -412,11 +429,11 @@ fn restore_verification_ref(
 }
 
 /// Recover any active restore-verification alert keyed to a declaration's old
-/// `(server, type, intent)`, called when an update moves a declaration's
-/// scope elsewhere. Mirrors the recovery [`BackupRestoreCheck::record_report`]
-/// performs for a healthy report — [`raise_group_event`] with `active: false`.
-/// If the old key is still overdue under some other declaration, the next
-/// [`sweep_overdue`] pass re-raises it.
+/// `(server, type, intent)`, called when the declaration stops covering that
+/// scope (it was deleted, or its scope moved elsewhere). Mirrors the recovery
+/// [`BackupRestoreCheck::record_report`] performs for a healthy report —
+/// [`raise_group_event`] with `active: false`. If the old key is still overdue
+/// under some other declaration, the next [`sweep_overdue`] pass re-raises it.
 async fn recover_old_scope_alerts(
 	db: &mut AsyncPgConnection,
 	old_group_id: Uuid,
@@ -442,7 +459,7 @@ async fn recover_old_scope_alerts(
 			Severity::Info,
 			None,
 			&format!(
-				"Restore verification no longer tracked at this scope: {old_type} / {old_intent} for server {sid} (declaration scope changed)"
+				"Restore verification no longer tracked at this scope: {old_type} / {old_intent} for server {sid}"
 			),
 			false,
 		)
@@ -451,7 +468,6 @@ async fn recover_old_scope_alerts(
 
 	Ok(())
 }
-
 /// A restore-health report submitted by a restore consumer: proof (or
 /// disproof) that a backup snapshot actually restores into a healthy
 /// database — the strongest available signal of backup health. `snapshot_id`

--- a/crates/database/tests/restore.rs
+++ b/crates/database/tests/restore.rs
@@ -800,3 +800,96 @@ async fn update_moving_scope_recovers_stale_alert_at_old_key() {
 	})
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_recovers_stale_alert_for_removed_scope() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn, "g").await;
+		let server = insert_server(&mut conn, group).await;
+		let r = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				Some(server),
+				RestoreIntent::from("verify"),
+				"n",
+			),
+		)
+		.await
+		.expect("create");
+
+		// Raise an active alert at the declaration's (server, type, verify) key.
+		BackupRestoreCheck::record_report(
+			&mut conn,
+			new_check(
+				consumer,
+				group,
+				server,
+				RestoreIntent::from("verify"),
+				RunOutcome::Failure,
+				false,
+			),
+		)
+		.await
+		.expect("record failure");
+		assert_eq!(active_restore_issues(&mut conn, group).await, 1);
+
+		// Deleting the declaration removes the only thing tracking that key.
+		// The sweep only walks current declarations, so without recovery the
+		// alert would never clear.
+		RestoreReplica::delete(&mut conn, r.id)
+			.await
+			.expect("delete");
+		assert_eq!(
+			active_restore_issues(&mut conn, group).await,
+			0,
+			"the removed scope's alert is recovered on delete"
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_group_wide_recovers_alerts_on_every_server() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn, "g").await;
+		let server_a = insert_server(&mut conn, group).await;
+		let server_b = insert_server(&mut conn, group).await;
+		let r = RestoreReplica::create(
+			&mut conn,
+			new_replica(consumer, group, None, RestoreIntent::from("verify"), "n"),
+		)
+		.await
+		.expect("create");
+
+		for sid in [server_a, server_b] {
+			BackupRestoreCheck::record_report(
+				&mut conn,
+				new_check(
+					consumer,
+					group,
+					sid,
+					RestoreIntent::from("verify"),
+					RunOutcome::Failure,
+					false,
+				),
+			)
+			.await
+			.expect("record failure");
+		}
+		assert_eq!(active_restore_issues(&mut conn, group).await, 2);
+
+		RestoreReplica::delete(&mut conn, r.id)
+			.await
+			.expect("delete");
+		assert_eq!(
+			active_restore_issues(&mut conn, group).await,
+			0,
+			"a group-wide declaration's alerts recover on every live server"
+		);
+	})
+	.await;
+}

--- a/crates/private-server/src/fns/restore_replicas.rs
+++ b/crates/private-server/src/fns/restore_replicas.rs
@@ -468,9 +468,10 @@ pub async fn update(
 /// Delete a restore replica declaration.
 ///
 /// Removes the declaration: the consumer stops being asked to maintain the
-/// replica and loses the backup access the declaration granted. Requires the
-/// caller to be on the admin allow-list. Responds 404 if the declaration
-/// does not exist.
+/// replica and loses the backup access the declaration granted. Any active
+/// restore-verification alert for the declaration's scope is recovered, since
+/// nothing tracks that scope any more. Requires the caller to be on the admin
+/// allow-list. Responds 404 if the declaration does not exist.
 #[utoipa::path(
 	post,
 	path = "/delete",

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -3791,7 +3791,7 @@
           "restore_replicas"
         ],
         "summary": "Delete a restore replica declaration.",
-        "description": "Removes the declaration: the consumer stops being asked to maintain the\nreplica and loses the backup access the declaration granted. Requires the\ncaller to be on the admin allow-list. Responds 404 if the declaration\ndoes not exist.",
+        "description": "Removes the declaration: the consumer stops being asked to maintain the\nreplica and loses the backup access the declaration granted. Any active\nrestore-verification alert for the declaration's scope is recovered, since\nnothing tracks that scope any more. Requires the caller to be on the admin\nallow-list. Responds 404 if the declaration does not exist.",
         "operationId": "restore_replicas_delete",
         "requestBody": {
           "content": {

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1911,9 +1911,10 @@ export interface paths {
         /**
          * Delete a restore replica declaration.
          * @description Removes the declaration: the consumer stops being asked to maintain the
-         *     replica and loses the backup access the declaration granted. Requires the
-         *     caller to be on the admin allow-list. Responds 404 if the declaration
-         *     does not exist.
+         *     replica and loses the backup access the declaration granted. Any active
+         *     restore-verification alert for the declaration's scope is recovered, since
+         *     nothing tracks that scope any more. Requires the caller to be on the admin
+         *     allow-list. Responds 404 if the declaration does not exist.
          */
         post: operations["restore_replicas_delete"];
         delete?: never;


### PR DESCRIPTION
🤖 Pre-existing bug found while making replica scope editable: `RestoreReplica::delete` was a bare row delete, so an active restore-verification alert for the deleted replica's `(server, type, intent)` stayed open forever — the overdue sweep only walks current declarations and would never recover it.

Delete now recovers active alerts for the removed scope (every live server in the group for a group-wide declaration) before the row goes away, using the same group-event primitive the healthy-report path uses.

DB tests cover the single-server and group-wide cases. Conflicts trivially with the scope-editing PR (same helper introduced on both); whichever merges second keeps this branch's neutral wording and both call sites, and regenerates the specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)