### PR TITLE
feat(public)!: strip status-push response to return-path fields only

### DIFF
--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -739,7 +739,7 @@
           "statuses"
         ],
         "summary": "Submit a status heartbeat for a server.",
-        "description": "Records a periodic status push against the server identified in the\npath: overall self-reported health, a per-check breakdown, and any\nfree-form extra data. Each failed or warning check opens (or keeps\nopen) an issue at that check's operator-configured severity, and each\npassed check closes any issue it previously opened; the server's\ntracked software version is also updated from the payload.\n\nThe calling device must be the one enrolled for this exact server (or\nhold the admin role). The response echoes back the stored status\nrecord, plus a `backup_now` list of backup types the server should\nback up immediately — devices should treat a non-empty list as a\nprompt to run those backups and report them afterwards — and a\n`check_severities` map describing how canopy classifies each known\nhealthcheck for this server (`skip`/`warn`/`fail`).",
+        "description": "Records a periodic status push against the server identified in the\npath: overall self-reported health, a per-check breakdown, and any\nfree-form extra data. Each failed or warning check opens (or keeps\nopen) an issue at that check's operator-configured severity, and each\npassed check closes any issue it previously opened; the server's\ntracked software version is also updated from the payload.\n\nThe calling device must be the one enrolled for this exact server (or\nhold the admin role). The response carries only return-path\ninstructions: a `backup_now` list of backup types the server should\nback up immediately — devices should treat a non-empty list as a\nprompt to run those backups and report them afterwards — and a\n`check_severities` map describing how canopy classifies each known\nhealthcheck for this server (`skip`/`warn`/`fail`). The stored status\nrecord is not echoed back.",
         "operationId": "submit_status",
         "parameters": [
           {
@@ -2033,64 +2033,6 @@
           }
         }
       },
-      "Status": {
-        "type": "object",
-        "description": "A stored status report from a server: one heartbeat's worth of\nself-reported health, version, and extra data.",
-        "required": [
-          "id",
-          "created_at",
-          "server_id",
-          "extra",
-          "healthy",
-          "health"
-        ],
-        "properties": {
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "When this status was received."
-          },
-          "device_id": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "uuid",
-            "description": "The device that submitted this status, or `null` for statuses\ngenerated internally (e.g. by the reachability sweep)."
-          },
-          "extra": {
-            "description": "Free-form extra data from the report (uptime, database version,\ntimezone, etc.), stored verbatim as a JSON object."
-          },
-          "health": {
-            "description": "Per-check breakdown, as an array of objects each with at least a\n`check` name and a result; any extra per-check fields are passed\nthrough verbatim."
-          },
-          "healthy": {
-            "type": "boolean",
-            "description": "Server's overall self-reported health. A report that omits this is\nrecorded as healthy."
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Unique identifier of this status record."
-          },
-          "server_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "The server this status was reported for."
-          },
-          "version": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/VersionStr",
-                "description": "The software version the server reported, if it reported one."
-              }
-            ]
-          }
-        }
-      },
       "StatusPayload": {
         "allOf": [
           {
@@ -2123,39 +2065,31 @@
         "description": "A status push: a server's periodic heartbeat carrying its self-reported\nhealth.\n\nBesides the reserved `healthy` and `health` keys described here, any\nadditional top-level fields are accepted and stored verbatim as extra\nstatus data."
       },
       "StatusResponse": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Status",
-            "description": "The status record as stored, flattened into the top level of the\nresponse."
+        "type": "object",
+        "description": "The status-push response: only the return-path instructions the device\ncan act on. The stored status record is deliberately not echoed back —\nthe device already has everything it sent.",
+        "required": [
+          "backup_now",
+          "check_severities"
+        ],
+        "properties": {
+          "backup_now": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Backup types the server should back up now: operator-requested\none-offs plus scheduled backups that are due. Each serializes as a\nplain string (e.g. `\"tamanu-postgres\"`). The device should run each\nlisted type, then report via `POST /backup-report`; an empty list\nmeans nothing to do."
           },
-          {
+          "check_severities": {
             "type": "object",
-            "required": [
-              "backup_now",
-              "check_severities"
-            ],
-            "properties": {
-              "backup_now": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "Backup types the server should back up now: operator-requested\none-offs plus scheduled backups that are due. Each serializes as a\nplain string (e.g. `\"tamanu-postgres\"`). The device should run each\nlisted type, then report via `POST /backup-report`; an empty list\nmeans nothing to do."
-              },
-              "check_severities": {
-                "type": "object",
-                "description": "The effective handling of every healthcheck canopy knows about, keyed\nby check name (as reported in `health[].check`): `skip` (silenced for\nthis server, or classified below warning), `warn` (warning), or `fail`\n(error or critical). Only the static severity baseline is reflected —\noperator-defined conditional rules are evaluated per push and not\nincluded. Checks absent from the map are new to canopy and default to\n`warn`. Clients that predate this field can safely ignore it; the\nsame mapping is served on demand at `GET /status/{server_id}/check-severities`.",
-                "additionalProperties": {
-                  "$ref": "#/components/schemas/CheckSeverity"
-                },
-                "propertyNames": {
-                  "type": "string"
-                }
-              }
+            "description": "The effective handling of every healthcheck canopy knows about, keyed\nby check name (as reported in `health[].check`): `skip` (silenced for\nthis server, or classified below warning), `warn` (warning), or `fail`\n(error or critical). Only the static severity baseline is reflected —\noperator-defined conditional rules are evaluated per push and not\nincluded. Checks absent from the map are new to canopy and default to\n`warn`. Clients that predate this field can safely ignore it; the\nsame mapping is served on demand at `GET /status/{server_id}/check-severities`.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CheckSeverity"
+            },
+            "propertyNames": {
+              "type": "string"
             }
           }
-        ],
-        "description": "The status-push response: the stored status record (its fields appear at\nthe top level of the response object) plus `backup_now`, the backup types\nthis server should back up *right now*. Clients that predate `backup_now`\ncan safely ignore it."
+        }
       },
       "TagMap": {
         "type": "object",
@@ -2356,11 +2290,6 @@
           "published",
           "yanked"
         ]
-      },
-      "VersionStr": {
-        "type": "string",
-        "description": "A semantic version string, e.g. `2.10.5`.",
-        "example": "2.10.5"
       },
       "ViewVersion": {
         "type": "object",

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -123,16 +123,11 @@ const HEALTH_REF: &str = "health";
 /// operators can silence the two independently.
 const BROKEN_REF: &str = "health-broken";
 
-/// The status-push response: the stored status record (its fields appear at
-/// the top level of the response object) plus `backup_now`, the backup types
-/// this server should back up *right now*. Clients that predate `backup_now`
-/// can safely ignore it.
+/// The status-push response: only the return-path instructions the device
+/// can act on. The stored status record is deliberately not echoed back —
+/// the device already has everything it sent.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct StatusResponse {
-	/// The status record as stored, flattened into the top level of the
-	/// response.
-	#[serde(flatten)]
-	pub status: Status,
 	/// Backup types the server should back up now: operator-requested
 	/// one-offs plus scheduled backups that are due. Each serializes as a
 	/// plain string (e.g. `"tamanu-postgres"`). The device should run each
@@ -167,12 +162,13 @@ pub fn routes() -> OpenApiRouter<AppState> {
 /// tracked software version is also updated from the payload.
 ///
 /// The calling device must be the one enrolled for this exact server (or
-/// hold the admin role). The response echoes back the stored status
-/// record, plus a `backup_now` list of backup types the server should
+/// hold the admin role). The response carries only return-path
+/// instructions: a `backup_now` list of backup types the server should
 /// back up immediately — devices should treat a non-empty list as a
 /// prompt to run those backups and report them afterwards — and a
 /// `check_severities` map describing how canopy classifies each known
-/// healthcheck for this server (`skip`/`warn`/`fail`).
+/// healthcheck for this server (`skip`/`warn`/`fail`). The stored status
+/// record is not echoed back.
 #[utoipa::path(
 	post,
 	path = "/{server_id}",
@@ -238,11 +234,10 @@ async fn create(
 		if !server.allow_legacy_status {
 			return Err(AppError::BadRequest("`health` array is required".into()));
 		}
-		let status = create_legacy_status(&mut db, server_id, id, extra, version).await?;
+		create_legacy_status(&mut db, server_id, id, extra, version).await?;
 		let check_severities =
 			effective_check_severities(&mut db, server_id, server.group_id).await?;
 		return Ok(Json(StatusResponse {
-			status,
 			backup_now,
 			check_severities,
 		}));
@@ -260,31 +255,29 @@ async fn create(
 
 	// Insert + file events atomically. NewEvent::save itself opens
 	// a transaction; diesel-async nests it as a SAVEPOINT.
-	let status = db
-		.transaction::<_, AppError, _>(async |conn| {
-			let status = NewStatus {
-				server_id,
-				device_id: Some(id),
-				version,
-				extra,
-				healthy,
-				health,
-			}
-			.save(conn)
-			.await?;
-
-			file_health_events(conn, server_id, Some(id), &status, &tags).await?;
-
-			Ok(status)
-		})
+	db.transaction::<_, AppError, _>(async |conn| {
+		let status = NewStatus {
+			server_id,
+			device_id: Some(id),
+			version,
+			extra,
+			healthy,
+			health,
+		}
+		.save(conn)
 		.await?;
+
+		file_health_events(conn, server_id, Some(id), &status, &tags).await?;
+
+		Ok(())
+	})
+	.await?;
 
 	// Computed after the transaction so checks first seen on this very push
 	// (upserted into the catalog above) are already in the map.
 	let check_severities = effective_check_severities(&mut db, server_id, server.group_id).await?;
 
 	Ok(Json(StatusResponse {
-		status,
 		backup_now,
 		check_severities,
 	}))
@@ -381,7 +374,7 @@ async fn create_legacy_status(
 	device_id: Uuid,
 	extra: serde_json::Value,
 	version: Option<VersionStr>,
-) -> Result<Status> {
+) -> Result<()> {
 	let (healthy, health) = match Status::latest_for_server(db, server_id).await? {
 		Some(prior) => (prior.healthy, prior.health),
 		None => (true, serde_json::Value::Array(Vec::new())),
@@ -395,7 +388,8 @@ async fn create_legacy_status(
 		health,
 	}
 	.save(db)
-	.await
+	.await?;
+	Ok(())
 }
 
 /// Resolve the server version to record on this status. Prefers the payload's

--- a/crates/public-server/tests/statuses.rs
+++ b/crates/public-server/tests/statuses.rs
@@ -147,19 +147,13 @@ async fn submit_status() {
 			response.assert_status_ok();
 			response.assert_header("content-type", "application/json");
 
-			// Verify the returned status data
-			let returned_status: serde_json::Value = response.json();
-			assert!(returned_status.get("id").is_some());
+			// The response carries only the return-path fields; the stored
+			// status record is not echoed back.
+			let body: serde_json::Value = response.json();
 			assert_eq!(
-				returned_status.get("server_id").and_then(|v| v.as_str()),
-				Some(server_id.to_string().as_str())
+				body,
+				serde_json::json!({"backup_now": [], "check_severities": {}}),
 			);
-			assert_eq!(
-				returned_status.get("device_id").and_then(|v| v.as_str()),
-				Some(device_id.to_string().as_str())
-			);
-			let extra = returned_status.get("extra").expect("extra field");
-			assert_eq!(extra.get("uptime").and_then(|v| v.as_i64()), Some(3600));
 
 			// Verify the status was actually stored in the database
 			let db_status: StatusResult = sql_query(
@@ -212,21 +206,6 @@ async fn submit_status_with_geolocation() {
 				.await;
 			response.assert_status_ok();
 			response.assert_header("content-type", "application/json");
-
-			// Verify the returned status data
-			let returned_status: serde_json::Value = response.json();
-			assert!(returned_status.get("id").is_some());
-			assert_eq!(
-				returned_status.get("server_id").and_then(|v| v.as_str()),
-				Some(server_id.to_string().as_str())
-			);
-			assert_eq!(
-				returned_status.get("device_id").and_then(|v| v.as_str()),
-				Some(device_id.to_string().as_str())
-			);
-			let extra = returned_status.get("extra").expect("extra field");
-			assert_eq!(extra.get("uptime").and_then(|v| v.as_i64()), Some(7200));
-			assert_eq!(extra.get("version").and_then(|v| v.as_str()), Some("2.8.1"));
 
 			// Verify the status was actually stored in the database
 			let db_status: StatusResult = sql_query(
@@ -307,24 +286,6 @@ async fn submit_status_with_cloud() {
 				.await;
 			response.assert_status_ok();
 			response.assert_header("content-type", "application/json");
-
-			// Verify the returned status data
-			let returned_status: serde_json::Value = response.json();
-			assert!(returned_status.get("id").is_some());
-			assert_eq!(
-				returned_status.get("server_id").and_then(|v| v.as_str()),
-				Some(server_id.to_string().as_str())
-			);
-			assert_eq!(
-				returned_status.get("device_id").and_then(|v| v.as_str()),
-				Some(device_id.to_string().as_str())
-			);
-			let extra = returned_status.get("extra").expect("extra field");
-			assert_eq!(extra.get("uptime").and_then(|v| v.as_i64()), Some(4800));
-			assert_eq!(
-				extra.get("platform").and_then(|v| v.as_str()),
-				Some("Linux")
-			);
 
 			// Verify the status was actually stored in the database
 			let db_status: StatusResult = sql_query(
@@ -408,25 +369,6 @@ async fn submit_status_with_geolocation_and_cloud() {
 				.await;
 			response.assert_status_ok();
 			response.assert_header("content-type", "application/json");
-
-			// Verify the returned status data
-			let returned_status: serde_json::Value = response.json();
-			assert!(returned_status.get("id").is_some());
-			assert_eq!(
-				returned_status.get("server_id").and_then(|v| v.as_str()),
-				Some(server_id.to_string().as_str())
-			);
-			assert_eq!(
-				returned_status.get("device_id").and_then(|v| v.as_str()),
-				Some(device_id.to_string().as_str())
-			);
-			let extra = returned_status.get("extra").expect("extra field");
-			assert_eq!(extra.get("uptime").and_then(|v| v.as_i64()), Some(10000));
-			assert_eq!(extra.get("version").and_then(|v| v.as_str()), Some("3.0.0"));
-			assert_eq!(
-				extra.get("timezone").and_then(|v| v.as_str()),
-				Some("America/New_York")
-			);
 
 			// Verify the status was actually stored in the database
 			let db_status: StatusResult = sql_query(


### PR DESCRIPTION
🤖 Follow-up to #358. The `POST /status/{server_id}` response used to flatten the stored `Status` row into the response body — useless to the device, which already has all of that data since it just sent it. The response is now only the return-path instructions the device can act on:

```json
{
  "backup_now": ["tamanu-postgres"],
  "check_severities": {
    "disk_space": "fail",
    "cert_expiry": "warn",
    "noisy_check": "skip"
  }
}
```

`StatusResponse` keeps its own dedicated struct (no longer embedding the `Status` view type), handler docs no longer describe the echo, and the endpoint tests assert the slim shape — coverage that `backup_now` and `check_severities` round-trip is unchanged. Storage-side assertions (the status row actually landing in the database) are untouched. Public openapi.json regenerated; the private spec and api-types are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)