### PR TITLE
fix(perf): bound unbounded lookbacks over the partitioned statuses table

### DIFF
--- a/.workhorse/specs/private-server/server-service-links.md
+++ b/.workhorse/specs/private-server/server-service-links.md
@@ -15,8 +15,11 @@ A server with no known address offers no application link.
 ## Munin link
 
 A server reports whether it runs Munin as a field in its pushed status.
-Canopy remembers the value with grace: the most recently reported value persists, a status that omits the flag leaves it unchanged, and the value is not bound by the window that governs a server's live status.
-So once a server has reported running Munin the link stays available even after the server stops reporting, and a server that reports it has stopped running Munin loses the link.
+Canopy remembers the value with grace: the most recently reported value persists, a status that omits the flag leaves it unchanged, and the value outlives the window that governs a server's live status.
+So a server that has reported running Munin keeps the link for a while after it stops reporting, and a server that reports it has stopped running Munin loses the link.
+
+The grace is a bounded lookback, not an indefinite memory: a server that has not reported the flag within the lookback is treated as not running Munin and offers no link.
+The bound is a deliberate cost of keeping the read cheap — status history is partitioned by time, so an unbounded lookback cannot be pruned to a slice of it and instead reads the whole history.
 
 The detail view offers a link to a server's Munin only when the server is known to run Munin and has a bound tailnet name.
 The link opens the server's Munin in a new tab, over HTTPS at the server's tailnet MagicDNS name on port 4950.

--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -19,6 +19,7 @@
 use crate::issues::Scope;
 use commons_errors::{AppError, Result};
 use commons_types::status::CheckResult;
+use diesel::dsl::{AsSelect, SqlTypeOf};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use jiff::Timestamp;
@@ -117,6 +118,34 @@ pub struct GradedResult {
 	/// Whether this check's effective failures escalate (notify
 	/// immediately, bypassing incident grace).
 	pub escalates: bool,
+}
+
+/// The catalog fields that grade one check, detached from the query that
+/// loaded them. Callers grading a whole report's worth of checks load these
+/// once via [`CheckPolicy::grading_table`] and grade in memory, rather than
+/// issuing a query per check.
+#[derive(Debug, Clone)]
+pub struct FleetGrading {
+	ceiling: CheckResult,
+	escalates: bool,
+	rules: Option<JsonValue>,
+	reviewed: bool,
+}
+
+impl FleetGrading {
+	/// An unparseable stored ceiling falls back to warning rather than
+	/// failing the whole grading pass — the column is constrained, so this
+	/// only covers data written outside the model.
+	fn from_row(
+		(ceiling, escalates, rules, reviewed): (String, bool, Option<JsonValue>, bool),
+	) -> Self {
+		Self {
+			ceiling: ceiling.parse().unwrap_or(CheckResult::Warning),
+			escalates,
+			rules,
+			reviewed,
+		}
+	}
 }
 
 impl CheckPolicy {
@@ -356,16 +385,36 @@ impl CheckPolicy {
 			.first(db)
 			.await
 			.optional()?;
-		let Some((ceiling_str, escalates, rules_json, reviewed)) = row else {
-			return Ok(GradedResult {
+		let entry = row.map(FleetGrading::from_row);
+		Ok(Self::grade(
+			entry.as_ref(),
+			source,
+			check_name,
+			observed,
+			ctx,
+		))
+	}
+
+	/// The pure half of [`Self::apply`]: grade `observed` through an
+	/// already-loaded catalog entry, with `None` standing for a check that
+	/// has no catalog row yet. Shared by the single-check path and the batch
+	/// path so there is exactly one grading implementation.
+	pub fn grade(
+		entry: Option<&FleetGrading>,
+		source: &str,
+		check_name: &str,
+		observed: CheckResult,
+		ctx: &EvaluationContext<'_>,
+	) -> GradedResult {
+		let Some(entry) = entry else {
+			return GradedResult {
 				effective: observed.capped_at(CheckResult::Warning),
 				escalates: false,
-			});
+			};
 		};
-		let ceiling = ceiling_str.parse().unwrap_or(CheckResult::Warning);
-		let mut effective = observed.capped_at(ceiling);
-		if let Some(rules) = rules_json {
-			match serde_json::from_value::<IfLadder>(rules) {
+		let mut effective = observed.capped_at(entry.ceiling);
+		if let Some(rules) = &entry.rules {
+			match serde_json::from_value::<IfLadder>(rules.clone()) {
 				Ok(ladder) => {
 					if let Some(result) = ladder.evaluate(ctx) {
 						effective = result;
@@ -382,13 +431,49 @@ impl CheckPolicy {
 			}
 		}
 		// A never-reviewed check is inert until an operator vets it.
-		if !reviewed {
+		if !entry.reviewed {
 			effective = effective.capped_at(CheckResult::Warning);
 		}
-		Ok(GradedResult {
+		GradedResult {
 			effective,
-			escalates,
-		})
+			escalates: entry.escalates,
+		}
+	}
+
+	/// Grading fields for every catalog row, keyed by `(source, check_name)`.
+	///
+	/// For callers grading many checks in one pass: the catalog holds one row
+	/// per distinct check the fleet reports, so a single load is far cheaper
+	/// than [`Self::apply`]'s query per check. Feed the entries to
+	/// [`Self::grade`].
+	pub async fn grading_table(
+		db: &mut AsyncPgConnection,
+	) -> Result<HashMap<(String, String), FleetGrading>> {
+		use crate::schema::check_policies::dsl;
+		let rows: Vec<(String, String, String, bool, Option<JsonValue>, bool)> =
+			dsl::check_policies
+				.select((
+					dsl::source,
+					dsl::check_name,
+					dsl::ceiling,
+					dsl::escalates,
+					dsl::rules,
+					dsl::reviewed_at.is_not_null(),
+				))
+				.load(db)
+				.await
+				.map_err(AppError::from)?;
+		Ok(rows
+			.into_iter()
+			.map(
+				|(source, check_name, ceiling, escalates, rules, reviewed)| {
+					(
+						(source, check_name),
+						FleetGrading::from_row((ceiling, escalates, rules, reviewed)),
+					)
+				},
+			)
+			.collect())
 	}
 
 	/// [`Self::apply`], then the scoped transforms that cover the filing's
@@ -417,14 +502,27 @@ impl CheckPolicy {
 		let fleet = Self::apply(db, source, check_name, observed, ctx).await?;
 		let scoped =
 			ScopedCheckPolicy::chain_for(db, source, check_name, server_id, group_id).await?;
+		Ok(Self::chain_scoped(fleet, &scoped, ctx))
+	}
+
+	/// The pure half of [`Self::apply_scoped`]: run an already-loaded scoped
+	/// chain over an already-computed fleet grade. Pair with [`Self::grade`]
+	/// plus [`CheckPolicy::grading_table`] and
+	/// [`ScopedCheckPolicy::chains_for_scope`] to grade a whole report's
+	/// checks without a query per check.
+	pub fn chain_scoped(
+		fleet: GradedResult,
+		chain: &[ScopedCheckPolicy],
+		ctx: &EvaluationContext<'_>,
+	) -> GradedResult {
 		let mut effective = fleet.effective;
-		for transform in &scoped {
+		for transform in chain {
 			effective = transform.transform(effective, ctx);
 		}
-		Ok(GradedResult {
+		GradedResult {
 			effective,
 			escalates: fleet.escalates,
-		})
+		}
 	}
 
 	/// Replace the documentation for a check (or clear it with `None`).
@@ -738,11 +836,55 @@ impl ScopedCheckPolicy {
 		group_id: Option<Uuid>,
 	) -> Result<Vec<Self>> {
 		use crate::schema::scoped_check_policies::dsl;
-		let mut query = dsl::scoped_check_policies
+		let query = Self::scoped_to(server_id, group_id)
+			.filter(dsl::source.eq(source).and(dsl::check_name.eq(check_name)));
+		let mut rows: Vec<Self> = query.load(db).await.map_err(AppError::from)?;
+		Self::order_chain(&mut rows);
+		Ok(rows)
+	}
+
+	/// Every scoped transform covering `(server_id, group_id)`, grouped by
+	/// `(source, check_name)` and in application order within each group —
+	/// the batch form of [`Self::chain_for`], for callers walking a whole
+	/// report's checks. One query for the lot instead of one per check.
+	pub async fn chains_for_scope(
+		db: &mut AsyncPgConnection,
+		server_id: Option<Uuid>,
+		group_id: Option<Uuid>,
+	) -> Result<HashMap<(String, String), Vec<Self>>> {
+		let rows: Vec<Self> = Self::scoped_to(server_id, group_id)
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		let mut chains: HashMap<(String, String), Vec<Self>> = HashMap::new();
+		for row in rows {
+			chains
+				.entry((row.source.clone(), row.check_name.clone()))
+				.or_default()
+				.push(row);
+		}
+		for chain in chains.values_mut() {
+			Self::order_chain(chain);
+		}
+		Ok(chains)
+	}
+
+	/// The scope half of the chain predicate: the rows whose scope covers a
+	/// filing against `(server_id, group_id)`. Shared so the single-check and
+	/// batch paths can never disagree about what a scope covers.
+	fn scoped_to(
+		server_id: Option<Uuid>,
+		group_id: Option<Uuid>,
+	) -> crate::schema::scoped_check_policies::BoxedQuery<
+		'static,
+		diesel::pg::Pg,
+		SqlTypeOf<AsSelect<Self, diesel::pg::Pg>>,
+	> {
+		use crate::schema::scoped_check_policies::dsl;
+		let query = dsl::scoped_check_policies
 			.select(Self::as_select())
-			.filter(dsl::source.eq(source).and(dsl::check_name.eq(check_name)))
 			.into_boxed();
-		query = match (server_id, group_id) {
+		match (server_id, group_id) {
 			(None, None) => {
 				query.filter(dsl::server_id.is_null().and(dsl::server_group_id.is_null()))
 			}
@@ -754,12 +896,13 @@ impl ScopedCheckPolicy {
 						.is_not_distinct_from(group)
 						.and(dsl::server_group_id.is_not_null())),
 			),
-		};
-		let mut rows: Vec<Self> = query.load(db).await.map_err(AppError::from)?;
-		// Group scope applies before server scope: the most specific
-		// transform has the last word.
+		}
+	}
+
+	/// Group scope applies before server scope: the most specific transform
+	/// has the last word.
+	fn order_chain(rows: &mut [Self]) {
 		rows.sort_by_key(|r| r.server_id.is_some());
-		Ok(rows)
 	}
 
 	/// Apply this transform to the effective result arriving from the

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -43,6 +43,33 @@ Tracks whether the sources canopy expects to report on this server are actually 
 
 Check whether the server is down, its network/VPN path to canopy, and whether its reporting agents are running. A source that was deliberately retired should be set to `quiet` or `off` in the source list.";
 
+/// How far back a "last value this server ever reported" read may look.
+///
+/// `statuses` is range-partitioned by week and prod already carries ~100
+/// partitions with the better part of a million rows *per server*. A
+/// predicate on `server_id` alone cannot be partition-pruned, so a query
+/// with no lower bound on `created_at` degrades into a scan of every
+/// partition — measured at 217s in production for a single row. Worse, the
+/// pruning-free plan reads far more than `shared_buffers` holds, so it
+/// evicts the buffer pool and drags every unrelated query down with it.
+///
+/// Every lookback here is therefore capped. The cost is that a server quiet
+/// for longer than the window reads as "never reported"; that is preferable
+/// to an unbounded scan, and the windows are generous next to how long a
+/// server can be down before someone notices.
+const GRACE_LOOKBACK_SQL: &str = "NOW() - INTERVAL '30 days'";
+
+/// [`GRACE_LOOKBACK_SQL`] as a span, for bounding a lookback relative to a
+/// caller-supplied point in time rather than to `NOW()`.
+const GRACE_LOOKBACK: SignedDuration = SignedDuration::from_hours(24 * 30);
+
+/// Lookback for the last version a server reported. Longer than
+/// [`GRACE_LOOKBACK_SQL`] because a group's displayed version is cached from
+/// its canonical member, and a member down for a month or two should not
+/// blank out the group's version label. Still bounded — see
+/// [`GRACE_LOOKBACK_SQL`] for why an unbounded read is not an option.
+const VERSION_LOOKBACK_SQL: &str = "NOW() - INTERVAL '90 days'";
+
 fn server_label(s: &Server) -> String {
 	s.name
 		.clone()
@@ -427,6 +454,11 @@ impl Status {
 	/// extras, and the server's tags resolved up the group). Scoped to
 	/// the check's own source — another source's same-named check may
 	/// carry entirely different fields.
+	///
+	/// Bounded to [`GRACE_LOOKBACK_SQL`]: a recent sample is the useful one,
+	/// and the `health @>` containment is not indexable, so without the
+	/// window a check that has stopped reporting scans every partition
+	/// across every server.
 	pub async fn latest_for_check_name(
 		db: &mut AsyncPgConnection,
 		source: &str,
@@ -444,12 +476,13 @@ impl Status {
 		// Two-step: pick the id via raw SQL (JSONB containment needs a
 		// parameterised JSON literal that Diesel's typed DSL doesn't
 		// express cleanly), then load the typed Status row by id.
-		let picked: Option<Picked> = sql_query(
+		let picked: Option<Picked> = sql_query(format!(
 			"SELECT id FROM statuses \
 			 WHERE source = $1 \
 			 AND health @> jsonb_build_array(jsonb_build_object('check', $2::text)) \
-			 ORDER BY created_at DESC LIMIT 1",
-		)
+			 AND created_at >= {GRACE_LOOKBACK_SQL} \
+			 ORDER BY created_at DESC LIMIT 1"
+		))
 		.bind::<Text, _>(source)
 		.bind::<Text, _>(check_name)
 		.get_result(db)
@@ -521,6 +554,14 @@ impl Status {
 	/// [`Self::at_time`], which collapses to a single row regardless of
 	/// source, this keeps every source's contribution, for reconstructing
 	/// the consolidated multi-source checks view as of a point in time.
+	///
+	/// Bounded to [`GRACE_LOOKBACK`] before the cutoff, so a source silent
+	/// for the whole window contributes nothing as of `at`. The bound is
+	/// load-bearing: `DISTINCT ON` cannot terminate early (it has to see
+	/// every candidate row before it knows which is each group's newest), so
+	/// an upper bound alone made this read a server's entire status history —
+	/// ~864k rows across every partition in prod — to return one row per
+	/// source. This is the same trap [`Self::latest_for_servers`] documents.
 	pub async fn latest_per_source_at(
 		db: &mut AsyncPgConnection,
 		server: Uuid,
@@ -529,13 +570,15 @@ impl Status {
 		use crate::schema::statuses::dsl::*;
 
 		let cutoff = at.unwrap_or_else(Timestamp::now);
+		let floor = cutoff.checked_sub(GRACE_LOOKBACK).unwrap_or(Timestamp::MIN);
 		statuses
 			.select(Status::as_select())
 			.filter(
 				server_id
 					.eq(server)
 					.and(id.ne(Uuid::nil()))
-					.and(created_at.le(jiff_diesel::Timestamp::from(cutoff))),
+					.and(created_at.le(jiff_diesel::Timestamp::from(cutoff)))
+					.and(created_at.ge(jiff_diesel::Timestamp::from(floor))),
 			)
 			.distinct_on(source)
 			.order((source, created_at.desc()))
@@ -544,10 +587,12 @@ impl Status {
 			.map_err(AppError::from)
 	}
 
-	/// The most recent status for `server` that carries a version — **not**
-	/// bounded by the live 7-day window. Used for the status card's headline
-	/// version, which should reflect the last version a server ever reported
-	/// even if it's currently down (and hence has no recent status).
+	/// The most recent status for `server` that carries a version — wider
+	/// than the live 7-day window. Used for the status card's headline
+	/// version, which should reflect the last version a server reported even
+	/// if it's currently down (and hence has no recent status). Capped at
+	/// [`VERSION_LOOKBACK_SQL`]; see [`GRACE_LOOKBACK_SQL`] for why the read
+	/// can't be left unbounded.
 	pub async fn last_with_version_for_server(
 		db: &mut AsyncPgConnection,
 		server: Uuid,
@@ -560,6 +605,7 @@ impl Status {
 				server_id
 					.eq(server)
 					.and(version.is_not_null())
+					.and(created_at.ge(diesel::dsl::sql(VERSION_LOOKBACK_SQL)))
 					.and(id.ne(Uuid::nil())),
 			)
 			.order(created_at.desc())
@@ -570,11 +616,16 @@ impl Status {
 	}
 
 	/// Whether `server` runs Munin, from the most recent status that carried
-	/// the `munin` flag — **not** bounded by the live 7-day window. Once a
-	/// server reports the flag the value persists even after it goes quiet,
-	/// and a later status that omits the flag leaves it untouched; only an
-	/// explicit later value overrides it. Returns `None` when the server has
-	/// never reported the flag.
+	/// the `munin` flag — wider than the live 7-day window, so the value
+	/// persists after a server goes quiet: a later status that omits the flag
+	/// leaves it untouched, and only an explicit later value overrides it.
+	/// Returns `None` when the server has not reported the flag within
+	/// [`GRACE_LOOKBACK_SQL`].
+	///
+	/// The lookback is what keeps this cheap. `jsonb_exists` is not
+	/// indexable, so the `LIMIT 1` cannot terminate early on a server that
+	/// never reports the flag (~2/3 of the fleet) — without the window this
+	/// drains all ~100 partitions.
 	// spec: SVC#munin-link
 	pub async fn latest_munin_for_server(
 		db: &mut AsyncPgConnection,
@@ -584,7 +635,12 @@ impl Status {
 
 		let row: Option<Status> = statuses
 			.select(Status::as_select())
-			.filter(server_id.eq(server).and(id.ne(Uuid::nil())))
+			.filter(
+				server_id
+					.eq(server)
+					.and(created_at.ge(diesel::dsl::sql(GRACE_LOOKBACK_SQL)))
+					.and(id.ne(Uuid::nil())),
+			)
 			.filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
 				"jsonb_exists(extra, 'munin')",
 			))

--- a/crates/database/tests/it/statuses_munin.rs
+++ b/crates/database/tests/it/statuses_munin.rs
@@ -80,3 +80,55 @@ async fn munin_flag_read_with_grace() {
 	})
 	.await
 }
+
+/// The grace read is capped rather than unbounded: `statuses` is partitioned
+/// weekly, and a lookback with no lower bound can't be partition-pruned, so
+/// it degrades into a scan of every partition. A server that hasn't reported
+/// the flag inside the window therefore reads as "never reported".
+// spec: SVC#munin-link
+#[tokio::test(flavor = "multi_thread")]
+async fn munin_flag_grace_is_bounded() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let host = format!("http://munin.invalid/{}", Uuid::new_v4());
+		let server: RowId = sql_query("INSERT INTO servers (host) VALUES ($1) RETURNING id")
+			.bind::<sql_types::Text, _>(host)
+			.get_result(&mut conn)
+			.await
+			.expect("insert server");
+		let server_id = server.id;
+
+		// Inside the 30-day window: still honoured.
+		insert_status(
+			&mut conn,
+			server_id,
+			r#"'{"munin": true}'"#,
+			"NOW() - INTERVAL '29 days'",
+		)
+		.await;
+		assert_eq!(
+			Status::latest_munin_for_server(&mut conn, server_id)
+				.await
+				.expect("query munin"),
+			Some(true),
+			"a flag reported inside the grace window is honoured",
+		);
+
+		// Push the only munin-bearing status outside the window.
+		sql_query(
+			"UPDATE statuses SET created_at = NOW() - INTERVAL '31 days' WHERE server_id = $1",
+		)
+		.bind::<sql_types::Uuid, _>(server_id)
+		.execute(&mut conn)
+		.await
+		.expect("age the status");
+
+		assert_eq!(
+			Status::latest_munin_for_server(&mut conn, server_id)
+				.await
+				.expect("query munin"),
+			None,
+			"beyond the grace window the flag reads as never reported",
+		);
+	})
+	.await
+}

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -761,7 +761,7 @@ async fn consolidated_checks_at(
 	at: Option<Timestamp>,
 ) -> commons_errors::Result<(commons_types::status::ConsolidatedChecks, serde_json::Value)> {
 	use commons_types::status::{CheckResult, ConsolidatedCheck, ConsolidatedChecks, HealthState};
-	use database::check_policies::{CheckPolicy, EvaluationContext};
+	use database::check_policies::{CheckPolicy, EvaluationContext, ScopedCheckPolicy};
 
 	let statuses = Status::latest_per_source_at(conn, server.id, at).await?;
 
@@ -790,6 +790,12 @@ async fn consolidated_checks_at(
 	// check-states (a source's catalog rows removed out from under its
 	// states) so the point-in-time view reconstructs the same shape.
 	let cataloged = CheckPolicy::live_cataloged_pairs(conn).await?;
+	// Grading tables loaded once, not once per check: a status can carry
+	// dozens of checks, and re-querying the catalog and the scoped chain for
+	// each one turned this reconstruction into a few hundred round-trips.
+	let grading = CheckPolicy::grading_table(conn).await?;
+	let chains =
+		ScopedCheckPolicy::chains_for_scope(conn, Some(server.id), server.group_id).await?;
 
 	let mut checks: Vec<ConsolidatedCheck> = Vec::new();
 	for status in &statuses {
@@ -831,16 +837,13 @@ async fn consolidated_checks_at(
 				check_extra: &check_extra,
 				tags: &tags,
 			};
-			let graded = CheckPolicy::apply_scoped(
-				conn,
-				&status.source,
-				name,
-				observed,
+			let key = (status.source.clone(), name.to_string());
+			let fleet = CheckPolicy::grade(grading.get(&key), &status.source, name, observed, &ctx);
+			let graded = CheckPolicy::chain_scoped(
+				fleet,
+				chains.get(&key).map_or(&[][..], Vec::as_slice),
 				&ctx,
-				Some(server.id),
-				server.group_id,
-			)
-			.await?;
+			);
 			// The check's own detail fields, verbatim.
 			let mut detail = obj.clone();
 			detail.remove("check");


### PR DESCRIPTION
🤖 The server detail page went from instant to 30+s, and the status snapshot from seconds to minutes. Both trace to reads over `statuses` with no lower bound on `created_at`.

`statuses` is range-partitioned by week. Prod carries **100 partitions** and **~864k rows for a single server**. A predicate on `server_id` alone cannot be partition-pruned, so those reads open and scan every partition.

Measured against prod for one server:

| query | as shipped | with a window |
|---|---|---|
| `latest_munin_for_server` | **217,194 ms** | **81 ms** |

Two factors made it worse than the raw numbers suggest:

- `jsonb_exists(extra, 'munin')` is not indexable, so the `LIMIT 1` cannot terminate early. **78 of 122 live servers never report the flag**, so most page loads hit the worst case — a full-history scan that finds nothing.
- The pruning-free plan reads ~2.4GB against a **200MB `shared_buffers`**, so it evicts the entire buffer pool. Every other query on the page then pays physical I/O too. This is why `get_detail` measured 17.9s cold and 2.1s immediately after those pages were cached, on identical code.

## What changed

Each lookback gets a window sized to its purpose, with the reasoning recorded next to the constants:

- `latest_munin_for_server` — 30d. The server-detail regression.
- `latest_per_source_at` — 30d before the cutoff. `DISTINCT ON` cannot terminate early (it must see every candidate row before it knows which is each group's newest), so an upper bound alone read the server's whole history to return one row per source. The status-snapshot regression. This is the same trap `latest_for_servers` already documents three functions below it.
- `last_with_version_for_server` — 90d, longer so a member down a month or two does not blank its group's cached version label.
- `latest_for_check_name` — 30d. Latent rather than implicated: it is only on the rule-editor sample endpoint, but the `health @>` containment is not indexable and it is not even server-scoped.

Separately, `consolidated_checks_at` graded each check with `apply_scoped`, one catalog query and one scoped-chain query **per check** — a few hundred round-trips for a status carrying dozens of checks (35 came from a single decommissioned source on the server that surfaced this). It now loads both tables once via `CheckPolicy::grading_table` and `ScopedCheckPolicy::chains_for_scope`. The grading logic is factored out of `apply`/`apply_scoped` into pure `CheckPolicy::grade` and `CheckPolicy::chain_scoped` so the ingestion path and the batch path share one implementation instead of drifting.

## Behaviour changes worth knowing

These are real narrowings, not pure optimisations:

- A server that has not reported the munin flag in 30 days now reads as not running Munin and loses its link. Harmless today — the flag only started being reported 2026-07-24 — but it is a weakening of the grace criteria, so the SVC spec now states the bound and why it exists rather than promising indefinite memory.
- A point-in-time snapshot no longer includes a source that was silent for the whole 30 days before the cutoff.

The alternatives that would preserve grace indefinitely — denormalising the flag onto `servers`, or a partial index on the partitioned parent — were considered and set aside in favour of the smaller change.

## Not addressed

`shared_buffers` at 200MB and a 10m CPU request on the database pods are both low for this workload, and they are what turned one slow query into a fleet-wide cache problem. That is an infra change, not this PR.
