### PR TITLE
Add RSS feed of releases to the public server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atom_syndication"
+version = "0.12.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc3fc78769244f4ee0a4fc1d959f0e1b96d9344d74510e0195723c87fd9a8bd"
+dependencies = [
+ "chrono",
+ "derive_builder 0.20.2",
+ "diligent-date-parser",
+ "quick-xml",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,7 +1409,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a7298287f1443f422d3f46e8ce9f855e75f0e43c06605adb4c52a262faeabd"
 dependencies = [
- "derive_builder",
+ "derive_builder 0.10.2",
  "getrandom 0.2.17",
  "rand 0.8.6",
  "thiserror 1.0.69",
@@ -1913,6 +1925,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -1943,6 +1965,20 @@ dependencies = [
  "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1981,6 +2017,17 @@ dependencies = [
  "darling_core 0.12.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2140,7 +2187,16 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.10.2",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro 0.20.2",
 ]
 
 [[package]]
@@ -2156,13 +2212,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.10.2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core 0.20.2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2316,6 +2394,15 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
+]
+
+[[package]]
+name = "diligent-date-parser"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ede7d79366f419921e2e2f67889c12125726692a313bffb474bd5f37a581e9"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -4808,6 +4895,7 @@ dependencies = [
  "qrcode",
  "reqwest",
  "ring",
+ "rss",
  "serde",
  "serde_json",
  "subtle",
@@ -4853,6 +4941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 dependencies = [
  "image",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -5261,6 +5359,17 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rss"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc13570823abc675c60d7837f1fe7daaf18dd181a3cacb3c6ba7a062eef581c0"
+dependencies = [
+ "atom_syndication",
+ "derive_builder 0.20.2",
+ "quick-xml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ node-semver = "2.2.0"
 problem_details = "0.9.0"
 pulldown-cmark = { version = "0.13.4", features = ["html"] }
 reqwest = { version = "0.13.3", default-features = false, features = ["json", "rustls", "stream"] }
+rss = "2.0.13"
 serde = "1.0.228"
 tera = "1.20.1"
 timesimp = "1.0.0"

--- a/crates/public-server/Cargo.toml
+++ b/crates/public-server/Cargo.toml
@@ -41,6 +41,7 @@ node-semver.workspace = true
 pulldown-cmark = { workspace = true, optional = true }
 qrcode = { version = "0.14.1", optional = true, features = ["svg"] }
 reqwest.workspace = true
+rss = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 tera = { workspace = true, optional = true }
 tokio.workspace = true
@@ -82,6 +83,7 @@ cli = [
 ui = [
 	"dep:pulldown-cmark",
 	"dep:qrcode",
+	"dep:rss",
 	"dep:subtle",
 	"dep:tera",
 	"dep:timesimp",

--- a/crates/public-server/src/versions.rs
+++ b/crates/public-server/src/versions.rs
@@ -111,6 +111,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 
 	#[cfg(feature = "ui")]
 	let extras = extras
+		.route("/rss", get(releases_rss))
 		.route("/{version}", get(view_artifacts))
 		.route("/{version}/mobile", get(view_mobile_install));
 
@@ -177,6 +178,82 @@ async fn list(State(db): State<Db>) -> Result<Json<Vec<Version>>> {
 	let versions = Version::get_all(&mut db).await?;
 	let versions = filter_ready(&mut db, versions).await?;
 	Ok(Json(versions))
+}
+
+/// Base URL for absolute links in the feed. Prefers the configured
+/// `PUBLIC_URL`; otherwise reconstructs the origin from the request's
+/// forwarded scheme and `Host` header so local and test runs still emit
+/// well-formed links.
+#[cfg(feature = "ui")]
+fn feed_base_url(headers: &axum::http::HeaderMap) -> String {
+	if let Ok(url) = std::env::var("PUBLIC_URL") {
+		let trimmed = url.trim_end_matches('/');
+		if !trimmed.is_empty() {
+			return trimmed.to_owned();
+		}
+	}
+
+	let scheme = headers
+		.get("x-forwarded-proto")
+		.and_then(|v| v.to_str().ok())
+		.unwrap_or("https");
+	let host = headers
+		.get(header::HOST)
+		.and_then(|v| v.to_str().ok())
+		.unwrap_or("localhost");
+	format!("{scheme}://{host}")
+}
+
+/// RSS 2.0 feed of published releases.
+///
+/// Emits one item per published, ready-to-serve version (the same set as
+/// the `/versions` listing), newest first, with the changelog rendered to
+/// HTML as the item content. Feed readers poll this to learn about new
+/// releases.
+#[cfg(feature = "ui")]
+async fn releases_rss(
+	State(db): State<Db>,
+	headers: axum::http::HeaderMap,
+) -> Result<impl IntoResponse> {
+	use rss::{ChannelBuilder, GuidBuilder, ItemBuilder};
+
+	let mut db = db.get().await?;
+	let versions = Version::get_all(&mut db).await?;
+	let versions = filter_ready(&mut db, versions).await?;
+
+	let base = feed_base_url(&headers);
+
+	let items: Vec<rss::Item> = versions
+		.into_iter()
+		.map(|v| {
+			let version = format!("{}.{}.{}", v.major, v.minor, v.patch);
+			let link = format!("{base}/versions/{version}");
+			// RFC 2822 date, in UTC (jiff timestamps carry no offset).
+			let pub_date = v
+				.created_at
+				.strftime("%a, %d %b %Y %H:%M:%S %z")
+				.to_string();
+			ItemBuilder::default()
+				.title(format!("Canopy {version}"))
+				.link(link.clone())
+				.guid(GuidBuilder::default().value(link).permalink(true).build())
+				.pub_date(pub_date)
+				.description(parse_markdown(&v.changelog))
+				.build()
+		})
+		.collect();
+
+	let channel = ChannelBuilder::default()
+		.title("Canopy releases")
+		.link(format!("{base}/"))
+		.description("Latest published Canopy releases and their changelogs.")
+		.items(items)
+		.build();
+
+	Ok((
+		[(header::CONTENT_TYPE, "application/rss+xml; charset=utf-8")],
+		channel.to_string(),
+	))
 }
 
 /// Publish a version with its changelog.

--- a/crates/public-server/templates/versions.html.tera
+++ b/crates/public-server/templates/versions.html.tera
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/svg+xml" href="/static/images/favicon.svg" />
     <title>Tamanu Versions</title>
+    <link rel="alternate" type="application/rss+xml" title="Canopy releases" href="/versions/rss" />
     <link rel="stylesheet" href="/static/public.css">
     <style>
         body {

--- a/crates/public-server/tests/it/versions.rs
+++ b/crates/public-server/tests/it/versions.rs
@@ -59,6 +59,63 @@ async fn versions_list_with_data() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn releases_rss_feed() {
+	commons_tests::server::run(async |mut conn, public, _| {
+		conn.batch_execute(
+			"INSERT INTO versions (major, minor, patch, changelog, status) VALUES
+			(1, 0, 0, 'Initial release', 'published'),
+			(1, 1, 0, '## Highlights\n\n- New thing', 'published'),
+			(1, 2, 0, 'Draft only', 'draft')",
+		)
+		.await
+		.unwrap();
+
+		let response = public.get("/versions/rss").await;
+		response.assert_status_ok();
+		response.assert_header("content-type", "application/rss+xml; charset=utf-8");
+
+		let body = response.text();
+		assert!(body.contains("<rss"), "should be an RSS document: {body}");
+		assert!(body.contains("<title>Canopy releases</title>"));
+		// Newest first, published only.
+		assert!(body.contains("Canopy 1.1.0"));
+		assert!(body.contains("Canopy 1.0.0"));
+		assert!(!body.contains("Canopy 1.2.0"), "drafts must not appear");
+		let first = body.find("Canopy 1.1.0").unwrap();
+		let second = body.find("Canopy 1.0.0").unwrap();
+		assert!(first < second, "items should be newest-first");
+		// Changelog markdown is rendered to HTML in the item body.
+		assert!(body.contains("New thing"));
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn releases_rss_feed_excludes_known_issue_versions() {
+	commons_tests::server::run(async |mut conn, public, _| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+			('11111111-1111-1111-1111-111111111100', 1, 0, 0, 'good', 'published'),
+			('11111111-1111-1111-1111-111111111101', 1, 0, 1, 'broken', 'published');
+			INSERT INTO version_known_issues (author, description, min_major, min_minor, min_patch)
+			VALUES ('admin', 'broken', 1, 0, 1)",
+		)
+		.await
+		.unwrap();
+
+		let response = public.get("/versions/rss").await;
+		response.assert_status_ok();
+		let body = response.text();
+		assert!(body.contains("Canopy 1.0.0"));
+		assert!(
+			!body.contains("Canopy 1.0.1"),
+			"known-issue versions must be hidden"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn view_version_artifacts_html() {
 	commons_tests::server::run(async |mut conn, public, _| {
 		conn.batch_execute(


### PR DESCRIPTION
## What

Adds an RSS 2.0 feed of releases to the public server, served at `GET /versions/rss`.

Each feed item corresponds to a published, ready-to-serve version — the same set the existing `/versions` JSON listing and homepage expose (published, not covered by a known-issue range), ordered newest first. The changelog markdown is rendered to HTML for the item body, mirroring the per-version HTML page.

## Details

- **Endpoint**: `GET /versions/rss`, mounted as a plain (non-OpenAPI) route in `versions::routes()` alongside the other HTML/streaming routes, gated behind the `ui` feature (it reuses `parse_markdown`). Content type `application/rss+xml; charset=utf-8`.
- **Feed generation**: uses the `rss` crate (added to the workspace and to public-server as an optional dep under the `ui` feature) rather than hand-rolling XML.
- **Item shape**: title `Canopy <version>`, link/guid pointing at the version's page, `pubDate` from `created_at` (RFC 2822, UTC), and the rendered changelog as the description.
- **Absolute links**: derived from `PUBLIC_URL` when configured, otherwise reconstructed from the request's `X-Forwarded-Proto` and `Host` headers so local and test runs still emit well-formed links.
- **Discoverability**: adds an `<link rel="alternate" type="application/rss+xml">` autodiscovery tag to the versions homepage.

## Tests

Adds two integration tests in `crates/public-server/tests/it/versions.rs`:
- `releases_rss_feed` — asserts the content type, RSS structure, newest-first ordering, exclusion of drafts, and that changelog markdown is rendered.
- `releases_rss_feed_excludes_known_issue_versions` — asserts versions covered by a known-issue range are hidden, matching `/versions`.

Both pass. The route is intentionally excluded from the OpenAPI spec (like the existing HTML/download routes), so no `openapi.json` regeneration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pmhmhs4kBJukuvJxcX9FQv)_