### PR TITLE
feat(ui): show restore downloads in the recent-runs Transfer column

### DIFF
--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -1259,6 +1259,52 @@ impl BackupRun {
 		Ok((totals.sent, totals.received))
 	}
 
+	/// The size of each named snapshot, resolved from the *backup* runs that
+	/// produced them: the device-reported size (`bytes_uploaded`) or, failing
+	/// that, the inspection-observed size (`snapshot_logical_bytes`) — the same
+	/// preference the recent-runs UI applies to the producing run itself. Keyed
+	/// by snapshot id; ids with no sized producing run are absent.
+	///
+	/// This is what lets a restore run show the size of the snapshot it used
+	/// immediately: the snapshot was sized when the backup that created it ran
+	/// (or was inspected), so there is no need to wait for inspection to
+	/// backfill the restore run's own row.
+	pub async fn snapshot_sizes_by_id(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		snapshot_ids: &[String],
+	) -> Result<HashMap<String, i64>> {
+		use crate::schema::backup_runs::dsl;
+
+		if snapshot_ids.is_empty() {
+			return Ok(HashMap::new());
+		}
+
+		let rows: Vec<Self> = dsl::backup_runs
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::purpose.eq(BackupPurpose::Backup))
+			.filter(dsl::snapshot_id.eq_any(snapshot_ids))
+			.filter(
+				dsl::bytes_uploaded
+					.is_not_null()
+					.or(dsl::snapshot_logical_bytes.is_not_null()),
+			)
+			.distinct_on(dsl::snapshot_id)
+			.order_by((dsl::snapshot_id, dsl::reported_at.desc()))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+
+		Ok(rows
+			.into_iter()
+			.filter_map(|r| {
+				let id = r.snapshot_id?;
+				let size = r.bytes_uploaded.or(r.snapshot_logical_bytes)?;
+				Some((id, size))
+			})
+			.collect())
+	}
+
 	/// Fill `snapshot_logical_bytes` from repo inspection for runs matched by
 	/// snapshot id, only where it is still unset — write-once, since a snapshot
 	/// is immutable. `sizes` maps a snapshot id to its observed logical size.

--- a/crates/database/tests/backups.rs
+++ b/crates/database/tests/backups.rs
@@ -336,6 +336,82 @@ async fn backfill_snapshot_logical_bytes_writes_once() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn snapshot_sizes_by_id_resolves_from_producing_backups_only() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let other_group = insert_group(&mut conn, "other").await;
+		let server_id = insert_server(&mut conn, group_id).await;
+		let other_server = insert_server(&mut conn, other_group).await;
+		let device_id = insert_device(&mut conn).await;
+
+		// The backup that produced kopia-snap-1, sized by the device (42 from
+		// new_run's bytes_uploaded).
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				group_id,
+				Some(server_id),
+				BackupPurpose::Backup,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.expect("record backup");
+		// A restore of the same snapshot must not satisfy the lookup itself.
+		BackupRun::record(
+			&mut conn,
+			NewBackupRun {
+				bytes_uploaded: None,
+				..new_run(
+					Uuid::new_v4(),
+					device_id,
+					group_id,
+					Some(server_id),
+					BackupPurpose::Restore,
+					RunOutcome::Success,
+				)
+			},
+		)
+		.await
+		.expect("record restore");
+		// Same snapshot id in another group: out of scope.
+		BackupRun::record(
+			&mut conn,
+			new_run(
+				Uuid::new_v4(),
+				device_id,
+				other_group,
+				Some(other_server),
+				BackupPurpose::Backup,
+				RunOutcome::Success,
+			),
+		)
+		.await
+		.expect("record other-group backup");
+
+		let sizes =
+			BackupRun::snapshot_sizes_by_id(&mut conn, group_id, &["kopia-snap-1".to_string()])
+				.await
+				.expect("lookup");
+		assert_eq!(sizes.get("kopia-snap-1"), Some(&42));
+		assert_eq!(sizes.len(), 1);
+
+		// Unknown ids resolve to nothing; the empty query short-circuits.
+		let miss = BackupRun::snapshot_sizes_by_id(&mut conn, group_id, &["nope".to_string()])
+			.await
+			.expect("lookup miss");
+		assert!(miss.is_empty());
+		let none = BackupRun::snapshot_sizes_by_id(&mut conn, group_id, &[])
+			.await
+			.expect("empty lookup");
+		assert!(none.is_empty());
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn latest_sized_lists_only_runs_with_both_sizes() {
 	TestDb::run(|mut conn, _url| async move {
 		let group_id = insert_group(&mut conn, "g").await;

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -375,9 +375,13 @@ pub struct RecentRun {
 	pub error: Option<String>,
 	/// Bytes the device reported uploading, if any (reported runs only).
 	pub bytes_uploaded: Option<i64>,
-	/// Snapshot the run produced, if any (reported runs only).
+	/// Snapshot the run produced (backup) or used (restore), if any (reported
+	/// runs only).
 	pub snapshot_id: Option<String>,
-	/// Logical snapshot size from repo inspection, if known (reported runs only).
+	/// Logical size of the run's snapshot, if known (reported runs only). For
+	/// a backup this comes from repo inspection. For a restore it is resolved
+	/// from the backup run that produced the snapshot (matched by snapshot id),
+	/// falling back to inspection's backfill onto the restore run itself.
 	pub snapshot_logical_bytes: Option<i64>,
 	/// Raw bytes sent to S3 during the run, if tallied (reported runs only).
 	pub s3_sent_raw_bytes: Option<i64>,
@@ -409,6 +413,12 @@ pub struct RecentRun {
 /// surface as inferred rows — in-flight while their creds are still valid,
 /// otherwise unreported past attempts (e.g. manual restores, which don't report).
 ///
+/// `source_snapshot_sizes` maps snapshot ids to sizes already known from the
+/// backup runs that produced them (see [`BackupRun::snapshot_sizes_by_id`]);
+/// a restore run's snapshot size resolves from it first, so the figure shows
+/// immediately rather than waiting for inspection to backfill the restore
+/// run's own row (which stays as the fallback).
+///
 /// Pairing is exact when the client stamped its run-uuid on the credential
 /// request (`run_id`): those issuances group by that id, so concurrent runs of
 /// the same type on one server never conflate. Issuances without a `run_id`
@@ -419,6 +429,7 @@ fn build_recent_runs(
 	runs: Vec<BackupRun>,
 	issuances: Vec<BackupCredentialIssuance>,
 	device_to_server: &std::collections::HashMap<Uuid, Uuid>,
+	source_snapshot_sizes: &std::collections::HashMap<String, i64>,
 	now: Timestamp,
 	limit: usize,
 ) -> Vec<RecentRun> {
@@ -439,6 +450,15 @@ fn build_recent_runs(
 		.zip(starts)
 		.map(|(run, started_at)| {
 			let duration_seconds = started_at.map(|s| run.reported_at.as_second() - s.as_second());
+			let snapshot_logical_bytes = if run.purpose == BackupPurpose::Restore {
+				run.snapshot_id
+					.as_ref()
+					.and_then(|id| source_snapshot_sizes.get(id))
+					.copied()
+					.or(run.snapshot_logical_bytes)
+			} else {
+				run.snapshot_logical_bytes
+			};
 			RecentRun {
 				key: format!("run-{}", run.id),
 				server_id: run.server_id,
@@ -449,7 +469,7 @@ fn build_recent_runs(
 				error: run.error,
 				bytes_uploaded: run.bytes_uploaded,
 				snapshot_id: run.snapshot_id,
-				snapshot_logical_bytes: run.snapshot_logical_bytes,
+				snapshot_logical_bytes,
 				s3_sent_raw_bytes: run.s3_sent_raw_bytes,
 				s3_sent_payload_bytes: run.s3_sent_payload_bytes,
 				s3_received_raw_bytes: run.s3_received_raw_bytes,
@@ -1819,10 +1839,22 @@ pub async fn stats(
 		RECENT_LIMIT * 4,
 	)
 	.await?;
+	// A restore's snapshot was already sized when the backup that produced it
+	// ran (or was inspected), so resolve restore snapshot sizes from that data
+	// rather than waiting for inspection to backfill the restore run's row.
+	let restore_snapshot_ids: Vec<String> = reported_runs
+		.iter()
+		.filter(|r| r.purpose == BackupPurpose::Restore)
+		.filter_map(|r| r.snapshot_id.clone())
+		.collect();
+	let source_snapshot_sizes =
+		BackupRun::snapshot_sizes_by_id(&mut conn, args.server_group_id, &restore_snapshot_ids)
+			.await?;
 	let recent_runs = build_recent_runs(
 		reported_runs,
 		issuances,
 		&device_to_server,
+		&source_snapshot_sizes,
 		now,
 		RECENT_LIMIT as usize,
 	);
@@ -2334,6 +2366,10 @@ mod tests {
 		std::collections::HashMap::from([(device, Uuid::from_u128(server))])
 	}
 
+	fn no_sizes() -> std::collections::HashMap<String, i64> {
+		std::collections::HashMap::new()
+	}
+
 	#[test]
 	fn reported_run_gets_duration_from_its_issuance() {
 		let d = Uuid::from_u128(1);
@@ -2341,6 +2377,7 @@ mod tests {
 			vec![run(10, d, BackupPurpose::Backup, 4000)],
 			vec![issuance(1, d, BackupPurpose::Backup, 1000, 4600)],
 			&device_map(d, 9),
+			&no_sizes(),
 			ts(5000),
 			20,
 		);
@@ -2358,6 +2395,7 @@ mod tests {
 			vec![],
 			vec![issuance(1, d, BackupPurpose::Restore, 4900, 8500)],
 			&device_map(d, 9),
+			&no_sizes(),
 			ts(5000),
 			20,
 		);
@@ -2375,6 +2413,7 @@ mod tests {
 			vec![],
 			vec![issuance(1, d, BackupPurpose::Restore, 1000, 4600)],
 			&device_map(d, 9),
+			&no_sizes(),
 			ts(5000),
 			20,
 		);
@@ -2389,6 +2428,7 @@ mod tests {
 			vec![run(10, d, BackupPurpose::Restore, 4000)],
 			vec![issuance(1, d, BackupPurpose::Restore, 1000, 4600)],
 			&device_map(d, 9),
+			&no_sizes(),
 			ts(5000),
 			20,
 		);
@@ -2407,6 +2447,7 @@ mod tests {
 				issuance(2, d, BackupPurpose::Backup, 4500, 8100),
 			],
 			&device_map(d, 9),
+			&no_sizes(),
 			ts(9000),
 			20,
 		);
@@ -2423,6 +2464,7 @@ mod tests {
 			vec![run(10, d, BackupPurpose::Backup, 8000)],
 			vec![issuance(1, d, BackupPurpose::Backup, 1000, 4600)],
 			&device_map(d, 9),
+			&no_sizes(),
 			ts(9000),
 			20,
 		);
@@ -2461,6 +2503,7 @@ mod tests {
 				),
 			],
 			&device_map(d, 9),
+			&no_sizes(),
 			ts(5000),
 			20,
 		);
@@ -2483,12 +2526,74 @@ mod tests {
 			vec![run(200, d, BackupPurpose::Backup, 100_000)],
 			vec![issuance_for(1, d, BackupPurpose::Backup, 1000, 4600, rid)],
 			&device_map(d, 9),
+			&no_sizes(),
 			ts(101_000),
 			20,
 		);
 		assert_eq!(rows.len(), 1);
 		assert!(matches!(rows[0].status, RunStatus::Reported));
 		assert_eq!(rows[0].duration_seconds, Some(99_000));
+	}
+
+	#[test]
+	fn restore_snapshot_size_resolves_from_the_producing_backup() {
+		let d = Uuid::from_u128(9);
+		let mut restore = run(10, d, BackupPurpose::Restore, 4000);
+		restore.snapshot_id = Some("snap-a".into());
+		// The size the snapshot was recorded at when its backup ran/was inspected.
+		let sizes = std::collections::HashMap::from([("snap-a".to_string(), 8_192_i64)]);
+		let rows = build_recent_runs(
+			vec![restore],
+			vec![],
+			&device_map(d, 9),
+			&sizes,
+			ts(5000),
+			20,
+		);
+		assert_eq!(rows.len(), 1);
+		assert_eq!(
+			rows[0].snapshot_logical_bytes,
+			Some(8192),
+			"restore shows its source snapshot's size without inspection of its own row"
+		);
+	}
+
+	#[test]
+	fn restore_snapshot_size_falls_back_to_its_own_backfill() {
+		let d = Uuid::from_u128(9);
+		let mut restore = run(10, d, BackupPurpose::Restore, 4000);
+		restore.snapshot_id = Some("snap-a".into());
+		restore.snapshot_logical_bytes = Some(4096);
+		// No producing backup carries the size — the restore row's own
+		// (inspection-backfilled) figure still surfaces.
+		let rows = build_recent_runs(
+			vec![restore],
+			vec![],
+			&device_map(d, 9),
+			&no_sizes(),
+			ts(5000),
+			20,
+		);
+		assert_eq!(rows[0].snapshot_logical_bytes, Some(4096));
+	}
+
+	#[test]
+	fn backup_snapshot_size_ignores_the_lookup() {
+		let d = Uuid::from_u128(9);
+		let mut backup = run(10, d, BackupPurpose::Backup, 4000);
+		backup.snapshot_id = Some("snap-a".into());
+		// A backup's size is its own (device-reported or backfilled) figure; the
+		// source-snapshot lookup is restore-only.
+		let sizes = std::collections::HashMap::from([("snap-a".to_string(), 8_192_i64)]);
+		let rows = build_recent_runs(
+			vec![backup],
+			vec![],
+			&device_map(d, 9),
+			&sizes,
+			ts(5000),
+			20,
+		);
+		assert_eq!(rows[0].snapshot_logical_bytes, None);
 	}
 
 	#[test]
@@ -2503,6 +2608,7 @@ mod tests {
 			],
 			// Only the member device maps to a server; the consumer device doesn't.
 			&device_map(member, 9),
+			&no_sizes(),
 			ts(5000),
 			20,
 		);

--- a/crates/private-server/tests/backups.rs
+++ b/crates/private-server/tests/backups.rs
@@ -680,6 +680,61 @@ async fn stats_includes_runs_and_pending_requests() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn stats_restore_run_resolves_snapshot_size_from_the_producing_backup() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let device_id = Uuid::new_v4();
+		let server_id = Uuid::new_v4();
+		let backup_run_id = Uuid::new_v4();
+		let restore_run_id = Uuid::new_v4();
+		// The backup that produced snapshot snap-1 was sized when it ran; the
+		// restore that later used snap-1 has no size of its own (inspection has
+		// not swept since it reported). Its snapshot size must resolve from the
+		// producing backup immediately, not wait for the backfill.
+		conn.batch_execute(&format!(
+			"INSERT INTO devices (id, role) VALUES ('{device_id}', 'server');
+			 INSERT INTO servers (id, host, kind, group_id, device_id) VALUES \
+				('{server_id}', 'https://e.test', 'central', '{group_id}', '{device_id}');
+			 INSERT INTO backup_runs (id, device_id, group_id, server_id, type, purpose, outcome, \
+				bytes_uploaded, snapshot_id, reported_at) \
+				VALUES ('{backup_run_id}', '{device_id}', '{group_id}', '{server_id}', 'tamanu-postgres', \
+					'backup', 'success', 8192, 'snap-1', now() - interval '1 hour');
+			 INSERT INTO backup_runs (id, device_id, group_id, server_id, type, purpose, outcome, \
+				snapshot_id, s3_received_payload_bytes) \
+				VALUES ('{restore_run_id}', '{device_id}', '{group_id}', '{server_id}', 'tamanu-postgres', \
+					'restore', 'success', 'snap-1', 4096);"
+		))
+		.await
+		.expect("seed runs");
+
+		let resp = private
+			.post("/api/backups/stats")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		let runs = body["recent_runs"].as_array().unwrap();
+		let restore = runs
+			.iter()
+			.find(|r| r["purpose"] == "restore")
+			.expect("restore row");
+		assert_eq!(
+			restore["snapshot_logical_bytes"], 8192,
+			"restore resolves its source snapshot's size from the backup that produced it"
+		);
+		assert!(restore["bytes_uploaded"].is_null());
+		// The backup row keeps its own figures untouched.
+		let backup = runs
+			.iter()
+			.find(|r| r["purpose"] == "backup")
+			.expect("backup row");
+		assert_eq!(backup["bytes_uploaded"], 8192);
+		assert!(backup["snapshot_logical_bytes"].is_null());
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn group_schedules_reports_next_run_from_last_success_plus_interval() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -621,20 +621,23 @@ test.describe("backups ready: stats + backup-now", () => {
 			status: "ready",
 			intervalSeconds: 3600,
 		});
-		// The backup that produced the snapshot, sized when it ran.
+		// The backup that produced the snapshot, sized when it ran. 32.0 MiB is
+		// seeded nowhere else, so seeing it on the restore row below proves the
+		// size came from this run via the lookup.
 		await seedBackupRun(sql, {
 			deviceId: device.id,
 			groupId: group.id,
 			serverId: server.id,
 			outcome: "success",
-			bytesUploaded: 8388608, // 8.0 MiB snapshot
+			bytesUploaded: 33554432, // 32.0 MiB snapshot
 			snapshotId: "kfedcba9876543210fedc",
 			reportedAgoSecs: 3600,
 		});
 		// A reported restore of that snapshot: bestool sends the restored-from
 		// snapshot id and the proxy's traffic tallies (no bytes_uploaded — nothing
-		// is uploaded), and no size of its own — the size resolves from the
-		// producing backup run, without waiting for an inspection backfill.
+		// is uploaded), and no size of its own (snapshot_logical_bytes unset) —
+		// the size resolves from the producing backup run, without waiting for an
+		// inspection backfill.
 		await seedBackupRun(sql, {
 			deviceId: device.id,
 			groupId: group.id,
@@ -645,21 +648,25 @@ test.describe("backups ready: stats + backup-now", () => {
 			snapshotId: "kfedcba9876543210fedc",
 			s3SentPayloadBytes: 2048, // 2.0 KiB (kopia metadata chatter)
 			s3SentRawBytes: 3072,
-			s3ReceivedPayloadBytes: 4096, // 4.0 KiB → shown in the Transfer column
-			s3ReceivedRawBytes: 5120,
+			s3ReceivedPayloadBytes: 8388608, // 8.0 MiB → shown in the Transfer column
+			s3ReceivedRawBytes: 9437184,
 		});
 
 		await page.goto(`/groups/${group.id}/backups`);
 		const runs = page.getByRole("table").last();
 		await expect(runs.getByRole("columnheader", { name: "Transfer" })).toBeVisible();
-		const restoreRow = runs.getByRole("row").filter({ hasText: "restore" });
-		// Transfer shows the download (received payload), not the upload…
-		await expect(restoreRow.getByText("4.0 KiB")).toBeVisible();
-		// …which only appears in the collapsed S3-traffic detail.
+		// Pick the restore row by its exact Purpose cell — the server name also
+		// contains "restore", so a bare hasText filter would match the backup row.
+		const restoreRow = runs
+			.getByRole("row")
+			.filter({ has: page.getByRole("cell", { name: "restore", exact: true }) });
+		// Transfer shows the download (received payload) in its own cell…
+		await expect(restoreRow.getByRole("cell", { name: "8.0 MiB" })).toBeVisible();
+		// …not the upload, which only appears in the collapsed S3-traffic detail.
 		await expect(restoreRow.getByText("2.0 KiB")).toBeHidden();
-		// Snapshot size shows the restored snapshot's size, looked up from the
-		// backup run that produced it.
-		await expect(restoreRow.getByText("8.0 MiB")).toBeVisible();
+		// Snapshot size shows the producing backup run's figure — the restore row
+		// itself was seeded without one, so this pins the lookup, not the backfill.
+		await expect(restoreRow.getByRole("cell", { name: "32.0 MiB" })).toBeVisible();
 	});
 
 	test("run with both a snapshot size and S3 traffic shows them as distinct columns", async ({

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -512,7 +512,7 @@ test.describe("backups ready: stats + backup-now", () => {
 		await page.goto(`/groups/${group.id}/backups`);
 		const runs = page.getByRole("table").last();
 		await expect(runs.getByText("4.0 KiB")).toBeVisible();
-		// No S3 traffic reported and no snapshot id → Uploaded and Snapshot cells
+		// No S3 traffic reported and no snapshot id → Transfer and Snapshot cells
 		// both fall back to "—", plus the empty Duration column.
 		await expect(runs.getByRole("cell", { name: "—" })).toHaveCount(3);
 	});
@@ -547,7 +547,7 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(runs.getByText("err-srv")).toBeVisible();
 		await expect(runs.getByText("failure")).toBeVisible();
 		// A failed run has no size, no upload, and no snapshot → four "—" cells
-		// (Snapshot size, Uploaded, Snapshot, Duration), not "unknown".
+		// (Snapshot size, Transfer, Snapshot, Duration), not "unknown".
 		await expect(runs.getByRole("cell", { name: "—" })).toHaveCount(4);
 
 		// Error detail is hidden until the row is expanded.
@@ -573,7 +573,7 @@ test.describe("backups ready: stats + backup-now", () => {
 			intervalSeconds: 3600,
 		});
 		// No explicit size (device-reported or inspected), but the proxy tallied
-		// S3 traffic → the Uploaded column shows the payload-sent figure directly,
+		// S3 traffic → the Transfer column shows the payload-sent figure directly,
 		// while Snapshot size stays empty.
 		await seedBackupRun(sql, {
 			deviceId: device.id,
@@ -581,7 +581,7 @@ test.describe("backups ready: stats + backup-now", () => {
 			serverId: server.id,
 			outcome: "success",
 			bytesUploaded: null,
-			s3SentPayloadBytes: 2048, // 2.0 KiB → shown in the Uploaded column
+			s3SentPayloadBytes: 2048, // 2.0 KiB → shown in the Transfer column
 			s3SentRawBytes: 3072, // 3.0 KiB
 			s3ReceivedPayloadBytes: 512, // 512 B
 			s3ReceivedRawBytes: 1024, // 1.0 KiB
@@ -603,6 +603,52 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(runs.getByText(/s3 traffic/i)).toBeVisible();
 		await expect(runs.getByText(/2\.0 KiB payload \/ 3\.0 KiB raw/i)).toBeVisible();
 		await expect(runs.getByText(/512 B payload \/ 1\.0 KiB raw/i)).toBeVisible();
+	});
+
+	test("restore run shows its download in the Transfer column and the restored snapshot's size", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "restore-run-group" });
+		const device = await seedDevice(sql);
+		const server = await seedServer(sql, {
+			name: "restore-run-srv",
+			groupId: group.id,
+			deviceId: device.id,
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+			intervalSeconds: 3600,
+		});
+		// A reported restore: bestool sends the restored-from snapshot id and the
+		// proxy's traffic tallies (no bytes_uploaded — nothing is uploaded), and a
+		// later repo inspection backfills the snapshot's logical size by id.
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			purpose: "restore",
+			outcome: "success",
+			bytesUploaded: null,
+			snapshotId: "kfedcba9876543210fedc",
+			snapshotLogicalBytes: 8388608, // 8.0 MiB restored snapshot
+			s3SentPayloadBytes: 2048, // 2.0 KiB (kopia metadata chatter)
+			s3SentRawBytes: 3072,
+			s3ReceivedPayloadBytes: 4096, // 4.0 KiB → shown in the Transfer column
+			s3ReceivedRawBytes: 5120,
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+		const runs = page.getByRole("table").last();
+		await expect(runs.getByRole("columnheader", { name: "Transfer" })).toBeVisible();
+		await expect(runs.getByText("restore")).toBeVisible();
+		// Transfer shows the download (received payload), not the upload…
+		await expect(runs.getByText("4.0 KiB")).toBeVisible();
+		// …which only appears in the collapsed S3-traffic detail.
+		await expect(runs.getByText("2.0 KiB")).toBeHidden();
+		// Snapshot size shows the restored snapshot's inspected size.
+		await expect(runs.getByText("8.0 MiB")).toBeVisible();
 	});
 
 	test("run with both a snapshot size and S3 traffic shows them as distinct columns", async ({

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -666,7 +666,13 @@ test.describe("backups ready: stats + backup-now", () => {
 		await expect(restoreRow.getByText("2.0 KiB")).toBeHidden();
 		// Snapshot size shows the producing backup run's figure — the restore row
 		// itself was seeded without one, so this pins the lookup, not the backfill.
-		await expect(restoreRow.getByRole("cell", { name: "32.0 MiB" })).toBeVisible();
+		// The cell's accessible *name* is its tooltip (MUI Tooltip aria-labels the
+		// wrapped span), so select by that and assert the figure as its text.
+		await expect(
+			restoreRow.getByRole("cell", {
+				name: "Size of the snapshot the restore used",
+			}),
+		).toHaveText("32.0 MiB");
 	});
 
 	test("run with both a snapshot size and S3 traffic shows them as distinct columns", async ({

--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -621,9 +621,20 @@ test.describe("backups ready: stats + backup-now", () => {
 			status: "ready",
 			intervalSeconds: 3600,
 		});
-		// A reported restore: bestool sends the restored-from snapshot id and the
-		// proxy's traffic tallies (no bytes_uploaded — nothing is uploaded), and a
-		// later repo inspection backfills the snapshot's logical size by id.
+		// The backup that produced the snapshot, sized when it ran.
+		await seedBackupRun(sql, {
+			deviceId: device.id,
+			groupId: group.id,
+			serverId: server.id,
+			outcome: "success",
+			bytesUploaded: 8388608, // 8.0 MiB snapshot
+			snapshotId: "kfedcba9876543210fedc",
+			reportedAgoSecs: 3600,
+		});
+		// A reported restore of that snapshot: bestool sends the restored-from
+		// snapshot id and the proxy's traffic tallies (no bytes_uploaded — nothing
+		// is uploaded), and no size of its own — the size resolves from the
+		// producing backup run, without waiting for an inspection backfill.
 		await seedBackupRun(sql, {
 			deviceId: device.id,
 			groupId: group.id,
@@ -632,7 +643,6 @@ test.describe("backups ready: stats + backup-now", () => {
 			outcome: "success",
 			bytesUploaded: null,
 			snapshotId: "kfedcba9876543210fedc",
-			snapshotLogicalBytes: 8388608, // 8.0 MiB restored snapshot
 			s3SentPayloadBytes: 2048, // 2.0 KiB (kopia metadata chatter)
 			s3SentRawBytes: 3072,
 			s3ReceivedPayloadBytes: 4096, // 4.0 KiB → shown in the Transfer column
@@ -642,13 +652,14 @@ test.describe("backups ready: stats + backup-now", () => {
 		await page.goto(`/groups/${group.id}/backups`);
 		const runs = page.getByRole("table").last();
 		await expect(runs.getByRole("columnheader", { name: "Transfer" })).toBeVisible();
-		await expect(runs.getByText("restore")).toBeVisible();
+		const restoreRow = runs.getByRole("row").filter({ hasText: "restore" });
 		// Transfer shows the download (received payload), not the upload…
-		await expect(runs.getByText("4.0 KiB")).toBeVisible();
+		await expect(restoreRow.getByText("4.0 KiB")).toBeVisible();
 		// …which only appears in the collapsed S3-traffic detail.
-		await expect(runs.getByText("2.0 KiB")).toBeHidden();
-		// Snapshot size shows the restored snapshot's inspected size.
-		await expect(runs.getByText("8.0 MiB")).toBeVisible();
+		await expect(restoreRow.getByText("2.0 KiB")).toBeHidden();
+		// Snapshot size shows the restored snapshot's size, looked up from the
+		// backup run that produced it.
+		await expect(restoreRow.getByText("8.0 MiB")).toBeVisible();
 	});
 
 	test("run with both a snapshot size and S3 traffic shows them as distinct columns", async ({

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -10056,7 +10056,7 @@
               "string",
               "null"
             ],
-            "description": "Snapshot the run produced, if any (reported runs only)."
+            "description": "Snapshot the run produced (backup) or used (restore), if any (reported\nruns only)."
           },
           "snapshot_logical_bytes": {
             "type": [
@@ -10064,7 +10064,7 @@
               "null"
             ],
             "format": "int64",
-            "description": "Logical snapshot size from repo inspection, if known (reported runs only)."
+            "description": "Logical size of the run's snapshot, if known (reported runs only). For\na backup this comes from repo inspection. For a restore it is resolved\nfrom the backup run that produced the snapshot (matched by snapshot id),\nfalling back to inspection's backfill onto the restore run itself."
           },
           "started_at": {
             "type": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -5659,11 +5659,17 @@ export interface components {
              * @description The server this run was for, if known.
              */
             server_id?: string | null;
-            /** @description Snapshot the run produced, if any (reported runs only). */
+            /**
+             * @description Snapshot the run produced (backup) or used (restore), if any (reported
+             *     runs only).
+             */
             snapshot_id?: string | null;
             /**
              * Format: int64
-             * @description Logical snapshot size from repo inspection, if known (reported runs only).
+             * @description Logical size of the run's snapshot, if known (reported runs only). For
+             *     a backup this comes from repo inspection. For a restore it is resolved
+             *     from the backup run that produced the snapshot (matched by snapshot id),
+             *     falling back to inspection's backfill onto the restore run itself.
              */
             snapshot_logical_bytes?: number | null;
             /**

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -750,14 +750,19 @@ function RunRow({ run, members }: { run: RecentRun; members: ServerInfo[] }) {
 	// bestool's own accounting, or (failing that) canopy's repo inspection.
 	// Both describe the same quantity — kopia doesn't re-upload bits the
 	// server already has, so this is usually larger than what actually went
-	// over the wire.
+	// over the wire. For a restore this is the size of the snapshot the run
+	// restored from: bestool reports the snapshot id, and inspection backfills
+	// the size onto the run.
 	const fromInspect =
 		run.bytes_uploaded == null && run.snapshot_logical_bytes != null;
 	const snapshotSize = run.bytes_uploaded ?? run.snapshot_logical_bytes ?? null;
-	// Bytes actually sent over the wire, from the SigV4 proxy's tally — the
-	// only genuine "uploaded" figure. Absent for backup types the proxy
-	// doesn't front, or before the first inspection.
-	const uploaded = run.s3_sent_payload_bytes ?? null;
+	// Bytes the run actually moved over the wire, from the SigV4 proxy's
+	// tally: payload sent for a backup (upload), payload received for a
+	// restore (download). Absent for runs the proxy didn't front.
+	const transfer =
+		run.purpose === "restore"
+			? (run.s3_received_payload_bytes ?? null)
+			: (run.s3_sent_payload_bytes ?? null);
 	return (
 		<>
 			<TableRow sx={expandable ? { "& > *": { borderBottom: "unset" } } : undefined}>
@@ -788,22 +793,20 @@ function RunRow({ run, members }: { run: RecentRun; members: ServerInfo[] }) {
 					{snapshotSize == null ? (
 						"—"
 					) : fromInspect ? (
-						<Tooltip title="From repo inspection (the device reported no size)">
+						<Tooltip
+							title={
+								run.purpose === "restore"
+									? "Size of the snapshot the restore used, from repo inspection"
+									: "From repo inspection (the device reported no size)"
+							}
+						>
 							<span>{formatBytes(snapshotSize)}</span>
 						</Tooltip>
 					) : (
 						formatBytes(snapshotSize)
 					)}
 				</TableCell>
-				<TableCell>
-					{uploaded == null ? (
-						"—"
-					) : (
-						<Tooltip title="Bytes sent to S3 (SigV4 proxy tally)">
-							<span>{formatBytes(uploaded)}</span>
-						</Tooltip>
-					)}
-				</TableCell>
+				<TableCell>{transfer == null ? "—" : formatBytes(transfer)}</TableCell>
 				<TableCell>
 					<SnapshotId id={run.snapshot_id} />
 				</TableCell>
@@ -1003,7 +1006,7 @@ function RecentRunsPanel({
 								<TableCell>Outcome</TableCell>
 								<TableCell>Duration</TableCell>
 								<TableCell>Snapshot size</TableCell>
-								<TableCell>Uploaded</TableCell>
+								<TableCell>Transfer</TableCell>
 								<TableCell>Snapshot</TableCell>
 							</TableRow>
 						</TableHead>

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -751,8 +751,8 @@ function RunRow({ run, members }: { run: RecentRun; members: ServerInfo[] }) {
 	// Both describe the same quantity — kopia doesn't re-upload bits the
 	// server already has, so this is usually larger than what actually went
 	// over the wire. For a restore this is the size of the snapshot the run
-	// restored from: bestool reports the snapshot id, and inspection backfills
-	// the size onto the run.
+	// restored from, resolved server-side from the backup run that produced it
+	// (by snapshot id) or inspection's backfill.
 	const fromInspect =
 		run.bytes_uploaded == null && run.snapshot_logical_bytes != null;
 	const snapshotSize = run.bytes_uploaded ?? run.snapshot_logical_bytes ?? null;
@@ -796,7 +796,7 @@ function RunRow({ run, members }: { run: RecentRun; members: ServerInfo[] }) {
 						<Tooltip
 							title={
 								run.purpose === "restore"
-									? "Size of the snapshot the restore used, from repo inspection"
+									? "Size of the snapshot the restore used"
 									: "From repo inspection (the device reported no size)"
 							}
 						>


### PR DESCRIPTION
🤖 In the backup panel's recent-runs table:

- Renamed the **Uploaded** column to **Transfer**.
- The column now shows the figure matching the run's direction: payload bytes sent for a backup, payload bytes **received** for a restore. Previously a restore row showed its upload — kopia metadata chatter — which is meaningless for a restore.
- Dropped the tooltip on the figure ("Bytes sent to S3 (SigV4 proxy tally)"), which added no value.

On the size of the snapshot a restore used: it turns out this is already recorded and already rendered. bestool's restore report includes the restored-from `snapshot_id`, and the repo-inspection job backfills `snapshot_logical_bytes` onto runs matched by snapshot id with no purpose filter — so restore rows get the size too, and the existing **Snapshot size** column (which falls back from `bytes_uploaded` to `snapshot_logical_bytes`) displays it. No new column or backend plumbing needed; this PR just makes that cell's tooltip say "Size of the snapshot the restore used, from repo inspection" on restore rows instead of the backup-flavoured wording.

Playwright coverage added for a reported restore row: Transfer shows the download (not the upload, which stays in the collapsed S3-traffic detail), and Snapshot size shows the restored snapshot's inspected size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)