### PR TITLE
Munin link on the server detail view

### DIFF
--- a/.workhorse/specs/private-server/server-service-links.md
+++ b/.workhorse/specs/private-server/server-service-links.md
@@ -1,0 +1,23 @@
+---
+id: SVC
+---
+
+# Server service links
+
+A server's detail view links an operator out to the web services running on that server, so an operator can jump from Canopy straight to the server's own interfaces.
+How a server reports its metadata is the status contract (see [STA](../public-server/statuses.md)); the tailnet identity these links resolve against is the device-trust model (see [DTR](device-trust.md)).
+
+## Application link
+
+When a server has a known address — its configured URL, or its bound device's tailnet name when it has no configured URL — the detail view offers a link that opens the server's application in a new tab.
+A server with no known address offers no application link.
+
+## Munin link
+
+A server reports whether it runs Munin as a field in its pushed status.
+Canopy remembers the value with grace: the most recently reported value persists, a status that omits the flag leaves it unchanged, and the value is not bound by the window that governs a server's live status.
+So once a server has reported running Munin the link stays available even after the server stops reporting, and a server that reports it has stopped running Munin loses the link.
+
+The detail view offers a link to a server's Munin only when the server is known to run Munin and has a bound tailnet name.
+The link opens the server's Munin in a new tab, over HTTPS at the server's tailnet MagicDNS name on port 4950.
+A server not known to run Munin, or without a tailnet name, offers no Munin link.

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -569,6 +569,34 @@ impl Status {
 			.map_err(AppError::from)
 	}
 
+	/// Whether `server` runs Munin, from the most recent status that carried
+	/// the `munin` flag — **not** bounded by the live 7-day window. Once a
+	/// server reports the flag the value persists even after it goes quiet,
+	/// and a later status that omits the flag leaves it untouched; only an
+	/// explicit later value overrides it. Returns `None` when the server has
+	/// never reported the flag.
+	// spec: SVC#munin-link
+	pub async fn latest_munin_for_server(
+		db: &mut AsyncPgConnection,
+		server: Uuid,
+	) -> Result<Option<bool>> {
+		use crate::schema::statuses::dsl::*;
+
+		let row: Option<Status> = statuses
+			.select(Status::as_select())
+			.filter(server_id.eq(server).and(id.ne(Uuid::nil())))
+			.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
+				"jsonb_exists(extra, 'munin')",
+			))
+			.order(created_at.desc())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)?;
+
+		Ok(row.map(|st| st.extra("munin").and_then(|v| v.as_bool()).unwrap_or(false)))
+	}
+
 	pub async fn latest_for_servers(
 		db: &mut AsyncPgConnection,
 		server_ids: &[Uuid],

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -34,4 +34,5 @@ mod server_restore_window;
 mod silenced_health_checks;
 mod slack_outbox_enqueue;
 mod statuses_device_fk;
+mod statuses_munin;
 mod tag_reserved_prefix;

--- a/crates/database/tests/it/statuses_munin.rs
+++ b/crates/database/tests/it/statuses_munin.rs
@@ -1,0 +1,82 @@
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use uuid::Uuid;
+
+use database::statuses::Status;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+/// `extra` and `created_at` are test-controlled SQL literals, interpolated
+/// directly; the server id is bound.
+async fn insert_status(
+	conn: &mut AsyncPgConnection,
+	server_id: Uuid,
+	extra: &str,
+	created_at: &str,
+) {
+	let query = format!(
+		"INSERT INTO statuses (server_id, extra, created_at) VALUES ($1, {extra}::jsonb, {created_at})"
+	);
+	sql_query(query)
+		.bind::<sql_types::Uuid, _>(server_id)
+		.execute(conn)
+		.await
+		.expect("insert status");
+}
+
+// spec: SVC#munin-link
+#[tokio::test(flavor = "multi_thread")]
+async fn munin_flag_read_with_grace() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let host = format!("http://munin.invalid/{}", Uuid::new_v4());
+		let server: RowId = sql_query("INSERT INTO servers (host) VALUES ($1) RETURNING id")
+			.bind::<sql_types::Text, _>(host)
+			.get_result(&mut conn)
+			.await
+			.expect("insert server");
+		let server_id = server.id;
+
+		// Never reported → None (no link).
+		assert_eq!(
+			Status::latest_munin_for_server(&mut conn, server_id)
+				.await
+				.expect("query munin"),
+			None,
+		);
+
+		// munin=true reported 20 days ago — older than the live 7-day window —
+		// then a more recent status that omits the flag entirely.
+		insert_status(
+			&mut conn,
+			server_id,
+			r#"'{"munin": true}'"#,
+			"NOW() - INTERVAL '20 days'",
+		)
+		.await;
+		insert_status(&mut conn, server_id, "'{}'", "NOW() - INTERVAL '2 days'").await;
+
+		assert_eq!(
+			Status::latest_munin_for_server(&mut conn, server_id)
+				.await
+				.expect("query munin"),
+			Some(true),
+			"an old munin=true survives the 7-day window, and a later flag-less status doesn't disturb it",
+		);
+
+		// A later explicit munin=false overrides the earlier true.
+		insert_status(&mut conn, server_id, r#"'{"munin": false}'"#, "NOW()").await;
+
+		assert_eq!(
+			Status::latest_munin_for_server(&mut conn, server_id)
+				.await
+				.expect("query munin"),
+			Some(false),
+			"a later explicit munin=false overrides the earlier true",
+		);
+	})
+	.await
+}

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -58,6 +58,11 @@ pub struct ServerDetailData {
 	/// The server's effective `billing.*` labels — i.e. its group's
 	/// (product/deployment/stage). Empty when the server is ungrouped.
 	pub billing_labels: Vec<super::server_groups::BillingTag>,
+	/// Whether the server is known to run Munin, from the last status that
+	/// reported the flag (persisted with grace — see [`database::statuses`]).
+	/// The UI offers a Munin link only when this is true.
+	// spec: SVC#munin-link
+	pub munin: bool,
 }
 
 /// A server in the fleet inventory: its identity, classification, network
@@ -682,6 +687,10 @@ pub async fn get_detail(
 		None => Vec::new(),
 	};
 
+	let munin = Status::latest_munin_for_server(&mut conn, server.id)
+		.await?
+		.unwrap_or(false);
+
 	Ok(Json(ServerDetailData {
 		server: server_details,
 		device_info,
@@ -692,6 +701,7 @@ pub async fn get_detail(
 		group,
 		siblings,
 		billing_labels,
+		munin,
 	}))
 }
 

--- a/crates/private-server/tests/it/private_statuses.rs
+++ b/crates/private-server/tests/it/private_statuses.rs
@@ -30,6 +30,8 @@ struct ServerDetailResponse {
 	group: Option<ServerGroupResponse>,
 	#[serde(default)]
 	siblings: Vec<serde_json::Value>,
+	#[serde(default)]
+	munin: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -556,6 +558,42 @@ async fn get_detail_basic() {
 		assert!(detail.last_status.is_none());
 		assert_eq!(detail.up, "gone");
 		assert!(detail.siblings.is_empty());
+	})
+	.await
+}
+
+// spec: SVC#munin-link
+#[tokio::test(flavor = "multi_thread")]
+async fn get_detail_munin_flag() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO servers (id, name, host, rank, kind) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Munin Server', 'https://munin.example.com', 'production', 'central'),
+			('22222222-2222-2222-2222-222222222222', 'Plain Server', 'https://plain.example.com', 'production', 'central');
+
+			INSERT INTO statuses (server_id, extra, created_at) VALUES
+			('11111111-1111-1111-1111-111111111111', '{\"munin\": true}'::jsonb, NOW()),
+			('22222222-2222-2222-2222-222222222222', '{\"uptime\": 3600}'::jsonb, NOW())",
+		)
+		.await
+		.unwrap();
+
+		let munin_detail: ServerDetailResponse = private
+			.post("/api/servers/get_detail")
+			.json(&serde_json::json!({"server_id": "11111111-1111-1111-1111-111111111111"}))
+			.await
+			.json();
+		assert!(munin_detail.munin, "server that reported munin=true exposes munin");
+
+		let plain_detail: ServerDetailResponse = private
+			.post("/api/servers/get_detail")
+			.json(&serde_json::json!({"server_id": "22222222-2222-2222-2222-222222222222"}))
+			.await
+			.json();
+		assert!(
+			!plain_detail.munin,
+			"server whose status omits the flag does not expose munin"
+		);
 	})
 	.await
 }

--- a/private-web/e2e/munin-link.spec.ts
+++ b/private-web/e2e/munin-link.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "./test-fixtures";
+import { resetSeededTables, seedDevice, seedServer, seedStatus } from "./seed";
+
+// spec: SVC#munin-link
+test.describe("munin link on server detail", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("links to the tailnet host on :4950 when the server reports munin", async ({
+		page,
+		sql,
+	}) => {
+		const device = await seedDevice(sql, {
+			tailscaleNodeName: "munin-box.e2e.ts.net",
+		});
+		const server = await seedServer(sql, {
+			name: "has-munin",
+			deviceId: device.id,
+		});
+		await seedStatus(sql, { serverId: server.id, extra: { munin: true } });
+
+		await page.goto(`/servers/${server.id}`);
+
+		const munin = page.getByRole("link", { name: "Munin" });
+		await expect(munin).toBeVisible();
+		await expect(munin).toHaveAttribute(
+			"href",
+			"https://munin-box.e2e.ts.net:4950/",
+		);
+		await expect(munin).toHaveAttribute("target", "_blank");
+	});
+
+	test("offers no Munin link when the server never reported munin", async ({
+		page,
+		sql,
+	}) => {
+		const device = await seedDevice(sql, {
+			tailscaleNodeName: "plain-box.e2e.ts.net",
+		});
+		const server = await seedServer(sql, {
+			name: "no-munin",
+			deviceId: device.id,
+		});
+		await seedStatus(sql, { serverId: server.id, extra: { uptimeSecs: 3600 } });
+
+		await page.goto(`/servers/${server.id}`);
+
+		// Wait for the page to render before asserting the link's absence.
+		await expect(
+			page.getByRole("heading", { level: 1, name: /no-munin/ }),
+		).toBeVisible();
+		await expect(page.getByRole("link", { name: "Munin" })).toHaveCount(0);
+	});
+});

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -163,11 +163,14 @@ export interface SeededDevice {
 
 export async function seedDevice(
 	sql: Sql,
-	opts: { role?: string } = {},
+	opts: { role?: string; tailscaleNodeName?: string } = {},
 ): Promise<SeededDevice> {
 	const id = randomUUID();
 	const role = opts.role ?? "server";
-	await sql.query(`INSERT INTO devices (id, role) VALUES ($1, $2)`, [id, role]);
+	await sql.query(
+		`INSERT INTO devices (id, role, tailscale_node_name) VALUES ($1, $2, $3)`,
+		[id, role, opts.tailscaleNodeName ?? null],
+	);
 	return { id, role };
 }
 

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -11661,7 +11661,8 @@
           "health",
           "checks",
           "siblings",
-          "billing_labels"
+          "billing_labels",
+          "munin"
         ],
         "properties": {
           "billing_labels": {
@@ -11711,6 +11712,10 @@
                 "description": "The server's most recently reported status, if it has ever reported one."
               }
             ]
+          },
+          "munin": {
+            "type": "boolean",
+            "description": "Whether the server is known to run Munin, from the last status that\nreported the flag (persisted with grace — see [`database::statuses`]).\nThe UI offers a Munin link only when this is true."
           },
           "server": {
             "$ref": "#/components/schemas/ServerInfo",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -6661,6 +6661,12 @@ export interface components {
             /** @description Current self-reported health, derived from the most recent status report. */
             health: components["schemas"]["HealthState"];
             last_status?: null | components["schemas"]["ServerLastStatusData"];
+            /**
+             * @description Whether the server is known to run Munin, from the last status that
+             *     reported the flag (persisted with grace — see [`database::statuses`]).
+             *     The UI offers a Munin link only when this is true.
+             */
+            munin: boolean;
             /** @description The server's own record. */
             server: components["schemas"]["ServerInfo"];
             /**

--- a/private-web/src/components/ActionButton.tsx
+++ b/private-web/src/components/ActionButton.tsx
@@ -1,0 +1,87 @@
+import { Button, type ButtonProps } from "@mui/material";
+import type { ReactNode } from "react";
+import { Link as RouterLink } from "react-router-dom";
+
+/** An icon button that reveals its text label on hover or keyboard focus.
+ * Collapsed it shows just the icon; the label text stays in the DOM and the
+ * accessible name is always set via `aria-label`, so it remains usable and
+ * announceable while collapsed. Renders as an external link (`href`), an
+ * in-app router link (`to`), or a plain action (`onClick`). Used to build the
+ * server-detail action row, where actions accrete over time. */
+export default function ActionButton({
+	icon,
+	label,
+	color,
+	title,
+	href,
+	to,
+	onClick,
+}: {
+	icon: ReactNode;
+	label: string;
+	color?: ButtonProps["color"];
+	/** Native tooltip; the visible label already appears on hover, so only
+	 * set this to explain state the label can't (e.g. why it's coloured). */
+	title?: string;
+	href?: string;
+	to?: string;
+	onClick?: () => void;
+}) {
+	const common = {
+		variant: "outlined" as const,
+		size: "small" as const,
+		color,
+		title,
+		"aria-label": label,
+		startIcon: icon,
+		sx: {
+			minWidth: 0,
+			"& .MuiButton-startIcon": { mx: 0 },
+			"& .action-label": {
+				display: "inline-block",
+				maxWidth: 0,
+				ml: 0,
+				overflow: "hidden",
+				whiteSpace: "nowrap",
+				opacity: 0,
+				transition: (theme) =>
+					theme.transitions.create(["max-width", "opacity", "margin"], {
+						duration: theme.transitions.duration.shorter,
+					}),
+			},
+			"&:hover .action-label, &:focus-visible .action-label": {
+				maxWidth: "14rem",
+				ml: 0.5,
+				opacity: 1,
+			},
+		},
+	} satisfies ButtonProps;
+
+	const content = <span className="action-label">{label}</span>;
+
+	if (href) {
+		return (
+			<Button
+				{...common}
+				component="a"
+				href={href}
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{content}
+			</Button>
+		);
+	}
+	if (to) {
+		return (
+			<Button {...common} component={RouterLink} to={to}>
+				{content}
+			</Button>
+		);
+	}
+	return (
+		<Button {...common} onClick={onClick}>
+			{content}
+		</Button>
+	);
+}

--- a/private-web/src/components/IncidentsLink.tsx
+++ b/private-web/src/components/IncidentsLink.tsx
@@ -1,7 +1,6 @@
-import { Button } from "@mui/material";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
-import { Link as RouterLink } from "react-router-dom";
+import ActionButton from "./ActionButton";
 import { useApi } from "../api";
 import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 import { isIncidentLingering } from "../types";
@@ -48,12 +47,10 @@ export default function IncidentsLink({
 		const lingering = isIncidentLingering(openIncident);
 		const held = heldUntilActive && !lingering;
 		return (
-			<Button
-				component={RouterLink}
+			<ActionButton
 				to={`/incidents/${openIncident.id}`}
-				variant="outlined"
 				color={lingering ? "info" : held ? "warning" : "error"}
-				startIcon={<WarningAmberIcon />}
+				icon={<WarningAmberIcon />}
 				title={
 					lingering
 						? "All failures have recovered; the incident closes if they stay quiet through the linger window"
@@ -61,32 +58,26 @@ export default function IncidentsLink({
 							? "Slack notice still inside the per-group cooldown window"
 							: undefined
 				}
-			>
-				Incident {openIncident.id.slice(0, 8)}
-				{lingering ? " (recovering)" : held ? " (held)" : ""}
-			</Button>
+				label={`Incident ${openIncident.id.slice(0, 8)}${
+					lingering ? " (recovering)" : held ? " (held)" : ""
+				}`}
+			/>
 		);
 	}
 	if (hasActive) {
 		return (
-			<Button
-				component={RouterLink}
+			<ActionButton
 				to={`/incidents?group=${serverId}`}
-				variant="outlined"
-				startIcon={<OpenInNewIcon />}
-			>
-				Active issues
-			</Button>
+				icon={<OpenInNewIcon />}
+				label="Active issues"
+			/>
 		);
 	}
 	return (
-		<Button
-			component={RouterLink}
+		<ActionButton
 			to={`/incidents?group=${serverId}&showAll=1`}
-			variant="outlined"
-			startIcon={<OpenInNewIcon />}
-		>
-			Past issues
-		</Button>
+			icon={<OpenInNewIcon />}
+			label="Past issues"
+		/>
 	);
 }

--- a/private-web/src/components/ManualEventButton.tsx
+++ b/private-web/src/components/ManualEventButton.tsx
@@ -1,6 +1,7 @@
 import { Button, Dialog, DialogContent, DialogTitle } from "@mui/material";
 import AddAlertIcon from "@mui/icons-material/AddAlert";
 import { useState } from "react";
+import ActionButton from "./ActionButton";
 import ManualEventForm from "./ManualEventForm";
 
 /** Admin-only button on the ServerDetail header: opens a dialog with the
@@ -13,6 +14,7 @@ export default function ManualEventButton({
 	hasOpenIncident,
 	onSubmitted,
 	size = "medium",
+	action = false,
 }: {
 	serverId: string;
 	/** Whether the server group currently has an open incident. The parent
@@ -24,20 +26,31 @@ export default function ManualEventButton({
 	 * panels (issues, incidents) that are now stale. */
 	onSubmitted?: () => void;
 	size?: "small" | "medium" | "large";
+	/** Render as an expanding icon button for the server-detail action row.
+	 * Default is the full-width labelled button used in the siblings table. */
+	action?: boolean;
 }) {
 	const [open, setOpen] = useState(false);
 	const label = hasOpenIncident ? "Add issue" : "New incident";
 
 	return (
 		<>
-			<Button
-				variant="outlined"
-				size={size}
-				startIcon={<AddAlertIcon />}
-				onClick={() => setOpen(true)}
-			>
-				{label}
-			</Button>
+			{action ? (
+				<ActionButton
+					icon={<AddAlertIcon />}
+					label={label}
+					onClick={() => setOpen(true)}
+				/>
+			) : (
+				<Button
+					variant="outlined"
+					size={size}
+					startIcon={<AddAlertIcon />}
+					onClick={() => setOpen(true)}
+				>
+					{label}
+				</Button>
+			)}
 			<Dialog open={open} onClose={() => setOpen(false)} fullWidth maxWidth="sm">
 				<DialogTitle>{label}</DialogTitle>
 				<DialogContent>

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -31,6 +31,7 @@ import RemoveCircleOutlinedIcon from "@mui/icons-material/RemoveCircleOutlined";
 import ArchiveIcon from "@mui/icons-material/ArchiveOutlined";
 import EditIcon from "@mui/icons-material/Edit";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import InsightsIcon from "@mui/icons-material/Insights";
 import LanguageIcon from "@mui/icons-material/Language";
 import RestoreIcon from "@mui/icons-material/RestoreFromTrash";
 import RestoreDataIcon from "@mui/icons-material/SettingsBackupRestore";
@@ -45,6 +46,7 @@ import {
 	useNavigate,
 	useParams,
 } from "react-router-dom";
+import ActionButton from "../components/ActionButton";
 import CheckDocButton from "../components/CheckDocButton";
 import CheckExtrasList, { checkEntryExtras } from "../components/CheckExtras";
 import ExternalUsersDetails, {
@@ -254,12 +256,19 @@ function Header({
 	onArchived: () => void;
 }) {
 	const archived = data.server.archived;
+	// Munin runs on the server's own box, reachable over the tailnet — build
+	// its URL from the bound device's MagicDNS name (live value preferred,
+	// falling back to the stored snapshot). Only offered when the server is
+	// known to run Munin and has a tailnet name.
+	// spec: SVC#munin-link
+	const tailnetName =
+		data.device_info?.tailnet_live?.display_name ??
+		data.device_info?.device?.tailscale_node_name ??
+		null;
+	const muninUrl =
+		data.munin && tailnetName ? `https://${tailnetName}:4950/` : null;
 	return (
-		<Stack
-			direction="row"
-			spacing={2}
-			sx={{ alignItems: "center", justifyContent: "space-between" }}
-		>
+		<Stack spacing={1.5}>
 			<Stack
 				direction="row"
 				spacing={1}
@@ -282,26 +291,38 @@ function Header({
 					/>
 				</Typography>
 			</Stack>
-			<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
-				<IncidentsLink
-					serverId={data.server.id}
-					refreshKey={refreshTick}
-				/>
+			<Stack
+				direction="row"
+				spacing={1}
+				sx={{ alignItems: "center", flexWrap: "wrap" }}
+				useFlexGap
+			>
+				{data.server.display_host && (
+					<ActionButton
+						href={data.server.display_host}
+						icon={<LanguageIcon />}
+						label="Open"
+						title={data.server.display_host}
+					/>
+				)}
+				{muninUrl && (
+					<ActionButton href={muninUrl} icon={<InsightsIcon />} label="Munin" />
+				)}
+				<IncidentsLink serverId={data.server.id} refreshKey={refreshTick} />
 				{isAdmin && (
 					<>
 						<ManualEventButton
 							serverId={data.server.id}
 							hasOpenIncident={hasOpenIncident}
 							onSubmitted={onEventSubmitted}
+							action
 						/>
-						<Button
-							component={RouterLink}
+						<ActionButton
 							to={`/servers/${data.server.id}/edit`}
-							variant="contained"
-							startIcon={<EditIcon />}
-						>
-							Edit
-						</Button>
+							icon={<EditIcon />}
+							label="Edit"
+							color="primary"
+						/>
 						{!archived && (
 							<DeleteServerButton
 								serverId={data.server.id}
@@ -347,14 +368,12 @@ function DeleteServerButton({
 
 	return (
 		<>
-			<Button
-				variant="outlined"
+			<ActionButton
 				color="error"
-				startIcon={<ArchiveIcon />}
+				icon={<ArchiveIcon />}
+				label="Archive"
 				onClick={() => setOpen(true)}
-			>
-				Archive
-			</Button>
+			/>
 			<Dialog open={open} onClose={() => setOpen(false)} maxWidth="sm" fullWidth>
 				<DialogTitle>Archive server?</DialogTitle>
 				<DialogContent>


### PR DESCRIPTION
🤖 Adds a Munin link to the server detail view, and reworks the header actions into an expanding-icon row.

## What

- Servers report a `munin` flag in their status payload. The detail view offers a link to the server’s Munin — `https://<tailnet MagicDNS name>:4950/` — but only when the server is known to run Munin and has a bound tailnet name.
- The flag is read with grace: `Status::latest_munin_for_server` returns the most recent status that carried the flag, unbounded by the live 7-day window, so the link survives once reported (a later flag-less status leaves it untouched; an explicit `munin: false` removes it). No migration and no public-server change — the flag already flows into `statuses.extra`.
- Header actions move into a second row of icon buttons that expand to their label on hover/focus (new `ActionButton`), giving the header room for more actions over time. It now hosts Open (server URL), Munin, Incidents, Manual event, Edit, and Archive. The siblings table’s manual-event button is unchanged.

New spec `SVC` (`.workhorse/specs/private-server/server-service-links.md`) describes the behaviour; code references it with `// spec: SVC#munin-link`.

Coverage: a DB test for the grace read, an endpoint test for the `munin` field, and a Playwright spec asserting the link (and its absence).