### PR TITLE
fix(checks): dead sources stop holding servers into a reachability warning

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -2522,22 +2522,21 @@ impl Issue {
 		db: &mut AsyncPgConnection,
 		server_ids: &[Uuid],
 	) -> Result<Vec<(Uuid, String, Timestamp)>> {
-		use crate::schema::{check_policies, issues::dsl};
-		use std::collections::{HashMap, HashSet};
+		use crate::check_policies::CheckPolicy;
+		use crate::schema::issues::dsl;
+		use std::collections::HashMap;
 		if server_ids.is_empty() {
 			return Ok(Vec::new());
 		}
 
-		// Checks retired fleet-wide don't keep their source "expected": a
-		// source whose every check is decommissioned drops out of freshness
-		// entirely, so per-server staleness stops being raised for it.
-		let decommissioned: HashSet<(String, String)> = check_policies::table
-			.select((check_policies::source, check_policies::check_name))
-			.filter(check_policies::decommissioned_at.is_not_null())
-			.load::<(String, String)>(db)
-			.await?
-			.into_iter()
-			.collect();
+		// A source is only "expected" through check-states backed by a live
+		// catalog row: this drops sources whose every check is decommissioned,
+		// and orphaned sources whose check-states have no catalog row at all
+		// (e.g. a superseded reporter like bestool-alertd) — otherwise a dead
+		// source would hold servers into a reachability warning forever, with
+		// no catalog entry to silence or decommission. Mirrors the health
+		// rollup (see [`health_from_check_state`]).
+		let cataloged = CheckPolicy::live_cataloged_pairs(db).await?;
 
 		let rows: Vec<(Uuid, String, String, jiff_diesel::Timestamp)> = dsl::issues
 			.filter(
@@ -2561,7 +2560,7 @@ impl Issue {
 
 		let mut latest: HashMap<(Uuid, String), Timestamp> = HashMap::new();
 		for (server, source, check, seen) in rows {
-			if decommissioned.contains(&(source.clone(), check)) {
+			if !cataloged.contains(&(source.clone(), check)) {
 				continue;
 			}
 			let seen: Timestamp = seen.into();

--- a/crates/database/tests/it/check_liveness.rs
+++ b/crates/database/tests/it/check_liveness.rs
@@ -131,6 +131,34 @@ async fn source_with_a_live_check_stays_expected() {
 	.await
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn orphaned_source_drops_out_of_freshness() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn).await;
+		file_check(
+			&mut conn,
+			filing(server_id, "bestool-alertd", "sync-errors"),
+		)
+		.await
+		.expect("file");
+		assert!(source_expected(&mut conn, server_id, "bestool-alertd").await);
+
+		// Strand the check-state by deleting its catalog row — a superseded
+		// source whose issue rows linger with no catalog entry. It must stop
+		// being "expected", or it would hold servers into a reachability
+		// warning forever with no catalog row to silence or decommission.
+		sql_query("DELETE FROM check_policies WHERE source = 'bestool-alertd'")
+			.execute(&mut conn)
+			.await
+			.expect("strand the check-state");
+		assert!(
+			!source_expected(&mut conn, server_id, "bestool-alertd").await,
+			"an orphaned source (no live catalog row) is not expected for reachability",
+		);
+	})
+	.await
+}
+
 #[derive(QueryableByName)]
 struct PolicyRow {
 	#[diesel(sql_type = sql_types::Bool)]

--- a/crates/database/tests/it/reachability_sweep.rs
+++ b/crates/database/tests/it/reachability_sweep.rs
@@ -83,6 +83,17 @@ async fn insert_check_state(
 	check: &str,
 	minutes_ago: i32,
 ) {
+	// Mirror ingestion's upsert_default: a check-state only keeps its source
+	// "expected" for reachability if a live catalog row backs it.
+	sql_query(
+		"INSERT INTO check_policies (source, check_name) VALUES ($1, $2) \
+		 ON CONFLICT (source, check_name) DO NOTHING",
+	)
+	.bind::<sql_types::Text, _>(source)
+	.bind::<sql_types::Text, _>(check)
+	.execute(conn)
+	.await
+	.expect("catalog the seeded check");
 	sql_query(
 		r#"
 			INSERT INTO issues

--- a/migrations/2026-07-23-041615-0000_purge_legacy_per_source_stale_checks/down.sql
+++ b/migrations/2026-07-23-041615-0000_purge_legacy_per_source_stale_checks/down.sql
@@ -1,0 +1,3 @@
+-- Irreversible: the legacy per-source stale check-states and their catalog
+-- rows are removed for good (no current code files `canopy`/`stale/<source>`).
+-- Nothing to restore.

--- a/migrations/2026-07-23-041615-0000_purge_legacy_per_source_stale_checks/up.sql
+++ b/migrations/2026-07-23-041615-0000_purge_legacy_per_source_stale_checks/up.sql
@@ -1,0 +1,23 @@
+-- The old per-source staleness mechanism filed a `canopy`/`stale/<source>`
+-- check per reporting source. It was folded into the single `reachability`
+-- check, and `delete_legacy_stale_checks` removed the old rows — but
+-- transitional code re-filed a batch during the deploy window, and no
+-- current code manages `stale/<source>` any more. Those check-states have
+-- lingered active/unresolved ever since, holding servers into a warning with
+-- no catalog entry an operator can act on.
+--
+-- Resolve the stranded check-states and drop their catalog rows for good.
+-- They grade to warning (never failed), so none can be holding an incident
+-- open; no incident re-evaluation is needed.
+UPDATE issues
+SET
+	active = false,
+	resolved_at = now(),
+	resolved_by = 'system',
+	resolved_reason = 'decommissioned'
+WHERE source = 'canopy'
+	AND check_name LIKE 'stale/%'
+	AND resolved_at IS NULL;
+
+DELETE FROM check_policies
+WHERE source = 'canopy' AND check_name LIKE 'stale/%';


### PR DESCRIPTION
🤖 Follow-up to #389, which stopped orphaned check-states from breaking the health rollup and server-detail view. Two reachability-side gaps remained, both diagnosed against prod (server 2728189d, source `bestool-alertd` gone quiet 47d):

## 1. Reachability counts orphaned sources

Reachability staleness (`Issue::source_freshness` → `Status::sweep_staleness`) builds the "expected sources" set from the `issues` table, excluding only **decommissioned** catalog pairs — it never required a *live catalog row*. So an orphaned source (check-states with no catalog row, e.g. superseded `bestool-alertd`) stays "expected", and once quiet canopy warns on it forever. It appears in neither the catalog nor the Sources list, so an operator cannot silence/decommission/`off` it. Zero recourse.

**Fix:** apply the same live-catalog invariant `health_from_check_state` uses — a source is only expected through check-states backed by a live catalog row (`CheckPolicy::live_cataloged_pairs`). Orphaned sources drop out; live cataloged sources still warn when genuinely stale.

## 2. Legacy per-source `stale/<source>` zombie checks

The old per-source staleness filed `canopy`/`stale/<source>` checks. These were folded into the single `reachability` check and removed by `delete_legacy_stale_checks` — but transitional code re-filed a batch during the deploy window, and no current code manages them. Prod carries **41 such check-states (21 active) across 3 sources**, all last touched moments after that migration ran and untouched for days since — lingering active and holding servers into warn with no recourse.

**Fix:** a migration resolves the stranded check-states and drops their catalog rows. They grade to warning (never failed), so none can hold an incident open.

Verified: database package 184/184, incl. a new `orphaned_source_drops_out_of_freshness` test; `reachability_sweep` fixtures now catalog their seeded checks (mirroring ingestion).