### PR TITLE
test(e2e): reset source policy between tests

### DIFF
--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,12 +47,17 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, check_policies, scoped_check_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
 	// self-alerts attach to that row, so put it back.
 	await sql.query(
 		"INSERT INTO servers (id, kind, name, host) VALUES ('00000000-0000-0000-0000-000000000000', 'canopy', 'Canopy', 'http://localhost')",
+	);
+	// Same for the migration's one seeded source policy: tamanu reports on
+	// its own schedule, so its silence is not a reachability signal.
+	await sql.query(
+		"INSERT INTO source_policies (source, reachability) VALUES ('tamanu', 'quiet')",
 	);
 }
 

--- a/private-web/e2e/source-ingest.spec.ts
+++ b/private-web/e2e/source-ingest.spec.ts
@@ -1,9 +1,15 @@
-import { seedCheckPolicy } from "./seed";
+import { resetSeededTables, seedCheckPolicy } from "./seed";
 import { expect, test } from "./test-fixtures";
 
 const SOURCES_PATH = "/settings/healthchecks/sources";
 
 test.describe("Source ingest gating", () => {
+	// A source's ingest mode outlives the test that sets it — the stack
+	// (and its database) is per worker, not per test.
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
 	test("setting ingest to deny persists and disables reachability", async ({
 		page,
 		sql,

--- a/private-web/e2e/source-reachability.spec.ts
+++ b/private-web/e2e/source-reachability.spec.ts
@@ -1,9 +1,16 @@
-import { seedCheckPolicy } from "./seed";
+import { resetSeededTables, seedCheckPolicy } from "./seed";
 import { expect, test } from "./test-fixtures";
 
 const SOURCES_PATH = "/settings/healthchecks/sources";
 
 test.describe("Source reachability", () => {
+	// Each test asserts against a source's starting policy, and a policy set
+	// here outlives the test that set it — the stack (and its database) is
+	// per worker, not per test.
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
 	test("an operator can change a source's reachability mode", async ({
 		page,
 		sql,

--- a/private-web/e2e/sources-page.spec.ts
+++ b/private-web/e2e/sources-page.spec.ts
@@ -1,7 +1,13 @@
-import { seedCheckPolicy } from "./seed";
+import { resetSeededTables, seedCheckPolicy } from "./seed";
 import { expect, test } from "./test-fixtures";
 
 test.describe("Sources page", () => {
+	// Source policy outlives the test that sets it — the stack (and its
+	// database) is per worker, not per test.
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
 	test("the healthcheck catalog links out to the sources page", async ({
 		page,
 		sql,


### PR DESCRIPTION
🤖 Noticed while running the e2e suite for #407.

`resetSeededTables` truncated the check catalog but not the source policy beside it, so a source's reachability and ingest modes outlived the test that set them — the stack, and its database, is per worker, not per test.

## What it fixes

That made the source specs order-dependent, in two different ways:

- **Within `source-reachability.spec.ts`**: the first test leaves `alertd` on `quiet`, so the second test's "the toggle starts on `on`" assertion fails.
- **Across a full-suite run**: `source-ingest.spec.ts` runs first and leaves `alertd` on `deny`, which disables the reachability toggle entirely — the second test then times out trying to click a disabled button.

Each of the affected tests passes in isolation, which is what makes it easy to miss. CI only gets away with it because a retry starts a fresh worker with a fresh database, so the run reports flaky rather than failed.

## The change

The truncate now takes `source_policies` too, restoring the one policy the migrations seed (`tamanu`/`quiet`) the same way the nil Canopy server is restored. The three specs that set source policy — reachability, ingest, and the sources page — reset first, as most other specs already do.

Test-only: nothing outside `private-web/e2e/` changes.

## Verification

Full Playwright suite: 167/167 passing, where it was 166 passing + 1 failing before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML964V9buRHqAdGdgcN8Mb

---
_Generated by [Claude Code](https://claude.ai/code/session_01ML964V9buRHqAdGdgcN8Mb)_