### PR TITLE
fix(ui): healthcheck settings — resilient admin probe + source-scoped editor

### DIFF
--- a/private-web/e2e/check-detail.spec.ts
+++ b/private-web/e2e/check-detail.spec.ts
@@ -340,7 +340,7 @@ test.describe("check detail page", () => {
 	}) => {
 		await seedCheckPolicy(sql, { checkName: "disk_space" });
 
-		await page.goto("/settings/healthchecks/disk_space");
+		await page.goto("/settings/healthchecks/alertd/disk_space");
 		await expect(
 			page.getByText("Nobody has documented this check yet", { exact: false }),
 		).toBeVisible();

--- a/private-web/e2e/healthcheck-settings.spec.ts
+++ b/private-web/e2e/healthcheck-settings.spec.ts
@@ -45,7 +45,7 @@ test.describe("healthcheck settings page", () => {
 		await seedCheckPolicy(sql, {
 			checkName: "version",
 			source: "bestool",
-			ceiling: "critical",
+			ceiling: "failed",
 		});
 
 		// The alertd page shows only alertd's entry (its warning ceiling),
@@ -78,8 +78,9 @@ test.describe("healthcheck settings page", () => {
 		await page.goto("/settings/healthchecks/alertd/caddy_version");
 
 		// The escalate toggle is an interactive, enabled switch for admins
-		// (non-admins get a read-only chip instead).
-		const escalate = page.getByRole("checkbox", { name: /Escalates/ });
+		// (non-admins get a read-only chip instead). MUI's Switch is exposed
+		// with role "switch".
+		const escalate = page.getByRole("switch", { name: /Escalates/ });
 		await expect(escalate).toBeEnabled();
 
 		// The documentation editor's entry button is present.

--- a/private-web/e2e/healthcheck-settings.spec.ts
+++ b/private-web/e2e/healthcheck-settings.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "./test-fixtures";
+import { resetSeededTables, seedCheckPolicy } from "./seed";
+
+test.describe("healthcheck settings page", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("shows a single source-qualified 'flagging' link, not a duplicate", async ({
+		page,
+		sql,
+	}) => {
+		await seedCheckPolicy(sql, {
+			checkName: "caddy_version",
+			source: "alertd",
+			ceiling: "warning",
+		});
+
+		await page.goto("/settings/healthchecks/caddy_version");
+
+		// The link used to be rendered twice (a copy-paste bug). There must be
+		// exactly one, and it must carry the source in its href — the settings
+		// URL is check-name-only, but the "who's affected" page is keyed on the
+		// (source, check) pair.
+		const links = page.getByRole("link", {
+			name: /See servers currently flagging this check/,
+		});
+		await expect(links).toHaveCount(1);
+		await expect(links).toHaveAttribute(
+			"href",
+			"/healthchecks/alertd/caddy_version",
+		);
+	});
+
+	test("admin sees editable controls (edit docs button, enabled escalate toggle)", async ({
+		page,
+		sql,
+	}) => {
+		await seedCheckPolicy(sql, {
+			checkName: "caddy_version",
+			source: "alertd",
+			ceiling: "warning",
+		});
+
+		await page.goto("/settings/healthchecks/caddy_version");
+
+		// The escalate toggle is an interactive, enabled switch for admins
+		// (non-admins get a read-only chip instead).
+		const escalate = page.getByRole("checkbox", { name: /Escalates/ });
+		await expect(escalate).toBeEnabled();
+
+		// The documentation editor's entry button is present.
+		await expect(
+			page.getByRole("button", { name: /Write documentation|^Edit$/ }),
+		).toBeVisible();
+	});
+});

--- a/private-web/e2e/healthcheck-settings.spec.ts
+++ b/private-web/e2e/healthcheck-settings.spec.ts
@@ -16,12 +16,11 @@ test.describe("healthcheck settings page", () => {
 			ceiling: "warning",
 		});
 
-		await page.goto("/settings/healthchecks/caddy_version");
+		await page.goto("/settings/healthchecks/alertd/caddy_version");
 
 		// The link used to be rendered twice (a copy-paste bug). There must be
-		// exactly one, and it must carry the source in its href — the settings
-		// URL is check-name-only, but the "who's affected" page is keyed on the
-		// (source, check) pair.
+		// exactly one, and it must carry the source in its href — the "who's
+		// affected" page is keyed on the (source, check) pair.
 		const links = page.getByRole("link", {
 			name: /See servers currently flagging this check/,
 		});
@@ -30,6 +29,40 @@ test.describe("healthcheck settings page", () => {
 			"href",
 			"/healthchecks/alertd/caddy_version",
 		);
+	});
+
+	test("is scoped to one (source, check): same-named checks edit independently", async ({
+		page,
+		sql,
+	}) => {
+		// Two unrelated checks that happen to share a name, from different
+		// sources, each with a distinct ceiling.
+		await seedCheckPolicy(sql, {
+			checkName: "version",
+			source: "alertd",
+			ceiling: "warning",
+		});
+		await seedCheckPolicy(sql, {
+			checkName: "version",
+			source: "bestool",
+			ceiling: "critical",
+		});
+
+		// The alertd page shows only alertd's entry (its warning ceiling),
+		// not a lumped-together view of both sources.
+		await page.goto("/settings/healthchecks/alertd/version");
+		await expect(page.getByText("source: alertd")).toBeVisible();
+		await expect(page.getByText("source: bestool")).toHaveCount(0);
+		await expect(
+			page.getByRole("link", {
+				name: /See servers currently flagging this check/,
+			}),
+		).toHaveCount(1);
+
+		// The bestool page is a separate, independently-addressable editor.
+		await page.goto("/settings/healthchecks/bestool/version");
+		await expect(page.getByText("source: bestool")).toBeVisible();
+		await expect(page.getByText("source: alertd")).toHaveCount(0);
 	});
 
 	test("admin sees editable controls (edit docs button, enabled escalate toggle)", async ({
@@ -42,7 +75,7 @@ test.describe("healthcheck settings page", () => {
 			ceiling: "warning",
 		});
 
-		await page.goto("/settings/healthchecks/caddy_version");
+		await page.goto("/settings/healthchecks/alertd/caddy_version");
 
 		// The escalate toggle is an interactive, enabled switch for admins
 		// (non-admins get a read-only chip instead).

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -220,7 +220,7 @@ export default function App() {
 						<Route path="recovery" element={<RecoveryVault />} />
 						<Route path="healthchecks" element={<Healthchecks />} />
 						<Route
-							path="healthchecks/:checkName"
+							path="healthchecks/:source/:checkName"
 							element={<HealthcheckSettings />}
 						/>
 						<Route path="restore-consumers" element={<RestoreConsumers />} />

--- a/private-web/src/components/CheckDocButton.tsx
+++ b/private-web/src/components/CheckDocButton.tsx
@@ -11,6 +11,7 @@ import {
 import { useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { useApi } from "../api";
+import { healthcheckSettingsPath } from "../types";
 import Markdown from "./Markdown";
 
 /** `?` affordance shown next to a check name wherever its state is
@@ -94,7 +95,7 @@ function DocContent({ source, check }: { source: string; check: string }) {
 			<Typography variant="caption" sx={{ display: "block", mt: 1 }}>
 				<MuiLink
 					component={RouterLink}
-					to={`/settings/healthchecks/${encodeURIComponent(check)}`}
+					to={healthcheckSettingsPath(source, check)}
 				>
 					{documentation ? "Edit documentation" : "Write it"}
 				</MuiLink>

--- a/private-web/src/hooks/useIsAdmin.tsx
+++ b/private-web/src/hooks/useIsAdmin.tsx
@@ -1,8 +1,9 @@
-import { type ReactNode, createContext, useContext } from "react";
+import { type ReactNode, createContext, useContext, useEffect, useState } from "react";
 import { useApi } from "../api";
+import { useReloadInterval } from "./useReloadInterval";
 
-/** `true` if confirmed admin, `false` if confirmed non-admin, `undefined` while
- * the probe is in-flight or errored. Treat undefined as non-admin for gating
+/** `true` if confirmed admin, `false` if confirmed non-admin, `undefined` only
+ * until the very first probe resolves. Treat undefined as non-admin for gating
  * edit-only UI — better to flicker missing buttons on for an admin than to
  * briefly expose them to a non-admin. */
 const AdminContext = createContext<boolean | undefined>(undefined);
@@ -11,9 +12,31 @@ const AdminContext = createContext<boolean | undefined>(undefined);
  * router root so every consumer reads the same value without each one
  * re-fetching the probe. */
 export function AdminProvider({ children }: { children: ReactNode }) {
-	const probe = useApi("commons", "is_current_user_admin");
-	const value = probe.status === "ok" ? probe.data : undefined;
-	return <AdminContext.Provider value={value}>{children}</AdminContext.Provider>;
+	// Re-probe periodically and when the tab regains focus. The provider
+	// mounts once and lives for the whole SPA session, so without this a
+	// single failed probe at initial load would hide every admin control
+	// until a manual hard reload.
+	const tick = useReloadInterval(5 * 60_000);
+	const probe = useApi("commons", "is_current_user_admin", {}, [tick]);
+
+	// Last confirmed answer. Kept sticky across background-refetch errors so a
+	// transient blip (e.g. the tailnet control plane momentarily unreachable)
+	// never yanks admin controls out from under an admin mid-session; only the
+	// first-ever load shows `undefined`.
+	const [known, setKnown] = useState<boolean | undefined>(undefined);
+	useEffect(() => {
+		if (probe.status === "ok") setKnown(probe.data);
+	}, [probe]);
+
+	// Until we've learned the status at least once, retry a failed probe
+	// quickly so the session self-heals without a hard reload.
+	useEffect(() => {
+		if (probe.status !== "error" || known !== undefined) return;
+		const id = window.setTimeout(() => probe.reload(), 3000);
+		return () => window.clearTimeout(id);
+	}, [probe, known]);
+
+	return <AdminContext.Provider value={known}>{children}</AdminContext.Provider>;
 }
 
 /** Returns `true`/`false` once the probe has resolved, or `undefined` while

--- a/private-web/src/routes/CheckDetail.tsx
+++ b/private-web/src/routes/CheckDetail.tsx
@@ -37,6 +37,7 @@ import { useReloadInterval } from "../hooks/useReloadInterval";
 import {
 	SERVER_RANK_ORDER,
 	compareServersByRankThenKind,
+	healthcheckSettingsPath,
 	type CheckDetailData,
 	type CheckDetailGroupData,
 	type CheckDetailServerData,
@@ -98,7 +99,7 @@ export default function CheckDetail() {
 				<Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
 					<MuiLink
 						component={RouterLink}
-						to={`/settings/healthchecks/${encodeURIComponent(check ?? "")}`}
+						to={healthcheckSettingsPath(source ?? "", check ?? "")}
 					>
 						Configure ceiling / rules / documentation
 					</MuiLink>

--- a/private-web/src/routes/HealthcheckSettings.tsx
+++ b/private-web/src/routes/HealthcheckSettings.tsx
@@ -189,13 +189,20 @@ function valueToInputText(value: unknown): string {
 // ── Page ──────────────────────────────────────────────────────────────────
 
 export default function HealthcheckSettings() {
-	const { checkName } = useParams<{ checkName: string }>();
+	const { source, checkName } = useParams<{ source: string; checkName: string }>();
 	usePageTitle(checkName ?? "Healthcheck");
 	const isAdmin = useIsAdmin() === true;
 	const list = useApi("healthchecks", "list");
 
-	const rows: CheckPolicyData[] =
-		list.status === "ok" ? list.data.filter((r) => r.check_name === checkName) : [];
+	// A check's identity is the (source, check) pair, so the editor targets
+	// exactly one catalog entry — never an aggregate across same-named checks
+	// from different sources, which are unrelated checks.
+	const row: CheckPolicyData | null =
+		list.status === "ok"
+			? (list.data.find(
+					(r) => r.source === source && r.check_name === checkName,
+				) ?? null)
+			: null;
 
 	return (
 		<Stack spacing={2}>
@@ -206,42 +213,38 @@ export default function HealthcheckSettings() {
 				<Typography variant="h6" component="h2" sx={{ fontFamily: "monospace" }}>
 					{checkName}
 				</Typography>
+				<Typography
+					variant="body2"
+					color="text.secondary"
+					sx={{ fontFamily: "monospace" }}
+				>
+					source: {source}
+				</Typography>
 			</Box>
 
 			{list.status === "loading" || list.status === "idle" ? (
 				<LinearProgress />
 			) : list.status === "error" ? (
 				<Alert severity="error">{list.error.message}</Alert>
-			) : rows.length === 0 ? (
+			) : row === null ? (
 				<Alert severity="warning">
-					No healthcheck named <code>{checkName}</code> in the catalog yet — it'll
-					appear here once a server reports it.
+					No healthcheck <code>{checkName}</code> reported by{" "}
+					<code>{source}</code> in the catalog yet — it'll appear here once that
+					source reports it.
 				</Alert>
 			) : (
-				rows.map((row) => (
-					<Stack key={row.source} spacing={2}>
-						{rows.length > 1 && (
-							<Typography variant="subtitle2" sx={{ fontFamily: "monospace" }}>
-								source: {row.source}
-							</Typography>
-						)}
-						<Typography variant="body2">
-							<RouterLink to={healthcheckPath(row.source, row.check_name)}>
-								See servers currently flagging this check
-								{rows.length > 1 && ` (as reported by ${row.source})`}
-							</RouterLink>
-						</Typography>
-						<RowMetadata row={row} />
-						<CeilingCard row={row} canEdit={isAdmin} onChanged={list.reload} />
-						<DocumentationCard
-							row={row}
-							canEdit={isAdmin}
-							onChanged={list.reload}
-						/>
-						<NotesCard row={row} canEdit={isAdmin} onChanged={list.reload} />
-						<RulesCard row={row} canEdit={isAdmin} onChanged={list.reload} />
-					</Stack>
-				))
+				<Stack spacing={2}>
+					<Typography variant="body2">
+						<RouterLink to={healthcheckPath(row.source, row.check_name)}>
+							See servers currently flagging this check
+						</RouterLink>
+					</Typography>
+					<RowMetadata row={row} />
+					<CeilingCard row={row} canEdit={isAdmin} onChanged={list.reload} />
+					<DocumentationCard row={row} canEdit={isAdmin} onChanged={list.reload} />
+					<NotesCard row={row} canEdit={isAdmin} onChanged={list.reload} />
+					<RulesCard row={row} canEdit={isAdmin} onChanged={list.reload} />
+				</Stack>
 			)}
 		</Stack>
 	);

--- a/private-web/src/routes/HealthcheckSettings.tsx
+++ b/private-web/src/routes/HealthcheckSettings.tsx
@@ -231,12 +231,6 @@ export default function HealthcheckSettings() {
 								{rows.length > 1 && ` (as reported by ${row.source})`}
 							</RouterLink>
 						</Typography>
-						<Typography variant="body2">
-							<RouterLink to={healthcheckPath(row.source, row.check_name)}>
-								See servers currently flagging this check
-								{rows.length > 1 && ` (as reported by ${row.source})`}
-							</RouterLink>
-						</Typography>
 						<RowMetadata row={row} />
 						<CeilingCard row={row} canEdit={isAdmin} onChanged={list.reload} />
 						<DocumentationCard
@@ -335,18 +329,32 @@ function CeilingCard({
 				) : (
 					<CheckResultChip result={row.ceiling as Ceiling} />
 				)}
-				<FormControlLabel
-					control={
-						<Switch
-							size="small"
-							checked={escalates}
-							onChange={(e) => setEscalates(e.target.checked)}
-							disabled={!canEdit || update.pending}
-						/>
-					}
-					label="Escalates: an effective failure notifies immediately, bypassing the incident grace period"
-					slotProps={{ typography: { variant: "caption" } }}
-				/>
+				{canEdit ? (
+					<FormControlLabel
+						control={
+							<Switch
+								size="small"
+								checked={escalates}
+								onChange={(e) => setEscalates(e.target.checked)}
+								disabled={update.pending}
+							/>
+						}
+						label="Escalates: an effective failure notifies immediately, bypassing the incident grace period"
+						slotProps={{ typography: { variant: "caption" } }}
+					/>
+				) : row.escalates ? (
+					<Chip
+						label="escalates"
+						color="error"
+						size="small"
+						variant="outlined"
+						title="An effective failure notifies immediately, bypassing the incident grace period"
+					/>
+				) : (
+					<Typography variant="caption" color="text.secondary">
+						Does not escalate
+					</Typography>
+				)}
 				{canEdit && (
 					<Button size="small" variant="outlined" onClick={save} disabled={update.pending}>
 						Save

--- a/private-web/src/routes/Healthchecks.tsx
+++ b/private-web/src/routes/Healthchecks.tsx
@@ -25,7 +25,12 @@ import CheckResultChip from "../components/CheckResultChip";
 import TimeAgo from "../components/TimeAgo";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
-import { CEILINGS, type Ceiling, type CheckPolicyData } from "../types";
+import {
+	CEILINGS,
+	healthcheckSettingsPath,
+	type Ceiling,
+	type CheckPolicyData,
+} from "../types";
 
 export default function Healthchecks() {
 	usePageTitle("Healthchecks");
@@ -157,13 +162,15 @@ function HealthcheckRow({
 		<TableRow hover>
 			<TableCell sx={{ fontFamily: "monospace" }}>{row.source}</TableCell>
 			<TableCell sx={{ fontFamily: "monospace" }}>
-				<RouterLink to={`/settings/healthchecks/${row.check_name}`}>{row.check_name}</RouterLink>
+				<RouterLink to={healthcheckSettingsPath(row.source, row.check_name)}>
+					{row.check_name}
+				</RouterLink>
 			</TableCell>
 			<TableCell>
 				{hasRules ? (
 					<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
 						<Typography variant="body2">
-							<RouterLink to={`/settings/healthchecks/${row.check_name}`}>
+							<RouterLink to={healthcheckSettingsPath(row.source, row.check_name)}>
 								Custom rules ({row.rule_count})
 							</RouterLink>
 						</Typography>
@@ -221,7 +228,7 @@ function HealthcheckRow({
 						)}
 						<Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
 							·{" "}
-							<RouterLink to={`/settings/healthchecks/${row.check_name}`}>
+							<RouterLink to={healthcheckSettingsPath(row.source, row.check_name)}>
 								Add custom rules
 							</RouterLink>
 						</Typography>

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -340,6 +340,15 @@ export function healthcheckPath(source: string, check: string): string {
 	return `/healthchecks/${encodeURIComponent(source)}/${encodeURIComponent(check)}`;
 }
 
+/// Route to the policy editor for `check`. Like [`healthcheckPath`], a
+/// check's identity is the (source, check) pair — the editor is scoped to
+/// one such pair, so every link builder must carry the source and go
+/// through this instead of interpolating the (arbitrary, not necessarily
+/// URL-safe) name directly.
+export function healthcheckSettingsPath(source: string, check: string): string {
+	return `/settings/healthchecks/${encodeURIComponent(source)}/${encodeURIComponent(check)}`;
+}
+
 /// The check name embedded in a health issue's `ref` (`health/<check>`,
 /// filed under whichever source reports the check), or `null` for
 /// issues whose ref isn't a healthcheck (backups, manual, canopy


### PR DESCRIPTION
## What & why

The healthcheck settings page had three problems that together made it look half-baked.

### 1. Transient admin-probe failure downgraded the whole session

Every edit control on the page (ceiling select, escalate toggle, documentation edit, rules) gates on `useIsAdmin()`, which reads a single `AdminProvider` context mounted once at the router root. The provider probed `is_current_user_admin` **exactly once, with no retry**. If that request errored or was still in flight at initial load — e.g. the tailnet control plane momentarily unreachable, for an admin-by-policy user rather than one on the DB allowlist — the value stayed `undefined`, treated as non-admin, **for the entire SPA session** until a manual hard reload. That's why the edit button vanished and the escalate toggle sat disabled, then came back after a reload.

The provider is now resilient: it re-probes periodically and on tab focus, retries quickly while the answer is still unknown, and keeps the last confirmed answer **sticky** so a later blip can't yank admin controls mid-session.

### 2. The settings page was never made source-aware

Commit `f2e425d3` made a check's identity the **(source, check) pair** and moved the detail page to `/healthchecks/:source/:check` — "aggregating same-named checks across sources made no sense." But the settings editor was left behind: it routed on the check name alone (`/settings/healthchecks/:checkName`), filtered the catalog by name, and rendered **one section per source** — the exact cross-source aggregation that commit removed. Callers that already held the source (`CheckDetail`, `CheckDocButton`, the per-(source, check) catalog rows) discarded it when linking, and several didn't even `encodeURIComponent` the name.

Now the editor is scoped to one `(source, check)`:
- route becomes `/settings/healthchecks/:source/:checkName`, matching the detail page;
- the page targets the single matching catalog entry (or a not-found state), dropping the multi-section aggregation;
- new `healthcheckSettingsPath(source, check)` helper (mirroring `healthcheckPath`) encodes both segments, and every link routes through it — the list rows, the detail "Configure…" link, and the doc-popover "Edit/Write" link all carry the source.

### 3. Duplicate link + disabled toggle for non-admins

- Removed the duplicated "See servers currently flagging this check" link (copy-paste from the earlier move to per-source links).
- Non-admins now see a read-only "escalates" chip (or "Does not escalate") instead of a permanently-disabled toggle, matching the healthchecks list page.

## Testing

- `npx tsc -b` passes.
- Extended Playwright coverage (`e2e/healthcheck-settings.spec.ts`): single source-qualified link, admin-visible edit controls, and two same-named checks from different sources editing independently.
- ⚠️ The e2e suite could not be run in the authoring environment (no Postgres server tools / unbuilt binaries) — please run `just test-e2e` locally before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfeqj5GoNCKv1iAjMg7yWC