### PR TITLE
Fix admin status probe to distinguish errors from authorization

### DIFF
--- a/.workhorse/specs/private-server/admin-access.md
+++ b/.workhorse/specs/private-server/admin-access.md
@@ -47,3 +47,16 @@ The administrative surface admits only callers bearing a tailnet user identity, 
 Administrative status derived from the policy reflects the policy as of the most recent successful read, refreshed periodically.
 Reading the policy requires read access to the tailnet policy file.
 When the policy cannot be read, the recorded allowlist remains authoritative, so a control-plane outage never withdraws administrative access held through the allowlist.
+
+## Reporting administrative status to a caller
+
+A caller can ask whether it is an administrator without itself being one, so that a client can decide whether to offer administrative controls before attempting anything.
+The answer is `true` for an administrator and `false` for a caller that definitely is not one, including a caller bearing no tailnet identity at all.
+A failure that is not an authorization outcome — the allowlist being unreadable, say — is reported as an error rather than as `false`, because a caller cannot tell a wrongly-negative answer from a real one.
+
+## Presenting administrative controls
+
+An operator client decides the whole session's administrative controls from a single answer, so that every part of a page agrees about whether the operator is an administrator.
+Until an answer arrives, administrative controls are withheld.
+Once an answer arrives it is retained for the session and refreshed periodically; a later failed refresh leaves the retained answer in place rather than withdrawing controls mid-session.
+While no answer has yet arrived and the request is failing, the client retries and tells the operator that administrative status is undetermined, rather than presenting an unexplained read-only view.

--- a/crates/private-server/src/fns/commons.rs
+++ b/crates/private-server/src/fns/commons.rs
@@ -57,10 +57,14 @@ pub async fn server_versions_url() -> Result<Json<Option<String>>> {
 /// Check whether the caller is an admin.
 ///
 /// Reports `true` if the caller is authenticated and their identity is on
-/// the admin allow-list, `false` otherwise — including when the caller is
-/// not authenticated at all. This endpoint intentionally requires no
-/// authentication of its own, since it exists so a client can check whether
-/// to show admin-only controls before doing anything else.
+/// the admin allow-list, `false` if the caller definitely isn't an admin —
+/// including when the caller is not authenticated at all. This endpoint
+/// intentionally requires no authentication of its own, since it exists so a
+/// client can check whether to show admin-only controls before doing anything
+/// else.
+///
+/// A failure that isn't an authorization outcome (a database blip while
+/// reading the allow-list, say) is reported as an error, not as `false`.
 // No `security` block: the handler intentionally accepts unauthenticated
 // callers and reports `false`. Marking it admin-gated (or even user-gated)
 // would make Swagger UI demand auth before letting you call it, defeating
@@ -71,10 +75,66 @@ pub async fn server_versions_url() -> Result<Json<Option<String>>> {
 	tag = "commons",
 	responses(
 		(status = 200, description = "`true` if the caller's Tailscale identity is an administrator (on the admin allow-list, or granted admin by the tailnet policy); `false` otherwise (including when no Tailscale identity is present).", body = bool, content_type = "application/json"),
+		(status = 500, description = "The caller's admin status could not be determined. Distinct from a `false` answer: retry rather than treating the caller as a non-admin.", body = ProblemDetailsSchema),
 	),
 )]
 pub async fn is_current_user_admin(
 	admin: std::result::Result<TailscaleAdmin, AppError>,
-) -> Json<bool> {
-	Json(admin.is_ok())
+) -> Result<Json<bool>> {
+	admin_probe_answer(admin).map(Json)
+}
+
+/// Classify an admin-extractor outcome into the probe's answer.
+///
+/// `TailscaleAdmin` rejects for two very different kinds of reason, and
+/// collapsing them both to `false` is a bug: the UI caches the answer for the
+/// session, so one database hiccup while checking the allow-list used to leave
+/// a real admin looking at a read-only app with no admin controls and no
+/// explanation. Only a definite authorization outcome is an answer; everything
+/// else propagates so the caller knows to retry.
+fn admin_probe_answer(admin: std::result::Result<TailscaleAdmin, AppError>) -> Result<bool> {
+	match admin {
+		Ok(_) => Ok(true),
+		Err(
+			AppError::AuthMissingHeader(_)
+			| AppError::AuthTailnetIdentityMissing
+			| AppError::AuthInsufficientPermissions { .. },
+		) => Ok(false),
+		Err(err) => Err(err),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use commons_servers::tailscale_auth::TailscaleUser;
+
+	#[test]
+	fn admin_is_true() {
+		let admin = TailscaleAdmin(TailscaleUser::default());
+		assert!(admin_probe_answer(Ok(admin)).unwrap());
+	}
+
+	#[test]
+	fn authorization_outcomes_are_a_definite_no() {
+		for err in [
+			AppError::AuthMissingHeader("Tailscale-User-Login"),
+			AppError::AuthTailnetIdentityMissing,
+			AppError::AuthInsufficientPermissions {
+				required: "admin".into(),
+			},
+		] {
+			assert!(!admin_probe_answer(Err(err)).unwrap());
+		}
+	}
+
+	#[test]
+	fn infrastructure_failures_are_not_an_answer() {
+		for err in [
+			AppError::custom("connection pool timed out"),
+			AppError::Upstream("tailnet control plane".into()),
+		] {
+			assert!(admin_probe_answer(Err(err)).is_err());
+		}
+	}
 }

--- a/private-web/e2e/admin-gating.spec.ts
+++ b/private-web/e2e/admin-gating.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "./test-fixtures";
+import { resetSeededTables, seedServerGroup } from "./seed";
+
+const PROBE = "**/api/commons/is_current_user_admin";
+
+// "New group" on the fleet listing is admin-only and unambiguous, so it makes a
+// good stand-in for every admin-gated control in the app: they all read the
+// same provider now.
+const adminControl = (page: import("@playwright/test").Page) =>
+	page.getByRole("link", { name: "New group" });
+
+test.describe("admin gating", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("the admin probe runs once for the whole session, not per page", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "probe-count-group" });
+
+		// Routes used to each run their own `is_current_user_admin` query. That
+		// gave every page an independent answer — and an independent chance to
+		// fail — which is how one half of a page ended up in admin mode while
+		// the other half wasn't. Now the provider owns the probe, so visiting
+		// more pages must not issue more of them. (Counting from a baseline
+		// rather than asserting exactly 1: React's StrictMode double-mounts in
+		// dev, and how many probes the initial mount costs isn't the point.)
+		let probes = 0;
+		await page.route(PROBE, async (route) => {
+			probes += 1;
+			await route.continue();
+		});
+
+		await page.goto("/servers");
+		await expect(adminControl(page)).toBeVisible();
+		const onLoad = probes;
+
+		// Client-side navigation, so the provider stays mounted throughout.
+		await page.getByRole("tab", { name: "Archived" }).click();
+		await expect(page.getByText("Nothing archived.")).toBeVisible();
+
+		await page.getByRole("tab", { name: "Groups" }).click();
+		await page.getByRole("link", { name: new RegExp(group.name) }).click();
+		await expect(
+			page.getByRole("heading", { name: group.name, level: 1 }),
+		).toBeVisible();
+		await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
+
+		expect(probes).toBe(onLoad);
+	});
+
+	test("a failing probe explains itself instead of silently hiding controls", async ({
+		page,
+	}) => {
+		await page.route(PROBE, (route) => route.fulfill({ status: 503, body: "" }));
+
+		await page.goto("/servers");
+
+		await expect(
+			page.getByText("Couldn't check your admin status"),
+		).toBeVisible();
+		await expect(adminControl(page)).toBeHidden();
+	});
+
+	test("the session self-heals once the probe recovers, without a reload", async ({
+		page,
+	}) => {
+		let failing = true;
+		await page.route(PROBE, async (route) => {
+			if (failing) {
+				await route.fulfill({ status: 503, body: "" });
+			} else {
+				await route.continue();
+			}
+		});
+
+		await page.goto("/servers");
+		const banner = page.getByText("Couldn't check your admin status");
+		await expect(banner).toBeVisible();
+
+		// The provider retries on its own; the button just skips the wait.
+		failing = false;
+		await page.getByRole("button", { name: "Retry" }).click();
+
+		await expect(banner).toBeHidden();
+		await expect(adminControl(page)).toBeVisible();
+	});
+});

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1656,7 +1656,7 @@
           "commons"
         ],
         "summary": "Check whether the caller is an admin.",
-        "description": "Reports `true` if the caller is authenticated and their identity is on\nthe admin allow-list, `false` otherwise — including when the caller is\nnot authenticated at all. This endpoint intentionally requires no\nauthentication of its own, since it exists so a client can check whether\nto show admin-only controls before doing anything else.",
+        "description": "Reports `true` if the caller is authenticated and their identity is on\nthe admin allow-list, `false` if the caller definitely isn't an admin —\nincluding when the caller is not authenticated at all. This endpoint\nintentionally requires no authentication of its own, since it exists so a\nclient can check whether to show admin-only controls before doing anything\nelse.\n\nA failure that isn't an authorization outcome (a database blip while\nreading the allow-list, say) is reported as an error, not as `false`.",
         "operationId": "is_current_user_admin",
         "responses": {
           "200": {
@@ -1665,6 +1665,16 @@
               "application/json": {
                 "schema": {
                   "type": "boolean"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The caller's admin status could not be determined. Distinct from a `false` answer: retry rather than treating the caller as a non-admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
                 }
               }
             }

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { NavLink, Navigate, Route, Routes } from "react-router-dom";
 import { useApi } from "./api";
+import AdminProbeBanner from "./components/AdminProbeBanner";
 import { AdminProvider } from "./hooks/useIsAdmin";
 import { useReloadInterval } from "./hooks/useReloadInterval";
 import Admins from "./routes/Admins";
@@ -179,6 +180,7 @@ export default function App() {
 					))}
 				</Toolbar>
 			</AppBar>
+			<AdminProbeBanner />
 			<SelfAlertsBanner reloadTick={reloadTick} />
 			<Container maxWidth="lg" sx={{ py: 3 }}>
 				<Routes>

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -805,10 +805,14 @@ export interface paths {
         /**
          * Check whether the caller is an admin.
          * @description Reports `true` if the caller is authenticated and their identity is on
-         *     the admin allow-list, `false` otherwise — including when the caller is
-         *     not authenticated at all. This endpoint intentionally requires no
-         *     authentication of its own, since it exists so a client can check whether
-         *     to show admin-only controls before doing anything else.
+         *     the admin allow-list, `false` if the caller definitely isn't an admin —
+         *     including when the caller is not authenticated at all. This endpoint
+         *     intentionally requires no authentication of its own, since it exists so a
+         *     client can check whether to show admin-only controls before doing anything
+         *     else.
+         *
+         *     A failure that isn't an authorization outcome (a database blip while
+         *     reading the allow-list, say) is reported as an error, not as `false`.
          */
         post: operations["is_current_user_admin"];
         delete?: never;
@@ -9009,6 +9013,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": boolean;
+                };
+            };
+            /** @description The caller's admin status could not be determined. Distinct from a `false` answer: retry rather than treating the caller as a non-admin. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
                 };
             };
         };

--- a/private-web/src/components/AdminProbeBanner.tsx
+++ b/private-web/src/components/AdminProbeBanner.tsx
@@ -1,0 +1,34 @@
+import { Alert, AlertTitle, Box, Button } from "@mui/material";
+import { useAdminStatus } from "../hooks/useIsAdmin";
+
+/// Shown while the admin probe has never answered and its last attempt failed.
+/// Without it the failure is invisible: admin-only controls are simply absent,
+/// and an operator who *is* an admin has no way to tell "you can't do this"
+/// from "canopy couldn't work out whether you can".
+///
+/// Only the unresolved case is worth a banner. Once the probe has answered, the
+/// provider keeps that answer sticky, so a later blip changes nothing on screen
+/// — and if the answer was stale, the action itself fails loudly with a 403.
+export default function AdminProbeBanner() {
+	const { resolved, error, reload } = useAdminStatus();
+	if (resolved || !error) return null;
+
+	return (
+		<Box sx={{ px: 3, pt: 2 }}>
+			<Alert
+				severity="warning"
+				action={
+					<Button color="inherit" size="small" onClick={reload}>
+						Retry
+					</Button>
+				}
+			>
+				<AlertTitle sx={{ mb: 0 }}>
+					Couldn't check your admin status
+				</AlertTitle>
+				Admin-only controls are hidden until this succeeds. Retrying
+				automatically. ({error.message})
+			</Alert>
+		</Box>
+	);
+}

--- a/private-web/src/hooks/useIsAdmin.tsx
+++ b/private-web/src/hooks/useIsAdmin.tsx
@@ -1,23 +1,54 @@
-import { type ReactNode, createContext, useContext, useEffect, useState } from "react";
+import {
+	type ReactNode,
+	createContext,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import { useApi } from "../api";
 import { useReloadInterval } from "./useReloadInterval";
 
-/** `true` if confirmed admin, `false` if confirmed non-admin, `undefined` only
- * until the very first probe resolves. Treat undefined as non-admin for gating
- * edit-only UI — better to flicker missing buttons on for an admin than to
- * briefly expose them to a non-admin. */
-const AdminContext = createContext<boolean | undefined>(undefined);
+/** How often to re-probe once we have an answer. */
+const REPROBE_MS = 5 * 60_000;
+/** How fast to retry while we have no answer at all. */
+const RETRY_MS = 3_000;
 
-/** Single source of truth for the caller's admin status. Mount once near the
- * router root so every consumer reads the same value without each one
- * re-fetching the probe. */
+export interface AdminStatus {
+	/** `true` if confirmed admin, `false` if confirmed non-admin, `undefined`
+	 * while the status is still unknown (no probe has ever succeeded). */
+	isAdmin: boolean | undefined;
+	/** The probe has answered at least once this session. While this is false,
+	 * `isAdmin` is `undefined` and admin-only UI is hidden. */
+	resolved: boolean;
+	/** The most recent probe failed. Only interesting when `resolved` is false:
+	 * once we have an answer we keep it and ride out transient failures. */
+	error: Error | null;
+	/** Re-probe now. Wired to the retry button in the unresolved banner. */
+	reload: () => void;
+}
+
+// `null` (not `undefined`) so the hooks can tell "no provider mounted" apart
+// from "provider mounted, status not yet known" and shout about the former
+// instead of silently reporting non-admin.
+const AdminContext = createContext<AdminStatus | null>(null);
+
+/** Single source of truth for the caller's admin status. Mounted once near the
+ * router root; every consumer reads the same value through {@link useIsAdmin}
+ * so the whole page agrees. Never probe `commons.is_current_user_admin`
+ * directly from a component — per-component probes have their own lifecycle
+ * and their own failure modes, which is how one half of a page ends up in
+ * admin mode while the other half isn't. */
 export function AdminProvider({ children }: { children: ReactNode }) {
 	// Re-probe periodically and when the tab regains focus. The provider
 	// mounts once and lives for the whole SPA session, so without this a
 	// single failed probe at initial load would hide every admin control
 	// until a manual hard reload.
-	const tick = useReloadInterval(5 * 60_000);
+	const tick = useReloadInterval(REPROBE_MS);
 	const probe = useApi("commons", "is_current_user_admin", {}, [tick]);
+	const { reload } = probe;
+	const answer = probe.status === "ok" ? probe.data : null;
+	const error = probe.status === "error" ? probe.error : null;
 
 	// Last confirmed answer. Kept sticky across background-refetch errors so a
 	// transient blip (e.g. the tailnet control plane momentarily unreachable)
@@ -25,22 +56,52 @@ export function AdminProvider({ children }: { children: ReactNode }) {
 	// first-ever load shows `undefined`.
 	const [known, setKnown] = useState<boolean | undefined>(undefined);
 	useEffect(() => {
-		if (probe.status === "ok") setKnown(probe.data);
-	}, [probe]);
+		if (answer !== null) setKnown(answer);
+	}, [answer]);
 
 	// Until we've learned the status at least once, retry a failed probe
-	// quickly so the session self-heals without a hard reload.
+	// quickly so the session self-heals without a hard reload. The deps are all
+	// stable values, not the per-render `probe` object — keying off that would
+	// let any re-render of the tree above us clear the pending timer before it
+	// ever fires. Reloading flips the status to `loading` first, so this
+	// re-arms itself on each successive failure.
 	useEffect(() => {
-		if (probe.status !== "error" || known !== undefined) return;
-		const id = window.setTimeout(() => probe.reload(), 3000);
+		if (!error || known !== undefined) return;
+		const id = window.setTimeout(reload, RETRY_MS);
 		return () => window.clearTimeout(id);
-	}, [probe, known]);
+	}, [error, known, reload]);
 
-	return <AdminContext.Provider value={known}>{children}</AdminContext.Provider>;
+	const value = useMemo<AdminStatus>(
+		() => ({
+			isAdmin: known,
+			resolved: known !== undefined,
+			error,
+			reload,
+		}),
+		[known, error, reload],
+	);
+
+	return (
+		<AdminContext.Provider value={value}>{children}</AdminContext.Provider>
+	);
 }
 
-/** Returns `true`/`false` once the probe has resolved, or `undefined` while
- * loading. Callers should `=== true` to gate admin-only UI. */
+/** Full admin status, including whether the probe has resolved and why not.
+ * Most callers want {@link useIsAdmin}; this is for UI that needs to explain
+ * the unknown state rather than just hide behind it. */
+export function useAdminStatus(): AdminStatus {
+	const ctx = useContext(AdminContext);
+	if (!ctx) {
+		throw new Error("useAdminStatus must be used inside <AdminProvider>");
+	}
+	return ctx;
+}
+
+/** Returns `true`/`false` once the probe has resolved, or `undefined` while the
+ * status is unknown. Callers should `=== true` to gate admin-only UI: better to
+ * briefly hide buttons from an admin than to briefly offer them to a non-admin.
+ * When the status is unknown because the probe is failing, `AdminProbeBanner`
+ * tells the user why the controls aren't there. */
 export function useIsAdmin(): boolean | undefined {
-	return useContext(AdminContext);
+	return useAdminStatus().isAdmin;
 }

--- a/private-web/src/routes/ArchivedList.tsx
+++ b/private-web/src/routes/ArchivedList.tsx
@@ -12,6 +12,7 @@ import RestoreIcon from "@mui/icons-material/RestoreFromTrash";
 import { Link as RouterLink } from "react-router-dom";
 import ServerShorty, { type ServerInfo } from "../components/ServerShorty";
 import { useApi, useApiAction } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { compareServersByRankThenKind } from "../types";
 
@@ -19,8 +20,7 @@ import { compareServersByRankThenKind } from "../types";
 /// find them — every other listing filters archived rows out.
 export default function ArchivedList() {
 	usePageTitle("Archived");
-	const isAdmin = useApi("commons", "is_current_user_admin", {}, []);
-	const admin = isAdmin.status === "ok" && isAdmin.data;
+	const admin = useIsAdmin() === true;
 	const groups = useApi("server_groups", "list_archived", {}, []);
 	const servers = useApi("servers", "list_archived", {}, []);
 

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -20,6 +20,7 @@ import ServerShorty from "../components/ServerShorty";
 import SilencedRefsSection from "../components/SilencedRefsSection";
 import TimeAgo from "../components/TimeAgo";
 import { useApi, useApiAction } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
 import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 import { usePageTitle } from "../hooks/usePageTitle";
 import {
@@ -37,7 +38,7 @@ export default function GroupDetail() {
 	const { id = "" } = useParams<{ id: string }>();
 	const navigate = useNavigate();
 	const detail = useApi("server_groups", "get", { server_group_id: id }, [id]);
-	const isAdmin = useApi("commons", "is_current_user_admin");
+	const admin = useIsAdmin() === true;
 	const archive = useApiAction("server_groups", "delete");
 	// Only the currently-open incident matters for the active-incident
 	// section; closed ones live behind the /incidents filter route.
@@ -65,7 +66,6 @@ export default function GroupDetail() {
 	}
 
 	const { group, servers, billing_labels } = detail.data;
-	const admin = isAdmin.status === "ok" && isAdmin.data;
 	const tagEntries = Object.entries(group.tags ?? {});
 	const operators =
 		groupStatuses.status === "ok"

--- a/private-web/src/routes/GroupsList.tsx
+++ b/private-web/src/routes/GroupsList.tsx
@@ -3,14 +3,14 @@ import AddIcon from "@mui/icons-material/Add";
 import { Link as RouterLink } from "react-router-dom";
 import GroupShorty from "../components/GroupShorty";
 import { useApi } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
 
 export default function GroupsList() {
 	usePageTitle("Server groups");
 	const groups = useApi("server_groups", "list", {}, []);
 	const counts = useApi("server_groups", "server_counts", {}, []);
-	const isAdmin = useApi("commons", "is_current_user_admin");
-	const admin = isAdmin.status === "ok" && isAdmin.data;
+	const admin = useIsAdmin() === true;
 
 	if (groups.status === "loading" || groups.status === "idle") {
 		return <LinearProgress />;

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -101,7 +101,7 @@ export default function ServerDetail() {
 		{ server_id: id },
 		[id],
 	);
-	const isAdmin = useApi("commons", "is_current_user_admin");
+	const admin = useIsAdmin() === true;
 	// Single refresh signal for everything on the page that talks to the
 	// issues/incidents APIs. Any mutation (manual-event submit, resolve/
 	// snooze on a row, etc.) bumps this so all sibling panels refetch in
@@ -148,7 +148,6 @@ export default function ServerDetail() {
 	}
 
 	const data = detail.data;
-	const admin = isAdmin.status === "ok" && isAdmin.data;
 	const archived = data.server.archived;
 	const registered = data.server.registered_at != null;
 

--- a/private-web/src/routes/VersionDetail.tsx
+++ b/private-web/src/routes/VersionDetail.tsx
@@ -34,6 +34,7 @@ import Markdown from "../components/Markdown";
 import TimeAgo from "../components/TimeAgo";
 import VersionStatusChip from "../components/VersionStatusChip";
 import { useApi, useApiAction } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { prettifyVersionRange } from "../lib/versionRange";
 import type {
@@ -53,7 +54,7 @@ export default function VersionDetail() {
 		{ version },
 		[version],
 	);
-	const isAdmin = useApi("commons", "is_current_user_admin");
+	const admin = useIsAdmin() === true;
 
 	if (detail.status === "loading" || detail.status === "idle") {
 		return <LinearProgress />;
@@ -64,7 +65,6 @@ export default function VersionDetail() {
 
 	const v = detail.data;
 	const versionStr = `${v.major}.${v.minor}.${v.patch}`;
-	const admin = isAdmin.status === "ok" && isAdmin.data;
 
 	return (
 		<Stack spacing={3}>


### PR DESCRIPTION
## Summary

The admin status probe now properly distinguishes between authorization outcomes (definite yes/no answers) and infrastructure failures (which should be retried). Previously, any probe failure was treated as "not admin", which could hide admin controls from real admins when transient errors occurred.

## Key Changes

- **Backend (`commons.rs`)**: Modified `is_current_user_admin` to return errors for infrastructure failures while returning `false` only for definite authorization outcomes (missing auth, insufficient permissions). Added `admin_probe_answer()` helper with comprehensive tests.

- **Frontend admin provider (`useIsAdmin.tsx`)**: 
  - Introduced `AdminStatus` interface exposing `isAdmin`, `resolved`, `error`, and `reload` fields
  - Added `useAdminStatus()` hook for full status details
  - Kept `useIsAdmin()` for simple boolean checks
  - Provider now caches the first successful answer and retries failed probes quickly until resolved
  - Uses `useMemo` to stabilize context value and prevent unnecessary re-renders

- **New error banner (`AdminProbeBanner.tsx`)**: Displays when the probe is failing and unresolved, explaining why admin controls are hidden and offering a retry button. Only shown during the initial unresolved state; later failures don't disrupt the UI since the answer is cached.

- **E2E tests (`admin-gating.spec.ts`)**: Added comprehensive tests verifying:
  - Single probe per session (not per-page)
  - Error banner appears on probe failure
  - Session self-heals when probe recovers without requiring a reload

- **Updated routes**: Modified `ServerDetail`, `GroupsList`, `GroupDetail`, `VersionDetail`, and `ArchivedList` to use the centralized `useIsAdmin()` hook instead of per-component probes.

- **App integration**: Added `AdminProbeBanner` to root layout to display probe errors globally.

## Implementation Details

The provider uses two retry timelines: `RETRY_MS` (3s) for quick retries while unresolved, and `REPROBE_MS` (5min) for periodic checks after resolution. The sticky answer pattern ensures transient infrastructure blips never withdraw controls mid-session, while the error banner ensures operators understand why controls are unavailable during initial failures.

https://claude.ai/code/session_013er8HAtgGow7dRSfzoJU8F