### PR TITLE
feat(servers): device self-identity endpoint (GET /servers/self)

### DIFF
--- a/.workhorse/specs/public-server/device-identity.md
+++ b/.workhorse/specs/public-server/device-identity.md
@@ -1,0 +1,18 @@
+---
+id: DID
+---
+
+# Device self-identity
+
+A device authenticates to the device API by presenting its enrolled certificate, and Canopy resolves its identity from that certificate rather than from any identifier the device sends.
+A device therefore never needs to know its own device or server identifiers to make authenticated calls, but it is assigned both when it completes enrollment (see [STA](statuses.md) for the enrolled-device contract).
+A device that has lost track of those identifiers can recover them from the device API.
+
+## Query
+
+A device asks the device API for its own identity by calling `GET /servers/self`.
+The caller presents its enrolled device certificate, or a certificate holding the admin role.
+
+The response carries the device's own identifier and the identifier of the server it is enrolled as — the same pair returned when the device completed enrollment.
+
+The request is refused when the caller presents no recognised certificate, when the resolved device is not attached to any server, and when it is attached to more than one server.

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -656,6 +656,63 @@
         }
       }
     },
+    "/servers/self": {
+      "get": {
+        "tags": [
+          "servers"
+        ],
+        "summary": "Report the calling device's own identity.",
+        "description": "Resolves the caller from its device certificate and returns the server\nit is enrolled as together with its own device ID — the same pair\nreturned when the device completed enrollment. A device authenticates\nentirely from its certificate, so it never needs these IDs to make\ncalls; this endpoint lets one that has lost track of them recover them.\n\n- **401**: the request has no client certificate, or the certificate\n  doesn't match a known device.\n- **409**: the calling device is attached to more than one server, which\n  should not normally happen; contact support if you see this.\n- **412**: the device is registered but has not yet been attached to a\n  server.",
+        "operationId": "server_self",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SelfResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "server-device": []
+          }
+        ]
+      }
+    },
     "/status/{server_id}": {
       "post": {
         "tags": [
@@ -1733,6 +1790,26 @@
           "success",
           "failure"
         ]
+      },
+      "SelfResponse": {
+        "type": "object",
+        "description": "The calling device's own identity, as assigned at enrollment.",
+        "required": [
+          "server_id",
+          "device_id"
+        ],
+        "properties": {
+          "device_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The calling device's own identity."
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The server the calling device is enrolled as."
+          }
+        }
       },
       "ServerRank": {
         "type": "string",

--- a/crates/public-server/src/servers.rs
+++ b/crates/public-server/src/servers.rs
@@ -4,7 +4,7 @@ use axum::{Json, extract::State, http::HeaderMap};
 use axum_client_ip::ClientIp;
 use base64::Engine;
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
-use commons_servers::device_auth::{mtls, pop};
+use commons_servers::device_auth::{ServerDevice, mtls, pop};
 use commons_servers::tailnet_directory::TailnetDirectory;
 
 use crate::ratelimit::RateLimiter;
@@ -37,6 +37,7 @@ const CHALLENGE_TTL: jiff::SignedDuration = jiff::SignedDuration::from_mins(5);
 pub fn routes() -> OpenApiRouter<AppState> {
 	OpenApiRouter::new()
 		.routes(routes!(list))
+		.routes(routes!(self_identity))
 		.routes(routes!(register_begin))
 		.routes(routes!(register_complete))
 }
@@ -107,6 +108,63 @@ pub async fn list(State(db): State<Db>) -> Result<Json<Vec<PublicServer>>> {
 	});
 
 	Ok(Json(servers))
+}
+
+/// The calling device's own identity, as assigned at enrollment.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SelfResponse {
+	/// The server the calling device is enrolled as.
+	pub server_id: Uuid,
+	/// The calling device's own identity.
+	pub device_id: Uuid,
+}
+
+/// Report the calling device's own identity.
+///
+/// Resolves the caller from its device certificate and returns the server
+/// it is enrolled as together with its own device ID — the same pair
+/// returned when the device completed enrollment. A device authenticates
+/// entirely from its certificate, so it never needs these IDs to make
+/// calls; this endpoint lets one that has lost track of them recover them.
+///
+/// - **401**: the request has no client certificate, or the certificate
+///   doesn't match a known device.
+/// - **409**: the calling device is attached to more than one server, which
+///   should not normally happen; contact support if you see this.
+/// - **412**: the device is registered but has not yet been attached to a
+///   server.
+// spec: DID
+#[utoipa::path(
+	get,
+	path = "/self",
+	operation_id = "server_self",
+	tag = "servers",
+	security(("server-device" = [])),
+	responses(
+		(status = 200, body = SelfResponse),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 409, body = ProblemDetailsSchema),
+		(status = 412, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn self_identity(
+	device: ServerDevice,
+	State(db): State<Db>,
+) -> Result<Json<SelfResponse>> {
+	let mut conn = db.get().await?;
+	let device_id = device.0.0.id;
+	let mut servers = Server::get_by_device_id(&mut conn, device_id).await?;
+	if servers.len() > 1 {
+		return Err(AppError::Conflict(format!(
+			"device {device_id} is attached to {} servers; expected at most one",
+			servers.len(),
+		)));
+	}
+	let server = servers.pop().ok_or(AppError::DeviceHasNoServer)?;
+	Ok(Json(SelfResponse {
+		server_id: server.id,
+		device_id,
+	}))
 }
 
 /// Request to start device enrollment against a server.

--- a/crates/public-server/tests/it/main.rs
+++ b/crates/public-server/tests/it/main.rs
@@ -16,6 +16,7 @@ mod openapi_spec;
 mod password;
 mod restore;
 mod server_enrollment;
+mod server_self;
 mod server_versions;
 mod servers_list;
 mod static_files;

--- a/crates/public-server/tests/it/server_self.rs
+++ b/crates/public-server/tests/it/server_self.rs
@@ -1,0 +1,69 @@
+use diesel::{sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use http::StatusCode;
+use serde::Deserialize;
+use uuid::Uuid;
+
+#[derive(Deserialize)]
+struct SelfResponse {
+	server_id: Uuid,
+	device_id: Uuid,
+}
+
+/// A registered, attached device recovers its own identity: the server it is
+/// enrolled as and its own device ID.
+#[tokio::test(flavor = "multi_thread")]
+async fn self_endpoint_returns_server_and_device_ids() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = Uuid::new_v4();
+			sql_query(
+				"INSERT INTO servers (id, host, kind, device_id) \
+				 VALUES ($1, 'https://self.example.com', 'central', $2)",
+			)
+			.bind::<sql_types::Uuid, _>(server_id)
+			.bind::<sql_types::Uuid, _>(device_id)
+			.execute(&mut conn)
+			.await
+			.unwrap();
+
+			let response = public
+				.get("/servers/self")
+				.add_header("mtls-certificate", &cert)
+				.await;
+			response.assert_status_ok();
+			let body: SelfResponse = response.json();
+			assert_eq!(body.server_id, server_id);
+			assert_eq!(body.device_id, device_id);
+		},
+	)
+	.await
+}
+
+/// A device that authenticates correctly but isn't attached to any server
+/// gets a 412 (precondition failed), matching the `/tags` endpoint.
+#[tokio::test(flavor = "multi_thread")]
+async fn self_endpoint_412_when_device_has_no_server() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut _conn, cert, _device_id, public, _| {
+			let response = public
+				.get("/servers/self")
+				.add_header("mtls-certificate", &cert)
+				.await;
+			response.assert_status(StatusCode::PRECONDITION_FAILED);
+		},
+	)
+	.await
+}
+
+/// A request with no client certificate is unauthenticated.
+#[tokio::test(flavor = "multi_thread")]
+async fn self_endpoint_401_without_certificate() {
+	commons_tests::server::run(async |_conn, public, _private| {
+		let response = public.get("/servers/self").await;
+		response.assert_status(StatusCode::UNAUTHORIZED);
+	})
+	.await
+}


### PR DESCRIPTION
🤖 A registered device authenticates entirely from its client certificate, so it never needs its own `device_id` or `server_id` to call the device API. This adds a way for a device that has lost track of them to recover both.

`GET /servers/self` resolves the caller from its certificate and returns the server it is enrolled as together with its own device id — the same pair returned when the device completed enrollment.

The error contract mirrors `GET /tags`:

- **401** — no client certificate, or a certificate that matches no known device
- **409** — the device is attached to more than one server (should not normally happen)
- **412** — the device is registered but not yet attached to a server

## Spec

New spec `DID` at `.workhorse/specs/public-server/device-identity.md`, cross-referencing `STA`; the handler is tied back with an inline `// spec: DID` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)