### PR TITLE
fix(checks): clear silences for dead checks

### DIFF
--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -243,6 +243,17 @@ impl CheckPolicy {
 			crate::issues::Issue::resolve(db, id, by, ResolvedReason::Decommissioned).await?;
 		}
 
+		// Clear any scoped silences for the now-dead check: a silence on a
+		// check that contributes to nothing is dead configuration, and it
+		// would otherwise linger in the operator's silence list forever.
+		use crate::schema::scoped_check_policies::dsl as scp;
+		diesel::delete(
+			scp::scoped_check_policies
+				.filter(scp::source.eq(source).and(scp::check_name.eq(check_name))),
+		)
+		.execute(db)
+		.await?;
+
 		// A source whose checks are all decommissioned drops out of
 		// source_freshness, so it stops counting toward reachability with no
 		// further action here.
@@ -706,14 +717,17 @@ impl ScopedCheckPolicy {
 	}
 
 	/// All silences (skipped-ceiling transforms) at one scope, newest
-	/// first.
+	/// first. Silences for dead checks — a `(source, check)` with no live
+	/// catalog row (decommissioned, or orphaned with no catalog row at all)
+	/// — are excluded: the check contributes to nothing, so its silence is
+	/// dead config that shouldn't clutter the operator's list.
 	pub async fn list_silences(
 		db: &mut AsyncPgConnection,
 		scope: PolicyScope,
 	) -> Result<Vec<Self>> {
 		use crate::schema::scoped_check_policies::dsl;
 		let (server, group) = Self::scope_filter(scope);
-		dsl::scoped_check_policies
+		let rows: Vec<Self> = dsl::scoped_check_policies
 			.select(Self::as_select())
 			.filter(
 				dsl::server_id
@@ -724,7 +738,12 @@ impl ScopedCheckPolicy {
 			.order(dsl::created_at.desc())
 			.load(db)
 			.await
-			.map_err(AppError::from)
+			.map_err(AppError::from)?;
+		let cataloged = CheckPolicy::live_cataloged_pairs(db).await?;
+		Ok(rows
+			.into_iter()
+			.filter(|r| cataloged.contains(&(r.source.clone(), r.check_name.clone())))
+			.collect())
 	}
 
 	/// The scoped transforms that apply to a filing, in application

--- a/crates/database/tests/it/scoped_check_policies.rs
+++ b/crates/database/tests/it/scoped_check_policies.rs
@@ -278,3 +278,77 @@ async fn silence_on_a_scoped_rule_row_keeps_the_rules() {
 	})
 	.await
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decommission_clears_the_checks_silences() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, None).await;
+		CheckPolicy::upsert_default(&mut conn, "alertd", "noisy")
+			.await
+			.expect("seed catalog");
+		ScopedCheckPolicy::silence(
+			&mut conn,
+			PolicyScope::Server(server_id),
+			"alertd",
+			"noisy",
+			Some("op"),
+		)
+		.await
+		.expect("silence");
+
+		CheckPolicy::decommission(&mut conn, "alertd", "noisy", "op")
+			.await
+			.expect("decommission");
+
+		// The silence row is deleted outright, not just hidden.
+		assert!(
+			ScopedCheckPolicy::get(&mut conn, PolicyScope::Server(server_id), "alertd", "noisy")
+				.await
+				.expect("get")
+				.is_none(),
+			"decommissioning a check clears its silences",
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_silences_excludes_orphaned_check_silences() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, None).await;
+		CheckPolicy::upsert_default(&mut conn, "bestool-alertd", "sync")
+			.await
+			.expect("seed catalog");
+		ScopedCheckPolicy::silence(
+			&mut conn,
+			PolicyScope::Server(server_id),
+			"bestool-alertd",
+			"sync",
+			Some("op"),
+		)
+		.await
+		.expect("silence");
+		assert_eq!(
+			ScopedCheckPolicy::list_silences(&mut conn, PolicyScope::Server(server_id))
+				.await
+				.expect("list")
+				.len(),
+			1,
+		);
+
+		// Orphan the check: its catalog row goes, its silence row lingers.
+		sql_query("DELETE FROM check_policies WHERE source = 'bestool-alertd'")
+			.execute(&mut conn)
+			.await
+			.expect("orphan the check");
+
+		assert!(
+			ScopedCheckPolicy::list_silences(&mut conn, PolicyScope::Server(server_id))
+				.await
+				.expect("list")
+				.is_empty(),
+			"a silence for a dead (orphaned) check is not listed",
+		);
+	})
+	.await
+}

--- a/crates/private-server/tests/it/issues.rs
+++ b/crates/private-server/tests/it/issues.rs
@@ -1079,7 +1079,9 @@ async fn list_silenced_refs_for_server_and_group() {
 		conn.batch_execute(&format!(
 			"INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g');
 			 INSERT INTO servers (id, host, kind, group_id) VALUES \
-				('{server_id}', 'https://l.example.com', 'central', '{group_id}');"
+				('{server_id}', 'https://l.example.com', 'central', '{group_id}');
+			 INSERT INTO check_policies (source, check_name) VALUES \
+				('manual', 'srv-ref'), ('canopy', 'grp-ref');"
 		))
 		.await
 		.expect("seed");

--- a/migrations/2026-07-23-042917-0000_purge_dead_check_silences/down.sql
+++ b/migrations/2026-07-23-042917-0000_purge_dead_check_silences/down.sql
@@ -1,0 +1,2 @@
+-- Irreversible: silences for dead checks are deleted for good. Nothing to
+-- restore.

--- a/migrations/2026-07-23-042917-0000_purge_dead_check_silences/up.sql
+++ b/migrations/2026-07-23-042917-0000_purge_dead_check_silences/up.sql
@@ -1,0 +1,15 @@
+-- Silences (scoped skipped-ceiling policies) for dead checks — a
+-- (source, check) with no live catalog row, i.e. decommissioned or orphaned
+-- (no catalog row at all, e.g. superseded sources like bestool-alertd) —
+-- linger forever. The check contributes to nothing, so the silence is dead
+-- configuration cluttering the operator's silence list. Going forward,
+-- decommission clears a check's silences and the silence list hides dead
+-- ones; this clears the ones already stranded.
+DELETE FROM scoped_check_policies scp
+WHERE scp.ceiling = 'skipped'
+	AND NOT EXISTS (
+		SELECT 1 FROM check_policies cp
+		WHERE cp.source = scp.source
+			AND cp.check_name = scp.check_name
+			AND cp.decommissioned_at IS NULL
+	);


### PR DESCRIPTION
🤖 Follow-up to #389/#390 (dead-check/source hygiene). A **silence** — a scoped skipped-ceiling policy — on a check that later dies lingers forever in the operator's silence list, pointing at a check that contributes to nothing. On prod, 8 of 25 silences are dead (5 `bestool-alertd`, 3 `alertd`).

A check dies two ways: **decommissioned** (catalog row kept, `decommissioned_at` set) or **orphaned** (no catalog row at all, e.g. a superseded source). Neither cleared its silences.

Apply the same live-catalog invariant used elsewhere:
- `decommission()` now deletes the check's scoped silences outright.
- `list_silences()` excludes silences whose `(source, check)` has no live catalog row — dead-check silences never clutter the list (covers the orphan path, which has no decommission event to hook).
- a migration purges the silences already stranded on dead checks.

Verified: database package 186/186 (incl. new `decommission_clears_the_checks_silences` and `list_silences_excludes_orphaned_check_silences` tests); private-server 257/257 (one silence-list fixture updated to catalog the check it silences, mirroring how a real silence targets an existing check).