### PR TITLE
feat(restore): human-unit byte and duration inputs for restore replicas

### DIFF
--- a/crates/commons-types/src/backup.rs
+++ b/crates/commons-types/src/backup.rs
@@ -471,6 +471,12 @@ pub enum ParamValidationError {
 		name: String,
 		expected: &'static str,
 	},
+	#[error("parameter {name:?}: {error}")]
+	Unit {
+		name: String,
+		#[source]
+		error: crate::units::UnitParseError,
+	},
 }
 
 /// Validate operator-supplied values against a schema. Every value must name a
@@ -508,6 +514,87 @@ pub fn validate_params(
 		}
 	}
 	Ok(())
+}
+
+/// Resolve human-unit string values into their raw stored form, per the
+/// schema: a string value for a `duration` parameter parses in jiff's
+/// "friendly" format (e.g. `2h 30m`) to whole seconds, and one for a `bytes`
+/// parameter parses as a 1024-based size (e.g. `20Gi`) to a byte count. Raw
+/// integer values pass through unchanged, as do values of other types and
+/// values for parameters the schema doesn't describe ([`validate_params`]
+/// deals with those separately).
+pub fn normalize_params(
+	schema: &ParamSchema,
+	values: &ParamValues,
+) -> Result<ParamValues, ParamValidationError> {
+	values
+		.iter()
+		.map(|(name, value)| {
+			let unit_err = |error| ParamValidationError::Unit {
+				name: name.clone(),
+				error,
+			};
+			let normalized = match (schema.get(name).map(|s| s.r#type), value.as_str()) {
+				(Some(ParamType::Duration), Some(text)) => {
+					crate::units::parse_duration_seconds(text)
+						.map_err(unit_err)?
+						.into()
+				}
+				(Some(ParamType::Bytes), Some(text)) => {
+					crate::units::parse_bytes(text).map_err(unit_err)?.into()
+				}
+				_ => value.clone(),
+			};
+			Ok((name.clone(), normalized))
+		})
+		.collect()
+}
+
+/// Format raw stored values as human-unit display strings, per the schema:
+/// a non-negative integer value of a `duration` parameter becomes a friendly
+/// duration string (e.g. `2h 30m`), and one of a `bytes` parameter becomes a
+/// Kubernetes-notation size (e.g. `20Gi`). Everything else passes through
+/// unchanged.
+pub fn display_params(schema: &ParamSchema, values: &ParamValues) -> ParamValues {
+	values
+		.iter()
+		.map(|(name, value)| {
+			let displayed = match (schema.get(name).map(|s| s.r#type), value.as_i64()) {
+				(Some(ParamType::Duration), Some(n)) if n >= 0 => {
+					crate::units::format_duration_seconds(n).into()
+				}
+				(Some(ParamType::Bytes), Some(n)) if n >= 0 => crate::units::format_bytes(n).into(),
+				_ => value.clone(),
+			};
+			(name.clone(), displayed)
+		})
+		.collect()
+}
+
+/// Format a schema's `duration`/`bytes` defaults as human-unit display
+/// strings, for operator-facing output; everything else passes through
+/// unchanged.
+pub fn display_param_defaults(schema: &ParamSchema) -> ParamSchema {
+	schema
+		.iter()
+		.map(|(name, spec)| {
+			let raw = spec.default.as_ref().and_then(|d| d.as_i64());
+			let default = match (spec.r#type, raw) {
+				(ParamType::Duration, Some(n)) if n >= 0 => {
+					Some(crate::units::format_duration_seconds(n).into())
+				}
+				(ParamType::Bytes, Some(n)) if n >= 0 => Some(crate::units::format_bytes(n).into()),
+				_ => spec.default.clone(),
+			};
+			(
+				name.clone(),
+				ParamSpec {
+					r#type: spec.r#type,
+					default,
+				},
+			)
+		})
+		.collect()
 }
 
 /// Resolve the values to send in the worklist: one entry per parameter the
@@ -614,6 +701,84 @@ mod tests {
 		assert_eq!(
 			serde_json::from_str::<ParamType>("\"boolean\"").unwrap(),
 			ParamType::Boolean
+		);
+	}
+
+	#[test]
+	fn normalize_params_resolves_unit_strings_to_raw_values() {
+		let values: ParamValues = serde_json::from_value(serde_json::json!({
+			"minimum_uptime": "2h 30m",
+			"max_size": "20G",
+			"anonymisation": true,
+		}))
+		.unwrap();
+		let normalized = normalize_params(&schema(), &values).unwrap();
+		assert_eq!(normalized["minimum_uptime"], serde_json::json!(9000));
+		assert_eq!(normalized["max_size"], serde_json::json!(20i64 << 30));
+		assert_eq!(normalized["anonymisation"], serde_json::json!(true));
+		assert!(validate_params(&schema(), &normalized).is_ok());
+	}
+
+	#[test]
+	fn normalize_params_passes_raw_integers_and_unknown_names_through() {
+		let values: ParamValues = serde_json::from_value(serde_json::json!({
+			"minimum_uptime": 3600,
+			"not_in_schema": "20G",
+		}))
+		.unwrap();
+		let normalized = normalize_params(&schema(), &values).unwrap();
+		assert_eq!(normalized["minimum_uptime"], serde_json::json!(3600));
+		assert_eq!(normalized["not_in_schema"], serde_json::json!("20G"));
+	}
+
+	#[test]
+	fn normalize_params_rejects_bad_unit_strings() {
+		for (name, value) in [
+			("minimum_uptime", "banana"),
+			("minimum_uptime", "1mo"),
+			("minimum_uptime", "-1h"),
+			("max_size", "20T"),
+			("max_size", "lots"),
+		] {
+			let values: ParamValues =
+				serde_json::from_value(serde_json::json!({ name: value })).unwrap();
+			let err = normalize_params(&schema(), &values).unwrap_err();
+			assert!(
+				matches!(err, ParamValidationError::Unit { .. }),
+				"{name}={value:?} gave {err:?}"
+			);
+		}
+	}
+
+	#[test]
+	fn display_params_formats_raw_values_as_unit_strings() {
+		let values: ParamValues = serde_json::from_value(serde_json::json!({
+			"minimum_uptime": 9000,
+			"max_size": 20i64 << 30,
+			"anonymisation": true,
+		}))
+		.unwrap();
+		let displayed = display_params(&schema(), &values);
+		assert_eq!(displayed["minimum_uptime"], serde_json::json!("2h 30m"));
+		assert_eq!(displayed["max_size"], serde_json::json!("20Gi"));
+		assert_eq!(displayed["anonymisation"], serde_json::json!(true));
+		// Displayed values normalize straight back to the raw ones.
+		let normalized = normalize_params(&schema(), &displayed).unwrap();
+		assert_eq!(normalized["minimum_uptime"], serde_json::json!(9000));
+		assert_eq!(normalized["max_size"], serde_json::json!(20i64 << 30));
+	}
+
+	#[test]
+	fn display_param_defaults_formats_duration_and_bytes_defaults() {
+		let displayed = display_param_defaults(&schema());
+		assert_eq!(
+			displayed["minimum_uptime"].default,
+			Some(serde_json::json!("2h"))
+		);
+		assert_eq!(displayed["max_size"].default, None);
+		assert_eq!(
+			displayed["anonymisation"].default,
+			Some(serde_json::json!(true))
 		);
 	}
 

--- a/crates/commons-types/src/lib.rs
+++ b/crates/commons-types/src/lib.rs
@@ -6,4 +6,5 @@ pub mod geo;
 pub mod issue;
 pub mod server;
 pub mod status;
+pub mod units;
 pub mod version;

--- a/crates/commons-types/src/units.rs
+++ b/crates/commons-types/src/units.rs
@@ -1,0 +1,216 @@
+//! Parsing and formatting of human-friendly units: byte sizes (1024-based,
+//! displayed in Kubernetes notation like `20Gi`) and durations (jiff's
+//! "friendly" format like `2h 30m`). Raw values remain whole bytes and whole
+//! seconds; these helpers only translate at the operator-facing edge.
+
+use jiff::{Span, SpanRelativeTo, SpanRound, Unit};
+
+/// A human-unit string failed to parse.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum UnitParseError {
+	/// Not a valid byte size.
+	#[error(
+		"invalid size {input:?}: expected a whole number of bytes with an optional 1024-based unit, e.g. `20Gi` or `512Mi`"
+	)]
+	Bytes {
+		/// The rejected input.
+		input: String,
+	},
+	/// Not a valid duration.
+	#[error("invalid duration {input:?}: {reason}")]
+	Duration {
+		/// The rejected input.
+		input: String,
+		/// Why it was rejected.
+		reason: String,
+	},
+}
+
+/// Parse a byte size with an optional unit suffix into a raw byte count.
+///
+/// Accepts a whole number followed by an optional `k`/`m`/`g` unit, itself
+/// optionally followed by `i` and/or `b` in any capitalisation (`20g`, `20G`,
+/// `20Gi`, `20GB`, `20GiB` are all the same). Every unit is 1024-based: `20G`
+/// means 20Gi in Kubernetes notation, never 20×10⁹. A bare number (or a `b`
+/// suffix) is a plain byte count.
+pub fn parse_bytes(input: &str) -> Result<i64, UnitParseError> {
+	let err = || UnitParseError::Bytes {
+		input: input.into(),
+	};
+	let trimmed = input.trim();
+	let digits_end = trimmed
+		.find(|c: char| !c.is_ascii_digit())
+		.unwrap_or(trimmed.len());
+	let (digits, suffix) = trimmed.split_at(digits_end);
+	if digits.is_empty() {
+		return Err(err());
+	}
+	let value: i64 = digits.parse().map_err(|_| err())?;
+	let multiplier: i64 = match suffix.trim_start().to_ascii_lowercase().as_str() {
+		"" | "b" => 1,
+		"k" | "ki" | "kb" | "kib" => 1 << 10,
+		"m" | "mi" | "mb" | "mib" => 1 << 20,
+		"g" | "gi" | "gb" | "gib" => 1 << 30,
+		_ => return Err(err()),
+	};
+	value.checked_mul(multiplier).ok_or_else(err)
+}
+
+/// Format a raw byte count in Kubernetes notation (`20Gi`, `512Mi`, `1Ki`),
+/// using the largest 1024-based unit that divides it exactly; counts that
+/// don't divide evenly (and zero) stay as plain byte numbers.
+pub fn format_bytes(bytes: i64) -> String {
+	if bytes > 0 {
+		for (factor, unit) in [(1 << 30, "Gi"), (1 << 20, "Mi"), (1 << 10, "Ki")] {
+			if bytes % factor == 0 {
+				return format!("{}{unit}", bytes / factor);
+			}
+		}
+	}
+	bytes.to_string()
+}
+
+/// Parse a duration in jiff's "friendly" format (or ISO 8601) into a whole
+/// number of seconds.
+///
+/// Accepts e.g. `2h 30m`, `90m`, `1d 12h`, `2 hours 30 minutes`; days and
+/// weeks are fixed at 24 hours and 7 days. Rejects negative durations,
+/// sub-second precision, calendar units (months and up), and bare numbers
+/// without a unit.
+pub fn parse_duration_seconds(input: &str) -> Result<i64, UnitParseError> {
+	let err = |reason: String| UnitParseError::Duration {
+		input: input.into(),
+		reason,
+	};
+	let span: Span = input
+		.trim()
+		.parse()
+		.map_err(|e: jiff::Error| err(e.to_string()))?;
+	let duration = span
+		.to_duration(SpanRelativeTo::days_are_24_hours())
+		.map_err(|e| err(e.to_string()))?;
+	if duration.is_negative() {
+		return Err(err("must not be negative".into()));
+	}
+	if duration.subsec_nanos() != 0 {
+		return Err(err("must be a whole number of seconds".into()));
+	}
+	Ok(duration.as_secs())
+}
+
+/// Format a whole number of seconds in jiff's "friendly" format, balanced up
+/// to days (24-hour days): `9000` → `2h 30m`, `129600` → `1d 12h`.
+pub fn format_duration_seconds(seconds: i64) -> String {
+	Span::new()
+		.try_seconds(seconds)
+		.and_then(|span| {
+			span.round(
+				SpanRound::new()
+					.largest(Unit::Day)
+					.relative(SpanRelativeTo::days_are_24_hours()),
+			)
+		})
+		.map(|span| format!("{span:#}"))
+		.unwrap_or_else(|_| format!("{seconds}s"))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn bytes_parse_all_suffix_spellings_as_1024_based() {
+		const GI: i64 = 1 << 30;
+		for input in [
+			"20g", "20G", "20gi", "20Gi", "20gb", "20GB", "20gib", "20GiB",
+		] {
+			assert_eq!(parse_bytes(input).unwrap(), 20 * GI, "input {input:?}");
+		}
+		assert_eq!(parse_bytes("512Mi").unwrap(), 512 << 20);
+		assert_eq!(parse_bytes("3k").unwrap(), 3 << 10);
+		assert_eq!(parse_bytes("3KiB").unwrap(), 3 << 10);
+	}
+
+	#[test]
+	fn bytes_parse_bare_and_b_suffixed_numbers_as_bytes() {
+		assert_eq!(parse_bytes("20").unwrap(), 20);
+		assert_eq!(parse_bytes("20b").unwrap(), 20);
+		assert_eq!(parse_bytes("20B").unwrap(), 20);
+		assert_eq!(parse_bytes("0").unwrap(), 0);
+		assert_eq!(parse_bytes(" 20 Gi ").unwrap(), 20 << 30);
+	}
+
+	#[test]
+	fn bytes_parse_rejects_junk() {
+		for input in [
+			"", "g", "20t", "20TB", "-20g", "20.5g", "20gg", "20 gi b", "abc", "20girib",
+		] {
+			assert!(parse_bytes(input).is_err(), "input {input:?}");
+		}
+		// Overflows i64.
+		assert!(parse_bytes("9999999999999999999").is_err());
+		assert!(parse_bytes("9999999999g").is_err());
+	}
+
+	#[test]
+	fn bytes_format_uses_largest_exact_unit() {
+		assert_eq!(format_bytes(20 << 30), "20Gi");
+		assert_eq!(format_bytes(512 << 20), "512Mi");
+		assert_eq!(format_bytes(1 << 10), "1Ki");
+		assert_eq!(format_bytes(2048 << 20), "2Gi");
+		assert_eq!(format_bytes(1536), "1536");
+		assert_eq!(format_bytes(0), "0");
+		assert_eq!(format_bytes(999), "999");
+	}
+
+	#[test]
+	fn bytes_round_trip() {
+		for n in [0, 999, 1536, 1 << 10, 512 << 20, 20 << 30] {
+			assert_eq!(parse_bytes(&format_bytes(n)).unwrap(), n, "value {n}");
+		}
+	}
+
+	#[test]
+	fn duration_parse_friendly_and_iso() {
+		assert_eq!(parse_duration_seconds("2h 30m").unwrap(), 9000);
+		assert_eq!(parse_duration_seconds("2h30m").unwrap(), 9000);
+		assert_eq!(parse_duration_seconds("90m").unwrap(), 5400);
+		assert_eq!(parse_duration_seconds("1d 12h").unwrap(), 129600);
+		assert_eq!(parse_duration_seconds("1w").unwrap(), 604800);
+		assert_eq!(parse_duration_seconds("2 hours 30 minutes").unwrap(), 9000);
+		assert_eq!(parse_duration_seconds("PT2H30M").unwrap(), 9000);
+		assert_eq!(parse_duration_seconds("0s").unwrap(), 0);
+	}
+
+	#[test]
+	fn duration_parse_rejects_junk() {
+		for input in [
+			"", "banana", "20", "1mo", "1y", "-1h", "1h ago", "0.5s", "1s 500ms",
+		] {
+			assert!(parse_duration_seconds(input).is_err(), "input {input:?}");
+		}
+	}
+
+	#[test]
+	fn duration_format_balances_up_to_days() {
+		assert_eq!(format_duration_seconds(0), "0s");
+		assert_eq!(format_duration_seconds(45), "45s");
+		assert_eq!(format_duration_seconds(90), "1m 30s");
+		assert_eq!(format_duration_seconds(3600), "1h");
+		assert_eq!(format_duration_seconds(9000), "2h 30m");
+		assert_eq!(format_duration_seconds(86400), "1d");
+		assert_eq!(format_duration_seconds(129600), "1d 12h");
+		assert_eq!(format_duration_seconds(604800), "7d");
+	}
+
+	#[test]
+	fn duration_round_trip() {
+		for n in [0, 45, 90, 3600, 9000, 86400, 129600, 604800] {
+			assert_eq!(
+				parse_duration_seconds(&format_duration_seconds(n)).unwrap(),
+				n,
+				"value {n}"
+			);
+		}
+	}
+}

--- a/crates/private-server/src/fns/restore_replicas.rs
+++ b/crates/private-server/src/fns/restore_replicas.rs
@@ -19,8 +19,9 @@ use commons_types::{
 	Uuid,
 	backup::{
 		BackupPurpose, BackupType, IntentDescriptor, ParamValues, RestoreIntent, RunOutcome,
-		validate_params,
+		display_param_defaults, display_params, normalize_params, validate_params,
 	},
+	units,
 };
 use database::diesel_async::AsyncPgConnection;
 use database::pg_duration::PgDuration;
@@ -74,12 +75,16 @@ pub struct RestoreReplicaView {
 	pub intent: RestoreIntent,
 	/// Operator-chosen display name for the declaration.
 	pub name: String,
-	/// Overdue bound in whole seconds: how long the replica may go without a
-	/// healthy restore report (or, for at-most-once intents, how long the
-	/// latest snapshot may go unverified) before it is considered overdue.
-	/// Null means no bound.
-	pub overdue_after_seconds: Option<i64>,
-	/// Operator-supplied parameter values (name → value).
+	/// Overdue bound as a human-friendly duration (e.g. `2h 30m` or `1d`):
+	/// how long the replica may go without a healthy restore report (or, for
+	/// at-most-once intents, how long the latest snapshot may go unverified)
+	/// before it is considered overdue. Null means no bound. The same format
+	/// is accepted back by `create` and `update`.
+	pub overdue_after: Option<String>,
+	/// Operator-supplied parameter values (name → value). Values of
+	/// `duration` and `bytes` parameters are formatted as human-friendly
+	/// strings (e.g. `2h 30m`, `20Gi`) when the intent's schema is known;
+	/// `create` and `update` accept these strings back.
 	#[schema(value_type = Object)]
 	pub params: serde_json::Value,
 	/// Whether the declaration is active. Disabled declarations are not
@@ -144,10 +149,13 @@ pub struct RestoreReplicasCreateArgs {
 	pub intent: RestoreIntent,
 	/// Display name for the declaration.
 	pub name: String,
-	/// Overdue bound in whole seconds; omit or null for no bound.
-	pub overdue_after_seconds: Option<i64>,
+	/// Overdue bound as a human-friendly duration (jiff's "friendly" format,
+	/// e.g. `2h 30m`, `36h`, `1d 12h`); omit, null, or blank for no bound.
+	pub overdue_after: Option<String>,
 	/// Parameter values for the intent (name → value), validated against the
-	/// consumer's advertised parameter schema. Defaults to empty.
+	/// consumer's advertised parameter schema. `duration` and `bytes`
+	/// parameters accept human-unit strings (e.g. `2h 30m`, `20Gi`) as well
+	/// as raw integer seconds/bytes. Defaults to empty.
 	#[serde(default)]
 	#[schema(value_type = Object)]
 	pub params: ParamValues,
@@ -180,10 +188,14 @@ pub struct RestoreReplicasUpdateArgs {
 	pub intent: RestoreIntent,
 	/// New display name for the declaration.
 	pub name: String,
-	/// New overdue bound in whole seconds; null removes the bound.
-	pub overdue_after_seconds: Option<i64>,
+	/// New overdue bound as a human-friendly duration (jiff's "friendly"
+	/// format, e.g. `2h 30m`, `36h`, `1d 12h`); null or blank removes the
+	/// bound.
+	pub overdue_after: Option<String>,
 	/// New parameter values (name → value), validated against the intent's
-	/// advertised parameter schema. Defaults to empty.
+	/// advertised parameter schema. `duration` and `bytes` parameters accept
+	/// human-unit strings (e.g. `2h 30m`, `20Gi`) as well as raw integer
+	/// seconds/bytes. Defaults to empty.
 	#[serde(default)]
 	#[schema(value_type = Object)]
 	pub params: ParamValues,
@@ -200,29 +212,42 @@ pub struct IdArgs {
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
-fn overdue_after_to_pg(seconds: Option<i64>) -> Option<PgDuration> {
-	seconds.map(|s| PgDuration(SignedDuration::from_secs(s)))
+/// Parse an operator-supplied overdue bound (jiff's "friendly" duration
+/// format, e.g. `2h 30m`) into the stored form; null or blank means no bound.
+/// A string that doesn't parse maps to 400.
+fn overdue_after_to_pg(overdue_after: Option<&str>) -> Result<Option<PgDuration>> {
+	let Some(text) = overdue_after.map(str::trim).filter(|t| !t.is_empty()) else {
+		return Ok(None);
+	};
+	let seconds = units::parse_duration_seconds(text)
+		.map_err(|e| AppError::BadRequest(format!("overdue bound: {e}")))?;
+	Ok(Some(PgDuration(SignedDuration::from_secs(seconds))))
 }
 
-/// Validate operator-supplied parameter values against the consumer's advertised
-/// schema for `intent`. If the intent is not advertised (a gap) there is no
-/// schema to check against, so the values are accepted as-is.
-async fn validate_params_for_intent(
+/// Resolve human-unit strings in operator-supplied parameter values to their
+/// raw stored form and validate them against the consumer's advertised schema
+/// for `intent`. If the intent is not advertised (a gap) there is no schema to
+/// resolve or check against, so the values are accepted as-is.
+async fn normalized_params_for_intent(
 	conn: &mut AsyncPgConnection,
 	consumer_device_id: Uuid,
 	intent: &RestoreIntent,
 	params: &ParamValues,
-) -> Result<()> {
+) -> Result<ParamValues> {
 	let descriptors =
 		RestoreConsumerCapability::list_for_consumer(conn, consumer_device_id).await?;
-	if let Some(desc) = descriptors.iter().find(|d| &d.intent == intent) {
-		validate_params(&desc.params, params).map_err(|e| AppError::BadRequest(e.to_string()))?;
-	}
-	Ok(())
+	let Some(desc) = descriptors.iter().find(|d| &d.intent == intent) else {
+		return Ok(params.clone());
+	};
+	let normalized =
+		normalize_params(&desc.params, params).map_err(|e| AppError::BadRequest(e.to_string()))?;
+	validate_params(&desc.params, &normalized).map_err(|e| AppError::BadRequest(e.to_string()))?;
+	Ok(normalized)
 }
 
 /// Build views from declarations, resolving consumer display names and the
-/// per-consumer capability set so `gap` can be computed.
+/// per-consumer capabilities so `gap` can be computed and stored `duration`/
+/// `bytes` parameter values can be shown as human-unit strings.
 async fn to_views(
 	conn: &mut AsyncPgConnection,
 	replicas: Vec<RestoreReplica>,
@@ -237,28 +262,34 @@ async fn to_views(
 			.map(|d| (d.id, d.tailscale_node_name))
 			.collect();
 
-	let mut caps: HashMap<Uuid, HashSet<RestoreIntent>> = HashMap::new();
+	let mut caps: HashMap<Uuid, Vec<IntentDescriptor>> = HashMap::new();
 	for id in consumer_ids {
-		let set: HashSet<RestoreIntent> = RestoreConsumerCapability::list_for_consumer(conn, id)
-			.await?
-			.into_iter()
-			.map(|d| d.intent)
-			.collect();
-		caps.insert(id, set);
+		let descriptors = RestoreConsumerCapability::list_for_consumer(conn, id).await?;
+		caps.insert(id, descriptors);
 	}
 
 	Ok(replicas
 		.into_iter()
 		.map(|r| {
-			let gap = !caps
+			let schema = caps
 				.get(&r.consumer_device_id)
-				.map(|s| s.contains(&r.intent))
-				.unwrap_or(false);
+				.and_then(|descs| descs.iter().find(|d| d.intent == r.intent))
+				.map(|d| &d.params);
+			// With no schema (a gap) the stored values pass through raw.
+			let params = match (schema, r.params) {
+				(Some(schema), serde_json::Value::Object(map)) => {
+					let values: ParamValues = map.into_iter().collect();
+					serde_json::to_value(display_params(schema, &values)).expect("params serialize")
+				}
+				(_, params) => params,
+			};
 			RestoreReplicaView {
+				gap: schema.is_none(),
 				consumer_name: names.get(&r.consumer_device_id).cloned().flatten(),
-				overdue_after_seconds: r.overdue_after.map(|f| f.0.as_secs()),
-				params: r.params,
-				gap,
+				overdue_after: r
+					.overdue_after
+					.map(|f| units::format_duration_seconds(f.0.as_secs())),
+				params,
 				id: r.id,
 				consumer_device_id: r.consumer_device_id,
 				group_id: r.group_id,
@@ -306,7 +337,8 @@ pub async fn for_group(
 /// restore intents it currently advertises (each with its description,
 /// semantics flags, and parameter schema). Use this to discover which
 /// consumers and intents a declaration can target and which parameters each
-/// intent accepts.
+/// intent accepts. Defaults of `duration` and `bytes` parameters are
+/// formatted as human-unit strings (e.g. `2h`, `20Gi`).
 #[utoipa::path(
 	post,
 	path = "/consumers",
@@ -320,7 +352,16 @@ pub async fn consumers(State(state): State<AppState>) -> Result<Json<Vec<Restore
 	let devices = Device::list_by_role(&mut conn, DeviceRole::BackupRestore).await?;
 	let mut out = Vec::with_capacity(devices.len());
 	for d in devices {
-		let intents = RestoreConsumerCapability::list_for_consumer(&mut conn, d.id).await?;
+		let intents = RestoreConsumerCapability::list_for_consumer(&mut conn, d.id)
+			.await?
+			.into_iter()
+			// `duration`/`bytes` defaults are shown to operators, so format
+			// them as human-unit strings like the declaration values.
+			.map(|mut desc| {
+				desc.params = display_param_defaults(&desc.params);
+				desc
+			})
+			.collect();
 		out.push(RestoreConsumerView {
 			device_id: d.id,
 			name: d.tailscale_node_name,
@@ -522,12 +563,15 @@ pub async fn checks(
 ///
 /// Creates a declaration instructing the chosen consumer to maintain a
 /// restored replica of the given backup type for the given intent, and
-/// records the calling operator as its creator. Parameter values are
-/// validated against the consumer's advertised schema for the intent; if the
-/// intent is not currently advertised, the values are accepted as-is and the
-/// declaration is created with a gap. Requires the caller to be on the admin
-/// allow-list. Responds 400 if a parameter value fails validation and 409 if
-/// a matching declaration already exists.
+/// records the calling operator as its creator. The overdue bound is a
+/// human-friendly duration string (e.g. `2h 30m`); `duration` and `bytes`
+/// parameter values likewise accept human-unit strings (e.g. `20Gi`), which
+/// are resolved to raw seconds/bytes before validation against the consumer's
+/// advertised schema for the intent and stored raw. If the intent is not
+/// currently advertised, the values are accepted as-is and the declaration is
+/// created with a gap. Requires the caller to be on the admin allow-list.
+/// Responds 400 if the overdue bound or a parameter value fails to parse or
+/// validate, and 409 if a matching declaration already exists.
 #[utoipa::path(
 	post,
 	path = "/create",
@@ -546,7 +590,7 @@ pub async fn create(
 	Json(args): Json<RestoreReplicasCreateArgs>,
 ) -> Result<Json<RestoreReplicaView>> {
 	let mut conn = state.db.get().await?;
-	validate_params_for_intent(
+	let params = normalized_params_for_intent(
 		&mut conn,
 		args.consumer_device_id,
 		&args.intent,
@@ -562,8 +606,8 @@ pub async fn create(
 			r#type: args.r#type,
 			intent: args.intent,
 			name: args.name,
-			overdue_after: overdue_after_to_pg(args.overdue_after_seconds),
-			params: serde_json::to_value(&args.params).expect("params serialize"),
+			overdue_after: overdue_after_to_pg(args.overdue_after.as_deref())?,
+			params: serde_json::to_value(&params).expect("params serialize"),
 			created_by: Some(admin.login),
 		},
 	)
@@ -576,15 +620,17 @@ pub async fn create(
 ///
 /// Replaces every field, including scope: the consumer, group, server,
 /// backup type, and intent can be retargeted in the same call as the name,
-/// overdue bound, parameter values, and enabled flag. Parameter values are
-/// validated against the *new* consumer+intent's advertised parameter schema;
-/// as with `create`, an intent the new consumer doesn't currently advertise
-/// is accepted and the values pass through unvalidated, leaving the
-/// declaration with a gap. If the scope changes, any active
-/// restore-verification alert for the declaration's old scope is recovered.
-/// Requires the caller to be on the admin allow-list. Responds 400 if a
-/// parameter value fails validation, 404 if the declaration does not exist,
-/// and 409 if the new scope collides with another declaration.
+/// overdue bound, parameter values, and enabled flag. The overdue bound and
+/// `duration`/`bytes` parameter values accept human-unit strings (e.g.
+/// `2h 30m`, `20Gi`), resolved to raw seconds/bytes and validated against the
+/// *new* consumer+intent's advertised parameter schema; as with `create`, an
+/// intent the new consumer doesn't currently advertise is accepted and the
+/// values pass through unvalidated, leaving the declaration with a gap. If
+/// the scope changes, any active restore-verification alert for the
+/// declaration's old scope is recovered. Requires the caller to be on the
+/// admin allow-list. Responds 400 if the overdue bound or a parameter value
+/// fails to parse or validate, 404 if the declaration does not exist, and 409
+/// if the new scope collides with another declaration.
 #[utoipa::path(
 	post,
 	path = "/update",
@@ -604,7 +650,7 @@ pub async fn update(
 	Json(args): Json<RestoreReplicasUpdateArgs>,
 ) -> Result<Json<RestoreReplicaView>> {
 	let mut conn = state.db.get().await?;
-	validate_params_for_intent(
+	let params = normalized_params_for_intent(
 		&mut conn,
 		args.consumer_device_id,
 		&args.intent,
@@ -621,8 +667,8 @@ pub async fn update(
 			r#type: args.r#type,
 			intent: args.intent,
 			name: args.name,
-			overdue_after: overdue_after_to_pg(args.overdue_after_seconds),
-			params: serde_json::to_value(&args.params).expect("params serialize"),
+			overdue_after: overdue_after_to_pg(args.overdue_after.as_deref())?,
+			params: serde_json::to_value(&params).expect("params serialize"),
 			enabled: args.enabled,
 		},
 	)

--- a/crates/private-server/tests/restore_replicas.rs
+++ b/crates/private-server/tests/restore_replicas.rs
@@ -65,6 +65,23 @@ async fn advertise_verify(conn: &mut AsyncPgConnection, consumer: Uuid) {
 		.expect("register caps");
 }
 
+/// Advertise a `sizing` intent accepting a duration `minimum_uptime` param
+/// (with a default) and a bytes `max_size` param.
+async fn advertise_sizing(conn: &mut AsyncPgConnection, consumer: Uuid) {
+	let descriptor: IntentDescriptor = serde_json::from_value(serde_json::json!({
+		"intent": "sizing",
+		"semantics": ["check"],
+		"params": {
+			"minimum_uptime": {"type": "duration", "default": 7200},
+			"max_size": {"type": "bytes"},
+		},
+	}))
+	.unwrap();
+	RestoreConsumerCapability::register(conn, consumer, &[descriptor])
+		.await
+		.expect("register caps");
+}
+
 /// Advertise both `verify` (no params) and `analytics` (boolean `anonymisation`)
 /// on the same consumer, so a declaration can be retargeted between them.
 async fn advertise_verify_and_analytics(conn: &mut AsyncPgConnection, consumer: Uuid) {
@@ -99,7 +116,7 @@ async fn create_rejects_wrong_typed_param() {
 				"type": "tamanu-postgres",
 				"intent": "analytics",
 				"name": "an-decl",
-				"overdue_after_seconds": null,
+				"overdue_after": null,
 				"params": { "anonymisation": "yes" },
 			}))
 			.await
@@ -124,7 +141,7 @@ async fn create_stores_valid_params_and_they_round_trip() {
 				"type": "tamanu-postgres",
 				"intent": "analytics",
 				"name": "an-decl",
-				"overdue_after_seconds": 7200,
+				"overdue_after": "2h",
 				"params": { "anonymisation": false },
 			}))
 			.await
@@ -137,9 +154,16 @@ async fn create_stores_valid_params_and_they_round_trip() {
 		resp.assert_status_ok();
 		let rows: Vec<serde_json::Value> = resp.json();
 		assert_eq!(rows.len(), 1, "got {rows:?}");
-		assert_eq!(rows[0]["overdue_after_seconds"], 7200);
+		assert_eq!(rows[0]["overdue_after"], "2h");
 		assert_eq!(rows[0]["params"]["anonymisation"], false);
 		assert_eq!(rows[0]["gap"], false, "advertised intent is not a gap");
+
+		// The bound is stored as a raw interval, not the display string.
+		let stored = database::RestoreReplica::list_for_group(&mut conn, group)
+			.await
+			.expect("list replicas");
+		assert_eq!(stored.len(), 1);
+		assert_eq!(stored[0].overdue_after.as_ref().unwrap().0.as_secs(), 7200);
 	})
 	.await;
 }
@@ -161,7 +185,7 @@ async fn create_replica(
 			"type": "tamanu-postgres",
 			"intent": intent,
 			"name": format!("{intent}-decl"),
-			"overdue_after_seconds": null,
+			"overdue_after": null,
 			"params": params,
 		}))
 		.await;
@@ -189,7 +213,7 @@ async fn update_changes_intent_and_round_trips() {
 				"type": "tamanu-postgres",
 				"intent": "analytics",
 				"name": "verify-decl",
-				"overdue_after_seconds": null,
+				"overdue_after": null,
 				"params": { "anonymisation": true },
 				"enabled": true,
 			}))
@@ -239,7 +263,7 @@ async fn update_scope_collision_conflicts() {
 				"type": "tamanu-postgres",
 				"intent": "verify",
 				"name": "analytics-decl",
-				"overdue_after_seconds": null,
+				"overdue_after": null,
 				"params": {},
 				"enabled": true,
 			}))
@@ -270,7 +294,7 @@ async fn update_revalidates_params_against_new_intent() {
 				"type": "tamanu-postgres",
 				"intent": "analytics",
 				"name": "verify-decl",
-				"overdue_after_seconds": null,
+				"overdue_after": null,
 				"params": { "anonymisation": "yes" },
 				"enabled": true,
 			}))
@@ -304,7 +328,7 @@ async fn update_can_change_consumer_and_server_scope() {
 				"type": "tamanu-postgres",
 				"intent": "verify",
 				"name": "verify-decl",
-				"overdue_after_seconds": null,
+				"overdue_after": null,
 				"params": {},
 				"enabled": true,
 			}))
@@ -348,7 +372,7 @@ async fn update_to_unadvertised_intent_creates_gap() {
 				"type": "tamanu-postgres",
 				"intent": "analytics",
 				"name": "verify-decl",
-				"overdue_after_seconds": null,
+				"overdue_after": null,
 				"params": { "not_in_any_schema": "kept-as-is" },
 				"enabled": true,
 			}))
@@ -424,6 +448,196 @@ async fn checks_reports_duration_and_surfaces_unreported_restores() {
 		let inflight = rows.iter().find(|r| r["status"] == "in_progress").unwrap();
 		assert!(inflight["server_id"].is_null(), "inferred row has no server");
 		assert!(inflight["duration_seconds"].is_null());
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_resolves_unit_strings_and_stores_raw_values() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group = insert_group(&mut conn).await;
+		let consumer = insert_consumer(&mut conn).await;
+		advertise_sizing(&mut conn, consumer).await;
+
+		private
+			.post("/api/restore_replicas/create")
+			.json(&serde_json::json!({
+				"consumer_device_id": consumer,
+				"group_id": group,
+				"server_id": null,
+				"type": "tamanu-postgres",
+				"intent": "sizing",
+				"name": "sizing-decl",
+				"overdue_after": "1d 12h",
+				"params": { "minimum_uptime": "2h 30m", "max_size": "20G" },
+			}))
+			.await
+			.assert_status_ok();
+
+		// Storage is raw: whole seconds and bytes, "20G" read as 1024-based.
+		let stored = database::RestoreReplica::list_for_group(&mut conn, group)
+			.await
+			.expect("list replicas");
+		assert_eq!(stored.len(), 1);
+		assert_eq!(stored[0].overdue_after.as_ref().unwrap().0.as_secs(), 129600);
+		assert_eq!(stored[0].params["minimum_uptime"], serde_json::json!(9000));
+		assert_eq!(
+			stored[0].params["max_size"],
+			serde_json::json!(20i64 * 1024 * 1024 * 1024)
+		);
+
+		// The view formats everything back as display strings.
+		let resp = private
+			.post("/api/restore_replicas/for_group")
+			.json(&serde_json::json!({ "server_group_id": group }))
+			.await;
+		resp.assert_status_ok();
+		let rows: Vec<serde_json::Value> = resp.json();
+		assert_eq!(rows.len(), 1, "got {rows:?}");
+		assert_eq!(rows[0]["overdue_after"], "1d 12h");
+		assert_eq!(rows[0]["params"]["minimum_uptime"], "2h 30m");
+		assert_eq!(rows[0]["params"]["max_size"], "20Gi");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_accepts_raw_integers_for_unit_params() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group = insert_group(&mut conn).await;
+		let consumer = insert_consumer(&mut conn).await;
+		advertise_sizing(&mut conn, consumer).await;
+
+		// Raw integer seconds/bytes (as the view once returned, and as gap
+		// declarations still carry) are accepted unchanged.
+		private
+			.post("/api/restore_replicas/create")
+			.json(&serde_json::json!({
+				"consumer_device_id": consumer,
+				"group_id": group,
+				"server_id": null,
+				"type": "tamanu-postgres",
+				"intent": "sizing",
+				"name": "raw-decl",
+				"overdue_after": null,
+				"params": { "minimum_uptime": 5400, "max_size": 1536 },
+			}))
+			.await
+			.assert_status_ok();
+
+		let resp = private
+			.post("/api/restore_replicas/for_group")
+			.json(&serde_json::json!({ "server_group_id": group }))
+			.await;
+		resp.assert_status_ok();
+		let rows: Vec<serde_json::Value> = resp.json();
+		assert_eq!(rows.len(), 1, "got {rows:?}");
+		assert!(rows[0]["overdue_after"].is_null());
+		assert_eq!(rows[0]["params"]["minimum_uptime"], "1h 30m");
+		// 1536 bytes isn't an exact multiple of 1024, so it displays raw.
+		assert_eq!(rows[0]["params"]["max_size"], "1536");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_rejects_bad_unit_strings() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group = insert_group(&mut conn).await;
+		let consumer = insert_consumer(&mut conn).await;
+		advertise_sizing(&mut conn, consumer).await;
+
+		for (name, params) in [
+			("bad duration", serde_json::json!({ "minimum_uptime": "banana" })),
+			("calendar unit", serde_json::json!({ "minimum_uptime": "1mo" })),
+			("negative", serde_json::json!({ "minimum_uptime": "-1h" })),
+			("sub-second", serde_json::json!({ "minimum_uptime": "0.5s" })),
+			("bare number", serde_json::json!({ "minimum_uptime": "20" })),
+			("bad size unit", serde_json::json!({ "max_size": "20T" })),
+			("size junk", serde_json::json!({ "max_size": "lots" })),
+		] {
+			let resp = private
+				.post("/api/restore_replicas/create")
+				.json(&serde_json::json!({
+					"consumer_device_id": consumer,
+					"group_id": group,
+					"server_id": null,
+					"type": "tamanu-postgres",
+					"intent": "sizing",
+					"name": "bad-decl",
+					"overdue_after": null,
+					"params": params,
+				}))
+				.await;
+			assert_eq!(resp.status_code(), 400, "case {name:?}");
+		}
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_rejects_bad_overdue_bound_and_allows_blank() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group = insert_group(&mut conn).await;
+		let consumer = insert_consumer(&mut conn).await;
+		advertise_verify(&mut conn, consumer).await;
+
+		private
+			.post("/api/restore_replicas/create")
+			.json(&serde_json::json!({
+				"consumer_device_id": consumer,
+				"group_id": group,
+				"server_id": null,
+				"type": "tamanu-postgres",
+				"intent": "verify",
+				"name": "bad-bound",
+				"overdue_after": "soon",
+				"params": {},
+			}))
+			.await
+			.assert_status_bad_request();
+
+		// A blank bound means no bound, same as null.
+		private
+			.post("/api/restore_replicas/create")
+			.json(&serde_json::json!({
+				"consumer_device_id": consumer,
+				"group_id": group,
+				"server_id": null,
+				"type": "tamanu-postgres",
+				"intent": "verify",
+				"name": "no-bound",
+				"overdue_after": "  ",
+				"params": {},
+			}))
+			.await
+			.assert_status_ok();
+
+		let stored = database::RestoreReplica::list_for_group(&mut conn, group)
+			.await
+			.expect("list replicas");
+		assert_eq!(stored.len(), 1);
+		assert!(stored[0].overdue_after.is_none());
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn consumers_format_unit_param_defaults_for_display() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let consumer = insert_consumer(&mut conn).await;
+		advertise_sizing(&mut conn, consumer).await;
+
+		let resp = private
+			.post("/api/restore_replicas/consumers")
+			.json(&serde_json::json!({}))
+			.await;
+		resp.assert_status_ok();
+		let rows: Vec<serde_json::Value> = resp.json();
+		assert_eq!(rows.len(), 1, "got {rows:?}");
+		let params = &rows[0]["intents"][0]["params"];
+		assert_eq!(params["minimum_uptime"]["default"], "2h");
+		assert!(params["max_size"].get("default").is_none());
 	})
 	.await;
 }

--- a/crates/private-server/tests/restore_replicas.rs
+++ b/crates/private-server/tests/restore_replicas.rs
@@ -479,7 +479,10 @@ async fn create_resolves_unit_strings_and_stores_raw_values() {
 			.await
 			.expect("list replicas");
 		assert_eq!(stored.len(), 1);
-		assert_eq!(stored[0].overdue_after.as_ref().unwrap().0.as_secs(), 129600);
+		assert_eq!(
+			stored[0].overdue_after.as_ref().unwrap().0.as_secs(),
+			129600
+		);
 		assert_eq!(stored[0].params["minimum_uptime"], serde_json::json!(9000));
 		assert_eq!(
 			stored[0].params["max_size"],
@@ -548,10 +551,19 @@ async fn create_rejects_bad_unit_strings() {
 		advertise_sizing(&mut conn, consumer).await;
 
 		for (name, params) in [
-			("bad duration", serde_json::json!({ "minimum_uptime": "banana" })),
-			("calendar unit", serde_json::json!({ "minimum_uptime": "1mo" })),
+			(
+				"bad duration",
+				serde_json::json!({ "minimum_uptime": "banana" }),
+			),
+			(
+				"calendar unit",
+				serde_json::json!({ "minimum_uptime": "1mo" }),
+			),
 			("negative", serde_json::json!({ "minimum_uptime": "-1h" })),
-			("sub-second", serde_json::json!({ "minimum_uptime": "0.5s" })),
+			(
+				"sub-second",
+				serde_json::json!({ "minimum_uptime": "0.5s" }),
+			),
 			("bare number", serde_json::json!({ "minimum_uptime": "20" })),
 			("bad size unit", serde_json::json!({ "max_size": "20T" })),
 			("size junk", serde_json::json!({ "max_size": "lots" })),

--- a/private-web/e2e/restore-replicas.spec.ts
+++ b/private-web/e2e/restore-replicas.spec.ts
@@ -364,11 +364,12 @@ test.describe("restore replicas", () => {
 		// The sole consumer is auto-selected and its sole intent chosen, so the
 		// description and parameter fields for `analytics` render.
 		await expect(dialog.getByText("Keeps a queryable replica running.")).toBeVisible();
-		const uptime = dialog.getByLabel("minimum_uptime (seconds)");
+		const uptime = dialog.getByLabel("minimum_uptime (duration)");
 		await expect(uptime).toBeVisible();
 		await expect(dialog.getByLabel("anonymisation")).toBeVisible();
 
-		await uptime.fill("3600");
+		// Duration values are typed with human units and stored as raw seconds.
+		await uptime.fill("1h");
 		await dialog.getByLabel("Name").fill("with-params");
 		await dialog.getByRole("button", { name: /^declare$/i }).click();
 
@@ -404,12 +405,11 @@ test.describe("restore replicas", () => {
 
 		const dialog = page.getByRole("dialog");
 		await expect(dialog.getByLabel("Name")).toHaveValue("before-edit");
-		await expect(dialog.getByLabel("Overdue after (hours, optional)")).toHaveValue(
-			"1",
-		);
+		// The stored 3600s bound is displayed in the human-friendly format.
+		await expect(dialog.getByLabel("Overdue after (optional)")).toHaveValue("1h");
 
 		await dialog.getByLabel("Name").fill("after-edit");
-		await dialog.getByLabel("Overdue after (hours, optional)").fill("4");
+		await dialog.getByLabel("Overdue after (optional)").fill("4h");
 		await dialog.getByLabel("Enabled").click();
 		await dialog.getByRole("button", { name: /^save$/i }).click();
 
@@ -463,9 +463,10 @@ test.describe("restore replicas", () => {
 		await page.getByRole("button", { name: "edit param-edit" }).click();
 
 		const dialog = page.getByRole("dialog");
-		const uptime = dialog.getByLabel("minimum_uptime (seconds)");
-		await expect(uptime).toHaveValue("3600");
-		await uptime.fill("1800");
+		const uptime = dialog.getByLabel("minimum_uptime (duration)");
+		// The stored raw 3600 seconds display as a human-friendly duration.
+		await expect(uptime).toHaveValue("1h");
+		await uptime.fill("30m");
 		await dialog.getByRole("button", { name: /^save$/i }).click();
 
 		await expect(page.getByRole("row", { name: /param-edit/ })).toBeVisible();
@@ -474,6 +475,87 @@ test.describe("restore replicas", () => {
 		);
 		expect(rows).toHaveLength(1);
 		expect(rows[0]!.params.minimum_uptime).toBe(1800);
+	});
+
+	test("size params accept 1024-based units and display in Kubernetes notation", async ({
+		page,
+		sql,
+	}) => {
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		await seedRestoreConsumerCapability(sql, {
+			deviceId: consumer.id,
+			intents: [
+				{
+					intent: "analytics",
+					description: "Keeps a queryable replica running.",
+					semantics: ["check", "url"],
+					params: {
+						minimum_uptime: { type: "duration", default: 7200 },
+						max_disk: { type: "bytes" },
+					},
+				},
+			],
+		});
+		const groupId = await groupWithBackups(sql, "size-group");
+
+		await page.goto(`/groups/${groupId}/backups`);
+		await page.getByRole("button", { name: /declare replica/i }).click();
+		const dialog = page.getByRole("dialog");
+
+		// Bare "20G" means 20Gi (1024-based), never 20×10⁹.
+		await dialog.getByLabel("max_disk (size)").fill("20G");
+		await dialog.getByLabel("minimum_uptime (duration)").fill("1h 30m");
+		await dialog.getByLabel("Name").fill("sized");
+		await dialog.getByRole("button", { name: /^declare$/i }).click();
+
+		const row = page.getByRole("row", { name: /sized/ });
+		await expect(row).toBeVisible();
+		// The table's param summary shows the display forms.
+		await expect(row).toContainText("max_disk=20Gi");
+		await expect(row).toContainText("minimum_uptime=1h 30m");
+
+		const rows = await sql.query<{
+			params: { max_disk?: number; minimum_uptime?: number };
+		}>("SELECT params FROM restore_replicas WHERE name = 'sized'");
+		expect(rows).toHaveLength(1);
+		expect(rows[0]!.params.max_disk).toBe(20 * 1024 ** 3);
+		expect(rows[0]!.params.minimum_uptime).toBe(5400);
+
+		// Reopening the edit dialog shows the display forms back in the fields.
+		await page.getByRole("button", { name: "edit sized" }).click();
+		const edit = page.getByRole("dialog");
+		await expect(edit.getByLabel("max_disk (size)")).toHaveValue("20Gi");
+		await expect(edit.getByLabel("minimum_uptime (duration)")).toHaveValue(
+			"1h 30m",
+		);
+	});
+
+	test("an invalid overdue bound is rejected inline and nothing is saved", async ({
+		page,
+		sql,
+	}) => {
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		await seedRestoreConsumerCapability(sql, {
+			deviceId: consumer.id,
+			intents: ["verify"],
+		});
+		const groupId = await groupWithBackups(sql, "badunit-group");
+
+		await page.goto(`/groups/${groupId}/backups`);
+		await page.getByRole("button", { name: /declare replica/i }).click();
+		const dialog = page.getByRole("dialog");
+
+		await dialog.getByLabel("Name").fill("bad-bound");
+		await dialog.getByLabel("Overdue after (optional)").fill("banana");
+		await dialog.getByRole("button", { name: /^declare$/i }).click();
+
+		// The backend rejects the bound; the dialog stays open with the error.
+		await expect(dialog.getByRole("alert")).toBeVisible();
+		await expect(dialog).toBeVisible();
+		const rows = await sql.query<{ count: string }>(
+			"SELECT count(*) AS count FROM restore_replicas",
+		);
+		expect(Number(rows[0]!.count)).toBe(0);
 	});
 
 	test("editing a declaration's intent retargets it and re-derives its parameters", async ({

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -3838,7 +3838,7 @@
           "restore_replicas"
         ],
         "summary": "List restore consumers and their advertised intents.",
-        "description": "Returns every device with the backup-restore role, together with the\nrestore intents it currently advertises (each with its description,\nsemantics flags, and parameter schema). Use this to discover which\nconsumers and intents a declaration can target and which parameters each\nintent accepts.",
+        "description": "Returns every device with the backup-restore role, together with the\nrestore intents it currently advertises (each with its description,\nsemantics flags, and parameter schema). Use this to discover which\nconsumers and intents a declaration can target and which parameters each\nintent accepts. Defaults of `duration` and `bytes` parameters are\nformatted as human-unit strings (e.g. `2h`, `20Gi`).",
         "operationId": "restore_replicas_consumers",
         "responses": {
           "200": {
@@ -3868,7 +3868,7 @@
           "restore_replicas"
         ],
         "summary": "Declare a managed restore replica.",
-        "description": "Creates a declaration instructing the chosen consumer to maintain a\nrestored replica of the given backup type for the given intent, and\nrecords the calling operator as its creator. Parameter values are\nvalidated against the consumer's advertised schema for the intent; if the\nintent is not currently advertised, the values are accepted as-is and the\ndeclaration is created with a gap. Requires the caller to be on the admin\nallow-list. Responds 400 if a parameter value fails validation and 409 if\na matching declaration already exists.",
+        "description": "Creates a declaration instructing the chosen consumer to maintain a\nrestored replica of the given backup type for the given intent, and\nrecords the calling operator as its creator. The overdue bound is a\nhuman-friendly duration string (e.g. `2h 30m`); `duration` and `bytes`\nparameter values likewise accept human-unit strings (e.g. `20Gi`), which\nare resolved to raw seconds/bytes before validation against the consumer's\nadvertised schema for the intent and stored raw. If the intent is not\ncurrently advertised, the values are accepted as-is and the declaration is\ncreated with a gap. Requires the caller to be on the admin allow-list.\nResponds 400 if the overdue bound or a parameter value fails to parse or\nvalidate, and 409 if a matching declaration already exists.",
         "operationId": "restore_replicas_create",
         "requestBody": {
           "content": {
@@ -3995,7 +3995,7 @@
           "restore_replicas"
         ],
         "summary": "Update a restore replica declaration.",
-        "description": "Replaces every field, including scope: the consumer, group, server,\nbackup type, and intent can be retargeted in the same call as the name,\noverdue bound, parameter values, and enabled flag. Parameter values are\nvalidated against the *new* consumer+intent's advertised parameter schema;\nas with `create`, an intent the new consumer doesn't currently advertise\nis accepted and the values pass through unvalidated, leaving the\ndeclaration with a gap. If the scope changes, any active\nrestore-verification alert for the declaration's old scope is recovered.\nRequires the caller to be on the admin allow-list. Responds 400 if a\nparameter value fails validation, 404 if the declaration does not exist,\nand 409 if the new scope collides with another declaration.",
+        "description": "Replaces every field, including scope: the consumer, group, server,\nbackup type, and intent can be retargeted in the same call as the name,\noverdue bound, parameter values, and enabled flag. The overdue bound and\n`duration`/`bytes` parameter values accept human-unit strings (e.g.\n`2h 30m`, `20Gi`), resolved to raw seconds/bytes and validated against the\n*new* consumer+intent's advertised parameter schema; as with `create`, an\nintent the new consumer doesn't currently advertise is accepted and the\nvalues pass through unvalidated, leaving the declaration with a gap. If\nthe scope changes, any active restore-verification alert for the\ndeclaration's old scope is recovered. Requires the caller to be on the\nadmin allow-list. Responds 400 if the overdue bound or a parameter value\nfails to parse or validate, 404 if the declaration does not exist, and 409\nif the new scope collides with another declaration.",
         "operationId": "restore_replicas_update",
         "requestBody": {
           "content": {
@@ -10575,17 +10575,16 @@
             "type": "string",
             "description": "Operator-chosen display name for the declaration."
           },
-          "overdue_after_seconds": {
+          "overdue_after": {
             "type": [
-              "integer",
+              "string",
               "null"
             ],
-            "format": "int64",
-            "description": "Overdue bound in whole seconds: how long the replica may go without a\nhealthy restore report (or, for at-most-once intents, how long the\nlatest snapshot may go unverified) before it is considered overdue.\nNull means no bound."
+            "description": "Overdue bound as a human-friendly duration (e.g. `2h 30m` or `1d`):\nhow long the replica may go without a healthy restore report (or, for\nat-most-once intents, how long the latest snapshot may go unverified)\nbefore it is considered overdue. Null means no bound. The same format\nis accepted back by `create` and `update`."
           },
           "params": {
             "type": "object",
-            "description": "Operator-supplied parameter values (name → value)."
+            "description": "Operator-supplied parameter values (name → value). Values of\n`duration` and `bytes` parameters are formatted as human-friendly\nstrings (e.g. `2h 30m`, `20Gi`) when the intent's schema is known;\n`create` and `update` accept these strings back."
           },
           "server_id": {
             "type": [
@@ -10634,17 +10633,16 @@
             "type": "string",
             "description": "Display name for the declaration."
           },
-          "overdue_after_seconds": {
+          "overdue_after": {
             "type": [
-              "integer",
+              "string",
               "null"
             ],
-            "format": "int64",
-            "description": "Overdue bound in whole seconds; omit or null for no bound."
+            "description": "Overdue bound as a human-friendly duration (jiff's \"friendly\" format,\ne.g. `2h 30m`, `36h`, `1d 12h`); omit, null, or blank for no bound."
           },
           "params": {
             "type": "object",
-            "description": "Parameter values for the intent (name → value), validated against the\nconsumer's advertised parameter schema. Defaults to empty."
+            "description": "Parameter values for the intent (name → value), validated against the\nconsumer's advertised parameter schema. `duration` and `bytes`\nparameters accept human-unit strings (e.g. `2h 30m`, `20Gi`) as well\nas raw integer seconds/bytes. Defaults to empty."
           },
           "server_id": {
             "type": [
@@ -10714,17 +10712,16 @@
             "type": "string",
             "description": "New display name for the declaration."
           },
-          "overdue_after_seconds": {
+          "overdue_after": {
             "type": [
-              "integer",
+              "string",
               "null"
             ],
-            "format": "int64",
-            "description": "New overdue bound in whole seconds; null removes the bound."
+            "description": "New overdue bound as a human-friendly duration (jiff's \"friendly\"\nformat, e.g. `2h 30m`, `36h`, `1d 12h`); null or blank removes the\nbound."
           },
           "params": {
             "type": "object",
-            "description": "New parameter values (name → value), validated against the intent's\nadvertised parameter schema. Defaults to empty."
+            "description": "New parameter values (name → value), validated against the intent's\nadvertised parameter schema. `duration` and `bytes` parameters accept\nhuman-unit strings (e.g. `2h 30m`, `20Gi`) as well as raw integer\nseconds/bytes. Defaults to empty."
           },
           "server_id": {
             "type": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1934,7 +1934,8 @@ export interface paths {
          *     restore intents it currently advertises (each with its description,
          *     semantics flags, and parameter schema). Use this to discover which
          *     consumers and intents a declaration can target and which parameters each
-         *     intent accepts.
+         *     intent accepts. Defaults of `duration` and `bytes` parameters are
+         *     formatted as human-unit strings (e.g. `2h`, `20Gi`).
          */
         post: operations["restore_replicas_consumers"];
         delete?: never;
@@ -1956,12 +1957,15 @@ export interface paths {
          * Declare a managed restore replica.
          * @description Creates a declaration instructing the chosen consumer to maintain a
          *     restored replica of the given backup type for the given intent, and
-         *     records the calling operator as its creator. Parameter values are
-         *     validated against the consumer's advertised schema for the intent; if the
-         *     intent is not currently advertised, the values are accepted as-is and the
-         *     declaration is created with a gap. Requires the caller to be on the admin
-         *     allow-list. Responds 400 if a parameter value fails validation and 409 if
-         *     a matching declaration already exists.
+         *     records the calling operator as its creator. The overdue bound is a
+         *     human-friendly duration string (e.g. `2h 30m`); `duration` and `bytes`
+         *     parameter values likewise accept human-unit strings (e.g. `20Gi`), which
+         *     are resolved to raw seconds/bytes before validation against the consumer's
+         *     advertised schema for the intent and stored raw. If the intent is not
+         *     currently advertised, the values are accepted as-is and the declaration is
+         *     created with a gap. Requires the caller to be on the admin allow-list.
+         *     Responds 400 if the overdue bound or a parameter value fails to parse or
+         *     validate, and 409 if a matching declaration already exists.
          */
         post: operations["restore_replicas_create"];
         delete?: never;
@@ -2029,15 +2033,17 @@ export interface paths {
          * Update a restore replica declaration.
          * @description Replaces every field, including scope: the consumer, group, server,
          *     backup type, and intent can be retargeted in the same call as the name,
-         *     overdue bound, parameter values, and enabled flag. Parameter values are
-         *     validated against the *new* consumer+intent's advertised parameter schema;
-         *     as with `create`, an intent the new consumer doesn't currently advertise
-         *     is accepted and the values pass through unvalidated, leaving the
-         *     declaration with a gap. If the scope changes, any active
-         *     restore-verification alert for the declaration's old scope is recovered.
-         *     Requires the caller to be on the admin allow-list. Responds 400 if a
-         *     parameter value fails validation, 404 if the declaration does not exist,
-         *     and 409 if the new scope collides with another declaration.
+         *     overdue bound, parameter values, and enabled flag. The overdue bound and
+         *     `duration`/`bytes` parameter values accept human-unit strings (e.g.
+         *     `2h 30m`, `20Gi`), resolved to raw seconds/bytes and validated against the
+         *     *new* consumer+intent's advertised parameter schema; as with `create`, an
+         *     intent the new consumer doesn't currently advertise is accepted and the
+         *     values pass through unvalidated, leaving the declaration with a gap. If
+         *     the scope changes, any active restore-verification alert for the
+         *     declaration's old scope is recovered. Requires the caller to be on the
+         *     admin allow-list. Responds 400 if the overdue bound or a parameter value
+         *     fails to parse or validate, 404 if the declaration does not exist, and 409
+         *     if the new scope collides with another declaration.
          */
         post: operations["restore_replicas_update"];
         delete?: never;
@@ -5989,14 +5995,19 @@ export interface components {
             /** @description Operator-chosen display name for the declaration. */
             name: string;
             /**
-             * Format: int64
-             * @description Overdue bound in whole seconds: how long the replica may go without a
-             *     healthy restore report (or, for at-most-once intents, how long the
-             *     latest snapshot may go unverified) before it is considered overdue.
-             *     Null means no bound.
+             * @description Overdue bound as a human-friendly duration (e.g. `2h 30m` or `1d`):
+             *     how long the replica may go without a healthy restore report (or, for
+             *     at-most-once intents, how long the latest snapshot may go unverified)
+             *     before it is considered overdue. Null means no bound. The same format
+             *     is accepted back by `create` and `update`.
              */
-            overdue_after_seconds?: number | null;
-            /** @description Operator-supplied parameter values (name → value). */
+            overdue_after?: string | null;
+            /**
+             * @description Operator-supplied parameter values (name → value). Values of
+             *     `duration` and `bytes` parameters are formatted as human-friendly
+             *     strings (e.g. `2h 30m`, `20Gi`) when the intent's schema is known;
+             *     `create` and `update` accept these strings back.
+             */
             params: Record<string, never>;
             /**
              * Format: uuid
@@ -6034,13 +6045,15 @@ export interface components {
             /** @description Display name for the declaration. */
             name: string;
             /**
-             * Format: int64
-             * @description Overdue bound in whole seconds; omit or null for no bound.
+             * @description Overdue bound as a human-friendly duration (jiff's "friendly" format,
+             *     e.g. `2h 30m`, `36h`, `1d 12h`); omit, null, or blank for no bound.
              */
-            overdue_after_seconds?: number | null;
+            overdue_after?: string | null;
             /**
              * @description Parameter values for the intent (name → value), validated against the
-             *     consumer's advertised parameter schema. Defaults to empty.
+             *     consumer's advertised parameter schema. `duration` and `bytes`
+             *     parameters accept human-unit strings (e.g. `2h 30m`, `20Gi`) as well
+             *     as raw integer seconds/bytes. Defaults to empty.
              */
             params?: Record<string, never>;
             /**
@@ -6095,13 +6108,16 @@ export interface components {
             /** @description New display name for the declaration. */
             name: string;
             /**
-             * Format: int64
-             * @description New overdue bound in whole seconds; null removes the bound.
+             * @description New overdue bound as a human-friendly duration (jiff's "friendly"
+             *     format, e.g. `2h 30m`, `36h`, `1d 12h`); null or blank removes the
+             *     bound.
              */
-            overdue_after_seconds?: number | null;
+            overdue_after?: string | null;
             /**
              * @description New parameter values (name → value), validated against the intent's
-             *     advertised parameter schema. Defaults to empty.
+             *     advertised parameter schema. `duration` and `bytes` parameters accept
+             *     human-unit strings (e.g. `2h 30m`, `20Gi`) as well as raw integer
+             *     seconds/bytes. Defaults to empty.
              */
             params?: Record<string, never>;
             /**

--- a/private-web/src/components/RestoreReplicasSection.tsx
+++ b/private-web/src/components/RestoreReplicasSection.tsx
@@ -63,12 +63,6 @@ function formatError(err: unknown): string {
 	return String(err);
 }
 
-function overdueLabel(seconds: number | null | undefined): string {
-	if (seconds == null) return "no bound";
-	const hours = seconds / 3600;
-	return hours >= 1 ? `${hours}h` : `${seconds}s`;
-}
-
 /** Pull a string `url` out of a check's opaque health details, if present — the
  * link a `url`-semantic intent attaches to its running replica. */
 function healthUrl(details: unknown): string | null {
@@ -133,7 +127,7 @@ export default function RestoreReplicasSection({
 				type: r.type,
 				intent: r.intent,
 				name: r.name,
-				overdue_after_seconds: r.overdue_after_seconds,
+				overdue_after: r.overdue_after,
 				params: r.params as Record<string, unknown>,
 				enabled,
 			});
@@ -222,7 +216,7 @@ export default function RestoreReplicasSection({
 											)}
 										</Stack>
 									</TableCell>
-									<TableCell>{overdueLabel(r.overdue_after_seconds)}</TableCell>
+									<TableCell>{r.overdue_after ?? "no bound"}</TableCell>
 									<TableCell>
 										<ParamSummary params={r.params} />
 									</TableCell>
@@ -365,18 +359,24 @@ function ParamField({
 		);
 	}
 
-	const numeric =
-		spec.type === "integer" || spec.type === "bytes" || spec.type === "duration";
+	// Duration and size values are typed with human units and resolved to raw
+	// seconds/bytes by the backend.
 	const unit =
-		spec.type === "duration" ? "seconds" : spec.type === "bytes" ? "bytes" : "";
+		spec.type === "duration" ? "duration" : spec.type === "bytes" ? "size" : "";
+	const example =
+		spec.type === "duration"
+			? "e.g. 2h 30m"
+			: spec.type === "bytes"
+				? "e.g. 20Gi"
+				: "";
 	return (
 		<TextField
 			size="small"
 			fullWidth
-			type={numeric ? "number" : "text"}
+			type={spec.type === "integer" ? "number" : "text"}
 			label={unit ? `${name} (${unit})` : name}
-			placeholder={def != null ? String(def) : "optional"}
-			helperText={defHint}
+			placeholder={def != null ? String(def) : (example || "optional")}
+			helperText={example ? `${example} — ${defHint}` : defHint}
 			value={value}
 			onChange={(e) => onChange(e.target.value)}
 		/>
@@ -426,14 +426,16 @@ function paramValuesToWire(
 		if (raw == null || raw === "") continue;
 		if (spec.type === "boolean") {
 			out[key] = raw === "true";
-		} else if (
-			spec.type === "integer" ||
-			spec.type === "bytes" ||
-			spec.type === "duration"
-		) {
+		} else if (spec.type === "integer") {
 			const n = Number(raw);
 			if (!Number.isFinite(n)) return `Parameter "${key}" must be a number`;
 			out[key] = n;
+		} else if (spec.type === "bytes" || spec.type === "duration") {
+			// Duration and size values go over the wire as human-unit strings
+			// (e.g. "2h 30m", "20Gi"); the backend resolves them to raw
+			// seconds/bytes, or rejects them with an error shown inline.
+			if (raw.trim() === "") continue;
+			out[key] = raw.trim();
 		} else {
 			out[key] = raw;
 		}
@@ -647,7 +649,7 @@ function CreateReplicaDialog({
 	const [intent, setIntent] = useState("");
 	const [name, setName] = useState("");
 	const [nameEdited, setNameEdited] = useState(false);
-	const [overdueHours, setOverdueHours] = useState("");
+	const [overdue, setOverdue] = useState("");
 	const [paramValues, setParamValues] = useState<Record<string, string>>({});
 	const [pending, setPending] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -696,12 +698,9 @@ function CreateReplicaDialog({
 		if (!consumerId) return setError("Pick a consumer");
 		if (!intent) return setError("Pick an intent the consumer advertises");
 		if (!name.trim()) return setError("Name cannot be empty");
-		const hours = overdueHours.trim();
-		const overdue_after_seconds =
-			hours === "" ? null : Math.round(Number(hours) * 3600);
-		if (overdue_after_seconds != null && !Number.isFinite(overdue_after_seconds)) {
-			return setError("Overdue bound must be a number of hours");
-		}
+		// The backend parses the human-friendly duration (e.g. "2h 30m") and
+		// rejects anything invalid with an error shown inline.
+		const overdue_after = overdue.trim() === "" ? null : overdue.trim();
 		const params = paramValuesToWire(paramSchema, paramValues);
 		if (typeof params === "string") return setError(params);
 		setPending(true);
@@ -714,7 +713,7 @@ function CreateReplicaDialog({
 				type,
 				intent,
 				name: name.trim(),
-				overdue_after_seconds,
+				overdue_after,
 				params,
 			});
 			onCreated();
@@ -762,11 +761,11 @@ function CreateReplicaDialog({
 					<TextField
 						size="small"
 						fullWidth
-						type="number"
-						label="Overdue after (hours, optional)"
+						label="Overdue after (optional)"
 						placeholder="no bound"
-						value={overdueHours}
-						onChange={(e) => setOverdueHours(e.target.value)}
+						helperText="e.g. 2h 30m, 36h, 1d 12h"
+						value={overdue}
+						onChange={(e) => setOverdue(e.target.value)}
 					/>
 
 					<ParamFieldsEditor
@@ -822,11 +821,7 @@ function EditReplicaDialog({
 	const [type, setType] = useState(replica.type);
 	const [intent, setIntent] = useState(replica.intent);
 	const [name, setName] = useState(replica.name);
-	const [overdueHours, setOverdueHours] = useState(
-		replica.overdue_after_seconds != null
-			? String(replica.overdue_after_seconds / 3600)
-			: "",
-	);
+	const [overdue, setOverdue] = useState(replica.overdue_after ?? "");
 	const [enabled, setEnabled] = useState(replica.enabled);
 	const [paramValues, setParamValues] = useState<Record<string, string>>(() => {
 		const initialDescriptor = consumers
@@ -862,12 +857,9 @@ function EditReplicaDialog({
 		if (!consumerId) return setError("Pick a consumer");
 		if (!intent) return setError("Pick an intent the consumer advertises");
 		if (!name.trim()) return setError("Name cannot be empty");
-		const hours = overdueHours.trim();
-		const overdue_after_seconds =
-			hours === "" ? null : Math.round(Number(hours) * 3600);
-		if (overdue_after_seconds != null && !Number.isFinite(overdue_after_seconds)) {
-			return setError("Overdue bound must be a number of hours");
-		}
+		// The backend parses the human-friendly duration (e.g. "2h 30m") and
+		// rejects anything invalid with an error shown inline.
+		const overdue_after = overdue.trim() === "" ? null : overdue.trim();
 		// With no schema (a gap intent) there are no param fields; carry the
 		// stored values through unchanged rather than wiping them.
 		let params: unknown = replica.params;
@@ -887,7 +879,7 @@ function EditReplicaDialog({
 				type,
 				intent,
 				name: name.trim(),
-				overdue_after_seconds,
+				overdue_after,
 				params,
 				enabled,
 			});
@@ -933,11 +925,11 @@ function EditReplicaDialog({
 					<TextField
 						size="small"
 						fullWidth
-						type="number"
-						label="Overdue after (hours, optional)"
+						label="Overdue after (optional)"
 						placeholder="no bound"
-						value={overdueHours}
-						onChange={(e) => setOverdueHours(e.target.value)}
+						helperText="e.g. 2h 30m, 36h, 1d 12h"
+						value={overdue}
+						onChange={(e) => setOverdue(e.target.value)}
 					/>
 
 					<FormControlLabel


### PR DESCRIPTION
🤖 Bytes and duration inputs in the restore-replica declare/edit forms now take human units, resolved in the backend:

- **Durations** (the overdue bound and `duration` intent params) parse and display in jiff's "friendly" format (`2h 30m`, `36h`, `1d 12h`; days/weeks fixed at 24h/7d, calendar units and sub-second precision rejected).
- **Byte sizes** (`bytes` intent params) accept `\d+[kmg]i?b?` in any capitalisation, all interpreted as 1024-based (`20G` = `20Gi` = `20GiB`), and display in Kubernetes notation (`20Gi`; non-multiples stay plain numbers).

The parsing/formatting lives in a new `commons_types::units` module; `normalize_params`/`display_params` translate `duration`/`bytes` intent-param values against the consumer's advertised schema at the wire edge (gap intents pass through raw, as before). The view's `overdue_after_seconds` becomes an `overdue_after` display string that `create`/`update` accept back, raw integers remain accepted for params, and storage stays raw seconds/bytes. Invalid unit strings map to the existing `bad-request` 400 problem type. Consumer param defaults are also display-formatted in the operator-facing `consumers` endpoint (the device-facing worklist and MCP views are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)