### PR TITLE
fix(checks): pending-review checks never open incidents; escalation constrained to a failed ceiling

### DIFF
--- a/.workhorse/specs/monitoring/checks.md
+++ b/.workhorse/specs/monitoring/checks.md
@@ -68,6 +68,7 @@ An entry carries:
 - an **escalates** flag — an effective failure of this check notifies immediately, bypassing incident grace (see [INC](incidents.md)).
 
 A check is registered in the catalog with a ceiling of `warning` the first time it is reported, and is pending operator review; operators confirm or adjust its policy from there, and checks still awaiting review are surfaced for it.
+While a check is pending review its effective result is hard-capped at warning — whatever its ceiling or rules would otherwise yield — so a never-vetted check records state but cannot open an incident (see [INC](incidents.md)); reviewing the policy, even a no-op save, lifts the cap.
 Canopy's own checks register already reviewed, with the policy their condition warrants instead of the default.
 
 ### Scoped policy

--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -98,6 +98,16 @@ pub struct CheckPolicy {
 	pub decommissioned_by: Option<String>,
 }
 
+/// Escalation only makes sense at a `failed` ceiling: it bypasses
+/// incident grace on an effective *failure*, and only a `failed` ceiling
+/// lets an effective result reach failed in the first place. At any lower
+/// ceiling the flag can never fire, so it is dropped rather than stored as
+/// dead configuration. The `check_policies` schema enforces the same
+/// invariant with a check constraint.
+fn escalates_normalised(ceiling: CheckResult, escalates: bool) -> bool {
+	escalates && ceiling == CheckResult::Failed
+}
+
 /// The outcome of applying a check's policy to an observed result.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GradedResult {
@@ -138,11 +148,15 @@ impl CheckPolicy {
 		sql_query(refresh).execute(db).await?;
 
 		// Re-animate any decommissioned check that has reported since it was
-		// retired: reset to the newly-registered state (warning ceiling,
-		// pending review, no rules) so its policy is re-vetted.
+		// retired: reset to the newly-registered state (warning ceiling, no
+		// escalation, pending review, no rules) so its policy is re-vetted.
+		// Escalation must clear alongside the drop to the warning ceiling —
+		// it is only valid at a failed ceiling (enforced by a check
+		// constraint).
 		let reanimated = sql_query(
 			"UPDATE check_policies SET decommissioned_at = NULL, decommissioned_by = NULL, \
-			 ceiling = 'warning', rules = NULL, reviewed_at = NULL, reviewed_by = NULL \
+			 ceiling = 'warning', escalates = FALSE, rules = NULL, \
+			 reviewed_at = NULL, reviewed_by = NULL \
 			 WHERE decommissioned_at IS NOT NULL AND last_seen IS NOT NULL \
 			 AND last_seen > decommissioned_at",
 		)
@@ -277,7 +291,7 @@ impl CheckPolicy {
 				dsl::source.eq(source),
 				dsl::check_name.eq(check_name),
 				dsl::ceiling.eq(ceiling.to_string()),
-				dsl::escalates.eq(escalates),
+				dsl::escalates.eq(escalates_normalised(ceiling, escalates)),
 				dsl::documentation.eq(documentation),
 				dsl::reviewed_at.eq(Some(now)),
 				dsl::reviewed_by.eq(Some(source)),
@@ -499,6 +513,11 @@ impl CheckPolicy {
 	/// check, stamping `reviewed_at = NOW()` and `reviewed_by = by`. Even
 	/// a no-op save marks the row reviewed — operators can ack a check
 	/// without changing it.
+	///
+	/// Escalation is only meaningful at a `failed` ceiling — it bypasses
+	/// incident grace on an effective failure, and only a `failed` ceiling
+	/// admits a failed effective result — so it is dropped at any lower
+	/// ceiling (see [`escalates_normalised`]).
 	pub async fn update(
 		db: &mut AsyncPgConnection,
 		source: &str,
@@ -515,7 +534,7 @@ impl CheckPolicy {
 		)
 		.set((
 			dsl::ceiling.eq(ceiling.to_string()),
-			dsl::escalates.eq(escalates),
+			dsl::escalates.eq(escalates_normalised(ceiling, escalates)),
 			dsl::notes.eq(notes),
 			dsl::reviewed_at.eq(jiff_diesel::Timestamp::from(now)),
 			dsl::reviewed_by.eq(by),

--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -256,6 +256,12 @@ impl CheckPolicy {
 	/// if no row exists yet. Canopy's own checks register with the policy
 	/// their condition warrants instead of the default warning ceiling;
 	/// operator edits stick (this never overwrites).
+	///
+	/// Registered checks are canopy's own or operator-raised (never
+	/// un-vetted device pushes, which go through [`Self::upsert_default`]),
+	/// so they register **already reviewed** (`reviewed_at` stamped) — they
+	/// alert at their real ceiling rather than being capped at warning like
+	/// a pending device check (see [`Self::apply`] and the CHK spec).
 	pub async fn register(
 		db: &mut AsyncPgConnection,
 		source: &str,
@@ -265,6 +271,7 @@ impl CheckPolicy {
 		documentation: Option<&str>,
 	) -> Result<()> {
 		use crate::schema::check_policies::dsl;
+		let now = jiff_diesel::Timestamp::from(Timestamp::now());
 		diesel::insert_into(dsl::check_policies)
 			.values((
 				dsl::source.eq(source),
@@ -272,6 +279,8 @@ impl CheckPolicy {
 				dsl::ceiling.eq(ceiling.to_string()),
 				dsl::escalates.eq(escalates),
 				dsl::documentation.eq(documentation),
+				dsl::reviewed_at.eq(Some(now)),
+				dsl::reviewed_by.eq(Some(source)),
 			))
 			.on_conflict((dsl::source, dsl::check_name))
 			.do_nothing()
@@ -287,6 +296,12 @@ impl CheckPolicy {
 	/// direction — rules can upgrade as well as downgrade); otherwise the
 	/// observed result is capped at the entry's ceiling.
 	///
+	/// A check still **pending operator review** (`reviewed_at IS NULL`)
+	/// has never been vetted, so it must not alert: its effective result is
+	/// hard-capped at warning (and warnings never open incidents),
+	/// whatever its ceiling or rules say. Reviewing the policy — even a
+	/// no-op save — lifts the cap.
+	///
 	/// Falls back to the default policy (ceiling = warning, no
 	/// escalation) if no row exists yet — in practice the status handler
 	/// upserts before reading, so this branch only covers the genuine
@@ -299,27 +314,30 @@ impl CheckPolicy {
 		ctx: &EvaluationContext<'_>,
 	) -> Result<GradedResult> {
 		use crate::schema::check_policies::dsl;
-		let row: Option<(String, bool, Option<JsonValue>)> = dsl::check_policies
-			.select((dsl::ceiling, dsl::escalates, dsl::rules))
+		let row: Option<(String, bool, Option<JsonValue>, bool)> = dsl::check_policies
+			.select((
+				dsl::ceiling,
+				dsl::escalates,
+				dsl::rules,
+				dsl::reviewed_at.is_not_null(),
+			))
 			.filter(dsl::source.eq(source).and(dsl::check_name.eq(check_name)))
 			.first(db)
 			.await
 			.optional()?;
-		let Some((ceiling_str, escalates, rules_json)) = row else {
+		let Some((ceiling_str, escalates, rules_json, reviewed)) = row else {
 			return Ok(GradedResult {
 				effective: observed.capped_at(CheckResult::Warning),
 				escalates: false,
 			});
 		};
 		let ceiling = ceiling_str.parse().unwrap_or(CheckResult::Warning);
+		let mut effective = observed.capped_at(ceiling);
 		if let Some(rules) = rules_json {
 			match serde_json::from_value::<IfLadder>(rules) {
 				Ok(ladder) => {
 					if let Some(result) = ladder.evaluate(ctx) {
-						return Ok(GradedResult {
-							effective: result,
-							escalates,
-						});
+						effective = result;
 					}
 				}
 				Err(err) => {
@@ -332,8 +350,12 @@ impl CheckPolicy {
 				}
 			}
 		}
+		// A never-reviewed check is inert until an operator vets it.
+		if !reviewed {
+			effective = effective.capped_at(CheckResult::Warning);
+		}
 		Ok(GradedResult {
-			effective: observed.capped_at(ceiling),
+			effective,
 			escalates,
 		})
 	}
@@ -346,6 +368,12 @@ impl CheckPolicy {
 	///
 	/// A scoped silence is a skipped ceiling in this chain: whatever the
 	/// fleet grading said, the effective result lands at skipped.
+	///
+	/// The pending-review warning cap (see [`Self::apply`]) is applied to
+	/// the fleet grade. Scoped transforms could in principle grade back up,
+	/// but the only surface that creates them is the silence (a skipped
+	/// ceiling, which only narrows), so a pending check stays capped in
+	/// every reachable state.
 	pub async fn apply_scoped(
 		db: &mut AsyncPgConnection,
 		source: &str,

--- a/crates/database/tests/it/check_liveness.rs
+++ b/crates/database/tests/it/check_liveness.rs
@@ -141,6 +141,8 @@ struct PolicyRow {
 	ceiling: String,
 	#[diesel(sql_type = sql_types::Bool)]
 	reviewed: bool,
+	#[diesel(sql_type = sql_types::Bool)]
+	escalates: bool,
 }
 
 async fn policy(
@@ -151,7 +153,7 @@ async fn policy(
 	sql_query(
 		"SELECT last_seen IS NOT NULL AS last_seen_present, \
 		 decommissioned_at IS NOT NULL AS decommissioned, \
-		 ceiling, reviewed_at IS NOT NULL AS reviewed \
+		 ceiling, reviewed_at IS NOT NULL AS reviewed, escalates \
 		 FROM check_policies WHERE source = $1 AND check_name = $2",
 	)
 	.bind::<sql_types::Text, _>(source)
@@ -212,10 +214,12 @@ async fn reconcile_reanimates_a_reported_decommissioned_check() {
 		file_check(&mut conn, filing(server_id, "alertd", "a"))
 			.await
 			.expect("file");
-		// Retire it in the past, with an operator-adjusted, reviewed policy.
+		// Retire it in the past, with an operator-adjusted, reviewed,
+		// escalating policy (valid only at the failed ceiling).
 		sql_query(
 			"UPDATE check_policies SET decommissioned_at = now() - interval '1 day', \
-			 decommissioned_by = 'op', ceiling = 'failed', reviewed_at = now(), reviewed_by = 'op' \
+			 decommissioned_by = 'op', ceiling = 'failed', escalates = true, \
+			 reviewed_at = now(), reviewed_by = 'op' \
 			 WHERE source = 'alertd' AND check_name = 'a'",
 		)
 		.execute(&mut conn)
@@ -234,6 +238,10 @@ async fn reconcile_reanimates_a_reported_decommissioned_check() {
 		assert!(!p.decommissioned, "a re-reported check is re-animated");
 		assert_eq!(p.ceiling, "warning", "re-animated at the warning ceiling");
 		assert!(!p.reviewed, "re-animated pending operator review");
+		assert!(
+			!p.escalates,
+			"re-animation clears escalation with the reset to warning",
+		);
 	})
 	.await
 }

--- a/crates/database/tests/it/check_policies.rs
+++ b/crates/database/tests/it/check_policies.rs
@@ -279,6 +279,70 @@ async fn register_marks_canopy_checks_already_reviewed() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn escalates_only_sticks_at_a_failed_ceiling() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		CheckPolicy::upsert_default(&mut conn, "alertd", "disk_space")
+			.await
+			.expect("seed");
+
+		// Escalation is meaningless below a failed ceiling: only a failed
+		// effective result opens an incident, so only there can escalation
+		// (bypassing incident grace) fire. Requesting it at a lower ceiling
+		// must not stick.
+		let warned = CheckPolicy::update(
+			&mut conn,
+			"alertd",
+			"disk_space",
+			CheckResult::Warning,
+			true,
+			None,
+			"op",
+		)
+		.await
+		.expect("update");
+		assert!(
+			!warned.escalates,
+			"escalates is dropped below a failed ceiling",
+		);
+
+		// At a failed ceiling it sticks.
+		let failed = CheckPolicy::update(
+			&mut conn,
+			"alertd",
+			"disk_space",
+			CheckResult::Failed,
+			true,
+			None,
+			"op",
+		)
+		.await
+		.expect("update");
+		assert!(failed.escalates, "escalates applies at a failed ceiling");
+
+		// register() normalises the same way.
+		CheckPolicy::register(
+			&mut conn,
+			"canopy",
+			"warn_only",
+			CheckResult::Warning,
+			true,
+			None,
+		)
+		.await
+		.expect("register");
+		let registered = CheckPolicy::get(&mut conn, "canopy", "warn_only")
+			.await
+			.expect("get")
+			.expect("row exists");
+		assert!(
+			!registered.escalates,
+			"register drops escalates below a failed ceiling",
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn update_stamps_review_metadata_even_on_no_op_save() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
 		CheckPolicy::upsert_default(&mut conn, "alertd", "noisy_check")

--- a/crates/database/tests/it/check_policies.rs
+++ b/crates/database/tests/it/check_policies.rs
@@ -181,6 +181,104 @@ async fn apply_caps_at_ceiling_or_defaults_to_warning() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn pending_review_policy_hard_caps_at_warning() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		use database::schema::check_policies::dsl;
+		use diesel::prelude::*;
+		use diesel_async::RunQueryDsl;
+
+		let empty_map = serde_json::Map::new();
+		let empty_tags = std::collections::HashMap::new();
+		let ctx = database::check_policies::EvaluationContext {
+			status_extra: &empty_map,
+			check_extra: &empty_map,
+			tags: &empty_tags,
+		};
+
+		// A pending-review policy (reviewed_at IS NULL) whose ceiling column
+		// says failed — the shape a never-vetted alertd check migrated in as,
+		// or a check registered before review. A never-vetted check must not
+		// open incidents: pending review hard-caps the effective result at
+		// warning regardless of the stored ceiling.
+		CheckPolicy::upsert_default(&mut conn, "alertd", "disk_space")
+			.await
+			.expect("seed");
+		diesel::update(dsl::check_policies)
+			.set(dsl::ceiling.eq(CheckResult::Failed.to_string()))
+			.execute(&mut conn)
+			.await
+			.expect("force a failed ceiling while leaving reviewed_at null");
+
+		let pending =
+			CheckPolicy::apply(&mut conn, "alertd", "disk_space", CheckResult::Failed, &ctx)
+				.await
+				.expect("apply");
+		assert_eq!(
+			pending.effective,
+			CheckResult::Warning,
+			"pending-review check caps at warning regardless of ceiling",
+		);
+
+		// Once an operator reviews it (any save stamps reviewed_at), the
+		// failed ceiling applies and failures pass through.
+		CheckPolicy::update(
+			&mut conn,
+			"alertd",
+			"disk_space",
+			CheckResult::Failed,
+			false,
+			None,
+			"dana",
+		)
+		.await
+		.expect("review");
+		let reviewed =
+			CheckPolicy::apply(&mut conn, "alertd", "disk_space", CheckResult::Failed, &ctx)
+				.await
+				.expect("apply after review");
+		assert_eq!(
+			reviewed.effective,
+			CheckResult::Failed,
+			"a reviewed check alerts normally",
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn register_marks_canopy_checks_already_reviewed() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		// Canopy's own checks (and operator-raised manual conditions) go
+		// through `register`, and the CHK spec says they register *already
+		// reviewed*, with the policy their condition warrants — so they
+		// alert at their real ceiling instead of being capped at warning
+		// like a pending, never-vetted device check.
+		CheckPolicy::register(
+			&mut conn,
+			"canopy",
+			"backup_stale",
+			CheckResult::Failed,
+			true,
+			None,
+		)
+		.await
+		.expect("register");
+
+		let row = CheckPolicy::get(&mut conn, "canopy", "backup_stale")
+			.await
+			.expect("get")
+			.expect("row exists");
+		assert_eq!(row.ceiling, CheckResult::Failed);
+		assert!(row.escalates);
+		assert!(
+			row.reviewed_at.is_some(),
+			"canopy's own checks register already reviewed",
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn update_stamps_review_metadata_even_on_no_op_save() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
 		CheckPolicy::upsert_default(&mut conn, "alertd", "noisy_check")

--- a/crates/private-server/tests/it/private_statuses.rs
+++ b/crates/private-server/tests/it/private_statuses.rs
@@ -1323,19 +1323,19 @@ async fn snapshot_merges_all_sources() {
 #[tokio::test(flavor = "multi_thread")]
 async fn snapshot_surfaces_per_check_results() {
 	commons_tests::server::run(async |mut conn, _, private| {
-		// Seed catalog: catalog_only stays at the default warning
-		// ceiling; elevated has its ceiling lifted to failed so the
+		// Seed catalog (all reviewed, so grading isn't capped to warning as
+		// a pending check would be): catalog_only stays at the default
+		// warning ceiling; elevated has its ceiling lifted to failed so the
 		// snapshot returns the operator-set grading; version_gated has a
-		// rules ladder firing on a specific status.bestoolVersion, and
-		// escalates.
+		// rules ladder firing on a specific status.bestoolVersion.
 		conn.batch_execute(
 			"INSERT INTO check_policies (source, check_name, ceiling, escalates) VALUES \
 				('alertd', 'catalog_only', 'warning', FALSE), \
 				('alertd', 'elevated', 'failed', FALSE), \
-				('alertd', 'version_gated', 'warning', TRUE); \
+				('alertd', 'version_gated', 'warning', FALSE); \
 			 UPDATE check_policies \
 				SET rules = '{\"if\":[{\"in_range\":[{\"var\":\"status.bestoolVersion\"},\">=1.0.0 <2.0.0\"]},\"failed\"]}'::jsonb \
-				WHERE check_name = 'version_gated';",
+				WHERE check_name = 'version_gated'; UPDATE check_policies SET reviewed_at = NOW(), reviewed_by = 'test' WHERE source = 'alertd';",
 		)
 		.await
 		.unwrap();
@@ -1389,7 +1389,7 @@ async fn snapshot_check_results_cover_result_form() {
 		conn.batch_execute(
 			"INSERT INTO check_policies (source, check_name, ceiling) VALUES \
 				('alertd', 'elevated', 'failed'), \
-				('alertd', 'degraded', 'failed');",
+				('alertd', 'degraded', 'failed'); UPDATE check_policies SET reviewed_at = NOW(), reviewed_by = 'test' WHERE source = 'alertd';",
 		)
 		.await
 		.unwrap();

--- a/crates/public-server/tests/it/statuses.rs
+++ b/crates/public-server/tests/it/statuses.rs
@@ -1782,12 +1782,18 @@ async fn set_check_rules(
 	.execute(conn)
 	.await
 	.expect("ensure catalog row");
-	sql_query("UPDATE check_policies SET rules = $1::jsonb WHERE check_name = $2")
-		.bind::<sql_types::Text, _>(rules.to_string())
-		.bind::<sql_types::Text, _>(check_name)
-		.execute(conn)
-		.await
-		.expect("set rules");
+	// Setting rules reviews the policy in production (via update_rules), and
+	// a pending-review policy is hard-capped at warning regardless of its
+	// rules — so stamp the review here to mirror the real path.
+	sql_query(
+		"UPDATE check_policies SET rules = $1::jsonb, reviewed_at = NOW(), reviewed_by = 'test' \
+		 WHERE check_name = $2",
+	)
+	.bind::<sql_types::Text, _>(rules.to_string())
+	.bind::<sql_types::Text, _>(check_name)
+	.execute(conn)
+	.await
+	.expect("set rules");
 }
 
 async fn set_server_tags(

--- a/migrations/2026-07-21-215914-0000_review_canopy_own_check_policies/down.sql
+++ b/migrations/2026-07-21-215914-0000_review_canopy_own_check_policies/down.sql
@@ -1,0 +1,10 @@
+-- Best-effort reversal: clear the review stamp only where it looks
+-- system-applied (reviewed_by equals the reserved source, as the up
+-- migration and register() both stamp it). Rows an operator reviewed
+-- carry their email in reviewed_by and are left untouched.
+UPDATE check_policies
+SET
+	reviewed_at = NULL,
+	reviewed_by = NULL
+WHERE source IN ('canopy', 'manual')
+	AND reviewed_by = source;

--- a/migrations/2026-07-21-215914-0000_review_canopy_own_check_policies/up.sql
+++ b/migrations/2026-07-21-215914-0000_review_canopy_own_check_policies/up.sql
@@ -1,0 +1,19 @@
+-- Canopy's own checks and operator-raised manual conditions register
+-- through file_check/register, and the CHK spec says they register
+-- "already reviewed". register() previously never stamped reviewed_at, so
+-- existing rows for these sources sit as pending review.
+--
+-- Grading now hard-caps a pending-review policy's effective result at
+-- warning (a never-vetted check must not open incidents). Left pending,
+-- these already-intended alerts — backup staleness, restore failures,
+-- tailscale key expiry, manual conditions — would be silenced. Stamp them
+-- reviewed to preserve their alerting, as they should have been all along.
+--
+-- Device-reported checks and never-vetted alertd checks are deliberately
+-- left pending: they are capped at warning until an operator reviews them.
+UPDATE check_policies
+SET
+	reviewed_at = COALESCE(reviewed_at, first_seen),
+	reviewed_by = COALESCE(reviewed_by, source)
+WHERE source IN ('canopy', 'manual')
+	AND reviewed_at IS NULL;

--- a/migrations/2026-07-21-225611-0000_constrain_escalates_to_failed_ceiling/down.sql
+++ b/migrations/2026-07-21-225611-0000_constrain_escalates_to_failed_ceiling/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE check_policies
+	DROP CONSTRAINT check_policies_escalates_needs_failed_ceiling;

--- a/migrations/2026-07-21-225611-0000_constrain_escalates_to_failed_ceiling/up.sql
+++ b/migrations/2026-07-21-225611-0000_constrain_escalates_to_failed_ceiling/up.sql
@@ -1,0 +1,12 @@
+-- Escalation only makes sense at a failed ceiling: it bypasses incident
+-- grace on an effective failure, and only a failed ceiling lets an
+-- effective result reach failed. Below that the flag is dead config, yet
+-- the policy editor let operators set it there. Drop the dead flags, then
+-- constrain the column so the meaningless combination cannot recur.
+UPDATE check_policies
+SET escalates = FALSE
+WHERE escalates AND ceiling <> 'failed';
+
+ALTER TABLE check_policies
+	ADD CONSTRAINT check_policies_escalates_needs_failed_ceiling
+	CHECK (NOT escalates OR ceiling = 'failed');

--- a/private-web/e2e/healthcheck-settings.spec.ts
+++ b/private-web/e2e/healthcheck-settings.spec.ts
@@ -72,7 +72,9 @@ test.describe("healthcheck settings page", () => {
 		await seedCheckPolicy(sql, {
 			checkName: "caddy_version",
 			source: "alertd",
-			ceiling: "warning",
+			// Escalation is only offered at a failed ceiling, so seed one to
+			// see the toggle in its enabled state.
+			ceiling: "failed",
 		});
 
 		await page.goto("/settings/healthchecks/alertd/caddy_version");
@@ -87,5 +89,31 @@ test.describe("healthcheck settings page", () => {
 		await expect(
 			page.getByRole("button", { name: /Write documentation|^Edit$/ }),
 		).toBeVisible();
+	});
+
+	test("escalate toggle is only enabled at a failed ceiling", async ({
+		page,
+		sql,
+	}) => {
+		// A warning-ceiling check can never produce a failed effective result,
+		// so there is nothing for escalation to bypass grace on: the toggle is
+		// disabled.
+		await seedCheckPolicy(sql, {
+			checkName: "caddy_version",
+			source: "alertd",
+			ceiling: "warning",
+		});
+
+		await page.goto("/settings/healthchecks/alertd/caddy_version");
+		const escalate = page.getByRole("switch", { name: /Escalates/ });
+		await expect(escalate).toBeDisabled();
+
+		// Raising the ceiling to failed makes escalation meaningful, so the
+		// toggle becomes enabled.
+		await page.getByRole("combobox").first().click();
+		await page
+			.getByRole("option", { name: /Failures count in full/ })
+			.click();
+		await expect(escalate).toBeEnabled();
 	});
 });

--- a/private-web/src/routes/HealthcheckSettings.tsx
+++ b/private-web/src/routes/HealthcheckSettings.tsx
@@ -285,13 +285,19 @@ function CeilingCard({
 	const update = useApiAction("healthchecks", "update");
 	const [ceiling, setCeiling] = useState<Ceiling>(row.ceiling as Ceiling);
 	const [escalates, setEscalates] = useState(row.escalates);
+	// Escalation only means anything at a failed ceiling: it bypasses
+	// incident grace on an effective failure, and only a failed ceiling
+	// admits a failed effective result. Below that it is dead config, so
+	// the toggle is disabled and never sent as set.
+	const canEscalate = ceiling === "failed";
+	const effectiveEscalates = canEscalate && escalates;
 	const save = async () => {
 		try {
 			await update.call({
 				source: row.source,
 				check_name: row.check_name,
 				ceiling,
-				escalates,
+				escalates: effectiveEscalates,
 				notes: row.notes,
 			});
 			onChanged();
@@ -337,12 +343,16 @@ function CeilingCard({
 						control={
 							<Switch
 								size="small"
-								checked={escalates}
+								checked={effectiveEscalates}
 								onChange={(e) => setEscalates(e.target.checked)}
-								disabled={update.pending}
+								disabled={update.pending || !canEscalate}
 							/>
 						}
-						label="Escalates: an effective failure notifies immediately, bypassing the incident grace period"
+						label={
+							canEscalate
+								? "Escalates: an effective failure notifies immediately, bypassing the incident grace period"
+								: "Escalates: only available at a failed ceiling — a lower ceiling never produces a failure to escalate"
+						}
 						slotProps={{ typography: { variant: "caption" } }}
 					/>
 				) : row.escalates ? (


### PR DESCRIPTION
🤖 A check pending operator review opened a Slack incident — it never should.

## Pending review must not alert

"Pending review" is `check_policies.reviewed_at IS NULL` — a policy an operator has never vetted. Nothing in the pipeline consulted it, so a pending-review policy graded and alerted exactly like a reviewed one. A pending row could reach a `failed` effective result (and thus open an incident) via the catalog back-fill — never-reviewed alertd `error`/`critical` checks migrated in at `ceiling = failed` — or via `register()`, which set ceilings/escalation but never stamped `reviewed_at`.

The intent (and what the shared warning colour on the pending-review chip implies) is that a pending check is hard-capped at warning, and warnings never open incidents.

- `apply()` caps the effective result at warning while the policy is pending, whatever its ceiling or rules yield; reviewing it (even a no-op save) lifts the cap.
- `register()` now stamps review metadata. It is only ever called for canopy-owned and operator-raised checks (device pushes go through `upsert_default`), so they register already reviewed per the CHK spec and keep alerting at their real ceiling.
- A migration marks existing pending `canopy`/`manual` rows reviewed, so real canopy alerts (backup staleness, restore, tailscale key expiry, manual conditions) keep firing after deploy. Device and never-vetted alertd rows stay pending and correctly cap at warning.

## Escalation only means something at a failed ceiling

Escalation bypasses incident grace on an effective failure, but only a `failed` ceiling can produce a failed effective result — so below that the flag was dead configuration the editor still offered.

- `update()`/`register()` drop escalation unless the ceiling is `failed`.
- A migration clears existing sub-failed escalation flags and adds a check constraint so the combination cannot recur.
- The policy editor disables the escalation toggle unless the ceiling is `failed`.

Spec (`checks.md`) updated with the pending-review cap.