### PR TITLE
fix(checks): orphaned check-states no longer break servers with no recourse

### DIFF
--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -166,15 +166,20 @@ impl CheckPolicy {
 		Ok(reanimated)
 	}
 
-	/// The set of decommissioned `(source, check)` pairs. Callers exclude
-	/// these from anything user-facing — health, incidents, presentation.
-	pub async fn decommissioned_pairs(
+	/// The set of `(source, check)` pairs backed by a **live** catalog row
+	/// (present and not decommissioned). Callers require membership before
+	/// treating a check-state as a real check — anything user-facing
+	/// (health, presentation) ignores states with no live catalog row: both
+	/// decommissioned checks and orphaned check-states (an `issues` row whose
+	/// (source, check) has no catalog row at all, e.g. a superseded source
+	/// whose catalog rows were removed while its states lingered).
+	pub async fn live_cataloged_pairs(
 		db: &mut AsyncPgConnection,
 	) -> Result<std::collections::HashSet<(String, String)>> {
 		use crate::schema::check_policies::dsl;
 		Ok(dsl::check_policies
 			.select((dsl::source, dsl::check_name))
-			.filter(dsl::decommissioned_at.is_not_null())
+			.filter(dsl::decommissioned_at.is_null())
 			.load::<(String, String)>(db)
 			.await?
 			.into_iter()

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -975,7 +975,7 @@ pub async fn health_from_check_state(
 	conn: &mut AsyncPgConnection,
 	servers: &[(Uuid, Option<Uuid>)],
 ) -> Result<std::collections::HashMap<Uuid, commons_types::status::HealthState>> {
-	use crate::schema::{check_policies, issues, scoped_check_policies};
+	use crate::schema::{issues, scoped_check_policies};
 	use commons_types::status::HealthState;
 	use std::collections::{HashMap, HashSet};
 
@@ -1004,16 +1004,10 @@ pub async fn health_from_check_state(
 		.load(conn)
 		.await?;
 
-	// Decommissioned checks contribute to nothing. Keyed fleet-wide by
-	// (source, check) in the catalog, so a check retired anywhere is
-	// skipped everywhere.
-	let decommissioned: HashSet<(String, String)> = check_policies::table
-		.select((check_policies::source, check_policies::check_name))
-		.filter(check_policies::decommissioned_at.is_not_null())
-		.load::<(String, String)>(conn)
-		.await?
-		.into_iter()
-		.collect();
+	// A check-state only contributes to health if a live catalog policy
+	// backs it: this skips decommissioned checks and orphaned check-states
+	// (no catalog row at all) fleet-wide. See `live_cataloged_pairs`.
+	let cataloged = crate::check_policies::CheckPolicy::live_cataloged_pairs(conn).await?;
 
 	let group_ids: Vec<Uuid> = group_of.values().filter_map(|g| *g).collect();
 	let silence_rows: Vec<(Option<Uuid>, Option<Uuid>, String, String)> =
@@ -1053,7 +1047,7 @@ pub async fn health_from_check_state(
 			continue;
 		};
 		let key = (server_id, source, check_name);
-		if decommissioned.contains(&(key.1.clone(), key.2.clone())) {
+		if !cataloged.contains(&(key.1.clone(), key.2.clone())) {
 			continue;
 		}
 		if server_silences.contains(&key) {
@@ -1101,7 +1095,7 @@ pub async fn consolidated_checks_latest(
 	server_id: Uuid,
 	group_id: Option<Uuid>,
 ) -> Result<commons_types::status::ConsolidatedChecks> {
-	use crate::schema::{check_policies, issues, scoped_check_policies};
+	use crate::schema::{issues, scoped_check_policies};
 	use commons_types::status::{ConsolidatedCheck, ConsolidatedChecks};
 	use std::collections::HashSet;
 
@@ -1125,13 +1119,11 @@ pub async fn consolidated_checks_latest(
 		.load(conn)
 		.await?;
 
-	let decommissioned: HashSet<(String, String)> = check_policies::table
-		.select((check_policies::source, check_policies::check_name))
-		.filter(check_policies::decommissioned_at.is_not_null())
-		.load::<(String, String)>(conn)
-		.await?
-		.into_iter()
-		.collect();
+	// A check-state only presents if a live catalog policy backs it: this
+	// excludes decommissioned checks and orphaned check-states (no catalog
+	// row at all — invisible in settings and unmanageable, so never a
+	// phantom failure here). See `live_cataloged_pairs`.
+	let cataloged = crate::check_policies::CheckPolicy::live_cataloged_pairs(conn).await?;
 
 	let group_ids: Vec<Uuid> = group_id.into_iter().collect();
 	let silence_rows: Vec<(Option<Uuid>, Option<Uuid>, String, String)> =
@@ -1161,7 +1153,7 @@ pub async fn consolidated_checks_latest(
 		.into_iter()
 		.filter_map(|(source, check_name, observed, effective, detail)| {
 			let check = check_name?;
-			if decommissioned.contains(&(source.clone(), check.clone())) {
+			if !cataloged.contains(&(source.clone(), check.clone())) {
 				return None;
 			}
 			let stored: CheckResult = effective.as_deref().and_then(|e| e.parse().ok())?;

--- a/crates/database/tests/it/consolidated_checks.rs
+++ b/crates/database/tests/it/consolidated_checks.rs
@@ -91,6 +91,46 @@ async fn latest_merges_all_sources_and_matches_rollup() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn latest_excludes_orphaned_check_states() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn).await;
+		// A failing check whose catalog row is then deleted, stranding its
+		// check-state row (the bestool-alertd situation: an `issues` row with
+		// no `check_policies` policy — invisible in settings, unmanageable).
+		file_check(
+			&mut conn,
+			filing(
+				server_id,
+				"bestool-alertd",
+				"sync-errors",
+				CheckResult::Failed,
+			),
+		)
+		.await
+		.expect("file");
+		sql_query("DELETE FROM check_policies WHERE source = 'bestool-alertd'")
+			.execute(&mut conn)
+			.await
+			.expect("strand the check-state");
+
+		let consolidated = consolidated_checks_latest(&mut conn, server_id, None)
+			.await
+			.expect("consolidated");
+
+		// An orphaned check-state (no catalog row) is not a manageable check:
+		// it must not surface in the detail view...
+		assert!(
+			consolidated.checks.is_empty(),
+			"orphaned check-state is excluded from the detail view",
+		);
+		// ...nor drag the health rollup — a server cannot be broken by a check
+		// that no longer exists in the catalog.
+		assert_eq!(consolidated.health_state, HealthState::Healthy);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn latest_excludes_decommissioned_and_flags_silenced() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
 		let server_id = insert_server(&mut conn).await;

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -785,7 +785,11 @@ async fn consolidated_checks_at(
 		.into_iter()
 		.map(|(k, v)| (k, serde_json::Value::String(v)))
 		.collect();
-	let decommissioned = CheckPolicy::decommissioned_pairs(conn).await?;
+	// Only present checks backed by a live catalog row, matching the live
+	// consolidated view: this drops decommissioned checks and orphaned
+	// check-states (a source's catalog rows removed out from under its
+	// states) so the point-in-time view reconstructs the same shape.
+	let cataloged = CheckPolicy::live_cataloged_pairs(conn).await?;
 
 	let mut checks: Vec<ConsolidatedCheck> = Vec::new();
 	for status in &statuses {
@@ -806,7 +810,7 @@ async fn consolidated_checks_at(
 			let Some(name) = obj.get("check").and_then(|v| v.as_str()) else {
 				continue;
 			};
-			if decommissioned.contains(&(status.source.clone(), name.to_string())) {
+			if !cataloged.contains(&(status.source.clone(), name.to_string())) {
 				continue;
 			}
 			let Some(observed) = CheckResult::from_entry(obj) else {

--- a/crates/private-server/tests/it/private_statuses.rs
+++ b/crates/private-server/tests/it/private_statuses.rs
@@ -832,7 +832,9 @@ async fn snapshot_returns_latest_when_at_omitted() {
 		.await
 		.unwrap();
 		conn.batch_execute(
-			"INSERT INTO statuses (server_id, created_at, healthy, health) VALUES
+			"INSERT INTO check_policies (source, check_name) VALUES ('alertd', 'db');
+
+			INSERT INTO statuses (server_id, created_at, healthy, health) VALUES
 			('20000000-0000-0000-0000-000000000001', NOW() - INTERVAL '2 hours', true, '[]'::jsonb),
 			('20000000-0000-0000-0000-000000000001', NOW() - INTERVAL '1 hour', false,
 				'[{\"check\":\"db\",\"healthy\":false}]'::jsonb)",
@@ -941,7 +943,8 @@ async fn snapshot_at_time_returns_prior_row() {
 	commons_tests::server::run(async |mut conn, _, private| {
 		conn.batch_execute(
 			"INSERT INTO servers (id, host, kind) VALUES
-			('20000000-0000-0000-0000-000000000002', 'https://snap2.example.com', 'central')",
+			('20000000-0000-0000-0000-000000000002', 'https://snap2.example.com', 'central');
+			INSERT INTO check_policies (source, check_name) VALUES ('alertd', 'old'), ('alertd', 'mid'), ('alertd', 'new')",
 		)
 		.await
 		.unwrap();
@@ -1283,6 +1286,7 @@ async fn snapshot_merges_all_sources() {
 		conn.batch_execute(
 			"INSERT INTO servers (id, host, kind) VALUES \
 				('30000000-0000-0000-0000-00000000000a', 'https://multi.example.com', 'central'); \
+				 INSERT INTO check_policies (source, check_name) VALUES ('alertd', 'db'), ('tamanu', 'tasks'); \
 			 INSERT INTO statuses (server_id, source, healthy, health, extra) VALUES \
 				('30000000-0000-0000-0000-00000000000a', 'alertd', true, \
 				 '[{\"check\":\"db\",\"result\":\"passed\"}]'::jsonb, '{\"queue\":3}'::jsonb), \
@@ -1332,7 +1336,7 @@ async fn snapshot_surfaces_per_check_results() {
 			"INSERT INTO check_policies (source, check_name, ceiling, escalates) VALUES \
 				('alertd', 'catalog_only', 'warning', FALSE), \
 				('alertd', 'elevated', 'failed', FALSE), \
-				('alertd', 'version_gated', 'warning', FALSE); \
+				('alertd', 'passing', 'warning', FALSE), ('alertd', 'version_gated', 'warning', FALSE); \
 			 UPDATE check_policies \
 				SET rules = '{\"if\":[{\"in_range\":[{\"var\":\"status.bestoolVersion\"},\">=1.0.0 <2.0.0\"]},\"failed\"]}'::jsonb \
 				WHERE check_name = 'version_gated'; UPDATE check_policies SET reviewed_at = NOW(), reviewed_by = 'test' WHERE source = 'alertd';",
@@ -1389,7 +1393,7 @@ async fn snapshot_check_results_cover_result_form() {
 		conn.batch_execute(
 			"INSERT INTO check_policies (source, check_name, ceiling) VALUES \
 				('alertd', 'elevated', 'failed'), \
-				('alertd', 'degraded', 'failed'); UPDATE check_policies SET reviewed_at = NOW(), reviewed_by = 'test' WHERE source = 'alertd';",
+				('alertd', 'degraded', 'failed'), ('alertd', 'busted', 'warning'), ('alertd', 'absent', 'warning'), ('alertd', 'fine', 'warning'); UPDATE check_policies SET reviewed_at = NOW(), reviewed_by = 'test' WHERE source = 'alertd';",
 		)
 		.await
 		.unwrap();
@@ -1456,6 +1460,8 @@ async fn get_detail_health_excludes_silenced_checks() {
 			INSERT INTO statuses (server_id, version, healthy, health, extra, created_at) VALUES
 			('11111111-1111-1111-1111-111111111111', '1.0.0', true,
 			 '[{\"check\": \"postgres\", \"result\": \"failed\"}]'::jsonb, '{}'::jsonb, NOW());
+
+			INSERT INTO check_policies (source, check_name, ceiling) VALUES ('alertd', 'postgres', 'failed');
 
 			INSERT INTO issues (server_id, source, ref, check_name, observed_result, effective_result, message, active, first_seen, last_seen, degraded_since, last_degraded_at) VALUES
 			('11111111-1111-1111-1111-111111111111', 'alertd', 'health/postgres', 'postgres', 'failed', 'failed', 'postgres failed', true, NOW(), NOW(), NOW(), NOW())",
@@ -1559,6 +1565,8 @@ async fn snapshot_reports_and_excludes_silenced_checks() {
 			INSERT INTO statuses (server_id, version, healthy, health, extra, created_at) VALUES
 			('11111111-1111-1111-1111-111111111111', '1.0.0', true,
 			 '[{\"check\": \"postgres\", \"result\": \"failed\"}, {\"check\": \"disk\", \"result\": \"passed\"}]'::jsonb, '{}'::jsonb, NOW());
+
+			INSERT INTO check_policies (source, check_name) VALUES ('alertd', 'postgres'), ('alertd', 'disk');
 
 			INSERT INTO scoped_check_policies (server_id, source, check_name, ceiling) VALUES
 			('11111111-1111-1111-1111-111111111111', 'alertd', 'postgres', 'skipped')",

--- a/migrations/2026-07-22-053304-0000_resolve_orphaned_check_states/down.sql
+++ b/migrations/2026-07-22-053304-0000_resolve_orphaned_check_states/down.sql
@@ -1,0 +1,16 @@
+-- Best-effort reversal: reopen the orphaned check-states this migration
+-- closed, identified by the exact stamp it wrote and by still having no
+-- catalog row. Rows resolved by an operator carry their login in
+-- resolved_by and are left untouched.
+UPDATE issues
+SET
+	resolved_at = NULL,
+	resolved_by = NULL,
+	resolved_reason = NULL
+WHERE check_name IS NOT NULL
+	AND resolved_by = 'system'
+	AND resolved_reason = 'decommissioned'
+	AND NOT EXISTS (
+		SELECT 1 FROM check_policies cp
+		WHERE cp.source = issues.source AND cp.check_name = issues.check_name
+	);

--- a/migrations/2026-07-22-053304-0000_resolve_orphaned_check_states/up.sql
+++ b/migrations/2026-07-22-053304-0000_resolve_orphaned_check_states/up.sql
@@ -1,0 +1,23 @@
+-- Close orphaned check-states: `issues` check-state rows whose
+-- (source, check_name) has no `check_policies` catalog row at all. These
+-- arose from legacy/superseded sources (e.g. bestool-alertd) whose catalog
+-- rows were removed while their states were left behind. An orphan is
+-- invisible in the healthchecks settings (which reads the catalog), yet the
+-- server-detail view and health rollup surfaced it as a failing check with
+-- no way for an operator to silence or decommission it.
+--
+-- The read paths now ignore check-states with no live catalog row, but
+-- these rows are still unresolved. Resolve them so they are properly closed
+-- (out of issue lists, incident eval, and staleness). None are members of
+-- open incidents, so no incident re-evaluation is needed here.
+UPDATE issues
+SET
+	resolved_at = now(),
+	resolved_by = 'system',
+	resolved_reason = 'decommissioned'
+WHERE check_name IS NOT NULL
+	AND resolved_at IS NULL
+	AND NOT EXISTS (
+		SELECT 1 FROM check_policies cp
+		WHERE cp.source = issues.source AND cp.check_name = issues.check_name
+	);

--- a/private-web/e2e/issues.spec.ts
+++ b/private-web/e2e/issues.spec.ts
@@ -70,6 +70,13 @@ test.describe("issue status snapshot", () => {
 				JSON.stringify({ jobs: "ok" }),
 			],
 		);
+		// Both checks need a live catalog row to present (mirrors ingestion,
+		// which upserts one per reported check); the snapshot excludes
+		// orphaned check-states with no catalog policy.
+		await sql.query(
+			`INSERT INTO check_policies (source, check_name) VALUES ('alertd', 'postgres'), ('tamanu', 'tasks')
+			 ON CONFLICT (source, check_name) DO NOTHING`,
+		);
 		// The issue provides the row (and its last_seen is the snapshot's `at`).
 		await seedIssue(sql, {
 			serverId: server.id,

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -256,6 +256,14 @@ export async function seedStatus(
 						: "failed"
 					: null;
 		if (result === null) continue;
+		// Mirror ingestion's upsert_default: a check-state only presents and
+		// counts if a live catalog row backs it. Never clobbers an explicit
+		// seedCheckPolicy for the same (source, check).
+		await sql.query(
+			`INSERT INTO check_policies (source, check_name) VALUES ('alertd', $1)
+			 ON CONFLICT (source, check_name) DO NOTHING`,
+			[check],
+		);
 		const degraded = ["failed", "warning", "broken"].includes(result);
 		await sql.query(
 			`INSERT INTO issues
@@ -484,6 +492,16 @@ export async function seedIssue(
 			? "warning"
 			: "failed";
 	const check = (opts.ref ?? "health").replace(/^health\//, "");
+	// A server-scoped check-state only presents/counts if a live catalog row
+	// backs it (mirrors ingestion's upsert_default); never clobbers an
+	// explicit seedCheckPolicy for the same (source, check).
+	if (opts.serverId) {
+		await sql.query(
+			`INSERT INTO check_policies (source, check_name) VALUES ($1, $2)
+			 ON CONFLICT (source, check_name) DO NOTHING`,
+			[opts.source ?? "alertd", check],
+		);
+	}
 	// Every seeded issue was degraded at some point — that's what makes it
 	// an issue rather than healthy check state, which the listings exclude.
 	await sql.query(


### PR DESCRIPTION
🤖 A server ('d8caf868…') showed permanently-failing healthchecks from source `bestool-alertd`, which does not appear anywhere in the healthchecks settings — so an operator had no way to silence, decommission, or otherwise clear them. The server was stuck broken.

## Root cause

An **orphaned check-state** is an `issues` check-state row whose `(source, check_name)` has **no `check_policies` catalog row** at all. These arose from legacy/superseded sources whose catalog rows were removed while their states were left behind (confirmed on prod: 260 unresolved orphans across `bestool-alertd`, old `alertd`, `canopy`, `manual`, spanning 29 servers — all stale, none reported in ≥4 days, none members of any open incident).

The server-detail view (`consolidated_checks_latest`) and the health rollup (`health_from_check_state`) excluded only **decommissioned** catalog rows — they never required a catalog row to *exist*. So an orphan slipped through both: it rendered as a failing check on the server detail and counted toward health, while being invisible in Settings (which reads the catalog) → no recourse.

## Fix

- Both read paths, plus the point-in-time snapshot, now require a **live catalog row** via `CheckPolicy::live_cataloged_pairs` (replacing `decommissioned_pairs`). Membership excludes decommissioned checks (as before) and orphaned check-states (new), in one coherent invariant: a check-state only presents or counts if a live policy backs it.
- A migration resolves the existing unresolved orphan check-states so they are properly closed (out of issue lists and staleness). None are in open incidents, so no incident re-evaluation is required.

Snapshot/detail test fixtures that seeded check-states without a catalog row were made faithful (ingestion always catalogs a check before filing its state).