### PR TITLE
refactor(scope): unify check-state scope into a single Scope type

### DIFF
--- a/.workhorse/plans/scope-unification.md
+++ b/.workhorse/plans/scope-unification.md
@@ -1,0 +1,73 @@
+# Unify check-state scope into one `Scope` type
+
+Check-state scope (server / group / canopy-wide) is modelled three ways
+today, all encoding the same idea:
+
+- `FilingScope { Server { server_id, device_id }, Group(Uuid), Global }` —
+  the write side (also bundles the reporting device, which is *provenance*,
+  not scope);
+- `PolicyScope { Server(Uuid), Group(Uuid), Global }` — scoped silences;
+- an ad-hoc `match (issue.server_id, issue.server_group_id)` that resolves an
+  issue's scope to an incident target, **repeated verbatim** in
+  `issue_target_and_monitored` and `reconcile_open_incidents`.
+
+Storage is fine and stays: `issues` and `scoped_check_policies` each carry
+nullable `server_id` / `server_group_id` (CHECK "at most one", three partial
+unique indexes, and `ON DELETE CASCADE` FKs). That native integrity is
+load-bearing — it's what stops check-states outliving their server/group —
+so no migration and no schema change. This is a Rust-only unification
+(chosen over a polymorphic `(scope, scope_record_id)` column precisely to
+keep the FK cascade + uniqueness Postgres enforces today).
+
+## The type
+
+New in the `database` crate (e.g. `crate::scope`):
+
+```rust
+pub enum Scope { Server(Uuid), Group(Uuid), Global }
+```
+
+The single place that maps to/from storage and to an incident target:
+
+- `Scope::to_columns(self) -> (Option<Uuid> /*server_id*/, Option<Uuid> /*server_group_id*/)`
+- `Scope::from_columns(server_id, server_group_id) -> Scope`
+- `Scope::resolve_incident_target(&mut conn) -> Result<Option<(IncidentTarget, bool /*monitored*/)>>`
+  — the one implementation of today's duplicated match (server → its group +
+  `is_monitored`; group → itself, monitored; global → Global; ungrouped
+  server → None).
+
+## Refactor
+
+1. `FilingScope` → `Scope`. Decouple provenance: `CheckFiling` gets
+   `scope: Scope` + a separate `device_id: Option<Uuid>`. `file_check`
+   routes on `scope` via `to_columns` (server → `save_with_state`, group →
+   `raise_group_event_with_state`, global → `raise_global_event_with_state`).
+   Update the write-side producers (tailnet_sweeps, statuses, self_alerts,
+   restore, backup/staleness, backup/reconcile) to pass `scope` + `device_id`.
+2. `PolicyScope` → `Scope`. `ScopedCheckPolicy` CRUD
+   (`silence`/`unsilence`/`get`/`list_silences`/`chain_for`) and the
+   `silenced_refs` shim take `Scope`; `scope_filter` becomes `to_columns`.
+3. Replace the duplicated `match (server_id, server_group_id)` in
+   `issue_target_and_monitored` and `reconcile_open_incidents` with
+   `Scope::from_columns(...).resolve_incident_target(conn)`.
+
+Leave direct scope-specific read filters as they are (e.g.
+`.filter(server_id.eq(x))` in `health_from_check_state`,
+`consolidated_checks_latest`, `source_freshness`, `list_*`): those query a
+known scope, they aren't the scope-interpretation hack.
+
+## No behaviour change
+
+Nothing observable changes and the DB is untouched, so the existing suite
+passing unchanged is the correctness bar. Add unit tests for
+`Scope::{to_columns, from_columns}` round-tripping and
+`resolve_incident_target` covering server-in-group / ungrouped-server /
+group / global.
+
+## Convention
+
+Add to `AGENTS.md` (Code Style & Patterns): check-state / issue / policy
+scope is the single `Scope` type — use it for filing, silences, and
+incident-target resolution; never add another scope enum or write ad-hoc
+`match (server_id, server_group_id)`. Map through
+`Scope::from_columns`/`to_columns`/`resolve_incident_target`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Avoid writing large summaries of actions taken when done.
 - Use `commons_tests::server::run()` for HTTP endpoint tests
 - Use `commons_tests::server::run_with_device_auth()` for authenticated device tests in the public server
 - Admin endpoints take a `TailscaleAdmin` axum extractor; the React UI gates with `commons.is_current_user_admin`
+- **Check-state / issue / policy scope** is the single `database::issues::Scope` enum (`Server(id)`, `Group(id)`, `Global`) — use it for filing (`CheckFiling.scope`, with `device_id` a *separate* provenance field), scoped silences (`ScopedCheckPolicy`), and incident-target resolution. Never add another scope enum or hand-write `match (server_id, server_group_id)`; map through `Scope::from_columns` / `to_columns` / `resolve_incident_target`. Storage stays two nullable FK columns (`server_id`, `server_group_id`) so Postgres keeps the `ON DELETE CASCADE` + uniqueness that prevents orphaned check-states.
 
 ## Private server architecture
 - **Server fns** under `crates/private-server/src/fns/<module>.rs` are bare axum handlers with `(State, [auth extractor], Json<Args>) -> Result<Json<T>>` signatures.

--- a/crates/commons-servers/src/tailnet_sweeps.rs
+++ b/crates/commons-servers/src/tailnet_sweeps.rs
@@ -6,7 +6,7 @@ use commons_errors::Result;
 use commons_types::{Uuid, status::CheckResult};
 use database::{
 	devices::Device,
-	issues::{CheckFiling, FilingScope, Issue, file_check},
+	issues::{CheckFiling, Issue, Scope, file_check},
 };
 use diesel_async::AsyncPgConnection;
 
@@ -105,10 +105,8 @@ pub async fn sweep_key_expiry(
 			db,
 			CheckFiling {
 				source: TAILSCALE_SOURCE,
-				scope: FilingScope::Server {
-					server_id: *server_id,
-					device_id: Some(device.id),
-				},
+				scope: Scope::Server(*server_id),
+				device_id: Some(device.id),
 				check: KEY_EXPIRY_REF,
 				observed,
 				title: title.as_deref(),

--- a/crates/database/src/backup/reconcile.rs
+++ b/crates/database/src/backup/reconcile.rs
@@ -38,7 +38,7 @@ use uuid::Uuid;
 
 use crate::{
 	backup::{refs, staleness::ScanRow},
-	issues::{CheckFiling, FilingScope, file_check},
+	issues::{CheckFiling, Scope, file_check},
 	servers::Server,
 };
 
@@ -109,7 +109,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Group(row.group_id),
+						scope: Scope::Group(row.group_id),
+						device_id: None,
 						check: &missing_ref,
 						observed: CheckResult::Failed,
 						title: None,
@@ -136,7 +137,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 						db,
 						CheckFiling {
 							source: crate::statuses::CANOPY_SOURCE,
-							scope: FilingScope::Group(row.group_id),
+							scope: Scope::Group(row.group_id),
+							device_id: None,
 							check: &missing_ref,
 							observed: CheckResult::Passed,
 							title: None,
@@ -163,10 +165,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Server {
-							server_id: row.server_id,
-							device_id: row.device_id,
-						},
+						scope: Scope::Server(row.server_id),
+						device_id: row.device_id,
 						check: &gap_ref,
 						observed: CheckResult::Warning,
 						title: None,
@@ -205,10 +205,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Server {
-							server_id: row.server_id,
-							device_id: row.device_id,
-						},
+						scope: Scope::Server(row.server_id),
+						device_id: row.device_id,
 						check: &size_ref,
 						observed: CheckResult::Warning,
 						title: None,
@@ -252,10 +250,8 @@ async fn clear_size_mismatch(
 		db,
 		CheckFiling {
 			source: crate::statuses::CANOPY_SOURCE,
-			scope: FilingScope::Server {
-				server_id: row.server_id,
-				device_id: row.device_id,
-			},
+			scope: Scope::Server(row.server_id),
+			device_id: row.device_id,
 			check: size_ref,
 			observed: CheckResult::Passed,
 			title: None,
@@ -287,10 +283,8 @@ async fn clear_report_gap(
 		db,
 		CheckFiling {
 			source: crate::statuses::CANOPY_SOURCE,
-			scope: FilingScope::Server {
-				server_id: row.server_id,
-				device_id: row.device_id,
-			},
+			scope: Scope::Server(row.server_id),
+			device_id: row.device_id,
 			check: gap_ref,
 			observed: CheckResult::Passed,
 			title: None,
@@ -316,6 +310,14 @@ async fn open_group_active(
 	crate::backup::staleness::open_group_issue_active(db, group_id, r#ref).await
 }
 
+/// Raw snapshot row: `(server_id, type, latest_snapshot_at, observed_at)`.
+type SnapshotRow = (
+	Option<Uuid>,
+	Option<String>,
+	Option<jiff_diesel::Timestamp>,
+	jiff_diesel::Timestamp,
+);
+
 /// Latest snapshot + observed-at per `(server_id, type)` for the given groups.
 /// Rows with a NULL `server_id` (sources we can't attribute to a server) are
 /// skipped.
@@ -329,12 +331,7 @@ async fn snapshot_info(
 		return Ok(HashMap::new());
 	}
 
-	let rows: Vec<(
-		Option<Uuid>,
-		Option<String>,
-		Option<jiff_diesel::Timestamp>,
-		jiff_diesel::Timestamp,
-	)> = s::table
+	let rows: Vec<SnapshotRow> = s::table
 		.filter(s::group_id.eq_any(group_ids))
 		.filter(s::server_id.is_not_null())
 		.select((

--- a/crates/database/src/backup/staleness.rs
+++ b/crates/database/src/backup/staleness.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 use crate::{
 	backup::refs,
-	issues::{CheckFiling, FilingScope, file_check},
+	issues::{CheckFiling, Scope, file_check},
 	servers::Server,
 };
 
@@ -108,6 +108,18 @@ impl ScanRow {
 	}
 }
 
+/// Raw scan-set row: `(server_id, group_id, is_monitored, device_id, type,
+/// expected_interval, config_created_at)`.
+type ScanBaseRow = (
+	Uuid,
+	Uuid,
+	bool,
+	Option<Uuid>,
+	String,
+	crate::pg_duration::PgDuration,
+	jiff_diesel::Timestamp,
+);
+
 /// Build the scan set: every enabled `(server, type)` capability in a
 /// `status='ready'` group whose effective schedule has a non-NULL
 /// `expected_interval`. Per `(server, type)`, attach the latest backup success
@@ -118,18 +130,9 @@ pub async fn scan_rows(db: &mut AsyncPgConnection) -> Result<Vec<ScanRow>> {
 		server_group_backup_config as cfg, server_group_backup_schedule as sched, servers,
 	};
 
-	// (server_id, group_id, is_monitored, device_id, type, expected_interval, config_created_at)
 	// Join: servers -> their group's ready config -> enabled capability ->
 	// per-(group,type) schedule with a non-NULL interval.
-	let base: Vec<(
-		Uuid,
-		Uuid,
-		bool,
-		Option<Uuid>,
-		String,
-		crate::pg_duration::PgDuration,
-		jiff_diesel::Timestamp,
-	)> = servers::table
+	let base: Vec<ScanBaseRow> = servers::table
 		.inner_join(cfg::table.on(cfg::group_id.nullable().eq(servers::group_id)))
 		.inner_join(cap::table.on(cap::server_id.eq(servers::id)))
 		.inner_join(
@@ -240,10 +243,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Server {
-							server_id: row.server_id,
-							device_id: row.device_id,
-						},
+						scope: Scope::Server(row.server_id),
+						device_id: row.device_id,
 						check: &staleness_ref,
 						observed: CheckResult::Failed,
 						title: None,
@@ -273,10 +274,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Server {
-							server_id: row.server_id,
-							device_id: row.device_id,
-						},
+						scope: Scope::Server(row.server_id),
+						device_id: row.device_id,
 						check: &staleness_ref,
 						observed: CheckResult::Passed,
 						title: None,
@@ -307,10 +306,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Server {
-							server_id: row.server_id,
-							device_id: row.device_id,
-						},
+						scope: Scope::Server(row.server_id),
+						device_id: row.device_id,
 						check: &never_ref,
 						observed: CheckResult::Warning,
 						title: None,
@@ -341,10 +338,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 						db,
 						CheckFiling {
 							source: crate::statuses::CANOPY_SOURCE,
-							scope: FilingScope::Server {
-								server_id: row.server_id,
-								device_id: row.device_id,
-							},
+							scope: Scope::Server(row.server_id),
+							device_id: row.device_id,
 							check: &never_ref,
 							observed: CheckResult::Passed,
 							title: None,
@@ -409,7 +404,8 @@ async fn sweep_maintenance(db: &mut AsyncPgConnection, now: Timestamp) -> Result
 				db,
 				CheckFiling {
 					source: crate::statuses::CANOPY_SOURCE,
-					scope: FilingScope::Group(group_id),
+					scope: Scope::Group(group_id),
+					device_id: None,
 					check: refs::MAINTENANCE_STALE,
 					observed: CheckResult::Failed,
 					title: None,
@@ -436,7 +432,8 @@ async fn sweep_maintenance(db: &mut AsyncPgConnection, now: Timestamp) -> Result
 				db,
 				CheckFiling {
 					source: crate::statuses::CANOPY_SOURCE,
-					scope: FilingScope::Group(group_id),
+					scope: Scope::Group(group_id),
+					device_id: None,
 					check: refs::MAINTENANCE_STALE,
 					observed: CheckResult::Passed,
 					title: None,
@@ -463,7 +460,8 @@ async fn sweep_maintenance(db: &mut AsyncPgConnection, now: Timestamp) -> Result
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Group(group_id),
+						scope: Scope::Group(group_id),
+						device_id: None,
 						check: refs::MAINTENANCE_ERROR,
 						observed: CheckResult::Failed,
 						title: None,
@@ -491,7 +489,8 @@ async fn sweep_maintenance(db: &mut AsyncPgConnection, now: Timestamp) -> Result
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Group(group_id),
+						scope: Scope::Group(group_id),
+						device_id: None,
 						check: refs::MAINTENANCE_ERROR,
 						observed: CheckResult::Passed,
 						title: None,

--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -16,6 +16,7 @@
 //! and edit the catalog via the private-server `/api/healthchecks`
 //! endpoints.
 
+use crate::issues::Scope;
 use commons_errors::{AppError, Result};
 use commons_types::status::CheckResult;
 use diesel::prelude::*;
@@ -562,15 +563,6 @@ impl CheckPolicy {
 	}
 }
 
-/// The scope a scoped transform (or silence) attaches to: a server, a
-/// server group, or canopy-wide — mirroring check targets.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PolicyScope {
-	Server(Uuid),
-	Group(Uuid),
-	Global,
-}
-
 /// A result transform scoped to one target, applied after the fleet
 /// catalog: fleet, then group, then server, each acting on the previous
 /// effective result. Either side may be present — a ceiling, a rules
@@ -612,23 +604,15 @@ pub struct ScopedCheckPolicy {
 }
 
 impl ScopedCheckPolicy {
-	fn scope_filter(scope: PolicyScope) -> (Option<Uuid>, Option<Uuid>) {
-		match scope {
-			PolicyScope::Server(id) => (Some(id), None),
-			PolicyScope::Group(id) => (None, Some(id)),
-			PolicyScope::Global => (None, None),
-		}
-	}
-
 	/// The transform at exactly this (scope, source, check), if any.
 	pub async fn get(
 		db: &mut AsyncPgConnection,
-		scope: PolicyScope,
+		scope: Scope,
 		source: &str,
 		check_name: &str,
 	) -> Result<Option<Self>> {
 		use crate::schema::scoped_check_policies::dsl;
-		let (server, group) = Self::scope_filter(scope);
+		let (server, group) = scope.to_columns();
 		dsl::scoped_check_policies
 			.select(Self::as_select())
 			.filter(
@@ -649,13 +633,13 @@ impl ScopedCheckPolicy {
 	/// ceiling becomes skipped. Idempotent.
 	pub async fn silence(
 		db: &mut AsyncPgConnection,
-		scope: PolicyScope,
+		scope: Scope,
 		source: &str,
 		check_name: &str,
 		created_by: Option<&str>,
 	) -> Result<Self> {
 		use crate::schema::scoped_check_policies::dsl;
-		let (server, group) = Self::scope_filter(scope);
+		let (server, group) = scope.to_columns();
 		if let Some(existing) = Self::get(db, scope, source, check_name).await? {
 			return diesel::update(dsl::scoped_check_policies.filter(dsl::id.eq(existing.id)))
 				.set((
@@ -687,7 +671,7 @@ impl ScopedCheckPolicy {
 	/// when scoped rules remain. A no-op if nothing is silenced there.
 	pub async fn unsilence(
 		db: &mut AsyncPgConnection,
-		scope: PolicyScope,
+		scope: Scope,
 		source: &str,
 		check_name: &str,
 	) -> Result<()> {
@@ -721,12 +705,9 @@ impl ScopedCheckPolicy {
 	/// catalog row (decommissioned, or orphaned with no catalog row at all)
 	/// — are excluded: the check contributes to nothing, so its silence is
 	/// dead config that shouldn't clutter the operator's list.
-	pub async fn list_silences(
-		db: &mut AsyncPgConnection,
-		scope: PolicyScope,
-	) -> Result<Vec<Self>> {
+	pub async fn list_silences(db: &mut AsyncPgConnection, scope: Scope) -> Result<Vec<Self>> {
 		use crate::schema::scoped_check_policies::dsl;
-		let (server, group) = Self::scope_filter(scope);
+		let (server, group) = scope.to_columns();
 		let rows: Vec<Self> = dsl::scoped_check_policies
 			.select(Self::as_select())
 			.filter(

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -421,7 +421,7 @@ impl NewEvent {
 					)
 					.await?;
 				}
-				let issue = diesel::update(issues::table.filter(issues::id.eq(existing.id)))
+				diesel::update(issues::table.filter(issues::id.eq(existing.id)))
 					.set((
 						issues::device_id.eq(device_id),
 						issues::description.eq(description),
@@ -452,8 +452,7 @@ impl NewEvent {
 					))
 					.returning(Issue::as_select())
 					.get_result(conn)
-					.await?;
-				issue
+					.await?
 			} else {
 				let inserted: Issue = diesel::insert_into(issues::table)
 					.values((
@@ -777,15 +776,60 @@ pub async fn raise_global_event_with_state(
 	.await
 }
 
-/// Where a canopy-determined check's state attaches.
-#[derive(Debug, Clone, Copy)]
-pub enum FilingScope {
-	Server {
-		server_id: Uuid,
-		device_id: Option<Uuid>,
-	},
+/// The scope a check-state, issue, or scoped policy attaches to: one
+/// server, a server group, or canopy as a whole. This is the single scope
+/// vocabulary for check state — do not reintroduce a parallel scope enum or
+/// an ad-hoc `match (server_id, server_group_id)`; map through the methods
+/// here. Provenance (which device reported a filing) is a separate concern
+/// (see `CheckFiling::device_id`), not part of scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+	Server(Uuid),
 	Group(Uuid),
 	Global,
+}
+
+impl Scope {
+	/// The `(server_id, server_group_id)` storage columns for this scope.
+	pub fn to_columns(self) -> (Option<Uuid>, Option<Uuid>) {
+		match self {
+			Scope::Server(id) => (Some(id), None),
+			Scope::Group(id) => (None, Some(id)),
+			Scope::Global => (None, None),
+		}
+	}
+
+	/// The scope encoded by a `(server_id, server_group_id)` pair. A set
+	/// group wins (the storage CHECK allows at most one set; both null is
+	/// canopy-wide).
+	pub fn from_columns(server_id: Option<Uuid>, server_group_id: Option<Uuid>) -> Self {
+		match (server_id, server_group_id) {
+			(_, Some(gid)) => Scope::Group(gid),
+			(Some(sid), None) => Scope::Server(sid),
+			(None, None) => Scope::Global,
+		}
+	}
+
+	/// Resolve this scope to the incident target it contributes to and
+	/// whether that contribution is monitored. A server maps to its group,
+	/// carrying the server's `is_monitored`; a group targets itself and a
+	/// canopy-wide scope the global target, both always monitored. An
+	/// ungrouped server has no target and no incident path.
+	pub async fn resolve_incident_target(
+		self,
+		conn: &mut AsyncPgConnection,
+	) -> Result<Option<(IncidentTarget, bool)>> {
+		match self {
+			Scope::Group(gid) => Ok(Some((IncidentTarget::Group(gid), true))),
+			Scope::Server(sid) => {
+				let server = Server::get_by_id(conn, sid).await?;
+				Ok(server
+					.group_id
+					.map(|gid| (IncidentTarget::Group(gid), server.is_monitored)))
+			}
+			Scope::Global => Ok(Some((IncidentTarget::Global, true))),
+		}
+	}
 }
 
 /// The source operator-raised manual conditions file under.
@@ -800,7 +844,10 @@ pub struct CheckFiling<'a> {
 	/// operator-raised conditions (server scope only), `canopy` for
 	/// canopy's own determinations.
 	pub source: &'a str,
-	pub scope: FilingScope,
+	pub scope: Scope,
+	/// The reporting device, for server-scoped filings — provenance, not
+	/// scope. `None` for operator/platform filings and non-server scopes.
+	pub device_id: Option<Uuid>,
 	/// The check's stable name (doubles as the issue ref under the
 	/// source): a contract with stored silences.
 	pub check: &'a str,
@@ -840,8 +887,7 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 
 	let source = filing.source;
 	debug_assert!(
-		matches!(filing.scope, FilingScope::Server { .. })
-			|| source == crate::statuses::CANOPY_SOURCE,
+		matches!(filing.scope, Scope::Server(_)) || source == crate::statuses::CANOPY_SOURCE,
 		"group- and canopy-wide filings are canopy's own",
 	);
 	CheckPolicy::register(
@@ -876,7 +922,7 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 		Option<Uuid>,
 		Option<Uuid>,
 	) = match filing.scope {
-		FilingScope::Server { server_id, .. } => {
+		Scope::Server(server_id) => {
 			let server = Server::get_by_id(conn, server_id).await?;
 			let group_id = server.group_id;
 			let tags = server
@@ -888,8 +934,8 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 				.collect();
 			(tags, Some(server_id), group_id)
 		}
-		FilingScope::Group(group_id) => (Default::default(), None, Some(group_id)),
-		FilingScope::Global => (Default::default(), None, None),
+		Scope::Group(group_id) => (Default::default(), None, Some(group_id)),
+		Scope::Global => (Default::default(), None, None),
 	};
 	let ctx = EvaluationContext {
 		status_extra: &status_extra,
@@ -921,10 +967,7 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 	};
 
 	match filing.scope {
-		FilingScope::Server {
-			server_id,
-			device_id,
-		} => {
+		Scope::Server(server_id) => {
 			NewEvent {
 				source: source.to_string(),
 				r#ref: filing.check.to_string(),
@@ -933,10 +976,10 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 				active: Some(active),
 				occurred_at: None,
 			}
-			.save_with_state(conn, server_id, device_id, Some(&stamp), false)
+			.save_with_state(conn, server_id, filing.device_id, Some(&stamp), false)
 			.await
 		}
-		FilingScope::Group(gid) => {
+		Scope::Group(gid) => {
 			raise_group_event_with_state(
 				conn,
 				gid,
@@ -948,7 +991,7 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 			)
 			.await
 		}
-		FilingScope::Global => {
+		Scope::Global => {
 			raise_global_event_with_state(
 				conn,
 				filing.check,
@@ -1292,7 +1335,7 @@ async fn re_evaluate_incident_membership(
 	use crate::schema::{incident_issues, incidents};
 
 	let was_in = is_issue_in_open_incident(conn, issue.id).await?;
-	let snoozed = issue.snoozed_until.map_or(false, |t| t > Timestamp::now());
+	let snoozed = issue.snoozed_until.is_some_and(|t| t > Timestamp::now());
 	// A group-scoped issue (server_id = None) can only be silenced at the
 	// group level; pass the nil server so only the group list is consulted.
 	// Canopy-wide issues have no silence scope (yet).
@@ -1520,16 +1563,9 @@ async fn issue_target_and_monitored(
 	conn: &mut AsyncPgConnection,
 	issue: &Issue,
 ) -> Result<Option<(IncidentTarget, bool)>> {
-	match (issue.server_id, issue.server_group_id) {
-		(_, Some(gid)) => Ok(Some((IncidentTarget::Group(gid), true))),
-		(Some(sid), None) => {
-			let server = Server::get_by_id(conn, sid).await?;
-			Ok(server
-				.group_id
-				.map(|gid| (IncidentTarget::Group(gid), server.is_monitored)))
-		}
-		(None, None) => Ok(Some((IncidentTarget::Global, true))),
-	}
+	Scope::from_columns(issue.server_id, issue.server_group_id)
+		.resolve_incident_target(conn)
+		.await
 }
 
 /// Re-evaluate every currently-open issue on `server_id` against incident
@@ -1853,10 +1889,14 @@ pub async fn reconcile_open_incidents(db: &mut AsyncPgConnection) -> Result<(usi
 		let now = Timestamp::now();
 		let mut evaluated = 0usize;
 		for issue in open_issues {
-			match (issue.server_id, issue.server_group_id) {
+			// Classify via the shared scope vocabulary, but resolve the
+			// server case from the batched `by_id` map (rather than
+			// `Scope::resolve_incident_target`, which queries per issue) to
+			// keep this startup sweep to a single server fetch.
+			match Scope::from_columns(issue.server_id, issue.server_group_id) {
 				// Group-scoped issue: resolve its group directly, bypass the
 				// per-server is_monitored gate (monitored = true).
-				(None, Some(gid)) => {
+				Scope::Group(gid) => {
 					re_evaluate_incident_membership(
 						conn,
 						&issue,
@@ -1869,7 +1909,7 @@ pub async fn reconcile_open_incidents(db: &mut AsyncPgConnection) -> Result<(usi
 					evaluated += 1;
 				}
 				// Server-scoped issue: look up the server and its group.
-				(Some(sid), _) => {
+				Scope::Server(sid) => {
 					let Some(server) = by_id.get(&sid) else {
 						continue;
 					};
@@ -1889,7 +1929,7 @@ pub async fn reconcile_open_incidents(db: &mut AsyncPgConnection) -> Result<(usi
 					evaluated += 1;
 				}
 				// Canopy-wide issue: the global target, always monitored.
-				(None, None) => {
+				Scope::Global => {
 					re_evaluate_incident_membership(
 						conn,
 						&issue,

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 use crate::backup::refs;
 use crate::backups::BackupRun;
-use crate::issues::{CheckFiling, FilingScope, file_check};
+use crate::issues::{CheckFiling, Scope, file_check};
 use crate::pg_duration::PgDuration;
 
 /// An operator's declaration that a restore consumer should maintain a
@@ -449,10 +449,7 @@ async fn recover_old_scope_alerts(
 			db,
 			CheckFiling {
 				source: crate::statuses::CANOPY_SOURCE,
-				scope: FilingScope::Server {
-					server_id: sid,
-					device_id: None,
-				},
+				scope: Scope::Server(sid), device_id: None,
 				check: &r#ref,
 				observed: CheckResult::Passed,
 				title: None,
@@ -596,10 +593,8 @@ impl BackupRestoreCheck {
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Server {
-							server_id: sid,
-							device_id: None,
-						},
+						scope: Scope::Server(sid),
+						device_id: None,
 						check: &r#ref,
 						observed: CheckResult::Passed,
 						title: None,
@@ -624,10 +619,8 @@ impl BackupRestoreCheck {
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: FilingScope::Server {
-							server_id: sid,
-							device_id: None,
-						},
+						scope: Scope::Server(sid),
+						device_id: None,
 						check: &r#ref,
 						observed: CheckResult::Failed,
 						title: Some("restore verification failed"),
@@ -875,10 +868,8 @@ pub async fn sweep_overdue(db: &mut AsyncPgConnection) -> Result<usize> {
 				db,
 				CheckFiling {
 					source: crate::statuses::CANOPY_SOURCE,
-					scope: FilingScope::Server {
-						server_id: sid,
-						device_id: None,
-					},
+					scope: Scope::Server(sid),
+					device_id: None,
 					check: &r#ref,
 					observed: CheckResult::Failed,
 					title: Some("restore verification overdue"),

--- a/crates/database/src/self_alerts.rs
+++ b/crates/database/src/self_alerts.rs
@@ -13,7 +13,7 @@ use commons_errors::Result;
 use commons_types::status::CheckResult;
 use diesel_async::AsyncPgConnection;
 
-use crate::issues::{CheckFiling, FilingScope, Issue, file_check, get_global_issue};
+use crate::issues::{CheckFiling, Issue, Scope, file_check, get_global_issue};
 
 /// An operator-notification delivery permanently failed (the drainer gave up
 /// on an outbox row). No automatic recovery: stays until operator-resolved.
@@ -111,7 +111,8 @@ pub async fn raise(
 		conn,
 		CheckFiling {
 			source: crate::statuses::CANOPY_SOURCE,
-			scope: FilingScope::Global,
+			scope: Scope::Global,
+			device_id: None,
 			check: r#ref,
 			observed,
 			title: Some(title),
@@ -147,7 +148,8 @@ pub async fn recover(
 		conn,
 		CheckFiling {
 			source: crate::statuses::CANOPY_SOURCE,
-			scope: FilingScope::Global,
+			scope: Scope::Global,
+			device_id: None,
 			check: r#ref,
 			observed: CheckResult::Passed,
 			title: None,

--- a/crates/database/src/silenced_refs.rs
+++ b/crates/database/src/silenced_refs.rs
@@ -21,9 +21,10 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::check_policies::{PolicyScope, ScopedCheckPolicy};
+use crate::check_policies::ScopedCheckPolicy;
 use crate::issues::{
-	MANUAL_SOURCE, reevaluate_open_issues_for_group_ref, reevaluate_open_issues_for_server_ref,
+	MANUAL_SOURCE, Scope, reevaluate_open_issues_for_group_ref,
+	reevaluate_open_issues_for_server_ref,
 };
 use crate::statuses::CANOPY_SOURCE;
 
@@ -99,15 +100,14 @@ pub async fn is_silenced(
 	let check = ref_to_check(r#ref);
 	let is_silence =
 		|p: Option<ScopedCheckPolicy>| p.is_some_and(|p| p.ceiling.as_deref() == Some("skipped"));
-	if is_silence(ScopedCheckPolicy::get(db, PolicyScope::Server(server_id), source, check).await?)
-	{
+	if is_silence(ScopedCheckPolicy::get(db, Scope::Server(server_id), source, check).await?) {
 		return Ok(true);
 	}
 	let Some(gid) = group_id else {
 		return Ok(false);
 	};
 	Ok(is_silence(
-		ScopedCheckPolicy::get(db, PolicyScope::Group(gid), source, check).await?,
+		ScopedCheckPolicy::get(db, Scope::Group(gid), source, check).await?,
 	))
 }
 
@@ -165,7 +165,7 @@ impl ServerSilencedRef {
 	) -> Result<Self> {
 		let policy = ScopedCheckPolicy::silence(
 			db,
-			PolicyScope::Server(server_id),
+			Scope::Server(server_id),
 			source,
 			ref_to_check(r#ref),
 			created_by,
@@ -183,20 +183,15 @@ impl ServerSilencedRef {
 		source: &str,
 		r#ref: &str,
 	) -> Result<()> {
-		ScopedCheckPolicy::unsilence(
-			db,
-			PolicyScope::Server(server_id),
-			source,
-			ref_to_check(r#ref),
-		)
-		.await?;
+		ScopedCheckPolicy::unsilence(db, Scope::Server(server_id), source, ref_to_check(r#ref))
+			.await?;
 		reevaluate_open_issues_for_server_ref(db, server_id, source, r#ref).await?;
 		Ok(())
 	}
 
 	pub async fn list_for_server(db: &mut AsyncPgConnection, server_id: Uuid) -> Result<Vec<Self>> {
 		Ok(
-			ScopedCheckPolicy::list_silences(db, PolicyScope::Server(server_id))
+			ScopedCheckPolicy::list_silences(db, Scope::Server(server_id))
 				.await?
 				.into_iter()
 				.filter_map(Self::from_policy)
@@ -225,7 +220,7 @@ impl ServerGroupSilencedRef {
 	) -> Result<Self> {
 		let policy = ScopedCheckPolicy::silence(
 			db,
-			PolicyScope::Group(server_group_id),
+			Scope::Group(server_group_id),
 			source,
 			ref_to_check(r#ref),
 			created_by,
@@ -243,7 +238,7 @@ impl ServerGroupSilencedRef {
 	) -> Result<()> {
 		ScopedCheckPolicy::unsilence(
 			db,
-			PolicyScope::Group(server_group_id),
+			Scope::Group(server_group_id),
 			source,
 			ref_to_check(r#ref),
 		)
@@ -257,7 +252,7 @@ impl ServerGroupSilencedRef {
 		server_group_id: Uuid,
 	) -> Result<Vec<Self>> {
 		Ok(
-			ScopedCheckPolicy::list_silences(db, PolicyScope::Group(server_group_id))
+			ScopedCheckPolicy::list_silences(db, Scope::Group(server_group_id))
 				.await?
 				.into_iter()
 				.filter_map(Self::from_policy)

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -401,10 +401,8 @@ impl Status {
 				db,
 				crate::issues::CheckFiling {
 					source: CANOPY_SOURCE,
-					scope: crate::issues::FilingScope::Server {
-						server_id: server.id,
-						device_id: None,
-					},
+					scope: crate::issues::Scope::Server(server.id),
+					device_id: None,
 					check: REACHABILITY_REF,
 					observed,
 					title: Some("Server reachability"),

--- a/crates/database/tests/it/check_liveness.rs
+++ b/crates/database/tests/it/check_liveness.rs
@@ -4,7 +4,7 @@
 
 use commons_types::status::{CheckResult, HealthState};
 use database::check_policies::CheckPolicy;
-use database::issues::{CheckFiling, FilingScope, Issue, file_check, health_from_check_state};
+use database::issues::{CheckFiling, Issue, Scope, file_check, health_from_check_state};
 use diesel::{QueryableByName, sql_query, sql_types};
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
@@ -17,10 +17,8 @@ fn filing_result<'a>(
 ) -> CheckFiling<'a> {
 	CheckFiling {
 		source,
-		scope: FilingScope::Server {
-			server_id,
-			device_id: None,
-		},
+		scope: Scope::Server(server_id),
+		device_id: None,
 		check,
 		observed,
 		title: Some("decommission test"),
@@ -50,10 +48,8 @@ async fn insert_server(conn: &mut diesel_async::AsyncPgConnection) -> Uuid {
 fn filing<'a>(server_id: Uuid, source: &'a str, check: &'a str) -> CheckFiling<'a> {
 	CheckFiling {
 		source,
-		scope: FilingScope::Server {
-			server_id,
-			device_id: None,
-		},
+		scope: Scope::Server(server_id),
+		device_id: None,
 		check,
 		observed: CheckResult::Passed,
 		title: None,

--- a/crates/database/tests/it/consolidated_checks.rs
+++ b/crates/database/tests/it/consolidated_checks.rs
@@ -2,7 +2,7 @@
 //! every source, graded, with the health rollup matching the headline.
 
 use commons_types::status::{CheckResult, HealthState};
-use database::issues::{CheckFiling, FilingScope, consolidated_checks_latest, file_check};
+use database::issues::{CheckFiling, Scope, consolidated_checks_latest, file_check};
 use diesel::{QueryableByName, sql_query, sql_types};
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
@@ -31,10 +31,8 @@ fn filing<'a>(
 ) -> CheckFiling<'a> {
 	CheckFiling {
 		source,
-		scope: FilingScope::Server {
-			server_id,
-			device_id: None,
-		},
+		scope: Scope::Server(server_id),
+		device_id: None,
 		check,
 		observed,
 		title: None,

--- a/crates/database/tests/it/health_rollup.rs
+++ b/crates/database/tests/it/health_rollup.rs
@@ -5,7 +5,7 @@
 
 use commons_types::issue::ResolvedReason;
 use commons_types::status::{CheckResult, HealthState};
-use database::issues::{CheckFiling, FilingScope, Issue, file_check, health_from_check_state};
+use database::issues::{CheckFiling, Issue, Scope, file_check, health_from_check_state};
 use diesel::{QueryableByName, sql_query, sql_types};
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
@@ -28,10 +28,8 @@ async fn insert_server(conn: &mut diesel_async::AsyncPgConnection) -> Uuid {
 fn failed_filing(server_id: Uuid, check: &str) -> CheckFiling<'_> {
 	CheckFiling {
 		source: "alertd",
-		scope: FilingScope::Server {
-			server_id,
-			device_id: None,
-		},
+		scope: Scope::Server(server_id),
+		device_id: None,
 		check,
 		observed: CheckResult::Failed,
 		title: Some("rollup test"),

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -24,6 +24,7 @@ mod mcp_tokens;
 mod reachability_sweep;
 mod recovery_vault;
 mod restore;
+mod scope;
 mod scoped_check_policies;
 mod self_alerts;
 mod server_enrollment;

--- a/crates/database/tests/it/scope.rs
+++ b/crates/database/tests/it/scope.rs
@@ -1,0 +1,105 @@
+//! The unified `Scope` type: storage-column mapping and incident-target
+//! resolution — the single place check-state scope is interpreted.
+
+use database::issues::{IncidentTarget, Scope};
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[test]
+fn columns_round_trip() {
+	let s = Uuid::new_v4();
+	let g = Uuid::new_v4();
+	assert_eq!(Scope::Server(s).to_columns(), (Some(s), None));
+	assert_eq!(Scope::Group(g).to_columns(), (None, Some(g)));
+	assert_eq!(Scope::Global.to_columns(), (None, None));
+	assert_eq!(Scope::from_columns(Some(s), None), Scope::Server(s));
+	assert_eq!(Scope::from_columns(None, Some(g)), Scope::Group(g));
+	assert_eq!(Scope::from_columns(None, None), Scope::Global);
+	// The storage CHECK forbids both being set; if it ever happens, a set
+	// group wins (matches the historical scope-resolution order).
+	assert_eq!(Scope::from_columns(Some(s), Some(g)), Scope::Group(g));
+}
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_group(conn: &mut diesel_async::AsyncPgConnection) -> Uuid {
+	let row: RowId = sql_query("INSERT INTO server_groups (name) VALUES ('g') RETURNING id")
+		.get_result(conn)
+		.await
+		.expect("insert group");
+	row.id
+}
+
+async fn insert_server(
+	conn: &mut diesel_async::AsyncPgConnection,
+	host: &str,
+	group: Option<Uuid>,
+	monitored: bool,
+) -> Uuid {
+	let row: RowId = sql_query(
+		"INSERT INTO servers (host, group_id, is_monitored) VALUES ($1, $2, $3) RETURNING id",
+	)
+	.bind::<sql_types::Text, _>(host)
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(group)
+	.bind::<sql_types::Bool, _>(monitored)
+	.get_result(conn)
+	.await
+	.expect("insert server");
+	row.id
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn resolve_incident_target_by_scope() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn).await;
+		let monitored = insert_server(&mut conn, "http://mon.invalid/", Some(group), true).await;
+		let unmonitored =
+			insert_server(&mut conn, "http://unmon.invalid/", Some(group), false).await;
+		let ungrouped = insert_server(&mut conn, "http://ungrouped.invalid/", None, true).await;
+
+		// A server in a group targets its group, carrying its is_monitored.
+		assert_eq!(
+			Scope::Server(monitored)
+				.resolve_incident_target(&mut conn)
+				.await
+				.expect("resolve"),
+			Some((IncidentTarget::Group(group), true)),
+		);
+		assert_eq!(
+			Scope::Server(unmonitored)
+				.resolve_incident_target(&mut conn)
+				.await
+				.expect("resolve"),
+			Some((IncidentTarget::Group(group), false)),
+		);
+		// An ungrouped server has no target and no incident path.
+		assert_eq!(
+			Scope::Server(ungrouped)
+				.resolve_incident_target(&mut conn)
+				.await
+				.expect("resolve"),
+			None,
+		);
+		// Group and canopy-wide scopes target themselves, always monitored.
+		assert_eq!(
+			Scope::Group(group)
+				.resolve_incident_target(&mut conn)
+				.await
+				.expect("resolve"),
+			Some((IncidentTarget::Group(group), true)),
+		);
+		assert_eq!(
+			Scope::Global
+				.resolve_incident_target(&mut conn)
+				.await
+				.expect("resolve"),
+			Some((IncidentTarget::Global, true)),
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/scoped_check_policies.rs
+++ b/crates/database/tests/it/scoped_check_policies.rs
@@ -5,8 +5,8 @@
 
 use commons_types::status::CheckResult;
 use database::{
-	check_policies::{CheckPolicy, EvaluationContext, PolicyScope, ScopedCheckPolicy},
-	issues::{CheckFiling, FilingScope, Issue, file_check},
+	check_policies::{CheckPolicy, EvaluationContext, ScopedCheckPolicy},
+	issues::{CheckFiling, Issue, Scope, file_check},
 	silenced_refs::ServerSilencedRef,
 	statuses::CANOPY_SOURCE,
 };
@@ -42,10 +42,8 @@ async fn insert_server(conn: &mut diesel_async::AsyncPgConnection, group_id: Opt
 fn filing(server_id: Uuid, check: &str, observed: CheckResult) -> CheckFiling<'_> {
 	CheckFiling {
 		source: CANOPY_SOURCE,
-		scope: FilingScope::Server {
-			server_id,
-			device_id: None,
-		},
+		scope: Scope::Server(server_id),
+		device_id: None,
 		check,
 		observed,
 		title: Some("Scoped test"),
@@ -101,7 +99,7 @@ async fn group_silence_covers_member_servers() {
 		let server_id = insert_server(&mut conn, Some(group_id)).await;
 		ScopedCheckPolicy::silence(
 			&mut conn,
-			PolicyScope::Group(group_id),
+			Scope::Group(group_id),
 			CANOPY_SOURCE,
 			"noisy",
 			Some("op"),
@@ -117,14 +115,9 @@ async fn group_silence_covers_member_servers() {
 
 		// Lifting the group silence restores normal grading on the next
 		// filing.
-		ScopedCheckPolicy::unsilence(
-			&mut conn,
-			PolicyScope::Group(group_id),
-			CANOPY_SOURCE,
-			"noisy",
-		)
-		.await
-		.expect("unsilence");
+		ScopedCheckPolicy::unsilence(&mut conn, Scope::Group(group_id), CANOPY_SOURCE, "noisy")
+			.await
+			.expect("unsilence");
 		file_check(&mut conn, filing(server_id, "noisy", CheckResult::Failed))
 			.await
 			.expect("file again");
@@ -229,48 +222,40 @@ async fn silence_on_a_scoped_rule_row_keeps_the_rules() {
 
 		ScopedCheckPolicy::silence(
 			&mut conn,
-			PolicyScope::Server(server_id),
+			Scope::Server(server_id),
 			"alertd",
 			"ruled",
 			Some("op"),
 		)
 		.await
 		.expect("silence");
-		let row =
-			ScopedCheckPolicy::get(&mut conn, PolicyScope::Server(server_id), "alertd", "ruled")
-				.await
-				.expect("get")
-				.expect("row exists");
+		let row = ScopedCheckPolicy::get(&mut conn, Scope::Server(server_id), "alertd", "ruled")
+			.await
+			.expect("get")
+			.expect("row exists");
 		assert_eq!(row.ceiling.as_deref(), Some("skipped"));
 		assert!(row.rules.is_some(), "silencing keeps the scoped rules");
 
 		// Unsilencing lifts the ceiling but keeps the rules row.
-		ScopedCheckPolicy::unsilence(&mut conn, PolicyScope::Server(server_id), "alertd", "ruled")
+		ScopedCheckPolicy::unsilence(&mut conn, Scope::Server(server_id), "alertd", "ruled")
 			.await
 			.expect("unsilence");
-		let row =
-			ScopedCheckPolicy::get(&mut conn, PolicyScope::Server(server_id), "alertd", "ruled")
-				.await
-				.expect("get")
-				.expect("row still exists");
+		let row = ScopedCheckPolicy::get(&mut conn, Scope::Server(server_id), "alertd", "ruled")
+			.await
+			.expect("get")
+			.expect("row still exists");
 		assert_eq!(row.ceiling, None);
 		assert!(row.rules.is_some());
 
 		// A plain silence row deletes outright on unsilence.
-		ScopedCheckPolicy::silence(
-			&mut conn,
-			PolicyScope::Server(server_id),
-			"alertd",
-			"plain",
-			None,
-		)
-		.await
-		.expect("plain silence");
-		ScopedCheckPolicy::unsilence(&mut conn, PolicyScope::Server(server_id), "alertd", "plain")
+		ScopedCheckPolicy::silence(&mut conn, Scope::Server(server_id), "alertd", "plain", None)
+			.await
+			.expect("plain silence");
+		ScopedCheckPolicy::unsilence(&mut conn, Scope::Server(server_id), "alertd", "plain")
 			.await
 			.expect("plain unsilence");
 		assert!(
-			ScopedCheckPolicy::get(&mut conn, PolicyScope::Server(server_id), "alertd", "plain")
+			ScopedCheckPolicy::get(&mut conn, Scope::Server(server_id), "alertd", "plain")
 				.await
 				.expect("get")
 				.is_none()
@@ -288,7 +273,7 @@ async fn decommission_clears_the_checks_silences() {
 			.expect("seed catalog");
 		ScopedCheckPolicy::silence(
 			&mut conn,
-			PolicyScope::Server(server_id),
+			Scope::Server(server_id),
 			"alertd",
 			"noisy",
 			Some("op"),
@@ -302,7 +287,7 @@ async fn decommission_clears_the_checks_silences() {
 
 		// The silence row is deleted outright, not just hidden.
 		assert!(
-			ScopedCheckPolicy::get(&mut conn, PolicyScope::Server(server_id), "alertd", "noisy")
+			ScopedCheckPolicy::get(&mut conn, Scope::Server(server_id), "alertd", "noisy")
 				.await
 				.expect("get")
 				.is_none(),
@@ -321,7 +306,7 @@ async fn list_silences_excludes_orphaned_check_silences() {
 			.expect("seed catalog");
 		ScopedCheckPolicy::silence(
 			&mut conn,
-			PolicyScope::Server(server_id),
+			Scope::Server(server_id),
 			"bestool-alertd",
 			"sync",
 			Some("op"),
@@ -329,7 +314,7 @@ async fn list_silences_excludes_orphaned_check_silences() {
 		.await
 		.expect("silence");
 		assert_eq!(
-			ScopedCheckPolicy::list_silences(&mut conn, PolicyScope::Server(server_id))
+			ScopedCheckPolicy::list_silences(&mut conn, Scope::Server(server_id))
 				.await
 				.expect("list")
 				.len(),
@@ -343,7 +328,7 @@ async fn list_silences_excludes_orphaned_check_silences() {
 			.expect("orphan the check");
 
 		assert!(
-			ScopedCheckPolicy::list_silences(&mut conn, PolicyScope::Server(server_id))
+			ScopedCheckPolicy::list_silences(&mut conn, Scope::Server(server_id))
 				.await
 				.expect("list")
 				.is_empty(),

--- a/crates/database/tests/it/self_alerts.rs
+++ b/crates/database/tests/it/self_alerts.rs
@@ -255,10 +255,8 @@ async fn quiet_check(conn: &mut diesel_async::AsyncPgConnection, check: &str, ho
 		conn,
 		database::issues::CheckFiling {
 			source: "alertd",
-			scope: database::issues::FilingScope::Server {
-				server_id,
-				device_id: None,
-			},
+			scope: database::issues::Scope::Server(server_id),
+			device_id: None,
 			check,
 			observed: CheckResult::Passed,
 			title: None,

--- a/crates/jobs/src/backup/complete.rs
+++ b/crates/jobs/src/backup/complete.rs
@@ -117,7 +117,8 @@ pub(crate) async fn complete_inspect(
 		db,
 		database::issues::CheckFiling {
 			source: database::statuses::CANOPY_SOURCE,
-			scope: database::issues::FilingScope::Group(group_id),
+			scope: database::issues::Scope::Group(group_id),
+			device_id: None,
 			check: database::backup::refs::CORRUPTION,
 			observed,
 			title,

--- a/crates/jobs/src/backup/preflight.rs
+++ b/crates/jobs/src/backup/preflight.rs
@@ -26,7 +26,7 @@ use commons_types::status::CheckResult;
 use database::{
 	BackupConfigStatus, ServerGroupBackupConfig,
 	backup::refs,
-	issues::{CheckFiling, FilingScope, file_check},
+	issues::{CheckFiling, Scope, file_check},
 };
 use jiff::Timestamp;
 use tokio::{
@@ -98,7 +98,8 @@ async fn recover_identity_alert(
 			db,
 			CheckFiling {
 				source: database::statuses::CANOPY_SOURCE,
-				scope: FilingScope::Group(group_id),
+				scope: Scope::Group(group_id),
+				device_id: None,
 				check: refs::PREFLIGHT_IDENTITY,
 				observed: CheckResult::Passed,
 				title: None,
@@ -245,7 +246,8 @@ async fn deep_check_group(
 				db,
 				CheckFiling {
 					source: database::statuses::CANOPY_SOURCE,
-					scope: FilingScope::Group(cfg.group_id),
+					scope: Scope::Group(cfg.group_id),
+					device_id: None,
 					check: refs::PREFLIGHT_ASSUME,
 					observed: CheckResult::Passed,
 					title: None,
@@ -264,7 +266,8 @@ async fn deep_check_group(
 				db,
 				CheckFiling {
 					source: database::statuses::CANOPY_SOURCE,
-					scope: FilingScope::Group(cfg.group_id),
+					scope: Scope::Group(cfg.group_id),
+					device_id: None,
 					check: refs::PREFLIGHT_ASSUME,
 					observed: CheckResult::Failed,
 					title: Some("backup maintenance-role access failed"),
@@ -284,7 +287,8 @@ async fn deep_check_group(
 				db,
 				CheckFiling {
 					source: database::statuses::CANOPY_SOURCE,
-					scope: FilingScope::Group(cfg.group_id),
+					scope: Scope::Group(cfg.group_id),
+					device_id: None,
 					check: refs::PREFLIGHT_OBJECT_LOCK,
 					observed: CheckResult::Passed,
 					title: None,
@@ -303,7 +307,8 @@ async fn deep_check_group(
 				db,
 				CheckFiling {
 					source: database::statuses::CANOPY_SOURCE,
-					scope: FilingScope::Group(cfg.group_id),
+					scope: Scope::Group(cfg.group_id),
+					device_id: None,
 					check: refs::PREFLIGHT_OBJECT_LOCK,
 					observed: CheckResult::Failed,
 					title: Some("bucket Object-Lock missing or weakened"),

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -5,8 +5,8 @@ use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::{TailscaleAdmin, TailscaleUser};
 use commons_types::{Uuid, issue::ResolvedReason, status::CheckResult};
 use database::issues::{
-	CheckFiling, FilingScope, Incident, Issue, IssueFilter, IssueIncidentRef, IssueListFilters,
-	MANUAL_SOURCE, file_check,
+	CheckFiling, Incident, Issue, IssueFilter, IssueIncidentRef, IssueListFilters, MANUAL_SOURCE,
+	Scope, file_check,
 };
 use database::notes::IssueNote;
 use database::servers::Server;
@@ -517,10 +517,8 @@ pub async fn submit_manual_event(
 		&mut conn,
 		CheckFiling {
 			source: MANUAL_SOURCE,
-			scope: FilingScope::Server {
-				server_id: args.server_id,
-				device_id: None,
-			},
+			scope: Scope::Server(args.server_id),
+			device_id: None,
 			check: &args.r#ref,
 			observed,
 			title: args.description.as_deref(),


### PR DESCRIPTION
🤖 Follow-up to the scope discussion. Check-state scope (server / group / canopy-wide) was modelled **three ways** — `FilingScope` (write side, which also bundled the reporting device), `PolicyScope` (scoped silences), and an ad-hoc `match (server_id, server_group_id)` duplicated verbatim in `issue_target_and_monitored` and `reconcile_open_incidents`. This unifies them.

## Design (chosen approach)

One `Scope { Server(Uuid), Group(Uuid), Global }` in `database::issues`, with the single place that maps to/from storage and to an incident target:
- `to_columns` / `from_columns` — the `(server_id, server_group_id)` mapping;
- `resolve_incident_target` — the one implementation of the old duplicated match (server → its group + `is_monitored`; group → itself; global → Global; ungrouped server → none).

`FilingScope` and `PolicyScope` are removed. `CheckFiling` carries `scope: Scope` plus a **separate** `device_id` (provenance, decoupled from scope). `ScopedCheckPolicy` + the `silenced_refs` shim take `Scope`.

## Why not a `(scope, scope_record_id)` column

We considered a polymorphic column but it cant FK to two tables, so it would sacrifice the `ON DELETE CASCADE` + partial-unique-index integrity Postgres enforces today — the very thing that prevents orphaned check-states (the class of bug fixed in #388/#389/#390/#391). So **storage is unchanged** (two nullable FK columns); this is a Rust-only unification.

## Safety

No behaviour change, no schema change. The **full suite (812) passes unchanged** — the correctness bar for a pure refactor — plus new `Scope` unit tests for the column and incident-target mapping. `AGENTS.md` records the convention so no fourth scope representation gets built.

Stacked on #392 (both touch filing); rebases onto main once that merges. Spec/plan: `.workhorse/plans/scope-unification.md`.