### PR TITLE
deps: bump bestool-kopia 0.3 → 0.4 (proxy S3P)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,9 +1093,9 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bestool-kopia"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03d98bc1690b9adaa51b3e4416ce19c1bc8472a520a269a33224b64abfd4757"
+checksum = "decbf63eebeda2982713bf322792c1a3d888ceb029579aae94087e6f48800875"
 dependencies = [
  "bytes",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ axum = "0.8.9"
 axum-test = "20.0.0"
 # bestool-kopia's SigV4 re-signing proxy (S3P spec). The proxy feature uses the
 # workspace's `aws-lc-rs` rustls provider.
-bestool-kopia = { version = "0.3.2", features = ["proxy"] }
+bestool-kopia = { version = "0.4.0", features = ["proxy"] }
 clap = "4.6.1"
 diesel = "2.3.9"
 diesel-async = "0.9.0"


### PR DESCRIPTION
🤖 Bumps `bestool-kopia` (the SigV4 re-signing proxy behind the S3P spec) from 0.3 to 0.4.

0.4.0's only changes are to `fetch_snapshots` / `SnapshotFilter` — snapshot tag filtering now runs via kopia's `--tags` flag rather than in-process. The `proxy` module, which is all canopy uses (`crates/jobs/src/backup/creds_server.rs`), is byte-identical between 0.3.4 and 0.4.0, so no code changes are needed.

`cargo check -p jobs` passes.