### PR TITLE
feat(public): send effective healthcheck severity mapping to devices

### DIFF
--- a/crates/commons-types/src/status.rs
+++ b/crates/commons-types/src/status.rs
@@ -2,6 +2,44 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
+use crate::issue::Severity;
+
+/// How a server should treat one of its healthchecks, distilled from
+/// canopy's operator-side configuration (the severity catalog and the
+/// silence lists) into a three-level device-facing vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckSeverity {
+	/// This check's failures are ignored on the canopy side — it is
+	/// silenced for this server, or its severity is classified below
+	/// warning.
+	Skip,
+	/// This check's failures are treated as warnings.
+	Warn,
+	/// This check's failures are treated as errors (incident-opening).
+	Fail,
+}
+
+impl From<Severity> for CheckSeverity {
+	fn from(severity: Severity) -> Self {
+		match severity {
+			Severity::Critical | Severity::Error => Self::Fail,
+			Severity::Warning => Self::Warn,
+			Severity::Info | Severity::Debug => Self::Skip,
+		}
+	}
+}
+
+impl Display for CheckSeverity {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			CheckSeverity::Skip => write!(f, "skip"),
+			CheckSeverity::Warn => write!(f, "warn"),
+			CheckSeverity::Fail => write!(f, "fail"),
+		}
+	}
+}
+
 /// Reachability of a server, based on how recently it last reported a status update.
 #[derive(
 	Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize, utoipa::ToSchema,

--- a/crates/database/src/healthcheck_severities.rs
+++ b/crates/database/src/healthcheck_severities.rs
@@ -14,7 +14,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use jiff::Timestamp;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// The severity policy for one named healthcheck. An entry is created
 /// automatically the first time a check with this name is reported, using
@@ -151,6 +151,25 @@ impl HealthcheckSeverity {
 			.get_result(db)
 			.await
 			.map_err(AppError::from)
+	}
+
+	/// The whole catalog as `check_name → base severity`, for building the
+	/// device-facing effective check-severity map. Deliberately reads only
+	/// the static `severity` column: conditional `rules` ladders are
+	/// expressions evaluated per push against the report's contents, so they
+	/// can't be resolved ahead of time and are ignored here. An unparseable
+	/// severity falls back to [`Severity::Warning`], same as `severity_for`.
+	pub async fn base_severity_map(db: &mut AsyncPgConnection) -> Result<BTreeMap<String, Severity>> {
+		use crate::schema::healthcheck_severities::dsl;
+		let rows: Vec<(String, String)> = dsl::healthcheck_severities
+			.select((dsl::check_name, dsl::severity))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		Ok(rows
+			.into_iter()
+			.map(|(name, sev)| (name, sev.parse().unwrap_or(Severity::Warning)))
+			.collect())
 	}
 
 	pub async fn list(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {

--- a/crates/database/src/healthcheck_severities.rs
+++ b/crates/database/src/healthcheck_severities.rs
@@ -159,7 +159,9 @@ impl HealthcheckSeverity {
 	/// expressions evaluated per push against the report's contents, so they
 	/// can't be resolved ahead of time and are ignored here. An unparseable
 	/// severity falls back to [`Severity::Warning`], same as `severity_for`.
-	pub async fn base_severity_map(db: &mut AsyncPgConnection) -> Result<BTreeMap<String, Severity>> {
+	pub async fn base_severity_map(
+		db: &mut AsyncPgConnection,
+	) -> Result<BTreeMap<String, Severity>> {
 		use crate::schema::healthcheck_severities::dsl;
 		let rows: Vec<(String, String)> = dsl::healthcheck_severities
 			.select((dsl::check_name, dsl::severity))

--- a/crates/database/src/silenced_refs.rs
+++ b/crates/database/src/silenced_refs.rs
@@ -111,6 +111,55 @@ pub async fn is_silenced(
 	Ok(group_hit > 0)
 }
 
+/// All refs silenced for this server under `source` and starting with
+/// `ref_prefix`, combining the server's own silence list with its group's.
+/// `group_id` is the server's current group; pass `None` if the server is
+/// ungrouped. Used to build the device-facing effective check-severity map.
+/// May contain duplicates when a ref is silenced at both scopes.
+pub async fn silenced_refs_with_prefix(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	group_id: Option<Uuid>,
+	source: &str,
+	ref_prefix: &str,
+) -> Result<Vec<String>> {
+	use crate::schema::{server_group_silenced_refs, server_silenced_refs};
+
+	debug_assert!(
+		!ref_prefix.contains(['%', '_', '\\']),
+		"prefix is used in a LIKE pattern and must not contain wildcards"
+	);
+
+	let mut refs: Vec<String> = server_silenced_refs::table
+		.select(server_silenced_refs::ref_)
+		.filter(
+			server_silenced_refs::server_id
+				.eq(server_id)
+				.and(server_silenced_refs::source.eq(source))
+				.and(server_silenced_refs::ref_.like(format!("{ref_prefix}%"))),
+		)
+		.load(db)
+		.await
+		.map_err(AppError::from)?;
+
+	if let Some(gid) = group_id {
+		let group_refs: Vec<String> = server_group_silenced_refs::table
+			.select(server_group_silenced_refs::ref_)
+			.filter(
+				server_group_silenced_refs::server_group_id
+					.eq(gid)
+					.and(server_group_silenced_refs::source.eq(source))
+					.and(server_group_silenced_refs::ref_.like(format!("{ref_prefix}%"))),
+			)
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		refs.extend(group_refs);
+	}
+
+	Ok(refs)
+}
+
 impl ServerSilencedRef {
 	/// Add a server-scoped silence and re-evaluate any currently-open
 	/// matching issues so they leave their incident. Idempotent: a

--- a/crates/database/tests/check_severity_map.rs
+++ b/crates/database/tests/check_severity_map.rs
@@ -1,0 +1,129 @@
+//! Queries backing the device-facing effective check-severity map:
+//! `HealthcheckSeverity::base_severity_map` (static catalog severities,
+//! ignoring conditional rules) and `silenced_refs::silenced_refs_with_prefix`
+//! (server- plus group-scope silences under a source/ref prefix).
+
+use commons_types::issue::Severity;
+use database::healthcheck_severities::{HealthcheckSeverity, IfLadder};
+use database::silenced_refs::{
+	ServerGroupSilencedRef, ServerSilencedRef, silenced_refs_with_prefix,
+};
+use diesel::{sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use serde_json::json;
+use uuid::Uuid;
+
+async fn insert_group(conn: &mut diesel_async::AsyncPgConnection) -> Uuid {
+	let group_id = Uuid::new_v4();
+	sql_query("INSERT INTO server_groups (id, name) VALUES ($1, 'severity-map-group')")
+		.bind::<sql_types::Uuid, _>(group_id)
+		.execute(conn)
+		.await
+		.expect("insert group");
+	group_id
+}
+
+async fn insert_server(conn: &mut diesel_async::AsyncPgConnection, group_id: Option<Uuid>) -> Uuid {
+	let server_id = Uuid::new_v4();
+	sql_query(
+		"INSERT INTO servers (id, host, kind, group_id) \
+		 VALUES ($1, 'https://severity-map.example.com', 'facility', $2)",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(group_id)
+	.execute(conn)
+	.await
+	.expect("insert server");
+	server_id
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn base_severity_map_returns_static_severities() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		for check in ["disk_space", "cert_expiry", "chatty"] {
+			HealthcheckSeverity::upsert_default(&mut conn, check)
+				.await
+				.expect("seed");
+		}
+		HealthcheckSeverity::update(&mut conn, "disk_space", Severity::Error, None, "alice")
+			.await
+			.expect("update disk_space");
+		HealthcheckSeverity::update(&mut conn, "chatty", Severity::Info, None, "alice")
+			.await
+			.expect("update chatty");
+
+		let map = HealthcheckSeverity::base_severity_map(&mut conn)
+			.await
+			.expect("map");
+		assert_eq!(map.len(), 3);
+		assert_eq!(map.get("disk_space"), Some(&Severity::Error));
+		assert_eq!(map.get("cert_expiry"), Some(&Severity::Warning));
+		assert_eq!(map.get("chatty"), Some(&Severity::Info));
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn base_severity_map_ignores_conditional_rules() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		HealthcheckSeverity::upsert_default(&mut conn, "ruled")
+			.await
+			.expect("seed");
+		let ladder: IfLadder = serde_json::from_value(json!({"if": [
+			{"==": [{"var": "check.result"}, "failed"]}, "critical",
+		]}))
+		.expect("parse ladder");
+		HealthcheckSeverity::update_rules(&mut conn, "ruled", Some(&ladder), "alice")
+			.await
+			.expect("set rules");
+
+		// The expression could raise a failure to critical at push time, but
+		// the static map must only reflect the base severity column.
+		let map = HealthcheckSeverity::base_severity_map(&mut conn)
+			.await
+			.expect("map");
+		assert_eq!(map.get("ruled"), Some(&Severity::Warning));
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn silenced_refs_with_prefix_combines_scopes_and_filters() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let group_id = insert_group(&mut conn).await;
+		let server_id = insert_server(&mut conn, Some(group_id)).await;
+		let other_server_id = insert_server(&mut conn, None).await;
+
+		ServerSilencedRef::add(&mut conn, server_id, "status", "health/flaky", None)
+			.await
+			.expect("server silence");
+		ServerGroupSilencedRef::add(&mut conn, group_id, "status", "health/groupwide", None)
+			.await
+			.expect("group silence");
+		// None of these may leak into the result: wrong source, wrong ref
+		// prefix (broken issues are a separate thread), wrong server.
+		ServerSilencedRef::add(&mut conn, server_id, "canopy", "health/wrong-source", None)
+			.await
+			.expect("other-source silence");
+		ServerSilencedRef::add(&mut conn, server_id, "status", "health-broken/flaky", None)
+			.await
+			.expect("broken silence");
+		ServerSilencedRef::add(&mut conn, other_server_id, "status", "health/other", None)
+			.await
+			.expect("other-server silence");
+
+		let mut refs =
+			silenced_refs_with_prefix(&mut conn, server_id, Some(group_id), "status", "health/")
+				.await
+				.expect("refs");
+		refs.sort();
+		assert_eq!(refs, vec!["health/flaky", "health/groupwide"]);
+
+		// Ungrouped lookup only sees the server-scope silences.
+		let refs = silenced_refs_with_prefix(&mut conn, server_id, None, "status", "health/")
+			.await
+			.expect("refs without group");
+		assert_eq!(refs, vec!["health/flaky"]);
+	})
+	.await
+}

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -739,7 +739,7 @@
           "statuses"
         ],
         "summary": "Submit a status heartbeat for a server.",
-        "description": "Records a periodic status push against the server identified in the\npath: overall self-reported health, a per-check breakdown, and any\nfree-form extra data. Each failed or warning check opens (or keeps\nopen) an issue at that check's operator-configured severity, and each\npassed check closes any issue it previously opened; the server's\ntracked software version is also updated from the payload.\n\nThe calling device must be the one enrolled for this exact server (or\nhold the admin role). The response echoes back the stored status\nrecord, plus a `backup_now` list of backup types the server should\nback up immediately — devices should treat a non-empty list as a\nprompt to run those backups and report them afterwards.",
+        "description": "Records a periodic status push against the server identified in the\npath: overall self-reported health, a per-check breakdown, and any\nfree-form extra data. Each failed or warning check opens (or keeps\nopen) an issue at that check's operator-configured severity, and each\npassed check closes any issue it previously opened; the server's\ntracked software version is also updated from the payload.\n\nThe calling device must be the one enrolled for this exact server (or\nhold the admin role). The response echoes back the stored status\nrecord, plus a `backup_now` list of backup types the server should\nback up immediately — devices should treat a non-empty list as a\nprompt to run those backups and report them afterwards — and a\n`check_severities` map describing how canopy classifies each known\nhealthcheck for this server (`skip`/`warn`/`fail`).",
         "operationId": "submit_status",
         "parameters": [
           {
@@ -795,6 +795,80 @@
             }
           },
           "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "server-device": []
+          }
+        ]
+      }
+    },
+    "/status/{server_id}/check-severities": {
+      "get": {
+        "tags": [
+          "statuses"
+        ],
+        "summary": "Fetch the effective healthcheck severity mapping for a server.",
+        "description": "Returns, for every healthcheck canopy knows about, how a failure of that\ncheck is classified for this server: `skip` (the check is silenced for\nthis server — at server or group scope — or its severity is below\nwarning), `warn` (warning), or `fail` (error or critical). Keys are check\nnames as reported in `health[].check` on status pushes. Only the static\nseverity baseline is reflected; operator-defined conditional rules are\nevaluated per push and not included here. The same mapping also rides\nalong every status-push response as `check_severities`.\n\nThe calling device must be the one enrolled for this exact server (or\nhold the admin role).",
+        "operationId": "check_severities",
+        "parameters": [
+          {
+            "name": "server_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Effective handling for each known check, keyed by check name.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/CheckSeverity"
+                  },
+                  "propertyNames": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "404": {
             "description": "",
             "content": {
               "application/json": {
@@ -1343,6 +1417,15 @@
           "failed",
           "broken",
           "skipped"
+        ]
+      },
+      "CheckSeverity": {
+        "type": "string",
+        "description": "How a server should treat one of its healthchecks, distilled from\ncanopy's operator-side configuration (the severity catalog and the\nsilence lists) into a three-level device-facing vocabulary.",
+        "enum": [
+          "skip",
+          "warn",
+          "fail"
         ]
       },
       "CompleteArgs": {
@@ -2048,7 +2131,8 @@
           {
             "type": "object",
             "required": [
-              "backup_now"
+              "backup_now",
+              "check_severities"
             ],
             "properties": {
               "backup_now": {
@@ -2057,6 +2141,16 @@
                   "type": "string"
                 },
                 "description": "Backup types the server should back up now: operator-requested\none-offs plus scheduled backups that are due. Each serializes as a\nplain string (e.g. `\"tamanu-postgres\"`). The device should run each\nlisted type, then report via `POST /backup-report`; an empty list\nmeans nothing to do."
+              },
+              "check_severities": {
+                "type": "object",
+                "description": "The effective handling of every healthcheck canopy knows about, keyed\nby check name (as reported in `health[].check`): `skip` (silenced for\nthis server, or classified below warning), `warn` (warning), or `fail`\n(error or critical). Only the static severity baseline is reflected —\noperator-defined conditional rules are evaluated per push and not\nincluded. Checks absent from the map are new to canopy and default to\n`warn`. Clients that predate this field can safely ignore it; the\nsame mapping is served on demand at `GET /status/{server_id}/check-severities`.",
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/CheckSeverity"
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -11,7 +11,10 @@ use commons_servers::{
 	backup_jobs::backups_due_now_for_server, device_auth::ServerDevice, headers::VersionHeader,
 };
 use commons_types::{
-	backup::BackupType, device::DeviceRole, issue::Severity, status::CheckResult,
+	backup::BackupType,
+	device::DeviceRole,
+	issue::Severity,
+	status::{CheckResult, CheckSeverity},
 	version::VersionStr,
 };
 use database::{
@@ -21,6 +24,7 @@ use database::{
 	healthcheck_severities::{EvaluationContext, HealthcheckSeverity},
 	issues::{Issue, NewEvent},
 	servers::Server,
+	silenced_refs::silenced_refs_with_prefix,
 	statuses::{NewStatus, Status},
 };
 use jiff::Timestamp;
@@ -136,10 +140,21 @@ pub struct StatusResponse {
 	/// means nothing to do.
 	#[schema(value_type = Vec<String>)]
 	pub backup_now: Vec<BackupType>,
+	/// The effective handling of every healthcheck canopy knows about, keyed
+	/// by check name (as reported in `health[].check`): `skip` (silenced for
+	/// this server, or classified below warning), `warn` (warning), or `fail`
+	/// (error or critical). Only the static severity baseline is reflected —
+	/// operator-defined conditional rules are evaluated per push and not
+	/// included. Checks absent from the map are new to canopy and default to
+	/// `warn`. Clients that predate this field can safely ignore it; the
+	/// same mapping is served on demand at `GET /status/{server_id}/check-severities`.
+	pub check_severities: BTreeMap<String, CheckSeverity>,
 }
 
 pub fn routes() -> OpenApiRouter<AppState> {
-	OpenApiRouter::new().routes(routes!(create))
+	OpenApiRouter::new()
+		.routes(routes!(create))
+		.routes(routes!(check_severities))
 }
 
 /// Submit a status heartbeat for a server.
@@ -155,7 +170,9 @@ pub fn routes() -> OpenApiRouter<AppState> {
 /// hold the admin role). The response echoes back the stored status
 /// record, plus a `backup_now` list of backup types the server should
 /// back up immediately — devices should treat a non-empty list as a
-/// prompt to run those backups and report them afterwards.
+/// prompt to run those backups and report them afterwards — and a
+/// `check_severities` map describing how canopy classifies each known
+/// healthcheck for this server (`skip`/`warn`/`fail`).
 #[utoipa::path(
 	post,
 	path = "/{server_id}",
@@ -222,7 +239,13 @@ async fn create(
 			return Err(AppError::BadRequest("`health` array is required".into()));
 		}
 		let status = create_legacy_status(&mut db, server_id, id, extra, version).await?;
-		return Ok(Json(StatusResponse { status, backup_now }));
+		let check_severities =
+			effective_check_severities(&mut db, server_id, server.group_id).await?;
+		return Ok(Json(StatusResponse {
+			status,
+			backup_now,
+			check_severities,
+		}));
 	};
 
 	// Resolve the server's effective tag map outside the write transaction.
@@ -256,7 +279,93 @@ async fn create(
 		})
 		.await?;
 
-	Ok(Json(StatusResponse { status, backup_now }))
+	// Computed after the transaction so checks first seen on this very push
+	// (upserted into the catalog above) are already in the map.
+	let check_severities = effective_check_severities(&mut db, server_id, server.group_id).await?;
+
+	Ok(Json(StatusResponse {
+		status,
+		backup_now,
+		check_severities,
+	}))
+}
+
+/// Fetch the effective healthcheck severity mapping for a server.
+///
+/// Returns, for every healthcheck canopy knows about, how a failure of that
+/// check is classified for this server: `skip` (the check is silenced for
+/// this server — at server or group scope — or its severity is below
+/// warning), `warn` (warning), or `fail` (error or critical). Keys are check
+/// names as reported in `health[].check` on status pushes. Only the static
+/// severity baseline is reflected; operator-defined conditional rules are
+/// evaluated per push and not included here. The same mapping also rides
+/// along every status-push response as `check_severities`.
+///
+/// The calling device must be the one enrolled for this exact server (or
+/// hold the admin role).
+#[utoipa::path(
+	get,
+	path = "/{server_id}/check-severities",
+	operation_id = "check_severities",
+	tag = "statuses",
+	security(("server-device" = [])),
+	params(
+		("server_id" = Uuid, Path),
+	),
+	responses(
+		(status = 200, description = "Effective handling for each known check, keyed by check name.", body = BTreeMap<String, CheckSeverity>),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+		(status = 404, body = ProblemDetailsSchema),
+	),
+)]
+async fn check_severities(
+	Path(server_id): Path<Uuid>,
+	State(db): State<Db>,
+	device: ServerDevice,
+) -> Result<Json<BTreeMap<String, CheckSeverity>>> {
+	let mut db = db.get().await?;
+	let Device { role, id, .. } = device.0.0;
+
+	let server = Server::get_by_id(&mut db, server_id).await?;
+	if role != DeviceRole::Admin && server.device_id != Some(id) {
+		return Err(AppError::custom(
+			"device is not authorized to read this server's check severities",
+		));
+	}
+
+	let map = effective_check_severities(&mut db, server_id, server.group_id).await?;
+	Ok(Json(map))
+}
+
+/// Build the effective per-check severity map for a server: every check in
+/// the operator catalog mapped from its static base severity (error and
+/// above → `fail`, warning → `warn`, below warning → `skip`), then any check
+/// silenced for this server (at server or group scope) forced to `skip`.
+/// Conditional severity rules are deliberately not consulted — they depend
+/// on each push's contents, so only the static baseline can be mapped ahead
+/// of time.
+async fn effective_check_severities(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	group_id: Option<Uuid>,
+) -> Result<BTreeMap<String, CheckSeverity>> {
+	let mut map: BTreeMap<String, CheckSeverity> = HealthcheckSeverity::base_severity_map(db)
+		.await?
+		.into_iter()
+		.map(|(name, severity)| (name, severity.into()))
+		.collect();
+
+	let health_prefix = format!("{HEALTH_REF}/");
+	for r#ref in
+		silenced_refs_with_prefix(db, server_id, group_id, STATUS_SOURCE, &health_prefix).await?
+	{
+		if let Some(check) = r#ref.strip_prefix(&health_prefix) {
+			map.insert(check.to_string(), CheckSeverity::Skip);
+		}
+	}
+
+	Ok(map)
 }
 
 /// Store a legacy-format push (no `health` array) for a server that's opted

--- a/crates/public-server/tests/check_severities.rs
+++ b/crates/public-server/tests/check_severities.rs
@@ -1,0 +1,236 @@
+//! Device-facing effective check-severity mapping: the dedicated
+//! `GET /status/{server_id}/check-severities` endpoint and the
+//! `check_severities` field riding along status-push responses.
+
+use diesel::{sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+use database::silenced_refs::{ServerGroupSilencedRef, ServerSilencedRef};
+
+async fn insert_group(conn: &mut diesel_async::AsyncPgConnection) -> Uuid {
+	let group_id = Uuid::new_v4();
+	sql_query("INSERT INTO server_groups (id, name) VALUES ($1, 'check-severities-group')")
+		.bind::<sql_types::Uuid, _>(group_id)
+		.execute(conn)
+		.await
+		.expect("insert group");
+	group_id
+}
+
+async fn insert_server(
+	conn: &mut diesel_async::AsyncPgConnection,
+	device_id: Option<Uuid>,
+	group_id: Option<Uuid>,
+) -> Uuid {
+	let server_id = Uuid::new_v4();
+	sql_query(
+		"INSERT INTO servers (id, host, kind, device_id, group_id) \
+		 VALUES ($1, 'https://checks.example.com', 'facility', $2, $3)",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(device_id)
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(group_id)
+	.execute(conn)
+	.await
+	.expect("insert server");
+	server_id
+}
+
+/// Seed a catalog row at a given severity, optionally with a conditional
+/// rules ladder (which the mapping must ignore).
+async fn seed_catalog(
+	conn: &mut diesel_async::AsyncPgConnection,
+	check_name: &str,
+	severity: &str,
+	rules: Option<serde_json::Value>,
+) {
+	sql_query(
+		"INSERT INTO healthcheck_severities (check_name, severity, rules, reviewed_at, reviewed_by) \
+		 VALUES ($1, $2, $3, NOW(), 'test') \
+		 ON CONFLICT (check_name) DO UPDATE \
+		 SET severity = EXCLUDED.severity, rules = EXCLUDED.rules",
+	)
+	.bind::<sql_types::Text, _>(check_name)
+	.bind::<sql_types::Text, _>(severity)
+	.bind::<sql_types::Nullable<sql_types::Jsonb>, _>(rules)
+	.execute(conn)
+	.await
+	.expect("seed catalog row");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn endpoint_maps_catalog_severities_and_silences() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let group_id = insert_group(&mut conn).await;
+			let server_id = insert_server(&mut conn, Some(device_id), Some(group_id)).await;
+
+			seed_catalog(&mut conn, "disk_space", "error", None).await;
+			seed_catalog(&mut conn, "cert_expiry", "warning", None).await;
+			seed_catalog(&mut conn, "chatty", "info", None).await;
+			seed_catalog(&mut conn, "verbose", "debug", None).await;
+			seed_catalog(&mut conn, "flaky", "critical", None).await;
+			seed_catalog(&mut conn, "groupwide", "error", None).await;
+			// A conditional ladder that would escalate to critical at push
+			// time must not leak into the static mapping.
+			seed_catalog(
+				&mut conn,
+				"ruled",
+				"warning",
+				Some(serde_json::json!({"if": [
+					{"==": [{"var": "check.result"}, "failed"]}, "critical",
+				]})),
+			)
+			.await;
+
+			// Silences: flaky at server scope, groupwide at group scope; a
+			// silence on disk_space's *broken* thread must not skip the
+			// check itself.
+			ServerSilencedRef::add(&mut conn, server_id, "status", "health/flaky", None)
+				.await
+				.expect("server silence");
+			ServerGroupSilencedRef::add(&mut conn, group_id, "status", "health/groupwide", None)
+				.await
+				.expect("group silence");
+			ServerSilencedRef::add(
+				&mut conn,
+				server_id,
+				"status",
+				"health-broken/disk_space",
+				None,
+			)
+			.await
+			.expect("broken silence");
+
+			let response = public
+				.get(&format!("/status/{server_id}/check-severities"))
+				.add_header("mtls-certificate", &cert)
+				.await;
+			response.assert_status_ok();
+			let map: serde_json::Value = response.json();
+			assert_eq!(
+				map,
+				serde_json::json!({
+					"disk_space": "fail",
+					"cert_expiry": "warn",
+					"chatty": "skip",
+					"verbose": "skip",
+					"flaky": "skip",
+					"groupwide": "skip",
+					"ruled": "warn",
+				}),
+			);
+		},
+	)
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn endpoint_works_for_ungrouped_server() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_server(&mut conn, Some(device_id), None).await;
+			seed_catalog(&mut conn, "disk_space", "error", None).await;
+			ServerSilencedRef::add(&mut conn, server_id, "status", "health/disk_space", None)
+				.await
+				.expect("silence");
+
+			let response = public
+				.get(&format!("/status/{server_id}/check-severities"))
+				.add_header("mtls-certificate", &cert)
+				.await;
+			response.assert_status_ok();
+			let map: serde_json::Value = response.json();
+			assert_eq!(map, serde_json::json!({"disk_space": "skip"}));
+		},
+	)
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn status_response_carries_check_severities() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let group_id = insert_group(&mut conn).await;
+			let server_id = insert_server(&mut conn, Some(device_id), Some(group_id)).await;
+
+			seed_catalog(&mut conn, "disk_space", "error", None).await;
+			seed_catalog(&mut conn, "cert_expiry", "critical", None).await;
+			ServerSilencedRef::add(&mut conn, server_id, "status", "health/cert_expiry", None)
+				.await
+				.expect("silence");
+
+			let response = public
+				.post(&format!("/status/{server_id}"))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({"health": [
+					{"check": "disk_space", "result": "passed"},
+					{"check": "cert_expiry", "result": "failed"},
+					{"check": "brand_new", "result": "passed"},
+				]}))
+				.await;
+			response.assert_status_ok();
+			let body: serde_json::Value = response.json();
+			// The map reflects the catalog and silences, including the check
+			// first seen on this very push (upserted at default Warning).
+			assert_eq!(
+				body.get("check_severities"),
+				Some(&serde_json::json!({
+					"disk_space": "fail",
+					"cert_expiry": "skip",
+					"brand_new": "warn",
+				})),
+			);
+		},
+	)
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn endpoint_rejects_device_not_bound_to_server() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, _device_id, public, _| {
+			// Server bound to no device: the caller's device doesn't match.
+			let server_id = insert_server(&mut conn, None, None).await;
+
+			let response = public
+				.get(&format!("/status/{server_id}/check-severities"))
+				.add_header("mtls-certificate", &cert)
+				.await;
+			response.assert_status_not_ok();
+		},
+	)
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn endpoint_404s_for_unknown_server() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |_conn, cert, _device_id, public, _| {
+			let response = public
+				.get(&format!("/status/{}/check-severities", Uuid::new_v4()))
+				.add_header("mtls-certificate", &cert)
+				.await;
+			response.assert_status_not_found();
+		},
+	)
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn endpoint_requires_device_auth() {
+	commons_tests::server::run(async |mut conn, public, _| {
+		let server_id = insert_server(&mut conn, None, None).await;
+		let response = public
+			.get(&format!("/status/{server_id}/check-severities"))
+			.await;
+		response.assert_status_not_ok();
+	})
+	.await
+}


### PR DESCRIPTION
🤖 Devices need to know how canopy classifies each of their healthchecks, so they can align local behaviour with the operator-side configuration (severity catalog + silence lists). This distils that configuration into a three-level device-facing vocabulary and serves it two ways:

- A dedicated device endpoint: `GET /status/{server_id}/check-severities` (mTLS device auth, same authorisation as status pushes).
- A `check_severities` field riding along every status-push response.

**Wire shape** (both places): a map of check name (as reported in `health[].check`) → `"skip" | "warn" | "fail"`:

```json
{
  "disk_space": "fail",
  "cert_expiry": "warn",
  "noisy_check": "skip"
}
```

Mapping rules:
- Checks silenced for the server — at server or group scope, on the `(status, health/<check>)` ref — are `skip`. Silences on the separate `health-broken/<check>` thread don't affect the check's own mapping.
- Otherwise the catalog's static base severity maps: below warning (info/debug) → `skip`, warning → `warn`, error and critical → `fail`.
- Conditional severity rules (the per-push `rules` if-ladders) are deliberately out of scope: they depend on each push's contents, so only the static baseline is reflected.

Clients should interpret those as ceilings (a `pass` shouldn't be upgraded to a `warn` etc).

New pieces: `CheckSeverity` enum in commons-types (with `From<Severity>`), `HealthcheckSeverity::base_severity_map` and `silenced_refs::silenced_refs_with_prefix` queries in the database crate (added alongside the existing query logic, no refactors), and the public-server handler + response field. In the status path, the map is computed after the ingest transaction so checks first seen on that very push are already included (at the default `warn`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)