### PR TITLE
feat: show the bestool version, resolve reported figures across sources

### DIFF
--- a/.workhorse/specs/private-server/server-figures.md
+++ b/.workhorse/specs/private-server/server-figures.md
@@ -1,0 +1,38 @@
+---
+id: FIG
+---
+
+# Reported server figures
+
+A server's detail view and its point-in-time status snapshot each present a row of figures describing the software the server runs.
+The figures are derived from the server-wide detail its sources report (see [STA](../public-server/statuses.md)), not from anything an operator enters.
+
+## Sourcing
+
+Several sources report on one server, each pushing its own server-wide detail, and they do not all report the same figures.
+Each figure is taken from the most recent source to report that figure, rather than from whichever source pushed most recently.
+So a figure holds its last reported value when the newest push comes from a source that does not carry it, and two figures presented together may come from different sources reporting at different times.
+
+A figure no source has reported in the last thirty days is not presented.
+Reads over status history are bounded, because a server accumulates enough history that an unbounded search for the last report of a figure is not affordable; the cost is that a server quiet for longer than that reads as having reported nothing.
+
+A figure that has never been reported is omitted from the row rather than presented empty.
+
+## Figures
+
+The application version is presented with how far behind the latest published version it is, and with the minimum embedded browser version that release requires.
+
+The platform names the operating system family the server runs, derived from the reported database engine.
+
+The timezone is the server's own configured timezone, presented so an operator can read the server's local time.
+
+The database engine version and the runtime version are presented as reported.
+When no source reports the runtime version, it falls back to the runtime named by the reporting device's connection metadata.
+
+The bestool version is the version of bestool, the first-party agent that reports on the server, as it reports it in its server-wide detail.
+A server reported on only by sources other than bestool presents no bestool version.
+
+## Point in time
+
+The status snapshot presents the same figures as of the moment being viewed.
+Each figure is taken from the most recent source to report it at or before that moment, within the same thirty-day bound measured back from that moment.

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -697,24 +697,20 @@ impl Status {
 			.collect())
 	}
 
+	/// This one status's server-wide detail, for a caller that has a single
+	/// status in hand rather than a server's set of sources. Prefer
+	/// [`MergedDetail::from_statuses`] where every source is available: a
+	/// figure this push doesn't carry is one another source may.
+	pub fn detail(&self) -> MergedDetail {
+		MergedDetail(self.extra.as_object().cloned().unwrap_or_default())
+	}
+
 	pub fn platform(&self) -> Option<String> {
-		self.extra("pgVersion")
-			.and_then(|pg| pg.as_str())
-			.map(|pg| {
-				if pg.contains("Visual C++") || pg.contains("windows") {
-					"Windows"
-				} else {
-					"Linux"
-				}
-				.into()
-			})
+		self.detail().platform()
 	}
 
 	pub fn postgres_version(&self) -> Option<String> {
-		self.extra("pgVersion")
-			.and_then(|pg| pg.as_str())
-			.and_then(|pg| pg.split_ascii_whitespace().nth(1))
-			.map(|vers| vers.trim_end_matches(',').into())
+		self.detail().postgres_version()
 	}
 
 	/// Node.js runtime version the server reported in its status payload
@@ -722,9 +718,7 @@ impl Status {
 	/// connection's User-Agent (see [`crate::devices::DeviceConnection::nodejs_version`]),
 	/// which only reflects whichever transport happened to set that header.
 	pub fn node_version(&self) -> Option<String> {
-		self.extra("nodeVersion")
-			.and_then(|v| v.as_str())
-			.map(ToOwned::to_owned)
+		self.detail().node_version()
 	}
 
 	/// Identified operators connected to the server as of this status
@@ -750,6 +744,95 @@ impl Status {
 	pub fn distance_from_version(&self, version: &Version) -> Option<u64> {
 		let current = self.version.as_ref().map(|v| &v.0)?;
 		Some(version_distance(current, version))
+	}
+}
+
+/// A server's server-wide detail resolved across all the sources reporting on
+/// it: for each key, the value from the most recent source that carries it.
+///
+/// Sources don't all report the same fields — only bestool reports
+/// `bestoolVersion`, while a legacy Tamanu push carries neither that nor
+/// `pgVersion` — so reading the figures off whichever source pushed last
+/// makes them blink out as sources interleave. Falling through to an older
+/// source per key holds each figure at its last reported value instead.
+// spec: FIG#sourcing
+#[derive(Debug, Clone, Default)]
+pub struct MergedDetail(serde_json::Map<String, serde_json::Value>);
+
+impl MergedDetail {
+	/// Fold `statuses` — one server's statuses, in any order — into the
+	/// resolved detail. Newer statuses win per key; a key absent from the
+	/// newest falls through to the newest status that has it.
+	///
+	/// Which statuses are passed sets the window this sees: callers hand it
+	/// each source's latest push (see [`Status::latest_per_source_at`]), so
+	/// a source silent beyond that lookback contributes nothing.
+	pub fn from_statuses(statuses: &[Status]) -> Self {
+		// latest_per_source_at orders by source name, not time, so sort
+		// rather than trusting the caller's order: "newest wins" reading as
+		// "last source alphabetically wins" would be silent and wrong.
+		let mut ordered: Vec<&Status> = statuses.iter().collect();
+		ordered.sort_by_key(|st| st.created_at);
+
+		let mut merged = serde_json::Map::new();
+		for status in ordered {
+			let Some(obj) = status.extra.as_object() else {
+				continue;
+			};
+			for (key, value) in obj {
+				if value.is_null() {
+					continue;
+				}
+				merged.insert(key.clone(), value.clone());
+			}
+		}
+		Self(merged)
+	}
+
+	pub fn get(&self, key: &str) -> Option<&serde_json::Value> {
+		self.0.get(key)
+	}
+
+	fn string(&self, key: &str) -> Option<String> {
+		self.get(key)
+			.and_then(|v| v.as_str())
+			.map(ToOwned::to_owned)
+	}
+
+	/// Operating system family, inferred from the shape of the reported
+	/// PostgreSQL version banner — which names its build toolchain, and so
+	/// distinguishes a Windows build from any other.
+	pub fn platform(&self) -> Option<String> {
+		self.string("pgVersion").map(|pg| {
+			if pg.contains("Visual C++") || pg.contains("windows") {
+				"Windows"
+			} else {
+				"Linux"
+			}
+			.into()
+		})
+	}
+
+	pub fn postgres_version(&self) -> Option<String> {
+		self.get("pgVersion")
+			.and_then(|pg| pg.as_str())
+			.and_then(|pg| pg.split_ascii_whitespace().nth(1))
+			.map(|vers| vers.trim_end_matches(',').into())
+	}
+
+	pub fn node_version(&self) -> Option<String> {
+		self.string("nodeVersion")
+	}
+
+	pub fn timezone(&self) -> Option<String> {
+		self.string("timezone")
+	}
+
+	/// Version of bestool itself, which it reports alongside the rest of its
+	/// server-wide detail. Absent for a server no bestool reports on.
+	// spec: FIG#figures
+	pub fn bestool_version(&self) -> Option<String> {
+		self.string("bestoolVersion")
 	}
 }
 

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -33,6 +33,7 @@ mod server_group_version_cache;
 mod server_restore_window;
 mod silenced_health_checks;
 mod slack_outbox_enqueue;
+mod status_figures;
 mod statuses_device_fk;
 mod statuses_munin;
 mod tag_reserved_prefix;

--- a/crates/database/tests/it/status_figures.rs
+++ b/crates/database/tests/it/status_figures.rs
@@ -1,0 +1,195 @@
+//! Resolving a server's reported figures across the sources reporting on it.
+//!
+//! Sources interleave and don't carry the same fields, so the figures are
+//! resolved per key from the most recent source to report each one.
+
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use uuid::Uuid;
+
+use database::statuses::{MergedDetail, Status};
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+/// `extra` and `created_at` are test-controlled SQL literals, interpolated
+/// directly; the server id and source are bound.
+async fn insert_status(
+	conn: &mut AsyncPgConnection,
+	server_id: Uuid,
+	source: &str,
+	extra: &str,
+	created_at: &str,
+) {
+	let query = format!(
+		"INSERT INTO statuses (server_id, source, extra, created_at) \
+		 VALUES ($1, $2, {extra}::jsonb, {created_at})"
+	);
+	sql_query(query)
+		.bind::<sql_types::Uuid, _>(server_id)
+		.bind::<sql_types::Text, _>(source)
+		.execute(conn)
+		.await
+		.expect("insert status");
+}
+
+async fn insert_server(conn: &mut AsyncPgConnection) -> Uuid {
+	let host = format!("http://figures.invalid/{}", Uuid::new_v4());
+	let server: RowId = sql_query("INSERT INTO servers (host) VALUES ($1) RETURNING id")
+		.bind::<sql_types::Text, _>(host)
+		.get_result(conn)
+		.await
+		.expect("insert server");
+	server.id
+}
+
+async fn figures(conn: &mut AsyncPgConnection, server_id: Uuid) -> MergedDetail {
+	let statuses = Status::latest_per_source_at(conn, server_id, None)
+		.await
+		.expect("load statuses per source");
+	MergedDetail::from_statuses(&statuses)
+}
+
+/// A newer push from a source that carries none of the figures doesn't blank
+/// them: each falls through to the most recent source that reports it.
+// spec: FIG#sourcing
+#[tokio::test(flavor = "multi_thread")]
+async fn figures_fall_through_to_the_source_that_reports_them() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn).await;
+
+		insert_status(
+			&mut conn,
+			server_id,
+			"alertd",
+			r#"'{"pgVersion": "PostgreSQL 16.3 on x86_64-pc-linux-gnu, compiled by gcc", "nodeVersion": "20.11.0", "bestoolVersion": "2.10.5", "timezone": "Pacific/Auckland"}'"#,
+			"NOW() - INTERVAL '2 hours'",
+		)
+		.await;
+		// The legacy Tamanu source reports later, and carries none of them.
+		insert_status(
+			&mut conn,
+			server_id,
+			"tamanu",
+			r#"'{"uptimeSecs": 6038594}'"#,
+			"NOW() - INTERVAL '1 hour'",
+		)
+		.await;
+
+		let figures = figures(&mut conn, server_id).await;
+		assert_eq!(figures.postgres_version().as_deref(), Some("16.3"));
+		assert_eq!(figures.node_version().as_deref(), Some("20.11.0"));
+		assert_eq!(figures.bestool_version().as_deref(), Some("2.10.5"));
+		assert_eq!(figures.timezone().as_deref(), Some("Pacific/Auckland"));
+		assert_eq!(figures.platform().as_deref(), Some("Linux"));
+	})
+	.await
+}
+
+/// Where two sources report the same figure, the newest report wins — by time,
+/// not by source name.
+// spec: FIG#sourcing
+#[tokio::test(flavor = "multi_thread")]
+async fn newest_report_wins_per_figure() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn).await;
+
+		// Source names ordered against their report times, so a merge that
+		// trusted the per-source query's (alphabetical) row order would take
+		// the stale value.
+		insert_status(
+			&mut conn,
+			server_id,
+			"zeta",
+			r#"'{"pgVersion": "PostgreSQL 14.1 on x86_64-pc-linux-gnu, compiled by gcc"}'"#,
+			"NOW() - INTERVAL '3 hours'",
+		)
+		.await;
+		insert_status(
+			&mut conn,
+			server_id,
+			"alpha",
+			r#"'{"pgVersion": "PostgreSQL 16.3 (Visual C++ build 1940), 64-bit"}'"#,
+			"NOW() - INTERVAL '1 hour'",
+		)
+		.await;
+
+		let figures = figures(&mut conn, server_id).await;
+		assert_eq!(
+			figures.postgres_version().as_deref(),
+			Some("16.3"),
+			"the later report supersedes the earlier one",
+		);
+		assert_eq!(
+			figures.platform().as_deref(),
+			Some("Windows"),
+			"platform follows the same report the version came from",
+		);
+	})
+	.await
+}
+
+/// A server no bestool reports on presents no bestool version.
+// spec: FIG#figures
+#[tokio::test(flavor = "multi_thread")]
+async fn bestool_version_absent_when_no_source_reports_it() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn).await;
+		insert_status(
+			&mut conn,
+			server_id,
+			"tamanu",
+			r#"'{"uptimeSecs": 42}'"#,
+			"NOW() - INTERVAL '5 minutes'",
+		)
+		.await;
+
+		assert_eq!(figures(&mut conn, server_id).await.bestool_version(), None);
+	})
+	.await
+}
+
+/// The figures see only as far back as the per-source lookback: a source
+/// silent beyond it contributes nothing, so its figures read as unreported
+/// rather than costing an unbounded scan of the partitioned history.
+// spec: FIG#sourcing
+#[tokio::test(flavor = "multi_thread")]
+async fn figures_from_a_long_silent_source_are_dropped() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn).await;
+		insert_status(
+			&mut conn,
+			server_id,
+			"alertd",
+			r#"'{"bestoolVersion": "2.10.5"}'"#,
+			"NOW() - INTERVAL '29 days'",
+		)
+		.await;
+		assert_eq!(
+			figures(&mut conn, server_id)
+				.await
+				.bestool_version()
+				.as_deref(),
+			Some("2.10.5"),
+			"a report inside the lookback still counts",
+		);
+
+		sql_query(
+			"UPDATE statuses SET created_at = NOW() - INTERVAL '31 days' WHERE server_id = $1",
+		)
+		.bind::<sql_types::Uuid, _>(server_id)
+		.execute(&mut conn)
+		.await
+		.expect("age the status out of the window");
+
+		assert_eq!(
+			figures(&mut conn, server_id).await.bestool_version(),
+			None,
+			"a source silent beyond the lookback contributes no figures",
+		);
+	})
+	.await
+}

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -18,7 +18,7 @@ use database::{
 	server_enrollment_tokens::ServerEnrollmentToken,
 	server_groups::ServerGroup,
 	servers::{PartialServer, Server},
-	statuses::Status,
+	statuses::{MergedDetail, Status},
 	versions::Version,
 };
 use futures::future::join;
@@ -151,6 +151,9 @@ pub struct ServerLastStatusData {
 	pub postgres: Option<String>,
 	/// Node.js version associated with the server, if known.
 	pub nodejs: Option<String>,
+	/// Version of bestool, the agent reporting on the server. Absent when no
+	/// source reports one.
+	pub bestool: Option<String>,
 	/// Timezone the server reported, if any.
 	pub timezone: Option<String>,
 	/// The source that pushed this status (e.g. `alertd`).
@@ -622,11 +625,17 @@ pub async fn get_detail(
 			None => None,
 		};
 
-		let platform = st.platform();
-		let postgres = st.postgres_version();
+		// The figures are resolved across every source reporting on the
+		// server, not just off `st`: sources don't all carry the same fields,
+		// so reading them off the latest push alone drops a figure whenever
+		// the source that reports it isn't the one that pushed last.
+		// spec: FIG#sourcing
+		let figures = MergedDetail::from_statuses(
+			&Status::latest_per_source_at(&mut conn, server.id, None).await?,
+		);
 		// Prefer the payload-reported `nodeVersion`; fall back to the device
 		// connection's User-Agent.
-		let nodejs = st
+		let nodejs = figures
 			.node_version()
 			.or_else(|| connection.and_then(|d| d.nodejs_version()));
 		let version_distance = latest_version
@@ -646,12 +655,11 @@ pub async fn get_detail(
 			version: st.version.clone(),
 			version_distance,
 			min_chrome_version,
-			platform,
-			postgres,
+			platform: figures.platform(),
+			postgres: figures.postgres_version(),
 			nodejs,
-			timezone: st
-				.extra("timezone")
-				.and_then(|s| s.as_str().map(|s| s.to_string())),
+			bestool: figures.bestool_version(),
+			timezone: figures.timezone(),
 			source: st.source.clone(),
 			extra: st.extra.clone(),
 			operators,

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -15,9 +15,14 @@ use commons_types::{
 	version::VersionStr,
 };
 use database::{
-	check_policies::CheckPolicy, devices::DeviceConnection, issues::Issue,
-	server_groups::ServerGroup, servers::Server, statuses::Status,
-	tailscale_users::TailscaleUser as CachedTailscaleUser, versions::Version,
+	check_policies::CheckPolicy,
+	devices::DeviceConnection,
+	issues::Issue,
+	server_groups::ServerGroup,
+	servers::Server,
+	statuses::{MergedDetail, Status},
+	tailscale_users::TailscaleUser as CachedTailscaleUser,
+	versions::Version,
 };
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -590,6 +595,9 @@ pub struct StatusSnapshotData {
 	pub postgres: Option<String>,
 	/// Reported runtime version.
 	pub nodejs: Option<String>,
+	/// Version of bestool, the agent reporting on the server. Absent when no
+	/// source reports one.
+	pub bestool: Option<String>,
 	/// Reported system timezone.
 	pub timezone: Option<String>,
 	/// Additional unstructured data reported alongside the snapshot, keyed
@@ -660,11 +668,22 @@ pub async fn snapshot(
 		Ok(v) => status.distance_from_version(&v.as_semver()),
 		Err(_) => None,
 	};
-	// Prefer the Node.js version the server reported in its status payload
+	// The consolidated checks as of this snapshot: every source's most
+	// recent report at-or-before `at`, re-graded through current policy,
+	// plus the figures those same reports resolve to. The single `status`
+	// above is still used for the push's own metadata (version, operators,
+	// etc.).
+	let SnapshotState {
+		checks,
+		by_source_extra,
+		figures,
+	} = consolidated_checks_at(&mut conn, &server, args.at).await?;
+
+	// Prefer the Node.js version reported in a status payload
 	// (`nodeVersion`). Fall back to scraping the *latest* device connection's
 	// User-Agent — that metadata isn't versioned in lockstep with status
 	// pushes, so looking it up "as of" a time would mostly mislead.
-	let nodejs = match status.node_version() {
+	let nodejs = match figures.node_version() {
 		Some(v) => Some(v),
 		None => {
 			if let Some(dev_id) = status.device_id {
@@ -683,17 +702,6 @@ pub async fn snapshot(
 	} else {
 		None
 	};
-	let timezone = status
-		.extra("timezone")
-		.and_then(|v| v.as_str().map(|s| s.to_string()));
-	let platform = status.platform();
-	let postgres = status.postgres_version();
-
-	// The consolidated checks as of this snapshot: every source's most
-	// recent report at-or-before `at`, re-graded through current policy.
-	// The single `status` above is still used for the push's metadata
-	// (version, platform, operators, etc.).
-	let (checks, extra) = consolidated_checks_at(&mut conn, &server, args.at).await?;
 	let mut operators = status.operators();
 	enrich_operators(&mut conn, operators.iter_mut()).await?;
 
@@ -705,11 +713,12 @@ pub async fn snapshot(
 		version: status.version,
 		version_distance,
 		min_chrome_version,
-		platform,
-		postgres,
+		platform: figures.platform(),
+		postgres: figures.postgres_version(),
 		nodejs,
-		timezone,
-		extra,
+		bestool: figures.bestool_version(),
+		timezone: figures.timezone(),
+		extra: by_source_extra,
 		operators,
 		checks,
 	})))
@@ -750,6 +759,16 @@ pub(crate) async fn enrich_operators(
 /// the public-server ingestion path (`file_health_events`) so the UI
 /// displays what *would* be filed. Broken checks aren't included — they
 /// file as warnings and the UI renders them from the result directly.
+/// What one pass over a server's per-source statuses yields: everything the
+/// snapshot needs from status history, so the pass isn't repeated per figure.
+struct SnapshotState {
+	checks: commons_types::status::ConsolidatedChecks,
+	/// Each source's raw payload, keyed by source.
+	by_source_extra: serde_json::Value,
+	/// The server-wide figures resolved across those sources.
+	figures: MergedDetail,
+}
+
 /// Reconstruct a server's consolidated checks as of a point in time (or
 /// latest) from status history: each source's most recent report at-or-
 /// before `at`, every check re-graded through current policy — the same
@@ -759,11 +778,17 @@ async fn consolidated_checks_at(
 	conn: &mut database::diesel_async::AsyncPgConnection,
 	server: &Server,
 	at: Option<Timestamp>,
-) -> commons_errors::Result<(commons_types::status::ConsolidatedChecks, serde_json::Value)> {
+) -> commons_errors::Result<SnapshotState> {
 	use commons_types::status::{CheckResult, ConsolidatedCheck, ConsolidatedChecks, HealthState};
 	use database::check_policies::{CheckPolicy, EvaluationContext, ScopedCheckPolicy};
 
 	let statuses = Status::latest_per_source_at(conn, server.id, at).await?;
+
+	// The figures come from the same set of statuses the checks do, so the
+	// snapshot presents each figure as of `at` from whichever source last
+	// reported it, rather than from whichever source happened to push last.
+	// spec: FIG#point-in-time
+	let figures = MergedDetail::from_statuses(&statuses);
 
 	// Each source's raw status-level payload, keyed by source, so the
 	// snapshot's raw-payload panel is consolidated rather than one source's
@@ -868,11 +893,12 @@ async fn consolidated_checks_at(
 	});
 	let health_state =
 		HealthState::from_results(checks.iter().filter(|c| !c.silenced).map(|c| c.effective));
-	Ok((
-		ConsolidatedChecks {
+	Ok(SnapshotState {
+		checks: ConsolidatedChecks {
 			health_state,
 			checks,
 		},
-		serde_json::Value::Object(by_source_extra),
-	))
+		by_source_extra: serde_json::Value::Object(by_source_extra),
+		figures,
+	})
 }

--- a/crates/private-server/tests/it/private_statuses.rs
+++ b/crates/private-server/tests/it/private_statuses.rs
@@ -67,6 +67,8 @@ struct ServerLastStatusData {
 	platform: Option<String>,
 	postgres: Option<String>,
 	nodejs: Option<String>,
+	#[serde(default)]
+	bestool: Option<String>,
 	timezone: Option<String>,
 	extra: serde_json::Value,
 }
@@ -639,6 +641,57 @@ async fn get_detail_with_status() {
 	.await
 }
 
+/// The detail view's figures come from every source reporting on the server,
+/// so a later push from a source that carries none of them leaves them intact
+/// — and a server no bestool reports on presents no bestool version.
+// spec: FIG#sourcing
+#[tokio::test(flavor = "multi_thread")]
+async fn get_detail_figures_resolve_across_sources() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO servers (id, name, host, rank, kind) VALUES
+			('11111111-1111-1111-1111-111111111111', 'Bestool Server', 'https://bestool.example.com', 'test', 'central'),
+			('22222222-2222-2222-2222-222222222222', 'Tamanu Only', 'https://tamanuonly.example.com', 'test', 'central');
+
+			INSERT INTO statuses (server_id, source, extra, created_at) VALUES
+			('11111111-1111-1111-1111-111111111111', 'alertd',
+			 '{\"bestoolVersion\": \"2.10.5\", \"pgVersion\": \"PostgreSQL 17.2, (x86_64-pc-linux-gnu, compiled by gcc)\", \"timezone\": \"Pacific/Auckland\"}'::jsonb,
+			 NOW() - INTERVAL '10 minutes'),
+			('11111111-1111-1111-1111-111111111111', 'tamanu', '{\"uptimeSecs\": 6038594}'::jsonb, NOW()),
+			('22222222-2222-2222-2222-222222222222', 'tamanu', '{\"uptimeSecs\": 42}'::jsonb, NOW())",
+		)
+		.await
+		.unwrap();
+
+		let detail: ServerDetailResponse = private
+			.post("/api/servers/get_detail")
+			.json(&serde_json::json!({"server_id": "11111111-1111-1111-1111-111111111111"}))
+			.await
+			.json();
+		let status = detail.last_status.expect("status reported");
+		assert_eq!(
+			status.bestool,
+			Some("2.10.5".to_string()),
+			"bestool's version survives a later push from a source that doesn't report one"
+		);
+		assert_eq!(status.postgres, Some("17.2".to_string()));
+		assert_eq!(status.platform, Some("Linux".to_string()));
+		assert_eq!(status.timezone, Some("Pacific/Auckland".to_string()));
+
+		let plain: ServerDetailResponse = private
+			.post("/api/servers/get_detail")
+			.json(&serde_json::json!({"server_id": "22222222-2222-2222-2222-222222222222"}))
+			.await
+			.json();
+		assert_eq!(
+			plain.last_status.expect("status reported").bestool,
+			None,
+			"a server no bestool reports on presents no bestool version"
+		);
+	})
+	.await
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn get_detail_with_device() {
 	commons_tests::server::run(async |mut conn, _, private| {
@@ -858,6 +911,12 @@ struct SnapshotData {
 	checks: Option<serde_json::Value>,
 	#[serde(default)]
 	nodejs: Option<String>,
+	#[serde(default)]
+	postgres: Option<String>,
+	#[serde(default)]
+	bestool: Option<String>,
+	#[serde(default)]
+	timezone: Option<String>,
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -894,6 +953,74 @@ async fn snapshot_returns_latest_when_at_omitted() {
 		let arr = checks["checks"].as_array().unwrap();
 		assert_eq!(arr.len(), 1);
 		assert_eq!(arr[0]["check"], "db");
+	})
+	.await
+}
+
+/// The snapshot's figures are resolved across sources: a later push from a
+/// source carrying none of them doesn't blank out what bestool reported.
+// spec: FIG#sourcing
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_figures_survive_a_later_push_from_another_source() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO servers (id, host, kind) VALUES
+			('20000000-0000-0000-0000-000000000030', 'https://figures.example.com', 'central');
+
+			INSERT INTO statuses (server_id, source, created_at, healthy, health, extra) VALUES
+			('20000000-0000-0000-0000-000000000030', 'alertd', NOW() - INTERVAL '2 hours', true, '[]'::jsonb,
+			 '{\"bestoolVersion\":\"2.10.5\",\"pgVersion\":\"PostgreSQL 16.3 on x86_64-pc-linux-gnu\",\"timezone\":\"Pacific/Auckland\"}'::jsonb),
+			('20000000-0000-0000-0000-000000000030', 'tamanu', NOW() - INTERVAL '1 hour', true, '[]'::jsonb,
+			 '{\"uptimeSecs\":6038594}'::jsonb)",
+		)
+		.await
+		.unwrap();
+
+		let r = private
+			.post("/api/statuses/snapshot")
+			.json(&serde_json::json!({
+				"server_id": "20000000-0000-0000-0000-000000000030"
+			}))
+			.await;
+		r.assert_status_ok();
+		let data: Option<SnapshotData> = r.json();
+		let data = data.expect("snapshot returned");
+		assert_eq!(
+			data.bestool,
+			Some("2.10.5".to_string()),
+			"bestool's version survives a later push from a source that doesn't report one"
+		);
+		assert_eq!(data.postgres, Some("16.3".to_string()));
+		assert_eq!(data.timezone, Some("Pacific/Auckland".to_string()));
+	})
+	.await
+}
+
+/// A server no bestool reports on presents no bestool version.
+// spec: FIG#figures
+#[tokio::test(flavor = "multi_thread")]
+async fn snapshot_has_no_bestool_version_when_unreported() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO servers (id, host, kind) VALUES
+			('20000000-0000-0000-0000-000000000031', 'https://nobestool.example.com', 'central');
+
+			INSERT INTO statuses (server_id, source, created_at, healthy, health, extra) VALUES
+			('20000000-0000-0000-0000-000000000031', 'tamanu', NOW() - INTERVAL '1 hour', true, '[]'::jsonb,
+			 '{\"uptimeSecs\":42}'::jsonb)",
+		)
+		.await
+		.unwrap();
+
+		let r = private
+			.post("/api/statuses/snapshot")
+			.json(&serde_json::json!({
+				"server_id": "20000000-0000-0000-0000-000000000031"
+			}))
+			.await;
+		r.assert_status_ok();
+		let data: Option<SnapshotData> = r.json();
+		assert_eq!(data.expect("snapshot returned").bestool, None);
 	})
 	.await
 }

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -213,19 +213,22 @@ export async function seedStatus(
 		healthy?: boolean;
 		health?: unknown[];
 		extra?: Record<string, unknown>;
+		/** Reporting source. Defaults to `alertd`, as ingestion does. */
+		source?: string;
 		/** ISO 8601 timestamp or relative SQL like `NOW() - INTERVAL '1 hour'`.
 		 * Defaults to NOW(). */
 		createdAt?: string;
 	},
 ): Promise<SeededStatus> {
 	const id = randomUUID();
+	const source = opts.source ?? "alertd";
 	const useSqlExpr =
 		opts.createdAt !== undefined && opts.createdAt.toUpperCase().startsWith("NOW");
 	const createdAtClause = opts.createdAt === undefined
 		? "NOW()"
 		: useSqlExpr
 			? opts.createdAt
-			: "$8";
+			: "$9";
 	const params: unknown[] = [
 		id,
 		opts.serverId,
@@ -234,12 +237,13 @@ export async function seedStatus(
 		opts.healthy ?? true,
 		JSON.stringify(opts.health ?? []),
 		JSON.stringify(opts.extra ?? {}),
+		source,
 	];
 	if (!useSqlExpr && opts.createdAt !== undefined) params.push(opts.createdAt);
 	const rows = await sql.query<{ created_at: string }>(
 		`INSERT INTO statuses
-		 (id, server_id, device_id, version, healthy, health, extra, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, ${createdAtClause})
+		 (id, server_id, device_id, version, healthy, health, extra, source, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, ${createdAtClause})
 		 RETURNING created_at`,
 		params,
 	);
@@ -263,15 +267,15 @@ export async function seedStatus(
 		// counts if a live catalog row backs it. Never clobbers an explicit
 		// seedCheckPolicy for the same (source, check).
 		await sql.query(
-			`INSERT INTO check_policies (source, check_name) VALUES ('alertd', $1)
+			`INSERT INTO check_policies (source, check_name) VALUES ($1, $2)
 			 ON CONFLICT (source, check_name) DO NOTHING`,
-			[check],
+			[source, check],
 		);
 		const degraded = ["failed", "warning", "broken"].includes(result);
 		await sql.query(
 			`INSERT INTO issues
 			 (server_id, source, ref, check_name, observed_result, effective_result, detail, message, active, first_seen, last_seen, degraded_since, last_degraded_at)
-			 VALUES ($1, 'alertd', $2, $3, $4, $4, $5::jsonb, $6, $7, NOW(), NOW(), $8, $9)
+			 VALUES ($1, $10, $2, $3, $4, $4, $5::jsonb, $6, $7, NOW(), NOW(), $8, $9)
 			 ON CONFLICT DO NOTHING`,
 			[
 				opts.serverId,
@@ -283,6 +287,7 @@ export async function seedStatus(
 				degraded,
 				degraded ? new Date().toISOString() : null,
 				degraded ? new Date().toISOString() : null,
+				source,
 			],
 		);
 	}

--- a/private-web/e2e/server-figures.spec.ts
+++ b/private-web/e2e/server-figures.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "./test-fixtures";
+import { resetSeededTables, seedServer, seedStatus } from "./seed";
+
+const BESTOOL_EXTRA = {
+	bestoolVersion: "2.10.5",
+	pgVersion: "PostgreSQL 17.2, (x86_64-pc-linux-gnu, compiled by gcc)",
+	nodeVersion: "20.11.0",
+};
+
+// spec: FIG
+test.describe("reported server figures", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("presents the bestool version, and holds it through a later push from another source", async ({
+		page,
+		sql,
+	}) => {
+		const server = await seedServer(sql, { name: "runs-bestool" });
+		await seedStatus(sql, {
+			serverId: server.id,
+			source: "alertd",
+			extra: BESTOOL_EXTRA,
+			createdAt: "NOW() - INTERVAL '10 minutes'",
+		});
+		// The legacy Tamanu source reports later and carries none of the figures.
+		await seedStatus(sql, {
+			serverId: server.id,
+			source: "tamanu",
+			extra: { uptimeSecs: 6038594 },
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		await expect(page.getByText("bestool", { exact: true })).toBeVisible();
+		await expect(page.getByText("2.10.5", { exact: true })).toBeVisible();
+		await expect(page.getByText("17.2", { exact: true })).toBeVisible();
+		await expect(page.getByText("20.11.0", { exact: true })).toBeVisible();
+	});
+
+	test("shows no bestool figure for a server no bestool reports on", async ({
+		page,
+		sql,
+	}) => {
+		const server = await seedServer(sql, { name: "no-bestool" });
+		await seedStatus(sql, {
+			serverId: server.id,
+			source: "tamanu",
+			extra: { uptimeSecs: 42 },
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		await expect(
+			page.getByRole("heading", { level: 1, name: /no-bestool/ }),
+		).toBeVisible();
+		await expect(page.getByText("bestool", { exact: true })).toHaveCount(0);
+	});
+
+	test("carries the figures into the point-in-time snapshot", async ({
+		page,
+		sql,
+	}) => {
+		const server = await seedServer(sql, {
+			name: "snapshot-bestool",
+			kind: "central",
+		});
+		await seedStatus(sql, {
+			serverId: server.id,
+			source: "alertd",
+			extra: BESTOOL_EXTRA,
+			health: [{ check: "postgres", result: "failed" }],
+			createdAt: "NOW() - INTERVAL '30 minutes'",
+		});
+		// A later push from another source carries none of the figures.
+		await seedStatus(sql, {
+			serverId: server.id,
+			source: "tamanu",
+			extra: { uptimeSecs: 6038594 },
+		});
+		// The failed check's own issue row is what opens the snapshot panel.
+		await page.goto("/incidents?showAll=1");
+		await page
+			.getByRole("button", {
+				name: "Status snapshot when this issue was last seen",
+			})
+			.first()
+			.click();
+
+		await expect(
+			page.getByText("Status snapshot", { exact: true }),
+		).toBeVisible();
+		await expect(page.getByText("bestool", { exact: true })).toBeVisible();
+		await expect(page.getByText("2.10.5", { exact: true })).toBeVisible();
+	});
+});

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -12171,6 +12171,13 @@
           "operators"
         ],
         "properties": {
+          "bestool": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Version of bestool, the agent reporting on the server. Absent when no\nsource reports one."
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -12834,6 +12841,13 @@
           "checks"
         ],
         "properties": {
+          "bestool": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Version of bestool, the agent reporting on the server. Absent when no\nsource reports one."
+          },
           "checks": {
             "$ref": "#/components/schemas/ConsolidatedChecks",
             "description": "The server's consolidated checks as of this snapshot: every source's\nchecks, graded and classified, with silenced flags and the rolled-up\nhealth state — the same shape the live view uses."

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -6936,6 +6936,11 @@ export interface components {
          */
         ServerLastStatusData: {
             /**
+             * @description Version of bestool, the agent reporting on the server. Absent when no
+             *     source reports one.
+             */
+            bestool?: string | null;
+            /**
              * Format: date-time
              * @description When this status was reported.
              */
@@ -7342,6 +7347,11 @@ export interface components {
          *     health and version information.
          */
         StatusSnapshotData: {
+            /**
+             * @description Version of bestool, the agent reporting on the server. Absent when no
+             *     source reports one.
+             */
+            bestool?: string | null;
             /**
              * @description The server's consolidated checks as of this snapshot: every source's
              *     checks, graded and classified, with silenced flags and the rolled-up

--- a/private-web/src/components/StatusSnapshot.tsx
+++ b/private-web/src/components/StatusSnapshot.tsx
@@ -138,6 +138,7 @@ function CuratedFields({ snap }: { snap: StatusSnapshotData }) {
 			)}
 			{snap.postgres && <Field label="PostgreSQL" value={snap.postgres} mono />}
 			{snap.nodejs && <Field label="Node.js" value={snap.nodejs} mono />}
+			{snap.bestool && <Field label="bestool" value={snap.bestool} mono />}
 			{snap.min_chrome_version != null && (
 				<Field
 					label="Chrome"

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -1460,6 +1460,9 @@ function StatusInfoFields({ status }: { status: ServerLastStatusData }) {
 			{status.nodejs && (
 				<InfoItem label="Node.js" value={status.nodejs} mono />
 			)}
+			{status.bestool && (
+				<InfoItem label="bestool" value={status.bestool} mono />
+			)}
 			{status.min_chrome_version != null && (
 				<InfoItem
 					label="Chrome"


### PR DESCRIPTION
🤖 The server detail page and the status snapshot present a row of figures — Tamanu version, platform, PostgreSQL, Node.js, timezone. This adds bestool's own version, which bestool reports as `bestoolVersion` in its server-wide detail.

## Sourcing

The figures were read off `latest_for_server` — the newest push from *any* source. But sources don't all carry the same fields: only bestool sends `bestoolVersion`, and a legacy Tamanu push carries neither that nor `pgVersion`. On a server where both report, whichever pushed last decided what the page showed, so the platform / PostgreSQL / Node.js figures blinked out whenever `tamanu` landed after `alertd`.

Adding a fourth field the same way would have inherited that, so the figures are now resolved per key across every source's latest report: each takes its value from the most recent source that actually carries it. Two figures shown side by side may come from different sources at different times, which is the point — they're independent facts about the server, not properties of one push.

`MergedDetail` does the fold and holds the derivations (`platform`, `postgres_version`, `node_version`, `timezone`, `bestool_version`). `Status::platform()` and friends stay as delegates over a single status, so callers that legitimately have one push in hand are unchanged.

The snapshot gets this for free: `consolidated_checks_at` already loads `latest_per_source_at`, so the same pass feeds both the checks and the figures. It returns a named `SnapshotState` now rather than a growing tuple. Server detail adds one bounded per-source read, and keeps its `latest_for_server` for the push's own identity — "when did this server last report" and "what PostgreSQL does it run" are different questions.

## Behaviour changes worth knowing

- Platform, PostgreSQL, Node.js and timezone stop disappearing when a source that doesn't report them pushes last.
- The flip side: they can now read up to 30 days stale if the source reporting them goes quiet, where before they'd blank out. That bound is the per-source lookback from #404 — the figures see exactly as far back as the checks do.
- A figure no source has reported inside that window is omitted from the row, matching how the existing figures handle absence.

## Also

`seedStatus` in the e2e helpers grows a `source` option. Threading it through revealed that the `check_policies` / `issues` rows it fabricates were hardcoded to `alertd`, so a caller seeding a `tamanu` push with checks would have filed them under the wrong source; that's fixed alongside.

Spec: new `FIG` (`.workhorse/specs/private-server/server-figures.md`) — the curated figures weren't specified anywhere, with `STA` covering the push contract and `SVC` the links.