### PR TITLE
feat(private-server): grant admin from tailnet policy capability

### DIFF
--- a/.workhorse/specs/private-server/admin-access.md
+++ b/.workhorse/specs/private-server/admin-access.md
@@ -1,0 +1,49 @@
+---
+id: ADM
+---
+
+# Administrative access
+
+The private server's administrative surface is restricted to administrators.
+Whether a caller is an administrator is decided at request time from the caller's authenticated tailnet identity.
+This concerns human operators of the administrative API and is distinct from the device administrator role (see [DTR](device-trust.md)).
+
+## Who is an administrator
+
+A caller is an administrator when either:
+
+- their login is on the recorded administrator allowlist, or
+- the tailnet policy grants them the Canopy administrator capability.
+
+The two sources are independent, and either alone suffices.
+An operator adds or removes an allowlist entry directly; the policy-granted set is authored in the tailnet policy and not editable through Canopy.
+
+## The administrator grant
+
+The tailnet policy confers administrative access through an application-capability grant.
+A grant confers administrative access when both hold:
+
+- its application capabilities include `bes.au/cap/canopy` with a value carrying `admin` set true, and
+- its destinations include the tag under which the Canopy service is published on the tailnet, `tag:server-canopy`.
+
+A capability value that does not carry `admin` set true confers no administrative access.
+The grant's sources name the principals who thereby become administrators.
+
+## Resolving grant sources
+
+Each source of an administrator-conferring grant is resolved, against the same policy, to the callers it covers:
+
+- A group resolves to its listed member logins.
+- A bare user login resolves to itself.
+- `autogroup:member` covers any caller bearing a tailnet user identity.
+- `autogroup:tagged` covers any caller identified only by a device tag.
+- Any other autogroup is not resolved and covers no caller.
+
+A caller holds policy-granted administrative access when their identity matches any resolved source of an administrator-conferring grant.
+The administrative surface admits only callers bearing a tailnet user identity, so a source resolving solely to tagged devices never yields administrative access in practice.
+
+## Freshness and availability
+
+Administrative status derived from the policy reflects the policy as of the most recent successful read, refreshed periodically.
+Reading the policy requires read access to the tailnet policy file.
+When the policy cannot be read, the recorded allowlist remains authoritative, so a control-plane outage never withdraws administrative access held through the allowlist.

--- a/crates/commons-servers/src/tailnet_directory.rs
+++ b/crates/commons-servers/src/tailnet_directory.rs
@@ -12,7 +12,7 @@
 //! the internet edge by type-system construction.
 
 use std::{
-	collections::HashMap,
+	collections::{HashMap, HashSet},
 	net::IpAddr,
 	sync::Arc,
 	time::{Duration, Instant},
@@ -103,6 +103,92 @@ struct Cache {
 	by_ip: HashMap<IpAddr, DirectoryEntry>,
 	by_node_id: HashMap<String, DirectoryEntry>,
 	last_refresh: Option<Instant>,
+	/// Administrators derived from the tailnet policy's `bes.au/cap/canopy`
+	/// grants, recomputed on each successful policy read. Empty until the
+	/// first successful read; a failed read leaves the previous value in
+	/// place so a control-plane outage never withdraws policy-granted admin.
+	admin: AdminGrants,
+}
+
+/// The Canopy application capability whose `admin: true` payload confers
+/// administrative access, and the service tag a conferring grant must target.
+const CANOPY_ADMIN_CAP: &str = "bes.au/cap/canopy";
+const CANOPY_SERVICE_TAG: &str = "tag:server-canopy";
+
+/// Administrative access resolved from the tailnet policy.
+#[derive(Debug, Default, Clone)]
+struct AdminGrants {
+	/// Explicit logins granted admin, from group members and bare user
+	/// sources, lowercased for case-insensitive comparison.
+	logins: HashSet<String>,
+	/// True when a conferring grant's source covers every tailnet user
+	/// identity (`autogroup:member`).
+	all_members: bool,
+}
+
+/// The subset of the tailnet policy file this directory reads.
+#[derive(Debug, Deserialize)]
+struct PolicyFile {
+	#[serde(default)]
+	groups: HashMap<String, Vec<String>>,
+	#[serde(default)]
+	grants: Vec<Grant>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Grant {
+	#[serde(default)]
+	src: Vec<String>,
+	#[serde(default)]
+	dst: Vec<String>,
+	#[serde(default)]
+	app: HashMap<String, Vec<serde_json::Value>>,
+}
+
+/// Resolve the set of administrators a policy file confers through
+/// `bes.au/cap/canopy` grants targeting the Canopy service tag.
+fn resolve_admins(policy: &PolicyFile) -> AdminGrants {
+	let mut out = AdminGrants::default();
+	for grant in &policy.grants {
+		let confers = grant.app.get(CANOPY_ADMIN_CAP).is_some_and(|values| {
+			values
+				.iter()
+				.any(|v| v.get("admin").and_then(serde_json::Value::as_bool) == Some(true))
+		});
+		if !confers {
+			continue;
+		}
+		if !grant.dst.iter().any(|d| d == CANOPY_SERVICE_TAG) {
+			continue;
+		}
+		for src in &grant.src {
+			match src.as_str() {
+				"autogroup:member" => out.all_members = true,
+				// Tagged devices never reach the administrative surface, so a
+				// tagged source contributes no administrative login.
+				"autogroup:tagged" => {}
+				s if s.starts_with("autogroup:") => {
+					tracing::warn!(source = %s, "canopy admin grant uses an unsupported autogroup; ignoring");
+				}
+				s if s.starts_with("group:") => match policy.groups.get(s) {
+					Some(members) => {
+						out.logins
+							.extend(members.iter().map(|m| m.to_ascii_lowercase()));
+					}
+					None => {
+						tracing::warn!(group = %s, "canopy admin grant references an undefined group; ignoring");
+					}
+				},
+				s if s.contains('@') => {
+					out.logins.insert(s.to_ascii_lowercase());
+				}
+				s => {
+					tracing::warn!(source = %s, "canopy admin grant uses an unsupported source; ignoring");
+				}
+			}
+		}
+	}
+	out
 }
 
 #[derive(Debug, Default)]
@@ -168,6 +254,11 @@ impl TailnetDirectory {
 		};
 
 		directory.refresh().await?;
+		// Non-fatal: without the policy read (e.g. the OAuth client lacks the
+		// policy-file read scope) admin access falls back to the allowlist.
+		if let Err(e) = directory.refresh_policy().await {
+			tracing::warn!(error = %e, "initial tailnet policy read failed; admin access falls back to the allowlist");
+		}
 
 		let bg = directory.clone();
 		tokio::spawn(async move {
@@ -177,10 +268,22 @@ impl TailnetDirectory {
 				if let Err(e) = bg.refresh().await {
 					tracing::warn!(error = %e, "tailnet directory refresh failed");
 				}
+				if let Err(e) = bg.refresh_policy().await {
+					tracing::warn!(error = %e, "tailnet policy refresh failed");
+				}
 			}
 		});
 
 		Ok(directory)
+	}
+
+	/// True when the login is granted administrative access by the tailnet
+	/// policy — either explicitly (a group member or named user) or because
+	/// a conferring grant covers every tailnet member. Case-insensitive.
+	pub async fn is_admin_by_policy(&self, login: &str) -> bool {
+		let login = login.to_ascii_lowercase();
+		let cache = self.inner.cache.read().await;
+		cache.admin.all_members || cache.admin.logins.contains(&login)
 	}
 
 	/// Lookup a tailnet IP. Returns `None` for unknown IPs. On a miss the
@@ -369,6 +472,61 @@ impl TailnetDirectory {
 		Ok(())
 	}
 
+	/// Force-refresh the administrator set from the tailnet policy file.
+	pub async fn refresh_policy(&self) -> Result<()> {
+		let token = self.access_token().await?;
+		let url = format!(
+			"{}/api/v2/tailnet/{}/acl",
+			self.inner.config.api_base.trim_end_matches('/'),
+			self.inner.config.tailnet,
+		);
+		let resp = self
+			.inner
+			.client
+			.get(&url)
+			.bearer_auth(&token)
+			.header(reqwest::header::ACCEPT, "application/json")
+			.send()
+			.await
+			.map_err(|e| AppError::custom(format!("tailscale policy request: {e}")))?;
+
+		if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+			self.inner.oauth.write().await.token = None;
+			let token = self.access_token().await?;
+			let retry = self
+				.inner
+				.client
+				.get(&url)
+				.bearer_auth(&token)
+				.header(reqwest::header::ACCEPT, "application/json")
+				.send()
+				.await
+				.map_err(|e| AppError::custom(format!("tailscale policy retry: {e}")))?;
+			return self.ingest_policy(retry).await;
+		}
+
+		self.ingest_policy(resp).await
+	}
+
+	async fn ingest_policy(&self, resp: reqwest::Response) -> Result<()> {
+		if !resp.status().is_success() {
+			let status = resp.status();
+			let body = resp.text().await.unwrap_or_default();
+			return Err(AppError::custom(format!(
+				"tailscale policy: {status}: {body}"
+			)));
+		}
+		let policy: PolicyFile = resp
+			.json()
+			.await
+			.map_err(|e| AppError::custom(format!("decoding policy response: {e}")))?;
+
+		let admin = resolve_admins(&policy);
+		let mut cache = self.inner.cache.write().await;
+		cache.admin = admin;
+		Ok(())
+	}
+
 	async fn access_token(&self) -> Result<String> {
 		{
 			let state = self.inner.oauth.read().await;
@@ -438,6 +596,7 @@ impl TailnetDirectory {
 			by_ip,
 			by_node_id,
 			last_refresh: Some(Instant::now()),
+			admin: AdminGrants::default(),
 		};
 		Self {
 			inner: Arc::new(Inner {
@@ -516,6 +675,86 @@ mod tests {
 		assert!(!is_tailnet_ip(IpAddr::V6(
 			"2001:db8::1".parse::<Ipv6Addr>().unwrap()
 		)));
+	}
+
+	fn policy(json: serde_json::Value) -> PolicyFile {
+		serde_json::from_value(json).unwrap()
+	}
+
+	#[test]
+	fn group_source_resolves_to_members() {
+		let admins = resolve_admins(&policy(serde_json::json!({
+			"groups": { "group:ops": ["Felix@BES.au", "sam@bes.au"] },
+			"grants": [{
+				"app": { "bes.au/cap/canopy": [{ "admin": true }] },
+				"dst": ["tag:server-canopy"],
+				"src": ["group:ops"],
+			}],
+		})));
+		assert!(!admins.all_members);
+		assert!(admins.logins.contains("felix@bes.au"));
+		assert!(admins.logins.contains("sam@bes.au"));
+	}
+
+	#[test]
+	fn bare_user_and_autogroup_member_sources() {
+		let admins = resolve_admins(&policy(serde_json::json!({
+			"grants": [{
+				"app": { "bes.au/cap/canopy": [{ "admin": true }] },
+				"dst": ["tag:server-canopy"],
+				"src": ["dana@bes.au", "autogroup:member"],
+			}],
+		})));
+		assert!(admins.all_members);
+		assert!(admins.logins.contains("dana@bes.au"));
+	}
+
+	#[test]
+	fn grant_needs_the_service_tag_and_admin_true() {
+		// Wrong dst: not conferring.
+		let wrong_dst = resolve_admins(&policy(serde_json::json!({
+			"groups": { "group:ops": ["felix@bes.au"] },
+			"grants": [{
+				"app": { "bes.au/cap/canopy": [{ "admin": true }] },
+				"dst": ["tag:server-other"],
+				"src": ["group:ops"],
+			}],
+		})));
+		assert!(wrong_dst.logins.is_empty() && !wrong_dst.all_members);
+
+		// Payload without `admin: true`: not conferring.
+		let no_admin = resolve_admins(&policy(serde_json::json!({
+			"groups": { "group:ops": ["felix@bes.au"] },
+			"grants": [{
+				"app": { "bes.au/cap/canopy": [{ "admin": false }] },
+				"dst": ["tag:server-canopy"],
+				"src": ["group:ops"],
+			}],
+		})));
+		assert!(no_admin.logins.is_empty() && !no_admin.all_members);
+
+		// Different capability: not conferring.
+		let other_cap = resolve_admins(&policy(serde_json::json!({
+			"groups": { "group:ops": ["felix@bes.au"] },
+			"grants": [{
+				"app": { "bes.au/cap/other": [{ "admin": true }] },
+				"dst": ["tag:server-canopy"],
+				"src": ["group:ops"],
+			}],
+		})));
+		assert!(other_cap.logins.is_empty() && !other_cap.all_members);
+	}
+
+	#[test]
+	fn unsupported_sources_are_ignored() {
+		let admins = resolve_admins(&policy(serde_json::json!({
+			"grants": [{
+				"app": { "bes.au/cap/canopy": [{ "admin": true }] },
+				"dst": ["tag:server-canopy"],
+				"src": ["autogroup:tagged", "tag:server-canopy", "*", "autogroup:admin"],
+			}],
+		})));
+		assert!(admins.logins.is_empty() && !admins.all_members);
 	}
 
 	#[test]

--- a/crates/commons-servers/src/tailscale_auth.rs
+++ b/crates/commons-servers/src/tailscale_auth.rs
@@ -4,6 +4,8 @@ use database::{Db, admins::Admin, tailscale_users::TailscaleUser as CachedTailsc
 use diesel_async::AsyncPgConnection;
 use http::request::Parts;
 
+use crate::tailnet_directory::TailnetDirectory;
+
 const TAILSCALE_USER_LOGIN: &str = "Tailscale-User-Login";
 const TAILSCALE_USER_NAME: &str = "Tailscale-User-Name";
 const TAILSCALE_USER_PROFILE_PIC: &str = "Tailscale-User-Profile-Pic";
@@ -16,8 +18,24 @@ pub struct TailscaleUser {
 }
 
 impl TailscaleUser {
-	pub async fn is_admin(&self, db: &mut AsyncPgConnection) -> Result<bool, AppError> {
-		Admin::check_email(db, &self.login).await
+	/// Admin if the login is on the recorded allowlist, or the tailnet policy
+	/// grants it admin (see [`crate::tailnet_directory`]). The allowlist is
+	/// checked first, so an unreachable control plane can't lock out an
+	/// allowlisted admin.
+	pub async fn is_admin(
+		&self,
+		db: &mut AsyncPgConnection,
+		directory: Option<&TailnetDirectory>,
+	) -> Result<bool, AppError> {
+		if Admin::check_email(db, &self.login).await? {
+			return Ok(true);
+		}
+		if let Some(directory) = directory
+			&& directory.is_admin_by_policy(&self.login).await
+		{
+			return Ok(true);
+		}
+		Ok(false)
 	}
 }
 
@@ -113,6 +131,7 @@ pub struct TailscaleAdmin(pub TailscaleUser);
 impl<S> FromRequestParts<S> for TailscaleAdmin
 where
 	Db: FromRef<S>,
+	Option<TailnetDirectory>: FromRef<S>,
 	S: Send + Sync,
 {
 	type Rejection = AppError;
@@ -128,7 +147,8 @@ where
 			let user =
 				<TailscaleUser as FromRequestParts<S>>::from_request_parts(parts, state).await?;
 			let mut db = Db::from_ref(state).get().await?;
-			if !user.is_admin(&mut db).await? {
+			let directory = Option::<TailnetDirectory>::from_ref(state);
+			if !user.is_admin(&mut db, directory.as_ref()).await? {
 				return Err(AppError::AuthInsufficientPermissions {
 					required: "admin".into(),
 				});

--- a/crates/private-server/src/fns/commons.rs
+++ b/crates/private-server/src/fns/commons.rs
@@ -52,7 +52,7 @@ pub async fn server_versions_url() -> Result<Json<Option<String>>> {
 	path = "/is_current_user_admin",
 	tag = "commons",
 	responses(
-		(status = 200, description = "`true` if the caller's Tailscale identity is on the admin allow-list; `false` otherwise (including when no Tailscale identity is present).", body = bool, content_type = "application/json"),
+		(status = 200, description = "`true` if the caller's Tailscale identity is an administrator (on the admin allow-list, or granted admin by the tailnet policy); `false` otherwise (including when no Tailscale identity is present).", body = bool, content_type = "application/json"),
 	),
 )]
 pub async fn is_current_user_admin(

--- a/crates/private-server/src/openapi.rs
+++ b/crates/private-server/src/openapi.rs
@@ -68,7 +68,7 @@ impl Modify for SecuritySchemes {
 			"tailscale-admin",
 			SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::with_description(
 				"Tailscale-User-Login",
-				"Identity header injected by the Tailscale sidecar. The login value must also be present on the admins allow-list.",
+				"Identity header injected by the Tailscale sidecar. The login must additionally be an administrator: either on the admins allow-list, or granted admin by the tailnet policy.",
 			))),
 		);
 	}

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1494,7 +1494,7 @@
         "operationId": "is_current_user_admin",
         "responses": {
           "200": {
-            "description": "`true` if the caller's Tailscale identity is on the admin allow-list; `false` otherwise (including when no Tailscale identity is present).",
+            "description": "`true` if the caller's Tailscale identity is an administrator (on the admin allow-list, or granted admin by the tailnet policy); `false` otherwise (including when no Tailscale identity is present).",
             "content": {
               "application/json": {
                 "schema": {
@@ -11483,7 +11483,7 @@
         "type": "apiKey",
         "in": "header",
         "name": "Tailscale-User-Login",
-        "description": "Identity header injected by the Tailscale sidecar. The login value must also be present on the admins allow-list."
+        "description": "Identity header injected by the Tailscale sidecar. The login must additionally be an administrator: either on the admins allow-list, or granted admin by the tailnet policy."
       },
       "tailscale-user": {
         "type": "apiKey",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -5642,7 +5642,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description `true` if the caller's Tailscale identity is on the admin allow-list; `false` otherwise (including when no Tailscale identity is present). */
+            /** @description `true` if the caller's Tailscale identity is an administrator (on the admin allow-list, or granted admin by the tailnet policy); `false` otherwise (including when no Tailscale identity is present). */
             200: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
🤖 Administrators of the private-server admin API can now be defined by the tailnet policy, in addition to the existing email allowlist.

## What

Admin status is now the **union** of two sources, evaluated per request against the caller Tailscale identity:

- the recorded admin allowlist (unchanged), and
- administrators derived from the tailnet policy.

A grant confers admin when it carries the `bes.au/cap/canopy` application capability with `admin: true` and its destination includes `tag:server-canopy`. The grant sources are resolved against the same policy:

- a `group:` source expands to its member logins;
- a bare user login resolves to itself;
- `autogroup:member` covers every tailnet user;
- `autogroup:tagged`, other autogroups, tags, and `*` resolve to nothing (fail-closed, logged).

The allowlist is checked first, so an unreachable control plane can never lock out an allowlisted admin. A failed policy read leaves the previous grant set in place rather than clearing it.

The policy is read on the same refresh loop as the tailnet device directory, so admin membership reflects the policy as of the last successful read.

## Deploy note

The Tailscale OAuth client must gain the `policy_file:read` scope. Without it the policy read returns 403 (logged each cycle) and admin falls back to the allowlist only.

## Spec

`ADM` — `.workhorse/specs/private-server/admin-access.md`.