### PR TITLE
feat(backup): per-server restore window for ad-hoc restores

### DIFF
--- a/crates/database/src/bin/seed.rs
+++ b/crates/database/src/bin/seed.rs
@@ -609,6 +609,8 @@ async fn seed_servers(
 			tags: TagMap::default(),
 			deleted_at: None,
 			registered_at: None,
+			restore_allowed_until: None,
+			restore_allowed_by: None,
 		}
 	}
 

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -493,6 +493,8 @@ diesel::table! {
 		deleted_at -> Nullable<Timestamptz>,
 		registered_at -> Nullable<Timestamptz>,
 		allow_legacy_status -> Bool,
+		restore_allowed_until -> Nullable<Timestamptz>,
+		restore_allowed_by -> Nullable<Text>,
 	}
 }
 

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -14,6 +14,11 @@ use super::url_field::UrlField;
 
 const TEN_MINUTES: PgDuration = PgDuration(SignedDuration::from_secs(600));
 
+/// How long a restore window stays open once an operator allows restores for a
+/// server. Restores read the group's backup repo, so the window is deliberately
+/// short-lived; opening it again re-arms it from the moment of the new request.
+const RESTORE_WINDOW: SignedDuration = SignedDuration::from_hours(24);
+
 /// Recompute each distinct, present group id, deduping repeats and skipping
 /// `None`. Used by the server write paths that can change a group's canonical
 /// member (membership/rank/kind/delete).
@@ -127,6 +132,23 @@ pub struct Server {
 		treat_none_as_default_value = false
 	)]
 	pub registered_at: Option<Timestamp>,
+	/// Until when this server is allowed to mint restore credentials for
+	/// itself (ad-hoc `bestool canopy restore`). An operator opens this
+	/// window and it auto-expires; `None` (or a past instant) means restores
+	/// are not currently allowed. Restores read the group's backup repo, so
+	/// they're gated behind this deliberate, time-boxed opt-in rather than
+	/// always available.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[diesel(
+		deserialize_as = jiff_diesel::NullableTimestamp,
+		serialize_as = jiff_diesel::NullableTimestamp,
+		treat_none_as_default_value = false
+	)]
+	pub restore_allowed_until: Option<Timestamp>,
+	/// Who opened the current restore window (Tailscale login), if any.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[diesel(treat_none_as_default_value = false)]
+	pub restore_allowed_by: Option<String>,
 }
 
 impl Server {
@@ -408,6 +430,52 @@ impl Server {
 			.await
 			.map_err(AppError::from)?;
 		Ok(())
+	}
+
+	/// Open the restore window for a server: allow it to mint restore
+	/// credentials for itself until [`RESTORE_WINDOW`] from now. Re-arming an
+	/// already-open window resets the expiry. Returns the new expiry so callers
+	/// can echo it back to the operator. `allowed_by` is the operator's identity
+	/// (Tailscale login) for audit.
+	pub async fn allow_restore(
+		db: &mut AsyncPgConnection,
+		server_id: Uuid,
+		allowed_by: Option<&str>,
+	) -> Result<Timestamp> {
+		use crate::schema::servers::dsl;
+		let until = Timestamp::now() + RESTORE_WINDOW;
+		diesel::update(dsl::servers.filter(dsl::id.eq(server_id)))
+			.set((
+				dsl::restore_allowed_until.eq(jiff_diesel::NullableTimestamp::from(Some(until))),
+				dsl::restore_allowed_by.eq(allowed_by),
+			))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(until)
+	}
+
+	/// Close the restore window for a server immediately (clears both the
+	/// expiry and the recorded operator). Clearing an already-closed window is a
+	/// no-op.
+	pub async fn disallow_restore(db: &mut AsyncPgConnection, server_id: Uuid) -> Result<()> {
+		use crate::schema::servers::dsl;
+		diesel::update(dsl::servers.filter(dsl::id.eq(server_id)))
+			.set((
+				dsl::restore_allowed_until.eq(jiff_diesel::NullableTimestamp::from(None)),
+				dsl::restore_allowed_by.eq::<Option<String>>(None),
+			))
+			.execute(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(())
+	}
+
+	/// Whether this server's restore window is currently open (set and not yet
+	/// expired).
+	pub fn restore_allowed(&self) -> bool {
+		self.restore_allowed_until
+			.is_some_and(|until| until > Timestamp::now())
 	}
 
 	pub async fn get_by_device_id(db: &mut AsyncPgConnection, dev_id: Uuid) -> Result<Vec<Self>> {
@@ -763,6 +831,8 @@ fn test_server_serialization() {
 		tags: TagMap::default(),
 		deleted_at: None,
 		registered_at: None,
+		restore_allowed_until: None,
+		restore_allowed_by: None,
 	};
 
 	let serialized = serde_json::to_string_pretty(&server).unwrap();
@@ -826,6 +896,8 @@ impl From<NewServer> for Server {
 			tags: TagMap::default(),
 			deleted_at: None,
 			registered_at: None,
+			restore_allowed_until: None,
+			restore_allowed_by: None,
 		}
 	}
 }

--- a/crates/database/tests/server_enrollment.rs
+++ b/crates/database/tests/server_enrollment.rs
@@ -27,6 +27,8 @@ fn new_server(host: &str) -> Server {
 		tags: TagMap::default(),
 		deleted_at: None,
 		registered_at: None,
+		restore_allowed_until: None,
+		restore_allowed_by: None,
 	}
 }
 

--- a/crates/database/tests/server_restore_window.rs
+++ b/crates/database/tests/server_restore_window.rs
@@ -1,0 +1,87 @@
+//! Model-level tests for the per-server restore window.
+
+use commons_types::server::{TagMap, kind::ServerKind};
+use database::{pg_duration::PgDuration, servers::Server, url_field::UrlField};
+use jiff::{SignedDuration, Timestamp};
+use uuid::Uuid;
+
+fn new_server() -> Server {
+	Server {
+		id: Uuid::new_v4(),
+		name: Some("t".into()),
+		host: Some(UrlField("https://restore.example/".parse().unwrap())),
+		kind: ServerKind::Central,
+		rank: None,
+		device_id: None,
+		group_id: None,
+		public_name: None,
+		cloud: None,
+		geolocation: None,
+		is_monitored: true,
+		allow_legacy_status: false,
+		alert_when_down_for: PgDuration(SignedDuration::from_secs(600)),
+		notes: String::new(),
+		tags: TagMap::default(),
+		deleted_at: None,
+		registered_at: None,
+		restore_allowed_until: None,
+		restore_allowed_by: None,
+	}
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_window_opens_for_a_day_then_closes() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		let created = Server::create(&mut conn, new_server()).await.unwrap();
+		assert!(!created.restore_allowed(), "restores start disallowed");
+		assert!(created.restore_allowed_until.is_none());
+
+		// Opening the window returns an expiry roughly a day out.
+		let until = Server::allow_restore(&mut conn, created.id, Some("op@example"))
+			.await
+			.unwrap();
+		let secs = until.duration_since(Timestamp::now()).as_secs();
+		assert!(
+			(23 * 3600..=25 * 3600).contains(&secs),
+			"window should be ~24h, got {secs}s"
+		);
+
+		let reloaded = Server::get_by_id(&mut conn, created.id).await.unwrap();
+		assert!(reloaded.restore_allowed(), "window is open");
+		// Postgres `timestamptz` keeps microseconds, so the round-tripped value
+		// drops the nanosecond tail of the returned instant — compare with a
+		// tolerance rather than for exact equality.
+		let stored = reloaded.restore_allowed_until.expect("expiry persisted");
+		assert!(
+			stored.duration_since(until).as_secs().abs() <= 1,
+			"stored expiry {stored} should match the returned {until}"
+		);
+		assert_eq!(reloaded.restore_allowed_by.as_deref(), Some("op@example"));
+
+		// Closing the window clears both the expiry and the recorded operator.
+		Server::disallow_restore(&mut conn, created.id)
+			.await
+			.unwrap();
+		let reloaded = Server::get_by_id(&mut conn, created.id).await.unwrap();
+		assert!(!reloaded.restore_allowed(), "window is closed");
+		assert!(reloaded.restore_allowed_until.is_none());
+		assert!(reloaded.restore_allowed_by.is_none());
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn expired_window_reads_as_closed() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		let mut server = new_server();
+		// A window that already lapsed: set but in the past.
+		server.restore_allowed_until = Some(Timestamp::now() - SignedDuration::from_hours(1));
+		server.restore_allowed_by = Some("op@example".into());
+		let created = Server::create(&mut conn, server).await.unwrap();
+		assert!(
+			!created.restore_allowed(),
+			"a past expiry must read as closed"
+		);
+	})
+	.await;
+}

--- a/crates/database/tests/tag_reserved_prefix.rs
+++ b/crates/database/tests/tag_reserved_prefix.rs
@@ -40,6 +40,8 @@ fn new_server(host: &str) -> Server {
 		tags: TagMap::default(),
 		deleted_at: None,
 		registered_at: None,
+		restore_allowed_until: None,
+		restore_allowed_by: None,
 	}
 }
 

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -64,6 +64,9 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(create_repo))
 		.routes(routes!(request_now))
 		.routes(routes!(cancel_request))
+		.routes(routes!(restore_window))
+		.routes(routes!(allow_restore))
+		.routes(routes!(disallow_restore))
 		.routes(routes!(request_maintenance))
 		.routes(routes!(cancel_maintenance))
 		.routes(routes!(stats))
@@ -357,6 +360,10 @@ pub struct BackupStatsView {
 	/// enabled state), so the "back up now" panel can offer the right types per
 	/// server and grey out servers that have declared none.
 	pub capabilities: Vec<ServerBackupCapabilityView>,
+	/// Member servers whose restore window is currently open, so the panel can
+	/// show which servers may restore right now and until when. Servers with no
+	/// open window are omitted.
+	pub restore_windows: Vec<RestoreWindowRow>,
 	/// Total raw S3 bytes uploaded to the bucket by the group's device backup
 	/// runs so far this calendar month (UTC). Repo maintenance/inspection
 	/// traffic isn't tallied anywhere, so this undercounts the bucket's
@@ -366,6 +373,46 @@ pub struct BackupStatsView {
 	/// backup runs so far this calendar month (UTC). Same undercount caveat
 	/// as `s3_month_sent_bytes`.
 	pub s3_month_received_bytes: i64,
+}
+
+/// A server's currently-open restore window, as shown in the group stats.
+#[derive(Serialize, ToSchema)]
+pub struct RestoreWindowRow {
+	/// The server the window applies to.
+	pub server_id: Uuid,
+	/// When the window closes; the server may mint restore credentials until
+	/// then.
+	pub allowed_until: Timestamp,
+	/// Who opened the window (Tailscale login), if known.
+	pub allowed_by: Option<String>,
+}
+
+/// A single server's restore-window state, for the server detail page.
+#[derive(Serialize, ToSchema)]
+pub struct RestoreWindowView {
+	/// When the restore window closes, or `null` if restores are not currently
+	/// allowed for this server.
+	pub allowed_until: Option<Timestamp>,
+	/// Who opened the current window (Tailscale login), if known.
+	pub allowed_by: Option<String>,
+}
+
+impl RestoreWindowView {
+	/// The window as reported to operators: reflects the stored values only
+	/// while the window is still open, so an expired window reads as closed.
+	fn of(server: &database::servers::Server) -> Self {
+		if server.restore_allowed() {
+			Self {
+				allowed_until: server.restore_allowed_until,
+				allowed_by: server.restore_allowed_by.clone(),
+			}
+		} else {
+			Self {
+				allowed_until: None,
+				allowed_by: None,
+			}
+		}
+	}
 }
 
 /// Effective scheduled interval (seconds) for a `(group, type)`: the per-group
@@ -1394,6 +1441,91 @@ pub async fn cancel_request(
 	Ok(Json(()))
 }
 
+/// The current restore-window state for a server.
+///
+/// Reports until when the server may mint restore credentials for itself, or
+/// `null` if restores are not currently allowed (never opened, or expired).
+#[utoipa::path(
+	post,
+	path = "/restore_window",
+	operation_id = "backups_restore_window",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = ServerArgs,
+	responses(
+		(status = 200, body = RestoreWindowView),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn restore_window(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<ServerArgs>,
+) -> Result<Json<RestoreWindowView>> {
+	let mut conn = state.db.get().await?;
+	let server = Server::get_by_id(&mut conn, args.server_id).await?;
+	Ok(Json(RestoreWindowView::of(&server)))
+}
+
+/// Allow this server to restore for the next 24 hours.
+///
+/// Opens the server's restore window so an operator can run an ad-hoc
+/// `bestool canopy restore` on it: while the window is open the device can mint
+/// read-only restore credentials for its group's backup repository. The window
+/// auto-expires after 24 hours; calling again re-arms it from now. Returns the
+/// new window. Restores are gated behind this deliberate opt-in because they
+/// grant read access to the group's entire backup history.
+#[utoipa::path(
+	post,
+	path = "/allow_restore",
+	operation_id = "backups_allow_restore",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = ServerArgs,
+	responses(
+		(status = 200, body = RestoreWindowView),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn allow_restore(
+	State(state): State<AppState>,
+	TailscaleAdmin(admin): TailscaleAdmin,
+	Json(args): Json<ServerArgs>,
+) -> Result<Json<RestoreWindowView>> {
+	let mut conn = state.db.get().await?;
+	let allowed_until =
+		Server::allow_restore(&mut conn, args.server_id, Some(&admin.login)).await?;
+	Ok(Json(RestoreWindowView {
+		allowed_until: Some(allowed_until),
+		allowed_by: Some(admin.login),
+	}))
+}
+
+/// Stop allowing this server to restore, immediately.
+///
+/// Closes the server's restore window now, before its 24-hour expiry. Any
+/// credentials already minted keep their (at most one hour) validity, but no
+/// new restore credentials can be minted until an operator allows restores
+/// again. Closing an already-closed window succeeds without effect.
+#[utoipa::path(
+	post,
+	path = "/disallow_restore",
+	operation_id = "backups_disallow_restore",
+	tag = "backups",
+	security(("tailscale-admin" = [])),
+	request_body = ServerArgs,
+	responses((status = 200)),
+)]
+pub async fn disallow_restore(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<ServerArgs>,
+) -> Result<Json<()>> {
+	let mut conn = state.db.get().await?;
+	Server::disallow_restore(&mut conn, args.server_id).await?;
+	Ok(Json(()))
+}
+
 /// Request an out-of-cycle full maintenance run for a group's backup
 /// repository.
 ///
@@ -1516,7 +1648,17 @@ pub async fn stats(
 		std::collections::HashMap::new();
 	let mut pending_requests = Vec::new();
 	let mut capabilities = Vec::new();
+	let mut restore_windows = Vec::new();
 	for server in &members {
+		if server.restore_allowed() {
+			if let Some(allowed_until) = server.restore_allowed_until {
+				restore_windows.push(RestoreWindowRow {
+					server_id: server.id,
+					allowed_until,
+					allowed_by: server.restore_allowed_by.clone(),
+				});
+			}
+		}
 		for req in BackupRequest::pending_for_server(&mut conn, server.id).await? {
 			pending_requests.push(PendingRequestRow {
 				server_id: req.server_id,
@@ -1569,6 +1711,7 @@ pub async fn stats(
 		recent_maintenance,
 		pending_requests,
 		capabilities,
+		restore_windows,
 		s3_month_sent_bytes,
 		s3_month_received_bytes,
 	}))

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -915,6 +915,8 @@ pub async fn create(
 		tags: args.tags.unwrap_or_default(),
 		deleted_at: None,
 		registered_at: None,
+		restore_allowed_until: None,
+		restore_allowed_by: None,
 	};
 
 	let created = Server::create(&mut conn, server).await?;

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -439,6 +439,87 @@ async fn request_now_upserts_and_cancel_deletes() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn allow_disallow_restore_window_round_trip() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let server_id = Uuid::new_v4();
+		conn.batch_execute(&format!(
+			"INSERT INTO servers (id, host, kind, group_id) VALUES \
+				('{server_id}', 'https://e.test', 'central', '{group_id}');"
+		))
+		.await
+		.expect("seed server");
+
+		let args = serde_json::json!({ "server_id": server_id });
+
+		// Initially closed: no window, and stats lists no open windows.
+		let win = private
+			.post("/api/backups/restore_window")
+			.json(&args)
+			.await;
+		win.assert_status_ok();
+		assert!(
+			win.json::<serde_json::Value>()["allowed_until"].is_null(),
+			"restores start disallowed"
+		);
+
+		// Allow → the endpoint echoes a future expiry.
+		let allowed = private.post("/api/backups/allow_restore").json(&args).await;
+		allowed.assert_status_ok();
+		assert!(
+			allowed.json::<serde_json::Value>()["allowed_until"].is_string(),
+			"allow_restore opens the window"
+		);
+
+		// The window is visible via both the per-server getter and group stats.
+		let win = private
+			.post("/api/backups/restore_window")
+			.json(&args)
+			.await;
+		assert!(win.json::<serde_json::Value>()["allowed_until"].is_string());
+
+		let stats = private
+			.post("/api/backups/stats")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		let windows = stats.json::<serde_json::Value>()["restore_windows"]
+			.as_array()
+			.cloned()
+			.unwrap();
+		assert_eq!(windows.len(), 1, "one open window");
+		assert_eq!(windows[0]["server_id"], serde_json::json!(server_id));
+
+		// Disallow → closed again, and dropped from stats.
+		private
+			.post("/api/backups/disallow_restore")
+			.json(&args)
+			.await
+			.assert_status_ok();
+		let win = private
+			.post("/api/backups/restore_window")
+			.json(&args)
+			.await;
+		assert!(
+			win.json::<serde_json::Value>()["allowed_until"].is_null(),
+			"disallow_restore closes the window"
+		);
+		let stats = private
+			.post("/api/backups/stats")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		assert_eq!(
+			stats.json::<serde_json::Value>()["restore_windows"]
+				.as_array()
+				.unwrap()
+				.len(),
+			0,
+			"closed window is not listed"
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn request_maintenance_flags_and_cancel_clears() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -164,7 +164,7 @@
           "backup"
         ],
         "summary": "Mint short-lived S3 credentials for a backup or restore run.",
-        "description": "Issues temporary AWS credentials scoped to the backup storage of the\ncalling server's group, in the `credential_process` output format. With\n`purpose: backup` the credentials can upload and manage backup data but\ncannot destroy existing backups; with `purpose: restore` they are strictly\nread-only. They expire after at most one hour, so request a fresh set for\neach run rather than caching them. Every issuance is recorded for audit.\n\nThe storage coordinates the credentials apply to (bucket, prefix, region)\ncome from `GET /backup-target`.\n\nErrors: 409 when the server is not in a group, when the group's backup\nconfiguration is not ready, or when the requested type is neither an\nenabled capability of this server nor the subject of a pending\noperator-requested run of the given purpose; 412 when the device is not\nbound to a live server; 502 when the credential issuer is unavailable or\nnot configured.",
+        "description": "Issues temporary AWS credentials scoped to the backup storage of the\ncalling server's group, in the `credential_process` output format. With\n`purpose: backup` the credentials can upload and manage backup data but\ncannot destroy existing backups; with `purpose: restore` they are strictly\nread-only. They expire after at most one hour, so request a fresh set for\neach run rather than caching them. Every issuance is recorded for audit.\n\nThe storage coordinates the credentials apply to (bucket, prefix, region)\ncome from `GET /backup-target`.\n\nErrors: 409 when the server is not in a group, when the group's backup\nconfiguration is not ready, when a `backup` type is neither an enabled\ncapability of this server nor the subject of a pending \"backup now\" request,\nor when a `restore` is requested but the server's restore window is not\nopen; 412 when the device is not bound to a live server; 502 when the\ncredential issuer is unavailable or not configured.",
         "operationId": "mint_backup_credentials",
         "requestBody": {
           "content": {
@@ -188,7 +188,7 @@
             }
           },
           "409": {
-            "description": "Server ungrouped, no ready config, or type not enabled.",
+            "description": "Server ungrouped, no ready config, backup type not enabled, or restore window not open.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1237,7 +1237,7 @@
           },
           "type": {
             "type": "string",
-            "description": "The backup type the credentials are for (e.g. `tamanu-postgres`). The\ntype must be an enabled capability of this server, or the subject of a\npending operator-requested run matching `purpose`; otherwise the request\nis rejected with 409."
+            "description": "The backup type the credentials are for (e.g. `tamanu-postgres`). For a\n`backup`, the type must be an enabled capability of this server or the\nsubject of a pending \"backup now\" request; for a `restore`, the server's\nrestore window must be open (an operator allows restores for it in\ncanopy). Otherwise the request is rejected with 409."
           }
         }
       },

--- a/crates/public-server/src/backup.rs
+++ b/crates/public-server/src/backup.rs
@@ -13,8 +13,9 @@
 //!
 //! All four resolve `device → live server → group_id → group backup config`
 //! identically: **412** when the device is bound to no live server, **409**
-//! when the server is ungrouped / has no `ready` config / the type is neither
-//! an enabled capability nor has a pending request, **502** when STS or kube
+//! when the server is ungrouped / has no `ready` config / (for a backup) the
+//! type is neither an enabled capability nor has a pending request / (for a
+//! restore) the server's restore window isn't open, **502** when STS or kube
 //! fails or isn't configured.
 
 use aws_sdk_sts::operation::RequestId as _;
@@ -102,28 +103,44 @@ async fn require_ready_config(
 	Ok(cfg)
 }
 
-/// The per-`(server, type)` credential-issuance gate. Mirrors what the
-/// heartbeat is willing to ask the device to run: a type may be issued creds
-/// when it's an enabled capability (on the auto-schedule), or when an on-demand
-/// request of this `purpose` is pending (an operator "backup now" / restore).
-/// Neither ⇒ 409.
-async fn require_issuable_capability(
+/// The per-`(server, type)` **backup**-issuance gate. Mirrors what the heartbeat
+/// is willing to ask the device to back up: a type may be issued backup creds
+/// when it's an enabled capability (on the auto-schedule) or has a pending
+/// operator "backup now" request. Neither ⇒ 409.
+async fn require_backupable_capability(
 	conn: &mut database::diesel_async::AsyncPgConnection,
 	server_id: Uuid,
 	r#type: &BackupType,
-	purpose: BackupPurpose,
 ) -> Result<()> {
 	let enabled = ServerBackupCapability::list_for_server(conn, server_id)
 		.await?
 		.into_iter()
 		.any(|c| &c.r#type == r#type && c.enabled);
-	if enabled || BackupRequest::exists(conn, server_id, r#type, purpose).await? {
+	if enabled || BackupRequest::exists(conn, server_id, r#type, BackupPurpose::Backup).await? {
 		Ok(())
 	} else {
 		Err(AppError::Conflict(format!(
-			"backup type {type} is not an enabled capability for this server, and no {purpose} is pending",
+			"backup type {type} is not an enabled capability for this server, and no backup is pending",
 			type = r#type
 		)))
+	}
+}
+
+/// The **restore**-issuance gate: an operator must have opened the server's
+/// time-boxed restore window. Restore creds are read access to the group's
+/// entire backup history, so an ad-hoc `bestool canopy restore` self-authorizes
+/// only while that deliberate window is open — it is not always available.
+/// (Canopy still drives *automated* restores separately, via the PGRO
+/// restore-replica path.) Window closed or expired ⇒ 409.
+fn require_restore_allowed(server: &Server) -> Result<()> {
+	if server.restore_allowed() {
+		Ok(())
+	} else {
+		Err(AppError::Conflict(
+			"restores are not currently allowed for this server; \
+			 enable restores for it in canopy (they stay open for 24 hours)"
+				.into(),
+		))
 	}
 }
 
@@ -202,10 +219,11 @@ async fn capabilities(
 /// restore run.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct BackupCredentialsArgs {
-	/// The backup type the credentials are for (e.g. `tamanu-postgres`). The
-	/// type must be an enabled capability of this server, or the subject of a
-	/// pending operator-requested run matching `purpose`; otherwise the request
-	/// is rejected with 409.
+	/// The backup type the credentials are for (e.g. `tamanu-postgres`). For a
+	/// `backup`, the type must be an enabled capability of this server or the
+	/// subject of a pending "backup now" request; for a `restore`, the server's
+	/// restore window must be open (an operator allows restores for it in
+	/// canopy). Otherwise the request is rejected with 409.
 	#[schema(value_type = String)]
 	pub r#type: BackupType,
 	/// What the credentials will be used for. `backup` (the default) grants
@@ -323,11 +341,11 @@ pub fn backup_session_policy(bucket: &str, prefix: &str) -> String {
 /// come from `GET /backup-target`.
 ///
 /// Errors: 409 when the server is not in a group, when the group's backup
-/// configuration is not ready, or when the requested type is neither an
-/// enabled capability of this server nor the subject of a pending
-/// operator-requested run of the given purpose; 412 when the device is not
-/// bound to a live server; 502 when the credential issuer is unavailable or
-/// not configured.
+/// configuration is not ready, when a `backup` type is neither an enabled
+/// capability of this server nor the subject of a pending "backup now" request,
+/// or when a `restore` is requested but the server's restore window is not
+/// open; 412 when the device is not bound to a live server; 502 when the
+/// credential issuer is unavailable or not configured.
 #[utoipa::path(
 	post,
 	path = "/backup-credentials",
@@ -337,7 +355,7 @@ pub fn backup_session_policy(bucket: &str, prefix: &str) -> String {
 	request_body = BackupCredentialsArgs,
 	responses(
 		(status = 200, body = CredentialProcessOutput),
-		(status = 409, description = "Server ungrouped, no ready config, or type not enabled.", body = ProblemDetailsSchema),
+		(status = 409, description = "Server ungrouped, no ready config, backup type not enabled, or restore window not open.", body = ProblemDetailsSchema),
 		(status = 412, description = "Device is not bound to a live server.", body = ProblemDetailsSchema),
 		(status = 502, description = "STS issuance failed or is not configured.", body = ProblemDetailsSchema),
 	),
@@ -354,7 +372,12 @@ async fn credentials(
 	let server = resolve_server(&mut conn, device_id).await?;
 	let group_id = require_group(&server)?;
 	let cfg = require_ready_config(&mut conn, group_id).await?;
-	require_issuable_capability(&mut conn, server.id, &args.r#type, args.purpose).await?;
+	match args.purpose {
+		BackupPurpose::Backup => {
+			require_backupable_capability(&mut conn, server.id, &args.r#type).await?
+		}
+		BackupPurpose::Restore => require_restore_allowed(&server)?,
+	}
 
 	// Always attach a bucket-scoped session policy so the issued creds can only
 	// reach this group's bucket — redundant for a dedicated per-bucket role

--- a/crates/public-server/tests/backup.rs
+++ b/crates/public-server/tests/backup.rs
@@ -82,6 +82,24 @@ async fn declare_capability_disabled(conn: &mut AsyncPgConnection, server_id: Uu
 	.expect("insert disabled capability");
 }
 
+/// Open the server's restore window, expiring an hour from now.
+async fn allow_restore(conn: &mut AsyncPgConnection, server_id: Uuid) {
+	sql_query("UPDATE servers SET restore_allowed_until = now() + interval '1 hour' WHERE id = $1")
+		.bind::<sql_types::Uuid, _>(server_id)
+		.execute(conn)
+		.await
+		.expect("open restore window");
+}
+
+/// Set an already-expired restore window (was opened, but the 24h lapsed).
+async fn expire_restore(conn: &mut AsyncPgConnection, server_id: Uuid) {
+	sql_query("UPDATE servers SET restore_allowed_until = now() - interval '1 hour' WHERE id = $1")
+		.bind::<sql_types::Uuid, _>(server_id)
+		.execute(conn)
+		.await
+		.expect("expire restore window");
+}
+
 async fn enqueue_request(
 	conn: &mut AsyncPgConnection,
 	server_id: Uuid,
@@ -207,6 +225,81 @@ async fn credentials_disabled_capability_no_request_is_409() {
 				.json(&serde_json::json!({ "type": "tamanu-config" }))
 				.await;
 			resp.assert_status(http::StatusCode::CONFLICT);
+		},
+	)
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn credentials_restore_closed_window_is_409() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let group = make_group(&mut conn).await;
+			make_server(&mut conn, device_id, Some(group)).await;
+			make_config(&mut conn, group, "ready").await;
+			// Restore with no window ever opened: rejected, and the message must
+			// speak to the restore window rather than the backup-schedule gate.
+			let resp = public
+				.post("/backup-credentials")
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "type": "tamanu-postgres", "purpose": "restore" }))
+				.await;
+			resp.assert_status(http::StatusCode::CONFLICT);
+			let body = resp.text();
+			assert!(
+				body.contains("restores are not currently allowed"),
+				"restore 409 should mention the restore window, got: {body}"
+			);
+			assert!(
+				!body.contains("enabled capability"),
+				"restore 409 must not mention the backup-schedule gate, got: {body}"
+			);
+		},
+	)
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn credentials_restore_expired_window_is_409() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let group = make_group(&mut conn).await;
+			let server = make_server(&mut conn, device_id, Some(group)).await;
+			make_config(&mut conn, group, "ready").await;
+			// A window that was opened but has since lapsed reads as closed.
+			expire_restore(&mut conn, server).await;
+			let resp = public
+				.post("/backup-credentials")
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "type": "tamanu-postgres", "purpose": "restore" }))
+				.await;
+			resp.assert_status(http::StatusCode::CONFLICT);
+		},
+	)
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn credentials_restore_open_window_passes_gate() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let group = make_group(&mut conn).await;
+			let server = make_server(&mut conn, device_id, Some(group)).await;
+			make_config(&mut conn, group, "ready").await;
+			// An open window authorises the restore even though no backup type is
+			// enabled for this server (the disaster-recovery case: a fresh box
+			// restoring onto itself). The gate passes, so with no STS configured
+			// we reach the 502 issuer-unavailable branch rather than a 409.
+			allow_restore(&mut conn, server).await;
+			let resp = public
+				.post("/backup-credentials")
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({ "type": "tamanu-postgres", "purpose": "restore" }))
+				.await;
+			resp.assert_status(http::StatusCode::BAD_GATEWAY);
 		},
 	)
 	.await;
@@ -615,7 +708,9 @@ async fn credentials_restore_sends_session_policy() {
 		let group = make_group(&mut conn).await;
 		let server = make_server(&mut conn, device_id, Some(group)).await;
 		make_config(&mut conn, group, "ready").await;
-		enable_capability(&mut conn, server, "tamanu-postgres").await;
+		// Restores are authorised by an open restore window, not by the type
+		// being on the backup schedule.
+		allow_restore(&mut conn, server).await;
 
 		// The rule only matches if a session policy naming the bucket was sent.
 		let rule = assume_role_rule(Some("arn:aws:s3:::grp-bucket"));

--- a/crates/public-server/tests/server_enrollment.rs
+++ b/crates/public-server/tests/server_enrollment.rs
@@ -41,6 +41,8 @@ fn new_server(host: &str) -> Server {
 		tags: TagMap::default(),
 		deleted_at: None,
 		registered_at: None,
+		restore_allowed_until: None,
+		restore_allowed_by: None,
 	}
 }
 

--- a/migrations/2026-07-04-151253-0000_add_server_restore_window/down.sql
+++ b/migrations/2026-07-04-151253-0000_add_server_restore_window/down.sql
@@ -1,0 +1,3 @@
+alter table servers
+	drop column restore_allowed_until,
+	drop column restore_allowed_by;

--- a/migrations/2026-07-04-151253-0000_add_server_restore_window/up.sql
+++ b/migrations/2026-07-04-151253-0000_add_server_restore_window/up.sql
@@ -1,0 +1,6 @@
+-- A per-server, time-boxed window during which the server may mint restore
+-- credentials for itself (ad-hoc `bestool canopy restore`). An operator opens
+-- the window; it auto-expires. NULL means restores are not currently allowed.
+alter table servers
+	add column restore_allowed_until timestamptz,
+	add column restore_allowed_by text;

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -1184,3 +1184,91 @@ test.describe("backups ready: repo maintenance panel", () => {
 		).toBeDisabled();
 	});
 });
+
+test.describe("restore window", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("group backups page: allow then disable restores for a server", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "restore-grp" });
+		const server = await seedServer(sql, {
+			name: "restore-srv",
+			groupId: group.id,
+		});
+		await seedServerBackupCapability(sql, { serverId: server.id });
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const row = page.getByRole("row").filter({ hasText: "restore-srv" });
+
+		// Opening the window persists a future expiry attributed to the operator.
+		await row.getByRole("button", { name: /allow restores/i }).click();
+		await expect(row.getByText(/restores allowed until/i)).toBeVisible();
+		const opened = await sql.query<{
+			until: string | null;
+			by: string | null;
+		}>(
+			`SELECT restore_allowed_until AS until, restore_allowed_by AS by
+			 FROM servers WHERE id = $1`,
+			[server.id],
+		);
+		expect(opened[0]!.until).not.toBeNull();
+		expect(opened[0]!.by).toBe("admin@localhost");
+
+		// Disabling clears it again.
+		await row.getByRole("button", { name: /^disable$/i }).click();
+		await expect(
+			row.getByRole("button", { name: /allow restores/i }),
+		).toBeVisible();
+		const closed = await sql.query<{ until: string | null }>(
+			`SELECT restore_allowed_until AS until FROM servers WHERE id = $1`,
+			[server.id],
+		);
+		expect(closed[0]!.until).toBeNull();
+	});
+
+	test("server detail page: allow then disable restores", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "restore-detail-grp" });
+		const server = await seedServer(sql, {
+			name: "restore-detail-srv",
+			groupId: group.id,
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		const backups = page.locator("#backups");
+
+		await backups.getByRole("button", { name: /allow restores/i }).click();
+		await expect(
+			backups.getByText(/restores are allowed for this server until/i),
+		).toBeVisible();
+		const opened = await sql.query<{ until: string | null }>(
+			`SELECT restore_allowed_until AS until FROM servers WHERE id = $1`,
+			[server.id],
+		);
+		expect(opened[0]!.until).not.toBeNull();
+
+		await backups.getByRole("button", { name: /^disable$/i }).click();
+		await expect(
+			backups.getByRole("button", { name: /allow restores/i }),
+		).toBeVisible();
+		const closed = await sql.query<{ until: string | null }>(
+			`SELECT restore_allowed_until AS until FROM servers WHERE id = $1`,
+			[server.id],
+		);
+		expect(closed[0]!.until).toBeNull();
+	});
+});

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -163,6 +163,53 @@
         ]
       }
     },
+    "/api/backups/allow_restore": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Allow this server to restore for the next 24 hours.",
+        "description": "Opens the server's restore window so an operator can run an ad-hoc\n`bestool canopy restore` on it: while the window is open the device can mint\nread-only restore credentials for its group's backup repository. The window\nauto-expires after 24 hours; calling again re-arms it from now. Returns the\nnew window. Restores are gated behind this deliberate opt-in because they\ngrant read access to the group's entire backup history.",
+        "operationId": "backups_allow_restore",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServerArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreWindowView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/backups/cancel_maintenance": {
       "post": {
         "tags": [
@@ -558,6 +605,36 @@
         ]
       }
     },
+    "/api/backups/disallow_restore": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "Stop allowing this server to restore, immediately.",
+        "description": "Closes the server's restore window now, before its 24-hour expiry. Any\ncredentials already minted keep their (at most one hour) validity, but no\nnew restore credentials can be minted until an operator allows restores\nagain. Closing an already-closed window succeeds without effect.",
+        "operationId": "backups_disallow_restore",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServerArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/backups/get": {
       "post": {
         "tags": [
@@ -942,6 +1019,53 @@
         "responses": {
           "200": {
             "description": ""
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/backups/restore_window": {
+      "post": {
+        "tags": [
+          "backups"
+        ],
+        "summary": "The current restore-window state for a server.",
+        "description": "Reports until when the server may mint restore credentials for itself, or\n`null` if restores are not currently allowed (never opened, or expired).",
+        "operationId": "backups_restore_window",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServerArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RestoreWindowView"
+                }
+              }
+            }
           },
           "404": {
             "description": "",
@@ -6824,6 +6948,7 @@
           "recent_maintenance",
           "pending_requests",
           "capabilities",
+          "restore_windows",
           "s3_month_sent_bytes",
           "s3_month_received_bytes"
         ],
@@ -6855,6 +6980,13 @@
               "$ref": "#/components/schemas/BackupRun"
             },
             "description": "The most recent backup runs across the group's member servers."
+          },
+          "restore_windows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RestoreWindowRow"
+            },
+            "description": "Member servers whose restore window is currently open, so the panel can\nshow which servers may restore right now and until when. Servers with no\nopen window are omitted."
           },
           "s3_month_received_bytes": {
             "type": "integer",
@@ -10575,6 +10707,54 @@
           "type": {
             "type": "string",
             "description": "The backup type to restore, for example `tamanu-postgres`."
+          }
+        }
+      },
+      "RestoreWindowRow": {
+        "type": "object",
+        "description": "A server's currently-open restore window, as shown in the group stats.",
+        "required": [
+          "server_id",
+          "allowed_until"
+        ],
+        "properties": {
+          "allowed_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Who opened the window (Tailscale login), if known."
+          },
+          "allowed_until": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the window closes; the server may mint restore credentials until\nthen."
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The server the window applies to."
+          }
+        }
+      },
+      "RestoreWindowView": {
+        "type": "object",
+        "description": "A single server's restore-window state, for the server detail page.",
+        "properties": {
+          "allowed_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Who opened the current window (Tailscale login), if known."
+          },
+          "allowed_until": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When the restore window closes, or `null` if restores are not currently\nallowed for this server."
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -67,6 +67,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/backups/allow_restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Allow this server to restore for the next 24 hours.
+         * @description Opens the server's restore window so an operator can run an ad-hoc
+         *     `bestool canopy restore` on it: while the window is open the device can mint
+         *     read-only restore credentials for its group's backup repository. The window
+         *     auto-expires after 24 hours; calling again re-arms it from now. Returns the
+         *     new window. Restores are gated behind this deliberate opt-in because they
+         *     grant read access to the group's entire backup history.
+         */
+        post: operations["backups_allow_restore"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/backups/cancel_maintenance": {
         parameters: {
             query?: never;
@@ -245,6 +270,29 @@ export interface paths {
          *     configuration.
          */
         post: operations["backups_delete"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/backups/disallow_restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stop allowing this server to restore, immediately.
+         * @description Closes the server's restore window now, before its 24-hour expiry. Any
+         *     credentials already minted keep their (at most one hour) validity, but no
+         *     new restore credentials can be minted until an operator allows restores
+         *     again. Closing an already-closed window succeeds without effect.
+         */
+        post: operations["backups_disallow_restore"];
         delete?: never;
         options?: never;
         head?: never;
@@ -448,6 +496,27 @@ export interface paths {
          *     existing pending request rather than creating a duplicate.
          */
         post: operations["backups_request_now"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/backups/restore_window": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * The current restore-window state for a server.
+         * @description Reports until when the server may mint restore credentials for itself, or
+         *     `null` if restores are not currently allowed (never opened, or expired).
+         */
+        post: operations["backups_restore_window"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3657,6 +3726,12 @@ export interface components {
             /** @description The most recent backup runs across the group's member servers. */
             recent_runs: components["schemas"]["BackupRun"][];
             /**
+             * @description Member servers whose restore window is currently open, so the panel can
+             *     show which servers may restore right now and until when. Servers with no
+             *     open window are omitted.
+             */
+            restore_windows: components["schemas"]["RestoreWindowRow"][];
+            /**
              * Format: int64
              * @description Total raw S3 bytes downloaded from the bucket by the group's device
              *     backup runs so far this calendar month (UTC). Same undercount caveat
@@ -6041,6 +6116,33 @@ export interface components {
             /** @description The backup type to restore, for example `tamanu-postgres`. */
             type: string;
         };
+        /** @description A server's currently-open restore window, as shown in the group stats. */
+        RestoreWindowRow: {
+            /** @description Who opened the window (Tailscale login), if known. */
+            allowed_by?: string | null;
+            /**
+             * Format: date-time
+             * @description When the window closes; the server may mint restore credentials until
+             *     then.
+             */
+            allowed_until: string;
+            /**
+             * Format: uuid
+             * @description The server the window applies to.
+             */
+            server_id: string;
+        };
+        /** @description A single server's restore-window state, for the server detail page. */
+        RestoreWindowView: {
+            /** @description Who opened the current window (Tailscale login), if known. */
+            allowed_by?: string | null;
+            /**
+             * Format: date-time
+             * @description When the restore window closes, or `null` if restores are not currently
+             *     allowed for this server.
+             */
+            allowed_until?: string | null;
+        };
         /**
          * @description How many backups to keep at each retention tier once older snapshots are
          *     pruned. The organization enforces minimum floors (at least 7 daily, 4
@@ -7453,6 +7555,37 @@ export interface operations {
             };
         };
     };
+    backups_allow_restore: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ServerArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RestoreWindowView"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
     backups_cancel_maintenance: {
         parameters: {
             query?: never;
@@ -7721,6 +7854,27 @@ export interface operations {
             };
         };
     };
+    backups_disallow_restore: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ServerArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     backups_get: {
         parameters: {
             query?: never;
@@ -7971,6 +8125,37 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    backups_restore_window: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ServerArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RestoreWindowView"];
+                };
             };
             404: {
                 headers: {

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -28,6 +28,7 @@ import {
 } from "@mui/material";
 import { useState } from "react";
 import BackupIcon from "@mui/icons-material/Backup";
+import RestoreIcon from "@mui/icons-material/SettingsBackupRestore";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
@@ -1263,9 +1264,83 @@ function ServersPanel({
 	);
 	const requestNow = useApiAction("backups", "request_now");
 	const cancel = useApiAction("backups", "cancel_request");
+	const allowRestore = useApiAction("backups", "allow_restore");
+	const disallowRestore = useApiAction("backups", "disallow_restore");
 
 	const pending = stats.status === "ok" ? stats.data.pending_requests : [];
 	const capabilities = stats.status === "ok" ? stats.data.capabilities : [];
+	const restoreWindows =
+		stats.status === "ok" ? stats.data.restore_windows : [];
+	const restoreWindowFor = (serverId: string) =>
+		restoreWindows.find((w) => w.server_id === serverId);
+
+	const onAllowRestore = async (serverId: string) => {
+		try {
+			await allowRestore.call({ server_id: serverId });
+			stats.reload();
+		} catch {
+			/* surfaced via allowRestore.error */
+		}
+	};
+	const onDisallowRestore = async (serverId: string) => {
+		try {
+			await disallowRestore.call({ server_id: serverId });
+			stats.reload();
+		} catch {
+			/* surfaced via disallowRestore.error */
+		}
+	};
+
+	// Per-server restore-window control, shown under the server name. Restores
+	// are gated behind a deliberate, time-boxed opt-in, so this is where an
+	// operator opens (or closes) the window before running `bestool canopy
+	// restore` on the box.
+	const restoreControl = (serverId: string) => {
+		if (!isAdmin) return null;
+		const win = restoreWindowFor(serverId);
+		const busy = allowRestore.pending || disallowRestore.pending;
+		if (win) {
+			return (
+				<Stack
+					direction="row"
+					spacing={0.5}
+					sx={{ alignItems: "center", flexWrap: "wrap" }}
+				>
+					<Chip
+						size="small"
+						color="warning"
+						variant="outlined"
+						icon={<RestoreIcon />}
+						label={
+							<>
+								restores allowed until{" "}
+								<TimeAgo timestamp={win.allowed_until} />
+							</>
+						}
+					/>
+					<Button
+						size="small"
+						color="warning"
+						onClick={() => onDisallowRestore(serverId)}
+						disabled={busy}
+					>
+						Disable
+					</Button>
+				</Stack>
+			);
+		}
+		return (
+			<Button
+				size="small"
+				color="warning"
+				startIcon={<RestoreIcon />}
+				onClick={() => onAllowRestore(serverId)}
+				disabled={busy}
+			>
+				Allow restores
+			</Button>
+		);
+	};
 
 	// The backup types to offer per server: the ones it has declared it can run
 	// (bestool fails fast on a type it has no definition for), unioned with any
@@ -1390,7 +1465,12 @@ function ServersPanel({
 								if (types.length === 0) {
 									return (
 										<TableRow key={m.id}>
-											<TableCell>{serverLink(m)}</TableCell>
+											<TableCell>
+												<Stack spacing={0.5} sx={{ alignItems: "flex-start" }}>
+													{serverLink(m)}
+													{restoreControl(m.id)}
+												</Stack>
+											</TableCell>
 											<TableCell colSpan={3}>
 												<Typography variant="body2" color="text.secondary">
 													No backup types registered yet
@@ -1423,7 +1503,13 @@ function ServersPanel({
 													rowSpan={types.length}
 													sx={{ verticalAlign: "top" }}
 												>
-													{serverLink(m)}
+													<Stack
+														spacing={0.5}
+														sx={{ alignItems: "flex-start" }}
+													>
+														{serverLink(m)}
+														{restoreControl(m.id)}
+													</Stack>
 												</TableCell>
 											)}
 											<TableCell>
@@ -1477,9 +1563,17 @@ function ServersPanel({
 					</Table>
 				</Box>
 			)}
-			{(requestNow.error || cancel.error) && (
+			{(requestNow.error ||
+				cancel.error ||
+				allowRestore.error ||
+				disallowRestore.error) && (
 				<Alert severity="error" sx={{ mt: 1 }}>
-					{(requestNow.error || cancel.error)!.message}
+					{
+						(requestNow.error ||
+							cancel.error ||
+							allowRestore.error ||
+							disallowRestore.error)!.message
+					}
 				</Alert>
 			)}
 		</Paper>

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -33,6 +33,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import LanguageIcon from "@mui/icons-material/Language";
 import RestoreIcon from "@mui/icons-material/RestoreFromTrash";
+import RestoreDataIcon from "@mui/icons-material/SettingsBackupRestore";
 import NotificationsActiveOutlinedIcon from "@mui/icons-material/NotificationsActiveOutlined";
 import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import NotificationsOffOutlinedIcon from "@mui/icons-material/NotificationsOffOutlined";
@@ -1634,6 +1635,36 @@ function BackupCapabilitiesSection({
 		{ server_group_id: groupId ?? NIL_UUID },
 		[groupId],
 	);
+	// The server's restore window: while open, an operator can run an ad-hoc
+	// `bestool canopy restore` on the box. Server-scoped, so it's shown here as
+	// well as on the group backups page.
+	const restore = useApi(
+		"backups",
+		"restore_window",
+		{ server_id: serverId },
+		[serverId],
+	);
+	const allowRestore = useApiAction("backups", "allow_restore");
+	const disallowRestore = useApiAction("backups", "disallow_restore");
+	const restoreUntil =
+		restore.status === "ok" ? restore.data.allowed_until : null;
+	const onAllowRestore = async () => {
+		try {
+			await allowRestore.call({ server_id: serverId });
+			restore.reload();
+		} catch {
+			/* surfaced via allowRestore.error */
+		}
+	};
+	const onDisallowRestore = async () => {
+		try {
+			await disallowRestore.call({ server_id: serverId });
+			restore.reload();
+		} catch {
+			/* surfaced via disallowRestore.error */
+		}
+	};
+
 	const inactive =
 		config.status === "ok" &&
 		!(config.data != null && config.data.status === "ready");
@@ -1681,6 +1712,47 @@ function BackupCapabilitiesSection({
 					</MuiLink>
 				)}
 			</Stack>
+
+			{groupId && isAdmin && (
+				<Box sx={{ mb: 1 }}>
+					{restoreUntil ? (
+						<Alert
+							severity="warning"
+							icon={<RestoreDataIcon fontSize="inherit" />}
+							action={
+								<Button
+									color="inherit"
+									size="small"
+									onClick={onDisallowRestore}
+									disabled={allowRestore.pending || disallowRestore.pending}
+								>
+									Disable
+								</Button>
+							}
+						>
+							Restores are allowed for this server until{" "}
+							<TimeAgo timestamp={restoreUntil} />. While open, the server can
+							restore backups on demand.
+						</Alert>
+					) : (
+						<Button
+							size="small"
+							color="warning"
+							variant="outlined"
+							startIcon={<RestoreDataIcon />}
+							onClick={onAllowRestore}
+							disabled={allowRestore.pending || disallowRestore.pending}
+						>
+							Allow restores (24h)
+						</Button>
+					)}
+					{(allowRestore.error || disallowRestore.error) && (
+						<Alert severity="error" sx={{ mt: 1 }}>
+							{(allowRestore.error || disallowRestore.error)!.message}
+						</Alert>
+					)}
+				</Box>
+			)}
 
 			{inactive && (
 				<Alert

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -156,6 +156,8 @@ export type PendingRequestRow = Solidify<Schemas["PendingRequestRow"]>;
 export type ServerBackupCapabilityView = Solidify<
 	Schemas["ServerBackupCapabilityView"]
 >;
+export type RestoreWindowRow = Solidify<Schemas["RestoreWindowRow"]>;
+export type RestoreWindowView = Solidify<Schemas["RestoreWindowView"]>;
 
 // `mode`/`status` arrive as plain strings on the wire (the Rust enums use a
 // custom Text serializer, so utoipa emits `string`). Narrow them in the UI so


### PR DESCRIPTION
🤖 Ad-hoc `bestool canopy restore` used to fail with a 409 whose message ("backup type X is not an enabled capability for this server, and no restore is pending") made no sense for a restore: the enabled-capability half is the *backup*-schedule gate, and "no restore pending" pointed at a flow with no operator surface.

## What this does

Restores now self-authorize while a **per-server restore window** is open, rather than being gated on backup-schedule state or a pending request:

- An operator opens the window from the **group backups servers table** or the **server detail → Backups** section ("Allow restores"). It auto-expires after **24 hours** and can be closed early ("Disable").
- The public `POST /backup-credentials` restore gate passes only while the window is open; the credentials it mints stay strictly read-only and bucket-scoped. Backup issuance is unchanged.
- This is the ad-hoc, human-initiated path. Canopy still drives *automated* restores separately via the PGRO restore-replica path.

## Shape

- `servers.restore_allowed_until` (+ `restore_allowed_by`), with `Server::allow_restore` (24h) / `disallow_restore` / `restore_allowed()`.
- Private admin endpoints `backups/allow_restore`, `disallow_restore`, `restore_window`, plus `restore_windows` on the group stats view.
- Regenerated private + public OpenAPI and TS types.
- Rust coverage for the gate (closed/expired → 409, open → passes) and the endpoints; Playwright coverage for the toggle on both pages.