### PR TITLE
fix(ui): order the backups servers list by rank like the group page

### DIFF
--- a/private-web/e2e/backups.spec.ts
+++ b/private-web/e2e/backups.spec.ts
@@ -252,6 +252,58 @@ test.describe("backups ready: stats + backup-now", () => {
 			.toBe("true:2");
 	});
 
+	test("servers panel groups by rank then kind, like the group page", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "rank-order-group" });
+		// Seed out of display order: expected order is the production bucket
+		// (central before facility) then clone then dev, with rank subheaders —
+		// not insertion or alphabetical order.
+		await seedServer(sql, {
+			groupId: group.id,
+			name: "aaa-dev",
+			rank: "dev",
+		});
+		await seedServer(sql, {
+			groupId: group.id,
+			name: "aaa-prod-facility",
+			rank: "production",
+			kind: "facility",
+		});
+		await seedServer(sql, {
+			groupId: group.id,
+			name: "ccc-clone",
+			rank: "clone",
+		});
+		await seedServer(sql, {
+			groupId: group.id,
+			name: "zzz-prod-central",
+			rank: "production",
+			kind: "central",
+		});
+		await seedServerGroupBackupConfig(sql, {
+			groupId: group.id,
+			status: "ready",
+		});
+
+		await page.goto(`/groups/${group.id}/backups`);
+
+		const panel = page
+			.getByRole("heading", { name: "Servers", exact: true })
+			.locator("..");
+		await expect(panel.locator('a[href^="/servers/"]')).toHaveText([
+			"zzz-prod-central",
+			"aaa-prod-facility",
+			"ccc-clone",
+			"aaa-dev",
+		]);
+		// Rank subheaders bucket the rows, same as the group page.
+		await expect(panel.getByText("production", { exact: true })).toBeVisible();
+		await expect(panel.getByText("clone", { exact: true })).toBeVisible();
+		await expect(panel.getByText("dev", { exact: true })).toBeVisible();
+	});
+
 	test("stats render with unknown bucket bytes and recent runs", async ({
 		page,
 		sql,

--- a/private-web/src/routes/BackupPanel.tsx
+++ b/private-web/src/routes/BackupPanel.tsx
@@ -26,7 +26,7 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import BackupIcon from "@mui/icons-material/Backup";
 import RestoreIcon from "@mui/icons-material/SettingsBackupRestore";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -56,6 +56,7 @@ import {
 	type BackupConfigStatus,
 	type BackupConfigView,
 	type BackupMaintenanceRun,
+	groupServersByRank,
 	type RecentRun,
 	type ServerInfo,
 } from "../types";
@@ -1525,105 +1526,124 @@ function ServersPanel({
 							</TableRow>
 						</TableHead>
 						<TableBody>
-							{members.map((m) => {
-								const types = typesForServer(m.id);
-								if (types.length === 0) {
-									return (
-										<TableRow key={m.id}>
-											<TableCell>
-												<Stack spacing={0.5} sx={{ alignItems: "flex-start" }}>
-													{serverLink(m)}
-													{restoreControl(m.id)}
-												</Stack>
-											</TableCell>
-											<TableCell colSpan={3}>
-												<Typography variant="body2" color="text.secondary">
-													No backup types registered yet
+							{groupServersByRank(members).map(([rank, rankMembers]) => (
+								<Fragment key={rank ?? "_unranked"}>
+									{rank && (
+										<TableRow>
+											<TableCell
+												colSpan={5}
+												sx={{ borderBottom: "none", pb: 0 }}
+											>
+												<Typography
+													variant="overline"
+													color="text.secondary"
+												>
+													{rank}
 												</Typography>
 											</TableCell>
-											<TableCell align="right">
-												<Tooltip title="This server hasn't registered any backup types yet.">
-													{/* span so the tooltip works on the disabled button */}
-													<span>
-														<Button
-															size="small"
-															variant="outlined"
-															startIcon={<BackupIcon />}
-															disabled
-														>
-															Backup now
-														</Button>
-													</span>
-												</Tooltip>
-											</TableCell>
 										</TableRow>
-									);
-								}
-								return types.map((t, i) => {
-									const cap = capFor(m.id, t);
-									return (
-										<TableRow key={`${m.id}:${t}`}>
-											{i === 0 && (
-												<TableCell
-													rowSpan={types.length}
-													sx={{ verticalAlign: "top" }}
-												>
-													<Stack
-														spacing={0.5}
-														sx={{ alignItems: "flex-start" }}
-													>
-														{serverLink(m)}
-														{restoreControl(m.id)}
-													</Stack>
-												</TableCell>
-											)}
-											<TableCell>
-												<Stack
-													direction="row"
-													spacing={1}
-													sx={{ alignItems: "center" }}
-												>
-													<Typography
-														variant="body2"
-														sx={{ fontFamily: "monospace" }}
-													>
-														{t}
-													</Typography>
-													{cap?.enabled === false && (
-														<Tooltip title="Not on the backup schedule for this server (toggle it on in the server's Backups section). You can still back it up on demand.">
-															<Chip
-																size="small"
-																variant="outlined"
-																label="not scheduled"
-															/>
+									)}
+									{rankMembers.map((m) => {
+										const types = typesForServer(m.id);
+										if (types.length === 0) {
+											return (
+												<TableRow key={m.id}>
+													<TableCell>
+														<Stack spacing={0.5} sx={{ alignItems: "flex-start" }}>
+															{serverLink(m)}
+															{restoreControl(m.id)}
+														</Stack>
+													</TableCell>
+													<TableCell colSpan={3}>
+														<Typography variant="body2" color="text.secondary">
+															No backup types registered yet
+														</Typography>
+													</TableCell>
+													<TableCell align="right">
+														<Tooltip title="This server hasn't registered any backup types yet.">
+															{/* span so the tooltip works on the disabled button */}
+															<span>
+																<Button
+																	size="small"
+																	variant="outlined"
+																	startIcon={<BackupIcon />}
+																	disabled
+																>
+																	Backup now
+																</Button>
+															</span>
 														</Tooltip>
+													</TableCell>
+												</TableRow>
+											);
+										}
+										return types.map((t, i) => {
+											const cap = capFor(m.id, t);
+											return (
+												<TableRow key={`${m.id}:${t}`}>
+													{i === 0 && (
+														<TableCell
+															rowSpan={types.length}
+															sx={{ verticalAlign: "top" }}
+														>
+															<Stack
+																spacing={0.5}
+																sx={{ alignItems: "flex-start" }}
+															>
+																{serverLink(m)}
+																{restoreControl(m.id)}
+															</Stack>
+														</TableCell>
 													)}
-													<BackupProcessingChip
-														since={cap?.processing_since}
-													/>
-												</Stack>
-											</TableCell>
-											<TableCell>
-												{cap?.next_backup_at ? (
-													<TimeAgo timestamp={cap.next_backup_at} />
-												) : (
-													<Typography variant="body2" color="text.secondary">
-														—
-													</Typography>
-												)}
-											</TableCell>
-											<TableCell>
-												<LatestSnapshot
-													id={cap?.latest_snapshot_id}
-													at={cap?.latest_snapshot_at}
-													bytes={cap?.latest_snapshot_bytes}
-												/>
-											</TableCell>
-											<TableCell align="right">{actionCell(m.id, t)}</TableCell>
-										</TableRow>
-									);
-								});
-							})}
+													<TableCell>
+														<Stack
+															direction="row"
+															spacing={1}
+															sx={{ alignItems: "center" }}
+														>
+															<Typography
+																variant="body2"
+																sx={{ fontFamily: "monospace" }}
+															>
+																{t}
+															</Typography>
+															{cap?.enabled === false && (
+																<Tooltip title="Not on the backup schedule for this server (toggle it on in the server's Backups section). You can still back it up on demand.">
+																	<Chip
+																		size="small"
+																		variant="outlined"
+																		label="not scheduled"
+																	/>
+																</Tooltip>
+															)}
+															<BackupProcessingChip
+																since={cap?.processing_since}
+															/>
+														</Stack>
+													</TableCell>
+													<TableCell>
+														{cap?.next_backup_at ? (
+															<TimeAgo timestamp={cap.next_backup_at} />
+														) : (
+															<Typography variant="body2" color="text.secondary">
+																—
+															</Typography>
+														)}
+													</TableCell>
+													<TableCell>
+														<LatestSnapshot
+															id={cap?.latest_snapshot_id}
+															at={cap?.latest_snapshot_at}
+															bytes={cap?.latest_snapshot_bytes}
+														/>
+													</TableCell>
+													<TableCell align="right">{actionCell(m.id, t)}</TableCell>
+												</TableRow>
+											);
+										});
+									})}
+								</Fragment>
+							))}
 						</TableBody>
 					</Table>
 				</Box>

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -26,13 +26,10 @@ import {
 	BACKUP_STATUS_INTENT,
 	BACKUP_STATUS_LABEL,
 	type BackupConfigStatus,
-	SERVER_RANK_ORDER,
 	aggregateOperators,
-	compareServersByRankThenKind,
+	groupServersByRank,
 	type AggregatedOperator,
 	type IncidentData,
-	type ServerInfo,
-	type ServerRank,
 } from "../types";
 
 export default function GroupDetail() {
@@ -417,31 +414,6 @@ function ActiveIncidentCard({ incident }: { incident: IncidentData }) {
 			</Stack>
 		</Paper>
 	);
-}
-
-/// Group a flat server list into rank buckets in display order, with
-/// each bucket internally sorted by kind (centrals first) then name.
-/// Servers without a rank land in a trailing `null` bucket.
-function groupServersByRank(
-	servers: ServerInfo[],
-): Array<[ServerRank | null, ServerInfo[]]> {
-	const buckets = new Map<ServerRank | null, ServerInfo[]>();
-	for (const s of servers) {
-		const rank = s.rank ?? null;
-		const list = buckets.get(rank);
-		if (list) list.push(s);
-		else buckets.set(rank, [s]);
-	}
-	const order: Array<ServerRank | null> = [...SERVER_RANK_ORDER, null];
-	const result: Array<[ServerRank | null, ServerInfo[]]> = [];
-	for (const rank of order) {
-		const list = buckets.get(rank);
-		if (list && list.length > 0) {
-			list.sort(compareServersByRankThenKind);
-			result.push([rank, list]);
-		}
-	}
-	return result;
 }
 
 function ArchivedGroupBanner({

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -72,9 +72,9 @@ import { humanSeconds } from "../lib/humanDuration";
 import ServerNameWithGroup from "../components/ServerNameWithGroup";
 import {
 	CHECK_RESULT_ORDER,
-	SERVER_RANK_ORDER,
 	checkResultOf,
 	compareServersByRankThenKind,
+	groupServersByRank,
 	healthcheckPath,
 	type CheckResult,
 	type DeviceInfo,
@@ -86,7 +86,6 @@ import {
 	type ServerGroupSilencedRef,
 	type ServerInfo,
 	type ServerLastStatusData,
-	type ServerRank,
 	type ServerSilencedRef,
 	type ShortStatus,
 } from "../types";
@@ -1497,22 +1496,7 @@ function SiblingServers({
 	// reader scanning ServerDetail's sibling section sees the production
 	// peers up top and the dev scratch at the bottom in a predictable
 	// order. Unranked servers fall into a trailing `null` bucket.
-	const buckets = new Map<ServerRank | null, ServerDetailData["siblings"]>();
-	for (const sib of siblings) {
-		const rank = sib.rank ?? null;
-		const list = buckets.get(rank);
-		if (list) list.push(sib);
-		else buckets.set(rank, [sib]);
-	}
-	const order: Array<ServerRank | null> = [...SERVER_RANK_ORDER, null];
-	const groups: Array<[ServerRank | null, ServerDetailData["siblings"]]> = [];
-	for (const rank of order) {
-		const list = buckets.get(rank);
-		if (list && list.length > 0) {
-			list.sort(compareServersByRankThenKind);
-			groups.push([rank, list]);
-		}
-	}
+	const groups = groupServersByRank(siblings);
 
 	return (
 		<Box>

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -224,6 +224,31 @@ export function compareServersByRankThenKind<
 	return an.localeCompare(bn);
 }
 
+/// Group a flat server list into rank buckets in display order, with
+/// each bucket internally sorted by kind (centrals first) then name.
+/// Servers without a rank land in a trailing `null` bucket.
+export function groupServersByRank<
+	T extends { rank?: ServerRank | null; kind: ServerKind; name?: string | null },
+>(servers: readonly T[]): Array<[ServerRank | null, T[]]> {
+	const buckets = new Map<ServerRank | null, T[]>();
+	for (const s of servers) {
+		const rank = s.rank ?? null;
+		const list = buckets.get(rank);
+		if (list) list.push(s);
+		else buckets.set(rank, [s]);
+	}
+	const order: Array<ServerRank | null> = [...SERVER_RANK_ORDER, null];
+	const result: Array<[ServerRank | null, T[]]> = [];
+	for (const rank of order) {
+		const list = buckets.get(rank);
+		if (list && list.length > 0) {
+			list.sort(compareServersByRankThenKind);
+			result.push([rank, list]);
+		}
+	}
+	return result;
+}
+
 /// Operator-facing severity vocabulary, loud → quiet. Used for both
 /// display and selection (the API now restricts severities to these
 /// five — see commons-types::issue::Severity and the


### PR DESCRIPTION
🤖 The Servers panel on the group backups page listed members in whatever order the API returned them. It now uses the same rank-bucket grouping as the group page: rank subheaders in `production → clone → demo → test → dev` order (unranked last), with each bucket sorted centrals-first then by name.

The grouping logic was duplicated in `GroupDetail` and inline in `ServerDetail`'s sibling list, so it's extracted to a shared `groupServersByRank` helper in `types.ts` (next to `compareServersByRankThenKind`) and all three call sites use it.

Playwright coverage added for the panel's ordering and subheaders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)