### PR TITLE
feat(ui): show duration in the backup maintenance runs table

### DIFF
--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -1080,7 +1080,7 @@ test.describe("backups ready: repo maintenance panel", () => {
 		await expect(panel.getByText(/no maintenance has run yet/i)).toBeVisible();
 	});
 
-	test("a successful run shows Healthy, last-success time, and reclaimed bytes", async ({
+	test("a successful run shows Healthy, last-success time, duration, and reclaimed bytes", async ({
 		page,
 		sql,
 	}) => {
@@ -1095,6 +1095,7 @@ test.describe("backups ready: repo maintenance panel", () => {
 			outcome: "success",
 			bytesReclaimed: 1048576, // 1.0 MiB
 			finishedAgoSecs: 3600,
+			durationSecs: 180, // renders as "3m"
 		});
 
 		await page.goto(`/groups/${group.id}/backups`);
@@ -1105,6 +1106,9 @@ test.describe("backups ready: repo maintenance panel", () => {
 		await expect(panel.getByText("Full", { exact: true })).toBeVisible();
 		// exact: the "Last successful maintenance" caption also contains "success".
 		await expect(panel.getByText("success", { exact: true })).toBeVisible();
+		await expect(
+			panel.getByRole("cell", { name: "3m", exact: true }),
+		).toBeVisible();
 		await expect(panel.getByText("1.0 MiB")).toBeVisible();
 	});
 
@@ -1159,6 +1163,10 @@ test.describe("backups ready: repo maintenance panel", () => {
 		// exact: the summary chip reads "Running" (capitalised); the row chip "running".
 		await expect(panel.getByText("running", { exact: true })).toBeVisible();
 		await expect(panel.getByText("Quick")).toBeVisible();
+		// The unfinished run has no Finished, Duration, or Reclaimed value.
+		await expect(
+			panel.getByRole("cell", { name: "—", exact: true }),
+		).toHaveCount(3);
 	});
 
 	test("an admin can queue and cancel an on-demand full maintenance run", async ({

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -484,8 +484,9 @@ export async function seedBackupRun(
 	return { id };
 }
 
-/** Seed a `backup_maintenance_runs` row. `finishedAgoSecs` backdates both
- * `started_at` and `finished_at`; omit `outcome` for an in-flight run. */
+/** Seed a `backup_maintenance_runs` row. `finishedAgoSecs` backdates
+ * `finished_at`, and `started_at` a further `durationSecs` (default 0) before
+ * that; omit `outcome` for an in-flight run. */
 export async function seedBackupMaintenanceRun(
 	sql: Sql,
 	opts: {
@@ -495,19 +496,24 @@ export async function seedBackupMaintenanceRun(
 		error?: string | null;
 		bytesReclaimed?: number | null;
 		finishedAgoSecs?: number;
+		durationSecs?: number;
 	},
 ): Promise<void> {
 	const ago = String(opts.finishedAgoSecs ?? 0);
+	const startedAgo = String(
+		(opts.finishedAgoSecs ?? 0) + (opts.durationSecs ?? 0),
+	);
 	const outcome = opts.outcome ?? null;
 	await sql.query(
 		`INSERT INTO backup_maintenance_runs
 		 (group_id, kind, started_at, finished_at, outcome, error, bytes_reclaimed)
 		 VALUES ($1, $2, NOW() - ($3 || ' seconds')::interval,
-		         CASE WHEN $4::text IS NULL THEN NULL ELSE NOW() - ($3 || ' seconds')::interval END,
-		         $4, $5, $6)`,
+		         CASE WHEN $5::text IS NULL THEN NULL ELSE NOW() - ($4 || ' seconds')::interval END,
+		         $5, $6, $7)`,
 		[
 			opts.groupId,
 			opts.kind ?? "full",
+			startedAgo,
 			ago,
 			outcome,
 			opts.error ?? null,

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -38,7 +38,7 @@ import { Link as RouterLink, useParams } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
 import { useReloadInterval } from "../hooks/useReloadInterval";
 import { useIsAdmin } from "../hooks/useIsAdmin";
-import { humanSeconds } from "../lib/humanDuration";
+import { humanDuration, humanSeconds } from "../lib/humanDuration";
 import { formatBytes } from "../lib/formatBytes";
 import {
 	estimatedBucketCostTooltip,
@@ -1065,12 +1065,17 @@ function MaintRow({ run }: { run: BackupMaintenanceRun }) {
 					{run.finished_at ? <TimeAgo timestamp={run.finished_at} /> : "—"}
 				</TableCell>
 				<TableCell>
+					{run.finished_at
+						? humanDuration(run.started_at, run.finished_at)
+						: "—"}
+				</TableCell>
+				<TableCell>
 					{run.bytes_reclaimed == null ? "—" : formatBytes(run.bytes_reclaimed)}
 				</TableCell>
 			</TableRow>
 			{hasError && (
 				<TableRow>
-					<TableCell colSpan={6} sx={{ py: 0, border: 0 }}>
+					<TableCell colSpan={7} sx={{ py: 0, border: 0 }}>
 						<Collapse in={open} timeout="auto" unmountOnExit>
 							<Alert severity="error" variant="outlined" sx={{ my: 1 }}>
 								<Typography
@@ -1287,6 +1292,7 @@ function MaintenancePanel({
 										<TableCell>Kind</TableCell>
 										<TableCell>Outcome</TableCell>
 										<TableCell>Finished</TableCell>
+										<TableCell>Duration</TableCell>
 										<TableCell>
 											<Tooltip title="Approximate: kopia's garbage collection is two-phase, so a run can under-report until a later full run sweeps quarantined blobs">
 												<span>Reclaimed</span>


### PR DESCRIPTION
🤖 Adds a Duration column to the repo maintenance runs table on the group backups page, computed as `finished_at − started_at` using the existing `humanDuration` helper. Unfinished (in-flight) runs show `—`, matching how the table already renders missing Finished/Reclaimed values.

The `seedBackupMaintenanceRun` e2e helper gains a `durationSecs` option (it previously always set `started_at = finished_at`), and the existing maintenance panel specs now assert the rendered duration and the blank cell for in-flight runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)