### PR TITLE
chore(build): optimise dependency builds in dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 
+# compile dependencies with some optimisations to reduce disk pressure
+[profile.dev.package."*"]
+opt-level = 1
+
+# compile build scripts and macros quickly
 [profile.dev.build-override]
 opt-level = 0
 codegen-units = 1024


### PR DESCRIPTION
🤖 Catch-up PR for an orphaned local commit.

Adds `[profile.dev.package."*"] opt-level = 1` so dependencies compile with light optimisation in dev builds, reducing debug-artefact size and disk pressure. Also documents the intent of the existing `build-override` section.

Build-config only; no behaviour or code changes.