### PR TITLE
ci(cd): silence expected static-glibc linker warnings in prod build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,15 @@ jobs:
       - name: Build binaries
         run: just build-servers-release ${{ matrix.target }}
         env:
-          RUSTFLAGS: "-C target-feature=+crt-static"
+          # Statically link glibc so the binaries run in the minimal
+          # busybox:glibc runtime image. glibc's NSS functions (getaddrinfo for
+          # DNS, getpwuid_r for username lookup) dlopen libnss_*.so at runtime
+          # and so can't be fully baked into a static binary — ld warns about
+          # this via rustc's linker_messages lint. It's benign here: the
+          # runtime image ships the matching glibc shared libs, so resolution
+          # works. Silence the (expected, prod-only) warnings to keep the build
+          # log clean.
+          RUSTFLAGS: "-C target-feature=+crt-static -A linker_messages"
 
       - name: Prepare artifacts
         run: |


### PR DESCRIPTION
## What

Silence the `linker_messages` warnings that appear all over the prod (`cd.yml`) build log by adding `-A linker_messages` to the build's `RUSTFLAGS`.

## Why

The prod build statically links glibc (`-C target-feature=+crt-static`) so the binaries run in the minimal `busybox:glibc` runtime image. glibc's NSS functions — `getaddrinfo` (DNS, used by `reqwest`/`std::net`) and `getpwuid_r` (used by `tokio-postgres` on connect) — `dlopen` `libnss_*.so` at runtime, so they can't be fully baked into a static binary. `ld` warns about this, and rustc's warn-by-default `linker_messages` lint surfaces it, producing 2 warnings per bin that touches DNS or Postgres (`chrome_versions`, `backups`, `slacker_outbox`, `ownstatus`, `public-server`, `public-openapi-dump`, …).

This is a known, upstream-by-design limitation of `+crt-static` on glibc — not a code bug. It's **benign in this deployment**: the `busybox:glibc` runtime image ships the matching glibc shared libs (including the `libnss_*` modules), so resolution works at runtime. That's confirmed by prod already connecting to Postgres and resolving DNS today.

## Scope

The `-A linker_messages` allow is added to the exact same `RUSTFLAGS` env that carries `+crt-static`, so it only affects the prod release build. CI (`ci.yml`) and local/dev builds don't set `+crt-static` and never emitted these warnings, so they're untouched.

## Alternative (not taken)

Switching the prod target to `aarch64-unknown-linux-musl` would eliminate the underlying condition (musl does true full static linking with no runtime NSS `dlopen`), making the warnings disappear at the source. That's a larger, higher-risk change (musl toolchain, crypto backends, new runtime base), so this PR takes the contained fix. Happy to pursue the musl route separately if a genuinely static binary is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvcGxnCWP9XwG9MEA5ZEh3)_