### PR TITLE
feat(statuses): silenced healthchecks show as skipped and don't count toward server health

### DIFF
--- a/crates/canopy-mcp/src/groups.rs
+++ b/crates/canopy-mcp/src/groups.rs
@@ -162,9 +162,23 @@ impl CanopyMcp {
 			.await
 			.map_err(mcp_err)?;
 		let st_by: HashMap<Uuid, &Status> = statuses.iter().map(|s| (s.server_id, s)).collect();
+		let member_groups: Vec<(Uuid, Option<Uuid>)> =
+			members.iter().map(|s| (s.id, s.group_id)).collect();
+		let silenced =
+			database::silenced_refs::silenced_health_checks_for_servers(&mut conn, &member_groups)
+				.await
+				.map_err(mcp_err)?;
+		let no_silences = std::collections::BTreeSet::new();
 		let member_summaries = members
 			.iter()
-			.map(|s| summarize(s, st_by.get(&s.id).copied(), Some(group.name.clone())))
+			.map(|s| {
+				summarize(
+					s,
+					st_by.get(&s.id).copied(),
+					Some(group.name.clone()),
+					silenced.get(&s.id).unwrap_or(&no_silences),
+				)
+			})
 			.collect();
 
 		let config = ServerGroupBackupConfig::get(&mut conn, id)

--- a/crates/canopy-mcp/src/servers.rs
+++ b/crates/canopy-mcp/src/servers.rs
@@ -1,7 +1,7 @@
 //! `find_servers` / `get_server` tools, and the [`ServerSummary`] shape
 //! reused by the groups module for member listings.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use commons_types::{
 	Uuid,
@@ -167,6 +167,13 @@ impl CanopyMcp {
 		let group_names = Server::group_names_by_server_ids(&mut conn, &ids)
 			.await
 			.map_err(mcp_err)?;
+		let server_groups: Vec<(Uuid, Option<Uuid>)> =
+			servers.iter().map(|s| (s.id, s.group_id)).collect();
+		let silenced =
+			database::silenced_refs::silenced_health_checks_for_servers(&mut conn, &server_groups)
+				.await
+				.map_err(mcp_err)?;
+		let no_silences = BTreeSet::new();
 
 		let summaries: Vec<ServerSummary> = servers
 			.iter()
@@ -175,6 +182,7 @@ impl CanopyMcp {
 					s,
 					st_by.get(&s.id).copied(),
 					group_names.get(&s.id).cloned().flatten(),
+					silenced.get(&s.id).unwrap_or(&no_silences),
 				)
 			})
 			.collect();
@@ -235,10 +243,20 @@ impl CanopyMcp {
 			});
 		}
 
+		// Operator-silenced healthchecks don't count toward the health
+		// rollup; `checks` still carries their raw results verbatim.
+		let silenced_checks = database::silenced_refs::silenced_health_checks_for_server(
+			&mut conn,
+			server.id,
+			server.group_id,
+		)
+		.await
+		.map_err(mcp_err)?;
+
 		let latest_status = latest.as_ref().map(|s| StatusOut {
 			reported_at: s.created_at,
 			version: version.clone(),
-			health: s.health_state(),
+			health: s.health_state_ignoring(&silenced_checks),
 			healthy: s.healthy,
 			reachability: s.short_status(),
 			platform: s.platform(),
@@ -263,9 +281,9 @@ impl CanopyMcp {
 			reachability: latest
 				.as_ref()
 				.map_or(ShortStatus::Gone, |s| s.short_status()),
-			health: latest
-				.as_ref()
-				.map_or(HealthState::default(), |s| s.health_state()),
+			health: latest.as_ref().map_or(HealthState::default(), |s| {
+				s.health_state_ignoring(&silenced_checks)
+			}),
 			latest_status,
 			backups,
 		})
@@ -273,10 +291,13 @@ impl CanopyMcp {
 }
 
 /// Shared with the groups module, for member listings on [`crate::groups::GroupDetail`].
+/// `silenced_checks` is the server's silenced healthcheck set (server +
+/// group scope) — those checks don't count toward `health`.
 pub(crate) fn summarize(
 	s: &Server,
 	st: Option<&Status>,
 	group_name: Option<String>,
+	silenced_checks: &BTreeSet<String>,
 ) -> ServerSummary {
 	ServerSummary {
 		id: s.id,
@@ -291,7 +312,9 @@ pub(crate) fn summarize(
 		last_seen: st.map(|s| s.created_at),
 		version: st.and_then(|s| s.version.clone()),
 		reachability: st.map_or(ShortStatus::Gone, |s| s.short_status()),
-		health: st.map_or(HealthState::default(), |s| s.health_state()),
+		health: st.map_or(HealthState::default(), |s| {
+			s.health_state_ignoring(silenced_checks)
+		}),
 	}
 }
 

--- a/crates/database/src/silenced_refs.rs
+++ b/crates/database/src/silenced_refs.rs
@@ -5,11 +5,17 @@
 //! (so the issue and event rows exist), but
 //! [`crate::issues::re_evaluate_incident_membership`] treats them as a
 //! "should leave" reason, the same way it treats snoozed or unmonitored.
+//! Healthcheck silences (`(status, health/<check>)`) additionally drop the
+//! check out of the server's health rollup — see
+//! [`silenced_health_checks_for_servers`] and
+//! [`crate::statuses::Status::health_state_ignoring`].
 //!
 //! Two sibling tables (`server_silenced_refs`, `server_group_silenced_refs`)
 //! keep referential integrity tight without nullable FKs. A given issue is
 //! silenced if either applies (server-scope wins for the server itself,
 //! group-scope catches the whole group).
+
+use std::collections::{BTreeSet, HashMap};
 
 use commons_errors::{AppError, Result};
 use diesel::prelude::*;
@@ -19,6 +25,15 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::issues::{reevaluate_open_issues_for_group_ref, reevaluate_open_issues_for_server_ref};
+
+/// The `source` the public-server status ingestion files healthcheck
+/// issues under, so a silence on a healthcheck is `(status,
+/// health/<check>)`. Mirrors the public-server's `STATUS_SOURCE`.
+const STATUS_SOURCE: &str = "status";
+
+/// The ref prefix (with trailing separator) healthcheck issues use
+/// under [`STATUS_SOURCE`]. Mirrors the public-server's `HEALTH_REF`.
+const HEALTH_REF_PREFIX: &str = "health/";
 
 /// A silenced issue reference scoped to a single server: issues matching
 /// this `(source, ref)` on this server are still recorded, but are excluded
@@ -158,6 +173,100 @@ pub async fn silenced_refs_with_prefix(
 	}
 
 	Ok(refs)
+}
+
+/// Healthcheck names silenced for each of the given `(server, group)`
+/// pairs, at either scope: the `<check>` of every `(status,
+/// health/<check>)` silence entry that applies to the server. Pass each
+/// server's current group id (`None` for ungrouped). Two batch queries,
+/// one per scope table, regardless of how many servers are asked about.
+/// Servers with no applicable silences are absent from the map.
+///
+/// This feeds [`crate::statuses::Status::health_state_ignoring`]: a
+/// silenced check keeps recording results but is presented as skipped
+/// and doesn't count toward the server's health rollup.
+pub async fn silenced_health_checks_for_servers(
+	db: &mut AsyncPgConnection,
+	servers: &[(Uuid, Option<Uuid>)],
+) -> Result<HashMap<Uuid, BTreeSet<String>>> {
+	use crate::schema::{server_group_silenced_refs, server_silenced_refs};
+
+	let mut out: HashMap<Uuid, BTreeSet<String>> = HashMap::new();
+	if servers.is_empty() {
+		return Ok(out);
+	}
+
+	let like_pattern = format!("{HEALTH_REF_PREFIX}%");
+
+	let server_ids: Vec<Uuid> = servers.iter().map(|(id, _)| *id).collect();
+	let server_rows: Vec<(Uuid, String)> = server_silenced_refs::table
+		.select((server_silenced_refs::server_id, server_silenced_refs::ref_))
+		.filter(server_silenced_refs::server_id.eq_any(&server_ids))
+		.filter(server_silenced_refs::source.eq(STATUS_SOURCE))
+		.filter(server_silenced_refs::ref_.like(&like_pattern))
+		.load(db)
+		.await
+		.map_err(AppError::from)?;
+	for (server_id, r#ref) in server_rows {
+		if let Some(check) = r#ref.strip_prefix(HEALTH_REF_PREFIX) {
+			out.entry(server_id).or_default().insert(check.to_string());
+		}
+	}
+
+	let group_ids: Vec<Uuid> = servers
+		.iter()
+		.filter_map(|(_, group)| *group)
+		.collect::<BTreeSet<_>>()
+		.into_iter()
+		.collect();
+	if !group_ids.is_empty() {
+		let group_rows: Vec<(Uuid, String)> = server_group_silenced_refs::table
+			.select((
+				server_group_silenced_refs::server_group_id,
+				server_group_silenced_refs::ref_,
+			))
+			.filter(server_group_silenced_refs::server_group_id.eq_any(&group_ids))
+			.filter(server_group_silenced_refs::source.eq(STATUS_SOURCE))
+			.filter(server_group_silenced_refs::ref_.like(&like_pattern))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		let mut by_group: HashMap<Uuid, Vec<String>> = HashMap::new();
+		for (group_id, r#ref) in group_rows {
+			if let Some(check) = r#ref.strip_prefix(HEALTH_REF_PREFIX) {
+				by_group
+					.entry(group_id)
+					.or_default()
+					.push(check.to_string());
+			}
+		}
+		for (server_id, group_id) in servers {
+			if let Some(checks) = group_id.as_ref().and_then(|g| by_group.get(g)) {
+				out.entry(*server_id)
+					.or_default()
+					.extend(checks.iter().cloned());
+			}
+		}
+	}
+
+	Ok(out)
+}
+
+/// Single-server variant of [`silenced_health_checks_for_servers`],
+/// via [`silenced_refs_with_prefix`]. `group_id` is the server's
+/// current group; pass `None` if ungrouped.
+pub async fn silenced_health_checks_for_server(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	group_id: Option<Uuid>,
+) -> Result<BTreeSet<String>> {
+	let refs = silenced_refs_with_prefix(db, server_id, group_id, STATUS_SOURCE, HEALTH_REF_PREFIX)
+		.await?;
+	Ok(refs
+		.iter()
+		.filter_map(|r| r.strip_prefix(HEALTH_REF_PREFIX))
+		.map(String::from)
+		.collect())
 }
 
 impl ServerSilencedRef {

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -581,6 +581,22 @@ impl Status {
 	/// - otherwise [`HealthState::Healthy`] (passed and skipped
 	///   entries don't count against the server)
 	pub fn health_state(&self) -> HealthState {
+		self.health_state_ignoring(&Default::default())
+	}
+
+	/// Like [`Self::health_state`], but entries whose check name is in
+	/// `silenced_checks` are treated as skipped: an operator-silenced
+	/// check keeps recording its results, they just don't count toward
+	/// the server's health rollup. Callers get the set from
+	/// [`crate::silenced_refs::silenced_health_checks_for_servers`].
+	///
+	/// The legacy top-level `healthy: false` short-circuit still wins:
+	/// that flag predates per-check results, so a false can't be
+	/// attributed to (and excused by) any particular silenced check.
+	pub fn health_state_ignoring(
+		&self,
+		silenced_checks: &std::collections::BTreeSet<String>,
+	) -> HealthState {
 		if !self.healthy {
 			return HealthState::Unhealthy;
 		}
@@ -590,6 +606,11 @@ impl Status {
 				let Some(obj) = entry.as_object() else {
 					continue;
 				};
+				if let Some(check) = obj.get("check").and_then(|v| v.as_str())
+					&& silenced_checks.contains(check)
+				{
+					continue;
+				}
 				let Some(result) = CheckResult::from_entry(obj) else {
 					continue;
 				};

--- a/crates/database/tests/silenced_health_checks.rs
+++ b/crates/database/tests/silenced_health_checks.rs
@@ -1,0 +1,158 @@
+//! `silenced_refs::silenced_health_checks_for_server(s)`: resolving the
+//! set of healthcheck names silenced for a server from its `(status,
+//! health/<check>)` silence entries, at server and group scope, in one
+//! batch. This set feeds `Status::health_state_ignoring` so silenced
+//! checks don't count toward the health rollup.
+
+use std::collections::BTreeSet;
+
+use commons_tests::db::TestDb;
+use database::silenced_refs::{
+	ServerGroupSilencedRef, ServerSilencedRef, silenced_health_checks_for_server,
+	silenced_health_checks_for_servers,
+};
+use diesel::{sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+async fn insert_group(conn: &mut database::diesel_async::AsyncPgConnection, name: &str) -> Uuid {
+	#[derive(diesel::QueryableByName)]
+	struct RowId {
+		#[diesel(sql_type = sql_types::Uuid)]
+		id: Uuid,
+	}
+	let row: RowId = sql_query("INSERT INTO server_groups (name) VALUES ($1) RETURNING id")
+		.bind::<sql_types::Text, _>(name)
+		.get_result(conn)
+		.await
+		.expect("insert group");
+	row.id
+}
+
+async fn insert_server(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	group_id: Option<Uuid>,
+) -> Uuid {
+	#[derive(diesel::QueryableByName)]
+	struct RowId {
+		#[diesel(sql_type = sql_types::Uuid)]
+		id: Uuid,
+	}
+	let host = format!("http://test.invalid/{}", Uuid::new_v4());
+	let row: RowId = sql_query(
+		"INSERT INTO servers (host, kind, group_id) VALUES ($1, 'central', $2) RETURNING id",
+	)
+	.bind::<sql_types::Text, _>(host)
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(group_id)
+	.get_result(conn)
+	.await
+	.expect("insert server");
+	row.id
+}
+
+fn checks(names: &[&str]) -> BTreeSet<String> {
+	names.iter().map(|s| s.to_string()).collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn resolves_server_and_group_scopes_in_batch() {
+	TestDb::run(async |mut conn, _url| {
+		let group = insert_group(&mut conn, "g").await;
+		let grouped = insert_server(&mut conn, Some(group)).await;
+		let ungrouped = insert_server(&mut conn, None).await;
+		let unsilenced = insert_server(&mut conn, Some(group)).await;
+
+		ServerSilencedRef::add(&mut conn, grouped, "status", "health/postgres", None)
+			.await
+			.unwrap();
+		ServerSilencedRef::add(&mut conn, ungrouped, "status", "health/disk", None)
+			.await
+			.unwrap();
+		ServerGroupSilencedRef::add(&mut conn, group, "status", "health/uploads", None)
+			.await
+			.unwrap();
+
+		let map = silenced_health_checks_for_servers(
+			&mut conn,
+			&[
+				(grouped, Some(group)),
+				(ungrouped, None),
+				(unsilenced, Some(group)),
+			],
+		)
+		.await
+		.unwrap();
+
+		// Server scope and group scope combine for the grouped server.
+		assert_eq!(map.get(&grouped), Some(&checks(&["postgres", "uploads"])));
+		// The ungrouped server only sees its own silences.
+		assert_eq!(map.get(&ungrouped), Some(&checks(&["disk"])));
+		// A group member with no server-scope silence still inherits the
+		// group's.
+		assert_eq!(map.get(&unsilenced), Some(&checks(&["uploads"])));
+
+		// The single-server convenience agrees.
+		assert_eq!(
+			silenced_health_checks_for_server(&mut conn, grouped, Some(group))
+				.await
+				.unwrap(),
+			checks(&["postgres", "uploads"]),
+		);
+	})
+	.await
+}
+
+/// Only `(status, health/<check>)` silences are healthcheck silences:
+/// other sources and non-health refs (e.g. canopy reachability) don't
+/// leak into the set.
+#[tokio::test(flavor = "multi_thread")]
+async fn ignores_non_healthcheck_silences() {
+	TestDb::run(async |mut conn, _url| {
+		let server = insert_server(&mut conn, None).await;
+
+		ServerSilencedRef::add(&mut conn, server, "canopy", "reachability", None)
+			.await
+			.unwrap();
+		ServerSilencedRef::add(&mut conn, server, "backups", "health/postgres", None)
+			.await
+			.unwrap();
+		ServerSilencedRef::add(&mut conn, server, "status", "something-else", None)
+			.await
+			.unwrap();
+
+		let map = silenced_health_checks_for_servers(&mut conn, &[(server, None)])
+			.await
+			.unwrap();
+		assert_eq!(map.get(&server), None);
+	})
+	.await
+}
+
+/// Removing a silence takes the check back out of the set.
+#[tokio::test(flavor = "multi_thread")]
+async fn unsilencing_removes_the_check() {
+	TestDb::run(async |mut conn, _url| {
+		let server = insert_server(&mut conn, None).await;
+
+		ServerSilencedRef::add(&mut conn, server, "status", "health/postgres", None)
+			.await
+			.unwrap();
+		assert_eq!(
+			silenced_health_checks_for_server(&mut conn, server, None)
+				.await
+				.unwrap(),
+			checks(&["postgres"]),
+		);
+
+		ServerSilencedRef::remove(&mut conn, server, "status", "health/postgres")
+			.await
+			.unwrap();
+		assert_eq!(
+			silenced_health_checks_for_server(&mut conn, server, None)
+				.await
+				.unwrap(),
+			BTreeSet::new(),
+		);
+	})
+	.await
+}

--- a/crates/database/tests/status_health_state.rs
+++ b/crates/database/tests/status_health_state.rs
@@ -96,3 +96,91 @@ fn result_passed_and_skipped_do_not_count() {
 		HealthState::Healthy,
 	);
 }
+
+/// A silenced failing check is treated as skipped: it doesn't drag the
+/// server to Unhealthy (or Warning), whatever form it was reported in.
+#[test]
+fn silenced_failing_check_does_not_count() {
+	let silenced = std::collections::BTreeSet::from(["b".to_string()]);
+	assert_eq!(
+		status(
+			true,
+			serde_json::json!([
+				{"check": "a", "result": "passed"},
+				{"check": "b", "result": "failed"},
+			])
+		)
+		.health_state_ignoring(&silenced),
+		HealthState::Healthy,
+	);
+	// Legacy per-check bool form.
+	assert_eq!(
+		status(
+			true,
+			serde_json::json!([
+				{"check": "a", "healthy": true},
+				{"check": "b", "healthy": false},
+			])
+		)
+		.health_state_ignoring(&silenced),
+		HealthState::Healthy,
+	);
+}
+
+/// Silencing one check doesn't excuse the others: an unsilenced failure
+/// still rolls up to Unhealthy.
+#[test]
+fn unsilenced_failing_check_still_counts() {
+	let silenced = std::collections::BTreeSet::from(["b".to_string()]);
+	assert_eq!(
+		status(
+			true,
+			serde_json::json!([
+				{"check": "b", "result": "failed"},
+				{"check": "c", "result": "failed"},
+			])
+		)
+		.health_state_ignoring(&silenced),
+		HealthState::Unhealthy,
+	);
+	assert_eq!(
+		status(
+			true,
+			serde_json::json!([
+				{"check": "b", "result": "failed"},
+				{"check": "c", "result": "warning"},
+			])
+		)
+		.health_state_ignoring(&silenced),
+		HealthState::Warning,
+	);
+}
+
+/// With no silences the two forms agree.
+#[test]
+fn empty_silence_set_matches_health_state() {
+	let st = status(
+		true,
+		serde_json::json!([
+			{"check": "a", "result": "warning"},
+			{"check": "b", "result": "failed"},
+		]),
+	);
+	assert_eq!(
+		st.health_state_ignoring(&Default::default()),
+		st.health_state(),
+	);
+}
+
+/// The legacy top-level `healthy: false` short-circuit predates
+/// per-check results, so it can't be attributed to a silenced check
+/// and still wins.
+#[test]
+fn top_level_false_ignores_silences() {
+	let silenced = std::collections::BTreeSet::from(["b".to_string()]);
+	assert_eq!(
+		status(false, serde_json::json!([{"check": "b", "healthy": false}]))
+			.health_state_ignoring(&silenced),
+		HealthState::Unhealthy,
+	);
+}

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -294,10 +294,20 @@ pub(super) async fn decorate_with_status(
 	let statuses = Status::latest_for_servers(conn, &ids).await?;
 	let by_server: std::collections::HashMap<Uuid, &Status> =
 		statuses.iter().map(|s| (s.server_id, s)).collect();
+	// Operator-silenced healthchecks don't count toward the health dot.
+	let server_groups: Vec<(Uuid, Option<Uuid>)> =
+		infos.iter().map(|i| (i.id, i.group_id)).collect();
+	let silenced =
+		database::silenced_refs::silenced_health_checks_for_servers(conn, &server_groups).await?;
+	let no_silences = std::collections::BTreeSet::new();
 	for info in infos.iter_mut() {
 		let st = by_server.get(&info.id).copied();
+		let silenced_checks = silenced.get(&info.id).unwrap_or(&no_silences);
 		info.up = Some(st.map(|s| s.short_status()).unwrap_or_default());
-		info.health = Some(st.map(|s| s.health_state()).unwrap_or_default());
+		info.health = Some(
+			st.map(|s| s.health_state_ignoring(silenced_checks))
+				.unwrap_or_default(),
+		);
 	}
 	Ok(())
 }
@@ -594,9 +604,17 @@ pub async fn get_detail(
 		.as_ref()
 		.map(|s| s.short_status())
 		.unwrap_or_default();
+	// Operator-silenced healthchecks don't count toward the headline
+	// health chip; the checks table still shows them (as skipped).
+	let silenced_checks = database::silenced_refs::silenced_health_checks_for_server(
+		&mut conn,
+		server.id,
+		server.group_id,
+	)
+	.await?;
 	let health = status
 		.as_ref()
-		.map(|s| s.health_state())
+		.map(|s| s.health_state_ignoring(&silenced_checks))
 		.unwrap_or_default();
 
 	let device_with_info = if let Some(device_id) = device_id {

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -220,6 +220,13 @@ pub async fn group_details(
 		.into_iter()
 		.map(|s| (s.server_id, s))
 		.collect();
+	// Operator-silenced healthchecks don't count toward member health.
+	let member_groups: Vec<(Uuid, Option<Uuid>)> =
+		servers.iter().map(|s| (s.id, s.group_id)).collect();
+	let silenced =
+		database::silenced_refs::silenced_health_checks_for_servers(&mut conn, &member_groups)
+			.await?;
+	let no_silences = BTreeSet::new();
 
 	// The card's headline version is the cached last reported version of the
 	// group's canonical member (highest rank, then highest kind), maintained by
@@ -244,11 +251,14 @@ pub async fn group_details(
 				}
 				_ => Vec::new(),
 			};
+			let silenced_checks = silenced.get(&s.id).unwrap_or(&no_silences);
 			FacilityServerStatus {
 				id: s.id,
 				name: s.name.clone().unwrap_or_default(),
 				up,
-				health: st.map(|s| s.health_state()).unwrap_or_default(),
+				health: st
+					.map(|s| s.health_state_ignoring(silenced_checks))
+					.unwrap_or_default(),
 				operators,
 				rank: s.rank,
 				kind: s.kind,
@@ -488,6 +498,11 @@ pub struct StatusSnapshotData {
 	/// omitted. An unhealthy check with no severity listed here should be
 	/// treated as a default (warning-level) severity.
 	pub check_severities: std::collections::HashMap<String, commons_types::issue::Severity>,
+	/// Check names currently silenced for this server (at server or
+	/// group scope). These don't count toward `health_state` and the UI
+	/// renders them with its skipped affordance. Reflects the silence
+	/// list as of the request, not as of the snapshot's push.
+	pub silenced_checks: BTreeSet<String>,
 }
 
 /// Selects a server and a point in time to fetch a status snapshot for.
@@ -534,6 +549,7 @@ pub async fn snapshot(
 	let Some(status) = status else {
 		return Ok(Json(None));
 	};
+	let server = Server::get_by_id(&mut conn, args.server_id).await?;
 
 	// If the deployment has no published versions yet, we just skip
 	// the distance computation rather than 404'ing the whole
@@ -574,8 +590,17 @@ pub async fn snapshot(
 	// Compute the per-unhealthy-check severity the rules engine would
 	// file at given this push. Healthy checks are omitted; the UI
 	// renders them with its 'passing' affordance regardless.
-	let check_severities = compute_check_severities(&mut conn, args.server_id, &status).await?;
-	let health_state = status.health_state();
+	let check_severities = compute_check_severities(&mut conn, &server, &status).await?;
+	// Operator-silenced healthchecks present as skipped and don't count
+	// toward the rollup, even on historical snapshots — a silence
+	// expresses current operator intent about the check, not the push.
+	let silenced_checks = database::silenced_refs::silenced_health_checks_for_server(
+		&mut conn,
+		server.id,
+		server.group_id,
+	)
+	.await?;
+	let health_state = status.health_state_ignoring(&silenced_checks);
 	let mut operators = status.operators();
 	enrich_operators(&mut conn, operators.iter_mut()).await?;
 
@@ -597,6 +622,7 @@ pub async fn snapshot(
 		extra: status.extra,
 		operators,
 		check_severities,
+		silenced_checks,
 	})))
 }
 
@@ -638,12 +664,11 @@ pub(crate) async fn enrich_operators(
 /// nothing.
 async fn compute_check_severities(
 	conn: &mut database::diesel_async::AsyncPgConnection,
-	server_id: Uuid,
+	server: &Server,
 	status: &Status,
 ) -> commons_errors::Result<std::collections::HashMap<String, commons_types::issue::Severity>> {
 	use commons_types::status::CheckResult;
 	use database::healthcheck_severities::{EvaluationContext, HealthcheckSeverity};
-	use database::servers::Server as DbServer;
 
 	let Some(arr) = status.health.as_array() else {
 		return Ok(Default::default());
@@ -682,7 +707,6 @@ async fn compute_check_severities(
 		return Ok(Default::default());
 	}
 
-	let server = DbServer::get_by_id(conn, server_id).await?;
 	let tag_map = server.tags_merged_with_group(conn).await?;
 	let tags: std::collections::HashMap<String, serde_json::Value> = tag_map
 		.0
@@ -704,8 +728,3 @@ async fn compute_check_severities(
 	}
 	Ok(out)
 }
-
-// Touch `Server` so the unused-import warning doesn't fire when this module
-// is compiled standalone in some configurations.
-#[allow(dead_code)]
-fn _server_touch(_s: Server) {}

--- a/crates/private-server/tests/private_statuses.rs
+++ b/crates/private-server/tests/private_statuses.rs
@@ -1388,3 +1388,127 @@ async fn snapshot_check_severities_cover_result_form() {
 	})
 	.await
 }
+
+/// A silenced healthcheck stops counting toward the server's health
+/// rollup (`get_detail`'s `health`), while the raw check result stays
+/// on `last_status.health` for display; unsilencing brings it back.
+#[tokio::test(flavor = "multi_thread")]
+async fn get_detail_health_excludes_silenced_checks() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, status, changelog, created_at) VALUES
+			('00000000-0000-0000-0000-000000000001', 1, 0, 0, 'published', 'Test version', NOW());
+
+			INSERT INTO servers (id, name, host, rank, kind) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Silence Server', 'https://silence.example.com', 'production', 'central');
+
+			INSERT INTO statuses (server_id, version, healthy, health, extra, created_at) VALUES
+			('11111111-1111-1111-1111-111111111111', '1.0.0', true,
+			 '[{\"check\": \"postgres\", \"result\": \"failed\"}]'::jsonb, '{}'::jsonb, NOW())",
+		)
+		.await
+		.unwrap();
+
+		let detail = async || {
+			let response = private
+				.post("/api/servers/get_detail")
+				.json(&serde_json::json!({"server_id": "11111111-1111-1111-1111-111111111111"}))
+				.await;
+			response.assert_status_ok();
+			let body: serde_json::Value = response.json();
+			body
+		};
+
+		let body = detail().await;
+		assert_eq!(body["health"], "unhealthy");
+
+		conn.batch_execute(
+			"INSERT INTO server_silenced_refs (server_id, source, ref) VALUES
+			('11111111-1111-1111-1111-111111111111', 'status', 'health/postgres')",
+		)
+		.await
+		.unwrap();
+
+		let body = detail().await;
+		assert_eq!(body["health"], "healthy");
+		// The check keeps recording — only the rollup changes.
+		assert_eq!(
+			body["last_status"]["health"][0]["result"], "failed",
+			"raw check result must stay on the status payload"
+		);
+
+		conn.batch_execute("DELETE FROM server_silenced_refs").await.unwrap();
+		let body = detail().await;
+		assert_eq!(body["health"], "unhealthy");
+	})
+	.await
+}
+
+/// Group-scope silences apply to every member's health rollup on the
+/// group card.
+#[tokio::test(flavor = "multi_thread")]
+async fn group_details_member_health_excludes_group_silenced_checks() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			// group_details 404s via NoMatchingVersions when nothing is
+			// published, so seed a version like its other tests do.
+			"INSERT INTO versions (id, major, minor, patch, status, changelog, created_at) VALUES
+			('00000000-0000-0000-0000-000000000001', 1, 0, 0, 'published', 'Test version', NOW());
+
+			INSERT INTO server_groups (id, name) VALUES
+			('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Silenced cluster');
+
+			INSERT INTO servers (id, name, host, rank, kind, group_id) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Member Server', 'https://member.example.com', 'production', 'central', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+
+			INSERT INTO statuses (server_id, version, healthy, health, extra, created_at) VALUES
+			('11111111-1111-1111-1111-111111111111', '1.0.0', true,
+			 '[{\"check\": \"disk\", \"result\": \"failed\"}]'::jsonb, '{}'::jsonb, NOW());
+
+			INSERT INTO server_group_silenced_refs (server_group_id, source, ref) VALUES
+			('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'status', 'health/disk')",
+		)
+		.await
+		.unwrap();
+
+		let response = private
+			.post("/api/statuses/group_details")
+			.json(&serde_json::json!({"server_group_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}))
+			.await;
+		response.assert_status_ok();
+		let body: serde_json::Value = response.json();
+		assert_eq!(body["members"][0]["health"], "healthy");
+	})
+	.await
+}
+
+/// The snapshot endpoint reports which checks are silenced and excludes
+/// them from its `health_state` rollup.
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_reports_and_excludes_silenced_checks() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO servers (id, name, host, rank, kind) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Snap Server', 'https://snap.example.com', 'production', 'central');
+
+			INSERT INTO statuses (server_id, version, healthy, health, extra, created_at) VALUES
+			('11111111-1111-1111-1111-111111111111', '1.0.0', true,
+			 '[{\"check\": \"postgres\", \"result\": \"failed\"}, {\"check\": \"disk\", \"result\": \"passed\"}]'::jsonb, '{}'::jsonb, NOW());
+
+			INSERT INTO server_silenced_refs (server_id, source, ref) VALUES
+			('11111111-1111-1111-1111-111111111111', 'status', 'health/postgres')",
+		)
+		.await
+		.unwrap();
+
+		let response = private
+			.post("/api/statuses/snapshot")
+			.json(&serde_json::json!({"server_id": "11111111-1111-1111-1111-111111111111"}))
+			.await;
+		response.assert_status_ok();
+		let body: serde_json::Value = response.json();
+		assert_eq!(body["health_state"], "healthy");
+		assert_eq!(body["silenced_checks"], serde_json::json!(["postgres"]));
+	})
+	.await
+}

--- a/private-web/e2e/health.spec.ts
+++ b/private-web/e2e/health.spec.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "./test-fixtures";
 import {
 	resetSeededTables,
+	seedGroupSilencedRef,
 	seedServer,
+	seedServerGroup,
+	seedServerSilencedRef,
 	seedStatus,
 	seedVersion,
 } from "./seed";
@@ -130,5 +133,98 @@ test.describe("server detail checks table", () => {
 		const skippedY = (await skipped.boundingBox())!.y;
 		expect(failedY).toBeLessThan(passedY);
 		expect(passedY).toBeLessThan(skippedY);
+	});
+});
+
+test.describe("silenced healthchecks", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("a server-silenced failing check renders skip-style and doesn't count toward health", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const server = await seedServer(sql, {
+			name: "hushed-server",
+			kind: "central",
+		});
+		// Named so alphabetical order would put the silenced check first:
+		// its position after the passing check proves silenced sorts with
+		// the skipped tail, not by name or by its raw failed result.
+		await seedStatus(sql, {
+			serverId: server.id,
+			healthy: true,
+			health: [
+				{ check: "a-silenced", result: "failed" },
+				{ check: "m-passes", result: "passed" },
+			],
+		});
+		await seedServerSilencedRef(sql, {
+			serverId: server.id,
+			ref: "health/a-silenced",
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		// Headline rollup ignores the silenced failure.
+		await expect(page.getByText("Healthy", { exact: true })).toBeVisible();
+		await expect(
+			page.getByText("Unhealthy", { exact: true }),
+		).not.toBeVisible();
+
+		// The row is still listed and flagged as silenced. Exact matching:
+		// the Silenced refs section also shows the full
+		// "status/health/a-silenced" ref, which substring-matches.
+		await expect(
+			page.getByText("a-silenced", { exact: true }),
+		).toBeVisible();
+		await expect(page.getByText("silenced (server)")).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Manage silence for a-silenced" }),
+		).toBeVisible();
+		// The neutral silenced icon renders three times for the row (result
+		// icon, silenced chip, admin silence button) and the red failure
+		// icon not at all — neither in the row nor the headline chip.
+		await expect(page.getByTestId("NotificationsOffIcon")).toHaveCount(3);
+		await expect(page.getByTestId("CancelIcon")).toHaveCount(0);
+
+		// And it sorts with the skipped tail, after passing checks.
+		const passed = page.getByText("m-passes", { exact: true });
+		const silenced = page.getByText("a-silenced", { exact: true });
+		const passedY = (await passed.boundingBox())!.y;
+		const silencedY = (await silenced.boundingBox())!.y;
+		expect(passedY).toBeLessThan(silencedY);
+	});
+
+	test("a group-silenced failing check doesn't count toward member health", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const group = await seedServerGroup(sql, { name: "hushed-group" });
+		const server = await seedServer(sql, {
+			name: "grouped-hushed-server",
+			kind: "central",
+			groupId: group.id,
+		});
+		await seedStatus(sql, {
+			serverId: server.id,
+			healthy: true,
+			health: [{ check: "database", result: "failed" }],
+		});
+		await seedGroupSilencedRef(sql, {
+			groupId: group.id,
+			ref: "health/database",
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		await expect(page.getByText("Healthy", { exact: true })).toBeVisible();
+		await expect(
+			page.getByText("Unhealthy", { exact: true }),
+		).not.toBeVisible();
+		await expect(page.getByText("silenced (group)")).toBeVisible();
 	});
 });

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -262,6 +262,45 @@ export async function seedHealthcheckSeverity(
 	return { checkName: opts.checkName };
 }
 
+/** Server-scope silence for a `(source, ref)` pair, as the UI's
+ * silence button would create. For a healthcheck, pass
+ * `ref: "health/<check>"` (source defaults to "status"). */
+export async function seedServerSilencedRef(
+	sql: Sql,
+	opts: {
+		serverId: string;
+		ref: string;
+		source?: string;
+		createdBy?: string | null;
+	},
+): Promise<void> {
+	await sql.query(
+		`INSERT INTO server_silenced_refs (server_id, source, ref, created_by)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT DO NOTHING`,
+		[opts.serverId, opts.source ?? "status", opts.ref, opts.createdBy ?? null],
+	);
+}
+
+/** Group-scope silence for a `(source, ref)` pair; see
+ * {@link seedServerSilencedRef}. */
+export async function seedGroupSilencedRef(
+	sql: Sql,
+	opts: {
+		groupId: string;
+		ref: string;
+		source?: string;
+		createdBy?: string | null;
+	},
+): Promise<void> {
+	await sql.query(
+		`INSERT INTO server_group_silenced_refs (server_group_id, source, ref, created_by)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT DO NOTHING`,
+		[opts.groupId, opts.source ?? "status", opts.ref, opts.createdBy ?? null],
+	);
+}
+
 /** Cache row for a Tailscale user's display info, as the auth layer
  * would have upserted it. Used to test avatar/name enrichment. */
 export async function seedTailscaleUser(

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -12235,7 +12235,8 @@
           "health",
           "extra",
           "operators",
-          "check_severities"
+          "check_severities",
+          "silenced_checks"
         ],
         "properties": {
           "check_severities": {
@@ -12321,6 +12322,14 @@
             "type": "string",
             "format": "uuid",
             "description": "Id of the server this status was reported by."
+          },
+          "silenced_checks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Check names currently silenced for this server (at server or\ngroup scope). These don't count toward `health_state` and the UI\nrenders them with its skipped affordance. Reflects the silence\nlist as of the request, not as of the snapshot's push.",
+            "uniqueItems": true
           },
           "timezone": {
             "type": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -7106,6 +7106,13 @@ export interface components {
              * @description Id of the server this status was reported by.
              */
             server_id: string;
+            /**
+             * @description Check names currently silenced for this server (at server or
+             *     group scope). These don't count toward `health_state` and the UI
+             *     renders them with its skipped affordance. Reflects the silence
+             *     list as of the request, not as of the snapshot's push.
+             */
+            silenced_checks: string[];
             /** @description Reported system timezone. */
             timezone?: string | null;
             version?: null | components["schemas"]["VersionStr"];

--- a/private-web/src/components/StatusSnapshot.tsx
+++ b/private-web/src/components/StatusSnapshot.tsx
@@ -14,6 +14,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import CircleIcon from "@mui/icons-material/Circle";
 import ErrorIcon from "@mui/icons-material/Error";
 import InfoIcon from "@mui/icons-material/Info";
+import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import PreviewIcon from "@mui/icons-material/Preview";
 import RemoveCircleOutlinedIcon from "@mui/icons-material/RemoveCircleOutlined";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
@@ -121,6 +122,7 @@ function PanelBody({
 				health={snap.health}
 				severities={snap.check_severities}
 				operators={snap.operators}
+				silencedChecks={snap.silenced_checks}
 			/>
 			<ExtrasBlock extra={snap.extra} />
 		</Stack>
@@ -189,12 +191,16 @@ function ChecksBlock({
 	health,
 	severities,
 	operators,
+	silencedChecks,
 }: {
 	health: StatusSnapshotData["health"];
 	severities: StatusSnapshotData["check_severities"];
 	operators: StatusSnapshotData["operators"];
+	silencedChecks: StatusSnapshotData["silenced_checks"];
 }) {
-	const entries = parseChecks(health);
+	// Silenced checks render skip-style and sort with the skipped tail —
+	// the backend excludes them from `health_state` the same way.
+	const entries = parseChecks(health, new Set(silencedChecks));
 	if (entries.length === 0) return null;
 	return (
 		<Box>
@@ -229,7 +235,9 @@ function ChecksBlock({
 								borderRadius: 1,
 								alignItems: "flex-start",
 								bgcolor:
-									entry.result === "passed" || entry.result === "skipped"
+									entry.result === "passed" ||
+									entry.result === "skipped" ||
+									entry.silenced
 										? undefined
 										: "action.hover",
 							}}
@@ -237,6 +245,7 @@ function ChecksBlock({
 							<CheckIcon
 								result={entry.result}
 								severity={severities[entry.check] ?? null}
+								silenced={entry.silenced}
 							/>
 							<Box sx={{ flex: 1, minWidth: 0 }}>
 								<Typography variant="body2" sx={{ fontFamily: "monospace" }}>
@@ -286,10 +295,17 @@ function ExtrasBlock({ extra }: { extra: StatusSnapshotData["extra"] }) {
 type ParsedCheck = {
 	check: string;
 	result: CheckResult;
+	/** Whether the check is silenced (server or group scope), per the
+	 * snapshot's `silenced_checks`: presented skip-style and excluded
+	 * from the health rollup. */
+	silenced: boolean;
 	extras: Array<[string, unknown]>;
 };
 
-function parseChecks(health: StatusSnapshotData["health"]): ParsedCheck[] {
+function parseChecks(
+	health: StatusSnapshotData["health"],
+	silencedChecks: Set<string>,
+): ParsedCheck[] {
 	if (!Array.isArray(health)) return [];
 	const parsed: ParsedCheck[] = [];
 	for (const raw of health as unknown[]) {
@@ -298,13 +314,20 @@ function parseChecks(health: StatusSnapshotData["health"]): ParsedCheck[] {
 		const check = obj.check;
 		const result = checkResultOf(obj);
 		if (typeof check !== "string" || result === null) continue;
-		parsed.push({ check, result, extras: checkEntryExtras(obj) });
+		parsed.push({
+			check,
+			result,
+			silenced: silencedChecks.has(check),
+			extras: checkEntryExtras(obj),
+		});
 	}
+	const sortResult = (e: ParsedCheck): CheckResult =>
+		e.silenced ? "skipped" : e.result;
 	parsed.sort((a, b) => {
-		if (a.result !== b.result) {
+		if (sortResult(a) !== sortResult(b)) {
 			return (
-				CHECK_RESULT_ORDER.indexOf(a.result) -
-				CHECK_RESULT_ORDER.indexOf(b.result)
+				CHECK_RESULT_ORDER.indexOf(sortResult(a)) -
+				CHECK_RESULT_ORDER.indexOf(sortResult(b))
 			);
 		}
 		return a.check.localeCompare(b.check);
@@ -320,14 +343,28 @@ function parseChecks(health: StatusSnapshotData["health"]): ParsedCheck[] {
 /// yellow triangle, error → red ⊘, critical → red filled exclamation).
 /// Falls back to the warning icon when the severity is absent — the
 /// catalog hasn't been touched for this check yet, so we surface it
-/// at the default level rather than miscolouring it.
+/// at the default level rather than miscolouring it. Silenced checks
+/// get the same neutral grey treatment as skipped ones, whatever they
+/// reported — they don't count toward the server's health.
 function CheckIcon({
 	result,
 	severity,
+	silenced = false,
 }: {
 	result: CheckResult;
 	severity: Severity | null;
+	silenced?: boolean;
 }) {
+	if (silenced) {
+		return (
+			<Tooltip
+				title={`Silenced — reported ${result}, not counted toward server health`}
+				arrow
+			>
+				<NotificationsOffIcon fontSize="small" color="disabled" />
+			</Tooltip>
+		);
+	}
 	switch (result) {
 		case "passed":
 			return (

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -75,6 +75,7 @@ import {
 	checkResultOf,
 	compareServersByRankThenKind,
 	groupServersByRank,
+	healthcheckNameFromRef,
 	healthcheckPath,
 	type CheckResult,
 	type DeviceInfo,
@@ -937,7 +938,15 @@ function ChecksTableBody({
 	serverSilences: ServerSilencedRef[];
 	groupSilences: ServerGroupSilencedRef[];
 }) {
-	const entries = parseChecks(health, overallHealthy);
+	// Silenced checks render skip-style and sort with the skipped tail —
+	// they don't count toward the server's health rollup (the backend
+	// applies the same exclusion to the headline HealthState).
+	const silencedChecks = new Set<string>();
+	for (const s of [...serverSilences, ...groupSilences]) {
+		const check = healthcheckNameFromRef(s.source, s.ref);
+		if (check !== null) silencedChecks.add(check);
+	}
+	const entries = parseChecks(health, overallHealthy, silencedChecks);
 	const [expanded, setExpanded] = useState(false);
 	if (entries.length === 0) return null;
 	const HIDE_AFTER = 5;
@@ -998,6 +1007,9 @@ function ChecksTableBody({
 type ParsedCheck = {
 	check: string;
 	result: CheckResult;
+	/** Whether the check's `(status, health/<check>)` ref is silenced at
+	 * either scope: presented skip-style and excluded from the rollup. */
+	silenced: boolean;
 	/** Everything other than the reserved `check` / `healthy` /
 	 * `result` keys, preserved in source order. */
 	extras: Array<[string, unknown]>;
@@ -1006,6 +1018,7 @@ type ParsedCheck = {
 function parseChecks(
 	health: ServerLastStatusData["health"],
 	overallHealthy: boolean,
+	silencedChecks: Set<string>,
 ): ParsedCheck[] {
 	if (!Array.isArray(health)) return [];
 	const parsed: ParsedCheck[] = [];
@@ -1022,15 +1035,23 @@ function parseChecks(
 		if (typeof obj.result !== "string" && result === "failed" && overallHealthy) {
 			result = "warning";
 		}
-		parsed.push({ check, result, extras: checkEntryExtras(obj) });
+		parsed.push({
+			check,
+			result,
+			silenced: silencedChecks.has(check),
+			extras: checkEntryExtras(obj),
+		});
 	}
-	// Most urgent first, then alphabetical by name. Stable: same input
-	// always produces the same visible order.
+	// Most urgent first, then alphabetical by name. Silenced checks sort
+	// as if skipped, whatever they reported. Stable: same input always
+	// produces the same visible order.
+	const sortResult = (e: ParsedCheck): CheckResult =>
+		e.silenced ? "skipped" : e.result;
 	parsed.sort((a, b) => {
-		if (a.result !== b.result) {
+		if (sortResult(a) !== sortResult(b)) {
 			return (
-				CHECK_RESULT_ORDER.indexOf(a.result) -
-				CHECK_RESULT_ORDER.indexOf(b.result)
+				CHECK_RESULT_ORDER.indexOf(sortResult(a)) -
+				CHECK_RESULT_ORDER.indexOf(sortResult(b))
 			);
 		}
 		return a.check.localeCompare(b.check);
@@ -1078,12 +1099,14 @@ function CheckRow({
 				borderRadius: 1,
 				alignItems: "flex-start",
 				bgcolor:
-					entry.result === "passed" || entry.result === "skipped"
+					entry.result === "passed" ||
+					entry.result === "skipped" ||
+					entry.silenced
 						? undefined
 						: "action.hover",
 			}}
 		>
-			<CheckResultIcon result={entry.result} />
+			<CheckResultIcon result={entry.result} silenced={entry.silenced} />
 			<Box sx={{ flex: 1, minWidth: 0 }}>
 				<Stack
 					direction="row"
@@ -1125,8 +1148,26 @@ function CheckRow({
 
 /** Per-check result icon for the checks table. Unlike the snapshot
  * panel this table has no computed severity to hand, so failed is a
- * flat red and warning a flat amber. */
-function CheckResultIcon({ result }: { result: CheckResult }) {
+ * flat red and warning a flat amber. A silenced check gets the same
+ * neutral grey treatment as a skipped one — its result still records,
+ * it just doesn't count toward the server's health. */
+function CheckResultIcon({
+	result,
+	silenced = false,
+}: {
+	result: CheckResult;
+	silenced?: boolean;
+}) {
+	if (silenced) {
+		return (
+			<Tooltip
+				title={`Silenced — reported ${result}, not counted toward server health`}
+				arrow
+			>
+				<NotificationsOffIcon fontSize="small" color="disabled" />
+			</Tooltip>
+		);
+	}
 	switch (result) {
 		case "passed":
 			return (


### PR DESCRIPTION
🤖 Silencing a healthcheck's `(status, health/<check>)` ref already kept its issues out of incidents, but the check still rendered as failing and still made the server look unhealthy. Now:

- `Status::health_state_ignoring(silenced_checks)` treats silenced checks like skipped ones in the rollup, and a new batched `silenced_refs::silenced_health_checks_for_servers` (two queries regardless of server count, server + group scope) feeds it everywhere the rollup is computed: server list/sibling dots, server detail headline, group card members, status snapshots, and the MCP `find_servers`/`get_server`/`get_group` tools. The legacy top-level `healthy: false` short-circuit is unchanged, since it can't be attributed to any particular check.
- In the server detail checks table and the snapshot panel, a silenced check renders a neutral grey silenced icon instead of its pass/fail state, loses the attention background, and sorts with the skipped tail. The snapshot response gains a `silenced_checks` field for this.
- Check results keep recording untouched — only their contribution to the rollup and their presentation change.

Not covered here: the per-healthcheck "who's affected" page (`/healthchecks/:check`) still lists silenced servers with their raw result, which stays true to that page's fleet-correlation purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)