### PR TITLE
feat(monitoring): defer incident evaluation off the status-ingest path

### DIFF
--- a/.workhorse/specs/monitoring/incidents.md
+++ b/.workhorse/specs/monitoring/incidents.md
@@ -30,6 +30,8 @@ An issue can leave and rejoin the same incident.
 
 Operator actions that change what counts (monitoring toggles, group membership changes, policy and silence changes) re-evaluate the affected issues' incident membership.
 
+Membership evaluation is asynchronous. A report records its issue state immediately; the resulting open, join, leave, or close follows within a short bounded delay rather than synchronously with the report. Membership is therefore eventually consistent with the current issue state.
+
 ## Notification
 
 Operators are notified over the notification channel: group incidents to the group's configured channel, Canopy-wide incidents to the operator channel.

--- a/crates/database/src/bin/seed.rs
+++ b/crates/database/src/bin/seed.rs
@@ -1008,7 +1008,7 @@ async fn seed_issues_and_incidents(
 			active: Some(active),
 			occurred_at: Some(occurred_at),
 		}
-		.save_with_state(conn, server_id, None, Some(&stamp))
+		.save_with_state(conn, server_id, None, Some(&stamp), false)
 		.await
 	}
 

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -341,7 +341,8 @@ impl NewEvent {
 		server_id: Uuid,
 		device_id: Option<Uuid>,
 	) -> Result<Issue> {
-		self.save_with_state(db, server_id, device_id, None).await
+		self.save_with_state(db, server_id, device_id, None, false)
+			.await
 	}
 
 	/// [`Self::save`], stamping the issue's check-state columns from a
@@ -353,6 +354,7 @@ impl NewEvent {
 		server_id: Uuid,
 		device_id: Option<Uuid>,
 		state: Option<&CheckStateStamp>,
+		defer_incident_eval: bool,
 	) -> Result<Issue> {
 		use crate::schema::issues;
 
@@ -479,7 +481,13 @@ impl NewEvent {
 			// 2. (re-)evaluate incident contribution against the new issue state.
 			//    `by = None`: this came from a device push, not an operator action.
 			//    Skipped when the server is ungrouped: incidents are group-keyed.
-			if let Some(gid) = server_group_id {
+			//    Skipped when `defer_incident_eval`: the high-frequency device
+			//    ingest path enqueues the server for the reeval worker instead
+			//    (see `enqueue_incident_reeval`), keeping the per-group lock off
+			//    the request path.
+			if let Some(gid) = server_group_id
+				&& !defer_incident_eval
+			{
 				re_evaluate_incident_membership(
 					conn,
 					&issue,
@@ -925,7 +933,7 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 				active: Some(active),
 				occurred_at: None,
 			}
-			.save_with_state(conn, server_id, device_id, Some(&stamp))
+			.save_with_state(conn, server_id, device_id, Some(&stamp), false)
 			.await
 		}
 		FilingScope::Group(gid) => {
@@ -1425,6 +1433,136 @@ pub async fn reevaluate_open_issues_for_server(
 		.await?;
 	}
 	Ok(())
+}
+
+/// Enqueue `server_id` for deferred incident (re-)evaluation.
+///
+/// The device status-ingest path calls this in place of the inline
+/// `re_evaluate_incident_membership` it used to run: recording the issue
+/// state is kept synchronous, but the incident work — which takes the
+/// per-group `server_groups` lock — is handed to the queue worker so
+/// request traffic never contends on that lock.
+///
+/// Idempotent: the primary key coalesces a burst of pushes into one queued
+/// unit. A push arriving while a re-evaluation is already pending is a
+/// no-op — the pending run reads current state when it fires, so it already
+/// covers the later push.
+pub async fn enqueue_incident_reeval(conn: &mut AsyncPgConnection, server_id: Uuid) -> Result<()> {
+	use crate::schema::incident_reeval_queue::dsl;
+	diesel::insert_into(dsl::incident_reeval_queue)
+		.values(dsl::server_id.eq(server_id))
+		.on_conflict(dsl::server_id)
+		.do_nothing()
+		.execute(conn)
+		.await?;
+	Ok(())
+}
+
+/// Re-evaluate incident membership for every issue on `server_id` that can
+/// currently affect an incident: issues that are active-and-unresolved
+/// (candidates to *join*), plus issues still linked to an open incident
+/// (candidates to *leave* — e.g. a check that just recovered and went
+/// inactive). [`reevaluate_open_issues_for_server`] deliberately only walks
+/// active issues, so it can't drive the leave transitions the ingest path
+/// needs; this is the ingest-equivalent set.
+///
+/// Active issues are evaluated before inactive ones so that when a failure
+/// replaces another within a single push, the incoming failure (re)joins
+/// the incident before the outgoing one leaves — otherwise the incident
+/// would briefly close and reopen. This mirrors the ingest-time filing
+/// order.
+pub async fn reevaluate_incidents_for_server(
+	conn: &mut AsyncPgConnection,
+	server_id: Uuid,
+) -> Result<()> {
+	use crate::schema::{incident_issues, incidents, issues};
+
+	let server = Server::get_by_id(conn, server_id).await?;
+	let Some(gid) = server.group_id else {
+		return Ok(());
+	};
+	let monitored = server.is_monitored;
+
+	let mut candidates: Vec<Issue> = issues::table
+		.select(Issue::as_select())
+		.filter(issues::server_id.eq(server_id))
+		.filter(
+			issues::active
+				.eq(true)
+				.and(issues::resolved_at.is_null())
+				.or(issues::id.eq_any(
+					incident_issues::table
+						.inner_join(
+							incidents::table.on(incidents::id.eq(incident_issues::incident_id)),
+						)
+						.filter(incident_issues::left_at.is_null())
+						.filter(incidents::closed_at.is_null())
+						.select(incident_issues::issue_id),
+				)),
+		)
+		.load(conn)
+		.await?;
+
+	// Active (potential joiners) before inactive (leavers).
+	candidates.sort_by_key(|issue| !issue.active);
+
+	let now = Timestamp::now();
+	for issue in candidates {
+		re_evaluate_incident_membership(
+			conn,
+			&issue,
+			IncidentTarget::Group(gid),
+			monitored,
+			now,
+			None,
+		)
+		.await?;
+	}
+	Ok(())
+}
+
+/// Drain the incident re-evaluation queue, running
+/// [`reevaluate_incidents_for_server`] for up to `limit` queued servers and
+/// removing each once handled. Returns the number of servers processed.
+///
+/// Each server is claimed and processed in its own transaction with
+/// `FOR UPDATE SKIP LOCKED`, so a slow re-evaluation doesn't hold a batch of
+/// queue rows locked, overlapping ticks don't double-process, and a failure
+/// on one server doesn't roll back the others.
+pub async fn process_incident_reeval_queue(
+	conn: &mut AsyncPgConnection,
+	limit: i64,
+) -> Result<usize> {
+	use crate::schema::incident_reeval_queue::dsl;
+
+	let mut processed = 0usize;
+	while (processed as i64) < limit {
+		let claimed: Option<Uuid> = conn
+			.transaction::<_, AppError, _>(async |tx| {
+				let Some(server_id): Option<Uuid> = dsl::incident_reeval_queue
+					.select(dsl::server_id)
+					.order(dsl::enqueued_at.asc())
+					.for_update()
+					.skip_locked()
+					.first(tx)
+					.await
+					.optional()?
+				else {
+					return Ok(None);
+				};
+				reevaluate_incidents_for_server(tx, server_id).await?;
+				diesel::delete(dsl::incident_reeval_queue.filter(dsl::server_id.eq(server_id)))
+					.execute(tx)
+					.await?;
+				Ok(Some(server_id))
+			})
+			.await?;
+		match claimed {
+			Some(_) => processed += 1,
+			None => break,
+		}
+	}
+	Ok(processed)
 }
 
 /// Re-evaluate every currently-open issue on `server_id` with the given

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -279,6 +279,13 @@ diesel::table! {
 }
 
 diesel::table! {
+	incident_reeval_queue (server_id) {
+		server_id -> Uuid,
+		enqueued_at -> Timestamptz,
+	}
+}
+
+diesel::table! {
 	incidents (id) {
 		id -> Uuid,
 		created_at -> Timestamptz,
@@ -615,6 +622,7 @@ diesel::joinable!(check_stability -> issues (issue_id));
 diesel::joinable!(incident_issues -> incidents (incident_id));
 diesel::joinable!(incident_issues -> issues (issue_id));
 diesel::joinable!(incident_notes -> incidents (incident_id));
+diesel::joinable!(incident_reeval_queue -> servers (server_id));
 diesel::joinable!(incidents -> server_groups (server_group_id));
 diesel::joinable!(issue_notes -> issues (issue_id));
 diesel::joinable!(issues -> devices (device_id));
@@ -661,6 +669,7 @@ diesel::allow_tables_to_appear_in_same_query!(
 	devices,
 	incident_issues,
 	incident_notes,
+	incident_reeval_queue,
 	incidents,
 	issue_notes,
 	issues,

--- a/crates/database/tests/it/check_stability.rs
+++ b/crates/database/tests/it/check_stability.rs
@@ -62,7 +62,7 @@ async fn observe(
 		active: Some(active),
 		occurred_at: None,
 	}
-	.save_with_state(conn, server_id, None, Some(&stamp))
+	.save_with_state(conn, server_id, None, Some(&stamp), false)
 	.await
 	.expect("file observation")
 	.id

--- a/crates/database/tests/it/incident_close_result.rs
+++ b/crates/database/tests/it/incident_close_result.rs
@@ -59,7 +59,7 @@ async fn save_event(
 		active: Some(active),
 		occurred_at: None,
 	}
-	.save_with_state(conn, server_id, None, Some(&stamp))
+	.save_with_state(conn, server_id, None, Some(&stamp), false)
 	.await
 	.expect("save event");
 }

--- a/crates/database/tests/it/incident_linger.rs
+++ b/crates/database/tests/it/incident_linger.rs
@@ -69,7 +69,7 @@ async fn save_event(
 		active: Some(active),
 		occurred_at: None,
 	}
-	.save_with_state(conn, server_id, None, Some(&stamp))
+	.save_with_state(conn, server_id, None, Some(&stamp), false)
 	.await
 	.expect("save event");
 }

--- a/crates/database/tests/it/incident_reeval_queue.rs
+++ b/crates/database/tests/it/incident_reeval_queue.rs
@@ -1,0 +1,190 @@
+//! Deferred incident (re-)evaluation. The status-ingest path records issue
+//! state synchronously, then enqueues the server; the reeval worker drains
+//! the queue and runs the incident work — which takes the per-group lock —
+//! off the request path.
+//!
+//! These cover the database layer: draining the queue opens an incident, and
+//! — the case [`reevaluate_open_issues_for_server`] can't, because it only
+//! walks *active* issues — a recovered, now-inactive member is driven to
+//! LEAVE its incident.
+
+use commons_types::status::CheckResult;
+use database::issues::{self, CheckStateStamp, NewEvent};
+use diesel::prelude::*;
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_grouped_server(conn: &mut diesel_async::AsyncPgConnection) -> Uuid {
+	let group: RowId = sql_query(
+		"INSERT INTO server_groups (name, slack_close_delay) \
+		 VALUES ('reeval-group', INTERVAL '5 minutes') RETURNING id",
+	)
+	.get_result(conn)
+	.await
+	.expect("group");
+	let server: RowId = sql_query(
+		"INSERT INTO servers (host, group_id) VALUES ('http://reeval.invalid/', $1) RETURNING id",
+	)
+	.bind::<sql_types::Uuid, _>(group.id)
+	.get_result(conn)
+	.await
+	.expect("server");
+	server.id
+}
+
+/// Record a check on `server_id`. `defer` mirrors the ingest path: when true
+/// the issue state is written but incident evaluation is skipped.
+async fn record_check(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	r#ref: &str,
+	result: CheckResult,
+	defer: bool,
+) {
+	let active = matches!(
+		result,
+		CheckResult::Failed | CheckResult::Warning | CheckResult::Broken
+	);
+	let stamp = CheckStateStamp {
+		check: r#ref.into(),
+		observed: result,
+		effective: result,
+		escalates: false,
+		detail: None,
+	};
+	NewEvent {
+		source: "test".into(),
+		r#ref: r#ref.into(),
+		description: None,
+		message: "m".into(),
+		active: Some(active),
+		occurred_at: None,
+	}
+	.save_with_state(conn, server_id, None, Some(&stamp), defer)
+	.await
+	.expect("record check");
+}
+
+#[derive(QueryableByName)]
+struct IncFlags {
+	#[diesel(sql_type = sql_types::Bool)]
+	is_open: bool,
+	#[diesel(sql_type = sql_types::Bool)]
+	is_lingering: bool,
+}
+
+async fn latest_incident(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+) -> Option<IncFlags> {
+	sql_query(
+		"SELECT (i.closed_at IS NULL) AS is_open, (i.closing_at IS NOT NULL) AS is_lingering \
+		 FROM incidents i JOIN servers s ON i.server_group_id = s.group_id \
+		 WHERE s.id = $1 ORDER BY i.opened_at DESC LIMIT 1",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.get_result::<IncFlags>(conn)
+	.await
+	.optional()
+	.expect("incident flags")
+}
+
+#[derive(QueryableByName)]
+struct Count {
+	#[diesel(sql_type = sql_types::BigInt)]
+	n: i64,
+}
+
+async fn queue_len(conn: &mut diesel_async::AsyncPgConnection) -> i64 {
+	sql_query("SELECT count(*) AS n FROM incident_reeval_queue")
+		.get_result::<Count>(conn)
+		.await
+		.expect("queue len")
+		.n
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn draining_the_queue_opens_the_incident_and_empties_the_queue() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn).await;
+
+		// Ingest records a failing check but defers the incident work and
+		// enqueues the server (mirrors the public-server handler).
+		record_check(&mut conn, server_id, "health/db", CheckResult::Failed, true).await;
+		issues::enqueue_incident_reeval(&mut conn, server_id)
+			.await
+			.expect("enqueue");
+
+		assert!(
+			latest_incident(&mut conn, server_id).await.is_none(),
+			"no incident before the queue is drained"
+		);
+		assert_eq!(queue_len(&mut conn).await, 1);
+
+		let processed = issues::process_incident_reeval_queue(&mut conn, i64::MAX)
+			.await
+			.expect("drain");
+		assert_eq!(processed, 1);
+		assert!(
+			latest_incident(&mut conn, server_id)
+				.await
+				.is_some_and(|i| i.is_open),
+			"draining the queue opens the incident"
+		);
+		assert_eq!(queue_len(&mut conn).await, 0, "queue emptied after drain");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn deferred_reeval_leaves_incident_when_member_recovers() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_grouped_server(&mut conn).await;
+
+		// Open an incident inline with a failing check.
+		record_check(
+			&mut conn,
+			server_id,
+			"health/db",
+			CheckResult::Failed,
+			false,
+		)
+		.await;
+		let inc = latest_incident(&mut conn, server_id)
+			.await
+			.expect("incident open");
+		assert!(inc.is_open && !inc.is_lingering, "open, not yet lingering");
+
+		// Recovery arrives on the deferred path: the issue goes inactive, but
+		// its incident membership is not re-evaluated inline.
+		record_check(&mut conn, server_id, "health/db", CheckResult::Passed, true).await;
+		let inc = latest_incident(&mut conn, server_id)
+			.await
+			.expect("still open");
+		assert!(
+			inc.is_open && !inc.is_lingering,
+			"the leave is deferred: still a member until reeval runs"
+		);
+
+		// The worker's re-evaluation walks inactive members too, so the
+		// recovered check leaves and the incident starts lingering.
+		issues::reevaluate_incidents_for_server(&mut conn, server_id)
+			.await
+			.expect("reeval");
+		let inc = latest_incident(&mut conn, server_id)
+			.await
+			.expect("still open (lingering)");
+		assert!(
+			inc.is_open && inc.is_lingering,
+			"recovered member left -> incident now lingering"
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/incident_result_semantics.rs
+++ b/crates/database/tests/it/incident_result_semantics.rs
@@ -63,7 +63,7 @@ async fn save_event(
 		active: Some(active),
 		occurred_at: None,
 	}
-	.save_with_state(conn, server_id, None, Some(&stamp))
+	.save_with_state(conn, server_id, None, Some(&stamp), false)
 	.await
 	.expect("save event");
 }

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -14,6 +14,7 @@ mod event_validation;
 mod incident_close_result;
 mod incident_get_with_issues;
 mod incident_linger;
+mod incident_reeval_queue;
 mod incident_result_semantics;
 mod incident_stats;
 mod mcp_tokens;

--- a/crates/database/tests/it/slack_outbox_enqueue.rs
+++ b/crates/database/tests/it/slack_outbox_enqueue.rs
@@ -134,7 +134,7 @@ async fn opening_incident_enqueues_slack_open_row() {
 			occurred_at: None,
 		};
 		let issue = event
-			.save_with_state(&mut conn, server_id, None, Some(&stamp))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
 			.await
 			.expect("save");
 
@@ -211,7 +211,7 @@ async fn resolving_incident_after_open_delivered_enqueues_resolve_row() {
 			occurred_at: None,
 		};
 		event
-			.save_with_state(&mut conn, server_id, None, Some(&stamp))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
 			.await
 			.expect("save");
 		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
@@ -266,7 +266,7 @@ async fn resolving_before_open_ships_cancels_open_and_skips_resolve() {
 			occurred_at: None,
 		};
 		event
-			.save_with_state(&mut conn, server_id, None, Some(&stamp))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
 			.await
 			.expect("save");
 		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
@@ -346,7 +346,7 @@ async fn cascade_close_via_issue_resolve_attributes_to_operator() {
 			occurred_at: None,
 		};
 		let issue = event
-			.save_with_state(&mut conn, server_id, None, Some(&stamp))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
 			.await
 			.expect("save");
 		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
@@ -407,7 +407,7 @@ async fn nil_server_events_do_not_open_incidents() {
 			occurred_at: None,
 		};
 		event
-			.save_with_state(&mut conn, Uuid::nil(), None, Some(&stamp))
+			.save_with_state(&mut conn, Uuid::nil(), None, Some(&stamp), false)
 			.await
 			.expect("save");
 
@@ -442,7 +442,7 @@ async fn mark_given_up_removes_row_from_claim_pending() {
 			occurred_at: None,
 		};
 		event
-			.save_with_state(&mut conn, server_id, None, Some(&stamp))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
 			.await
 			.expect("save");
 		// `event.save` enqueues an open whose deliver_after sits
@@ -495,7 +495,7 @@ async fn claim_pending_skips_rows_whose_deliver_after_is_in_the_future() {
 			occurred_at: None,
 		};
 		event
-			.save_with_state(&mut conn, server_id, None, Some(&stamp))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
 			.await
 			.expect("save");
 		let pending_before = SlackOutbox::claim_pending(&mut conn, 10)
@@ -546,7 +546,7 @@ async fn open_delay_honours_per_group_slack_open_delay() {
 			occurred_at: None,
 		};
 		event
-			.save_with_state(&mut conn, server_id, None, Some(&stamp))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
 			.await
 			.expect("save");
 
@@ -594,7 +594,7 @@ async fn pending_opens_until_filters_to_undelivered_in_window() {
 			occurred_at: None,
 		};
 		event
-			.save_with_state(&mut conn, held_server, None, Some(&stamp))
+			.save_with_state(&mut conn, held_server, None, Some(&stamp), false)
 			.await
 			.expect("save held");
 		let held_incident = Incident::list_for_server(&mut conn, held_server, false, 10)
@@ -620,7 +620,7 @@ async fn pending_opens_until_filters_to_undelivered_in_window() {
 			occurred_at: None,
 		};
 		event
-			.save_with_state(&mut conn, delivered_server, None, Some(&stamp))
+			.save_with_state(&mut conn, delivered_server, None, Some(&stamp), false)
 			.await
 			.expect("save delivered");
 		let delivered_incident = Incident::list_for_server(&mut conn, delivered_server, false, 10)
@@ -675,7 +675,7 @@ async fn rejoining_open_incident_does_not_re_enqueue_open() {
 			occurred_at: None,
 		};
 		event_a
-			.save_with_state(&mut conn, server_id, None, Some(&stamp_a))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp_a), false)
 			.await
 			.expect("save a");
 		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
@@ -702,7 +702,7 @@ async fn rejoining_open_incident_does_not_re_enqueue_open() {
 			occurred_at: None,
 		};
 		event_b
-			.save_with_state(&mut conn, server_id, None, Some(&stamp_b))
+			.save_with_state(&mut conn, server_id, None, Some(&stamp_b), false)
 			.await
 			.expect("save b");
 

--- a/crates/jobs/src/bin/monitor.rs
+++ b/crates/jobs/src/bin/monitor.rs
@@ -93,12 +93,44 @@ async fn backfill_stability_on_startup(pool: &database::Db) {
 	}
 }
 
+/// How often the deferred incident-reeval worker drains its queue. Short so
+/// incidents open/close promptly after a status push; work is coalesced per
+/// server, so a tight cadence is cheap.
+const REEVAL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Backstop cap on servers drained per reeval tick, so one tick can't hog the
+/// pod. The queue coalesces per server, so this is rarely reached.
+const REEVAL_BATCH: i64 = 256;
+
 pub fn spawn() -> JoinHandle<()> {
 	let pool = database::init();
 	task::spawn(async move {
 		reconcile_on_startup(&pool).await;
 		let backfill_pool = pool.clone();
 		task::spawn(async move { backfill_stability_on_startup(&backfill_pool).await });
+
+		// Deferred incident (re-)evaluation worker. The status-ingest path
+		// enqueues servers instead of evaluating incident membership inline
+		// (which took the per-group `server_groups` lock and convoyed the
+		// fleet under load). This single worker drains the queue on a short
+		// cadence, so it — not request traffic — is the only taker of that
+		// lock, and incidents still open/close promptly. The main loop below
+		// drains too, as a backstop if this task ever dies.
+		let reeval_pool = pool.clone();
+		task::spawn(async move {
+			loop {
+				sleep(REEVAL_INTERVAL).await;
+				let Ok(mut db) = reeval_pool.get().await else {
+					error!("reeval worker: failed to get database connection");
+					continue;
+				};
+				match database::issues::process_incident_reeval_queue(&mut db, REEVAL_BATCH).await {
+					Ok(0) => {}
+					Ok(n) => debug!("reeval worker: processed {n} queued server(s)"),
+					Err(err) => error!("incident reeval worker failed: {err}"),
+				}
+			}
+		});
 
 		// The directory is optional: in dev / single-tenant deploys the
 		// TAILSCALE_* env vars aren't set, and the key-expiry sweep just
@@ -145,6 +177,16 @@ pub fn spawn() -> JoinHandle<()> {
 				Ok(0) => {}
 				Ok(n) => debug!("closed {n} lingering incident(s)"),
 				Err(err) => error!("incident linger sweep failed: {err}"),
+			}
+
+			// Backstop drain of the incident-reeval queue in case the dedicated
+			// worker task above has died. Safe to run concurrently with it:
+			// `process_incident_reeval_queue` claims rows `FOR UPDATE SKIP
+			// LOCKED`, so the two never double-process a server.
+			match database::issues::process_incident_reeval_queue(&mut db, REEVAL_BATCH).await {
+				Ok(0) => {}
+				Ok(n) => debug!("reeval backstop: processed {n} queued server(s)"),
+				Err(err) => error!("incident reeval backstop failed: {err}"),
 			}
 
 			// Backup staleness + report-vs-inventory reconciliation: another

--- a/crates/private-server/tests/it/mcp.rs
+++ b/crates/private-server/tests/it/mcp.rs
@@ -804,7 +804,7 @@ async fn observe_wobbly(
 		active: Some(active),
 		occurred_at: None,
 	}
-	.save_with_state(conn, server_id, None, Some(&stamp))
+	.save_with_state(conn, server_id, None, Some(&stamp), false)
 	.await
 	.expect("file observation");
 }

--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -597,7 +597,7 @@ async fn file_health_events(
 			active: Some(active),
 			occurred_at,
 		}
-		.save_with_state(conn, server_id, device_id, Some(&stamp))
+		.save_with_state(conn, server_id, device_id, Some(&stamp), true)
 		.await?;
 	}
 
@@ -624,8 +624,17 @@ async fn file_health_events(
 			active: Some(false),
 			occurred_at,
 		}
-		.save_with_state(conn, server_id, device_id, Some(&stamp))
+		.save_with_state(conn, server_id, device_id, Some(&stamp), true)
 		.await?;
+	}
+
+	// Incident (re-)evaluation is deferred off this request: the issue state
+	// above is recorded synchronously, but the incident work — which takes
+	// the per-group `server_groups` lock — is handed to the reeval worker so
+	// concurrent check-ins never convoy on that lock. Only grouped servers
+	// participate in incidents.
+	if group_id.is_some() {
+		database::issues::enqueue_incident_reeval(conn, server_id).await?;
 	}
 
 	Ok(())

--- a/crates/public-server/tests/it/statuses.rs
+++ b/crates/public-server/tests/it/statuses.rs
@@ -153,6 +153,62 @@ async fn expire_linger(conn: &mut diesel_async::AsyncPgConnection) {
 		.expect("linger sweep");
 }
 
+/// Stand in for the monitor pod's reeval worker: drain every queued
+/// server so the test sees the settled incident state that the ingest
+/// request no longer computes inline.
+async fn drain_reeval(conn: &mut diesel_async::AsyncPgConnection) {
+	database::issues::process_incident_reeval_queue(conn, i64::MAX)
+		.await
+		.expect("drain incident reeval queue");
+}
+
+/// The ingest request records the status and per-check issues, but incident
+/// (re-)evaluation — the part that takes the per-group lock — is deferred to
+/// the reeval worker. Nothing opens an incident until the queue is drained.
+#[tokio::test(flavor = "multi_thread")]
+async fn submit_status_defers_incident_open_until_reeval_drained() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+			set_check_severity(&mut conn, "database", "error").await;
+
+			// Raw post (bypassing the auto-draining test helpers) so we can
+			// observe the state between ingest and reeval.
+			public
+				.post(&format!("/status/{server_id}"))
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({
+					"healthy": false,
+					"health": [ { "check": "database", "healthy": false } ],
+				}))
+				.await
+				.assert_status_ok();
+
+			// The per-check issue is recorded synchronously on the request.
+			assert!(
+				fetch_issue(&mut conn, server_id, "alertd", "health/database")
+					.await
+					.is_some(),
+				"per-check issue must be recorded on the ingest request"
+			);
+			// The incident is NOT opened by the request itself.
+			assert!(
+				fetch_open_incident(&mut conn, server_id).await.is_none(),
+				"incident open must be deferred off the ingest request"
+			);
+
+			// The worker drains the queue and the incident opens.
+			drain_reeval(&mut conn).await;
+			assert!(
+				fetch_open_incident(&mut conn, server_id).await.is_some(),
+				"incident opens once the reeval queue is drained"
+			);
+		},
+	)
+	.await
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn submit_status() {
 	commons_tests::server::run_with_device_auth(
@@ -810,6 +866,7 @@ async fn submit_status_legacy_transforms_to_tamanu_heartbeat() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({ "healthy": false, "uptime": 7 }),
 			)
@@ -860,6 +917,7 @@ async fn submit_status_legacy_leaves_other_sources_alone() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "disk", "healthy": false, "free_pct": 4 } ],
@@ -875,6 +933,7 @@ async fn submit_status_legacy_leaves_other_sources_alone() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({ "healthy": true, "uptime": 99 }),
 			)
@@ -896,6 +955,7 @@ async fn submit_status_legacy_leaves_other_sources_alone() {
 async fn post_status(
 	public: &axum_test::TestServer,
 	cert: &str,
+	conn: &mut diesel_async::AsyncPgConnection,
 	server_id: Uuid,
 	body: serde_json::Value,
 ) {
@@ -905,6 +965,10 @@ async fn post_status(
 		.json(&body)
 		.await;
 	response.assert_status_ok();
+	// Incident evaluation is deferred off the ingest request to the reeval
+	// worker; drain it here so callers observe the settled incident state,
+	// as they would shortly after a real push.
+	drain_reeval(conn).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -917,6 +981,7 @@ async fn submit_status_legacy_files_no_health_issues() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({ "uptime": 1, "health": [] }),
 			)
@@ -943,6 +1008,7 @@ async fn submit_status_warning_check_only() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": true,
@@ -994,6 +1060,7 @@ async fn submit_status_unhealthy_with_checks_opens_incident() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1045,6 +1112,7 @@ async fn submit_status_unhealthy_no_checks_files_nothing() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({ "healthy": false, "health": [] }),
 			)
@@ -1092,6 +1160,7 @@ async fn submit_status_with_all_failing_checks_silenced_opens_no_incident() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1150,6 +1219,7 @@ async fn submit_status_with_partial_silence_opens_incident_for_unsilenced() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1198,6 +1268,7 @@ async fn submit_status_per_check_severity_is_catalog_driven() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1215,6 +1286,7 @@ async fn submit_status_per_check_severity_is_catalog_driven() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": true,
@@ -1249,6 +1321,7 @@ async fn submit_status_check_recovery_explicit() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1259,6 +1332,7 @@ async fn submit_status_check_recovery_explicit() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": true,
@@ -1286,6 +1360,7 @@ async fn submit_status_check_recovery_via_drop() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1298,6 +1373,7 @@ async fn submit_status_check_recovery_via_drop() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": true,
@@ -1330,6 +1406,7 @@ async fn submit_status_full_recovery_closes_incident() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1345,6 +1422,7 @@ async fn submit_status_full_recovery_closes_incident() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": true,
@@ -1404,6 +1482,7 @@ async fn submit_status_reachability_to_health_handoff() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1460,6 +1539,7 @@ async fn submit_status_keeps_incident_open_when_failure_swaps() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1477,6 +1557,7 @@ async fn submit_status_keeps_incident_open_when_failure_swaps() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1550,6 +1631,7 @@ async fn submit_status_seeds_catalog_for_new_checks() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": true,
@@ -1593,6 +1675,7 @@ async fn submit_status_uses_catalog_severity_on_failure() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1672,6 +1755,7 @@ async fn submit_status_rule_on_check_extra_overrides_base() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1690,6 +1774,7 @@ async fn submit_status_rule_on_check_extra_overrides_base() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1730,6 +1815,7 @@ async fn submit_status_rule_on_bestool_version_range() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1747,6 +1833,7 @@ async fn submit_status_rule_on_bestool_version_range() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1791,6 +1878,7 @@ async fn submit_status_rule_on_server_tag() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1832,6 +1920,7 @@ async fn submit_status_tiered_ladder() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1850,6 +1939,7 @@ async fn submit_status_tiered_ladder() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -1883,6 +1973,7 @@ async fn submit_status_result_validation() {
 				post_status(
 					&public,
 					&cert,
+					&mut conn,
 					server_id,
 					serde_json::json!({
 						"health": [ { "check": "db", "result": result } ],
@@ -1937,6 +2028,7 @@ async fn submit_status_result_failed_uses_catalog_severity() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "failed", "lag_ms": 5000 } ],
@@ -1975,6 +2067,7 @@ async fn submit_status_result_warning_ignores_catalog_severity() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "warning" } ],
@@ -2020,6 +2113,7 @@ async fn submit_status_result_rule_on_check_result() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "warning" } ],
@@ -2052,6 +2146,7 @@ async fn submit_status_result_broken_warns_on_the_check_ref() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "broken", "error": "config not found" } ],
@@ -2081,6 +2176,7 @@ async fn submit_status_result_broken_warns_on_the_check_ref() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "passed" } ],
@@ -2111,6 +2207,7 @@ async fn submit_status_failed_then_broken_retains_the_failure() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "failed" } ],
@@ -2120,6 +2217,7 @@ async fn submit_status_failed_then_broken_retains_the_failure() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "broken" } ],
@@ -2152,6 +2250,7 @@ async fn submit_status_failed_then_broken_retains_the_failure() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "passed" } ],
@@ -2179,6 +2278,7 @@ async fn submit_status_result_skipped_closes_failure_with_message() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "cert", "result": "failed" } ],
@@ -2188,6 +2288,7 @@ async fn submit_status_result_skipped_closes_failure_with_message() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "cert", "result": "skipped" } ],
@@ -2224,6 +2325,7 @@ async fn submit_status_result_skipped_closes_broken() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "cert", "result": "broken" } ],
@@ -2233,6 +2335,7 @@ async fn submit_status_result_skipped_closes_broken() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "cert", "result": "skipped" } ],
@@ -2262,6 +2365,7 @@ async fn submit_status_legacy_to_result_transition() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"healthy": false,
@@ -2272,6 +2376,7 @@ async fn submit_status_legacy_to_result_transition() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [ { "check": "db", "result": "passed" } ],
@@ -2301,6 +2406,7 @@ async fn submit_status_result_all_kinds_upsert_catalog() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({
 					"health": [
@@ -2596,6 +2702,7 @@ async fn submit_status_version_prefers_tamanu_version_over_header() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({ "tamanuVersion": "2.11.0", "health": [] }),
 			)
@@ -2623,6 +2730,7 @@ async fn submit_status_version_falls_back_to_header() {
 			post_status(
 				&public,
 				&cert,
+				&mut conn,
 				server_id,
 				serde_json::json!({ "health": [] }),
 			)

--- a/migrations/2026-07-20-041732-0000_incident_reeval_queue/down.sql
+++ b/migrations/2026-07-20-041732-0000_incident_reeval_queue/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE incident_reeval_queue;

--- a/migrations/2026-07-20-041732-0000_incident_reeval_queue/up.sql
+++ b/migrations/2026-07-20-041732-0000_incident_reeval_queue/up.sql
@@ -1,0 +1,16 @@
+-- Work queue for deferred incident (re-)evaluation.
+--
+-- The device status-ingest path records the status row and per-check issue
+-- state synchronously, then enqueues the server here instead of evaluating
+-- incident membership inline. Inline evaluation took a per-group
+-- `server_groups FOR UPDATE` lock and held it for the whole push, serialising
+-- every check-in for the group and, under load, convoying the fleet. The
+-- monitor pod drains this queue and runs the (single-writer) evaluation off
+-- the request path.
+--
+-- `server_id` is the primary key: at most one pending re-evaluation per
+-- server, so a burst of pushes coalesces into one unit of work.
+CREATE TABLE incident_reeval_queue (
+    server_id UUID PRIMARY KEY REFERENCES servers (id) ON DELETE CASCADE,
+    enqueued_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
🤖 Part 1 of the alerting lock-contention work: make the device status-ingest path lock-less by moving incident evaluation off it.

## Problem

`POST /status/{server_id}` evaluated incident membership inline, inside the request's write transaction. `find_or_open_incident` takes a per-group `server_groups FOR UPDATE` lock, held (via the nested savepoint) until the outer transaction commits — so the lock spans the entire push, across every check. Concurrent check-ins for the same server group therefore serialise on that one row lock, and because the monitor's linger sweep needs the same lock, high concurrency on a group can back it up and delay incident close.

## Change

- Ingest records the status row and per-check issue/check-state synchronously (per-server rows, no cross-server lock), then enqueues the server into a new `incident_reeval_queue` instead of evaluating inline.
- A single reeval worker in the monitor pod drains the queue on a short cadence and runs incident membership off the request path — it becomes the only taker of the per-group lock, so request traffic never contends on it. The main 60s monitor loop also drains, as a backstop if the worker task dies.
- `reevaluate_incidents_for_server` walks active-and-unresolved issues **plus** still-open incident members, so it drives both joins and the leave transitions a recovered (now-inactive) check needs. `reevaluate_open_issues_for_server` only walks active issues and would miss those.

## Behaviour change

Incident open/close is now asynchronous — eventually consistent within a short bounded delay rather than synchronous with the report. This sits well within the existing 3-min open / 5-min close grace windows. Spec updated (INC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
