### PR TITLE
fix(restore): let a reported-on replica declaration be deleted, and keep names unique

### DIFF
--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -114,18 +114,22 @@ Each declaration carries:
 - the **type** of backup to restore;
 - a **server** within the group, or all servers in the group when none is named;
 - an **intent** the chosen consumer advertises;
-- a human-readable **name**;
+- a human-readable **name**, distinct from every other declaration assigned to the same consumer;
 - **parameter values** for the intent's schema, defaulted where the schema provides one;
 - an **overdue bound**: the maximum time a replica may go without meeting its intent's health expectation before Canopy considers it overdue, interpreted per the intent's semantics (see [Alerting](#alerting));
 - whether the declaration is **enabled**.
 
 A declaration's intent must be one the chosen consumer advertises (see [Consumer capabilities](#consumer-capabilities)); a declaration whose intent is unadvertised is a gap, surfaced to the operator and never dispatched.
 
+The name identifies the replica to the consumer that maintains it and to the operator reading the list, so a consumer's declarations must not share one.
+Two declarations that differ only by intent are a distinct scope but still need distinct names, and Canopy refuses the second rather than accepting an ambiguous pair.
+
 A declaration scoped to a whole group expands to one replica per current server in that group.
 Servers joining or leaving a group change what the consumer is asked to maintain, with no per-server operator action.
 
 Declarations are managed through the operator interface (create, edit, enable/disable, delete) and are audited.
 Deleting a declaration stops the consumer being asked to maintain that replica and revokes its authorization for that `(group, type)` if no other declaration covers it; recorded restore-health history is retained.
+The reports it collected survive the deletion, keeping the group, server, type, and intent they concern but no longer naming a declaration, so a declaration that has been reported on is no harder to retire than one that never was.
 
 ## The worklist
 

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -112,11 +112,42 @@ pub struct RestoreReplicaUpdate {
 	pub enabled: bool,
 }
 
+/// Normalise an operator-supplied declaration name: surrounding whitespace is
+/// insignificant, and a name that is blank once trimmed is rejected. Names are
+/// unique per consumer, so leaving the whitespace on would let a near-identical
+/// name slip past the index.
+fn normalize_name(name: String) -> Result<String> {
+	let trimmed = name.trim();
+	if trimmed.is_empty() {
+		return Err(AppError::BadRequest(
+			"restore replica name cannot be empty".into(),
+		));
+	}
+	Ok(trimmed.to_owned())
+}
+
+/// Turn a unique violation into a `409` that names the collision actually hit —
+/// a declaration's scope and its name are separately unique, and the operator
+/// needs to know which one to change.
+fn unique_violation(info: &dyn diesel::result::DatabaseErrorInformation) -> AppError {
+	match info.constraint_name() {
+		Some("restore_replicas_consumer_name") => {
+			AppError::Conflict("this consumer already has a restore replica with that name".into())
+		}
+		_ => AppError::Conflict("a matching restore replica is already declared".into()),
+	}
+}
+
 impl RestoreReplica {
 	/// Create a declaration. A duplicate `(consumer, group, type, intent,
-	/// server)` scope maps to `409`.
+	/// server)` scope, or a name already used by another of the consumer's
+	/// declarations, maps to `409`.
 	pub async fn create(db: &mut AsyncPgConnection, new: NewRestoreReplica) -> Result<Self> {
 		use crate::schema::restore_replicas::dsl;
+		let new = NewRestoreReplica {
+			name: normalize_name(new.name)?,
+			..new
+		};
 		match diesel::insert_into(dsl::restore_replicas)
 			.values(new)
 			.returning(Self::as_select())
@@ -124,9 +155,9 @@ impl RestoreReplica {
 			.await
 		{
 			Ok(row) => Ok(row),
-			Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => Err(
-				AppError::Conflict("a matching restore replica is already declared".into()),
-			),
+			Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, info)) => {
+				Err(unique_violation(&*info))
+			}
 			Err(e) => Err(AppError::from(e)),
 		}
 	}
@@ -185,7 +216,8 @@ impl RestoreReplica {
 
 	/// Edit every field of a declaration, including its scope. A scope change
 	/// that collides with another declaration's `(consumer, group, type,
-	/// intent, server)` maps to `409`, same as [`Self::create`]. If the scope
+	/// intent, server)`, or a name already used by another of the consumer's
+	/// declarations, maps to `409`, same as [`Self::create`]. If the scope
 	/// (group, server, or type/intent) moves, any active restore-verification
 	/// alert keyed to the *old* scope is recovered — the overdue sweep only
 	/// walks current declarations, so a stale key would otherwise never clear.
@@ -197,6 +229,7 @@ impl RestoreReplica {
 		use crate::schema::restore_replicas::dsl;
 
 		let existing = Self::get(db, id).await?;
+		let name = normalize_name(update.name)?;
 
 		let result = match diesel::update(dsl::restore_replicas.filter(dsl::id.eq(id)))
 			.set((
@@ -205,7 +238,7 @@ impl RestoreReplica {
 				dsl::server_id.eq(update.server_id),
 				dsl::type_.eq(update.r#type),
 				dsl::intent.eq(update.intent),
-				dsl::name.eq(update.name),
+				dsl::name.eq(name),
 				dsl::overdue_after.eq(update.overdue_after),
 				dsl::params.eq(update.params),
 				dsl::enabled.eq(update.enabled),
@@ -215,10 +248,8 @@ impl RestoreReplica {
 			.await
 		{
 			Ok(row) => row,
-			Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => {
-				return Err(AppError::Conflict(
-					"a matching restore replica is already declared".into(),
-				));
+			Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, info)) => {
+				return Err(unique_violation(&*info));
 			}
 			Err(DieselError::NotFound) => {
 				return Err(AppError::DatabaseQuery(DieselError::NotFound));
@@ -249,6 +280,11 @@ impl RestoreReplica {
 	/// walks current declarations, so an alert left behind by a deleted one
 	/// would otherwise never clear. Runs in a single transaction so a failure
 	/// partway can't leave the row deleted with its alerts unrecovered.
+	///
+	/// Restore-health reports the declaration collected are retained: the FK
+	/// from `backup_restore_checks` is `ON DELETE SET NULL`, so each report
+	/// survives with its group, server, type, and intent, no longer attached to
+	/// a declaration.
 	pub async fn delete(db: &mut AsyncPgConnection, id: Uuid) -> Result<()> {
 		db.transaction::<_, AppError, _>(async |conn| {
 			use crate::schema::restore_replicas::dsl;

--- a/crates/database/tests/it/restore.rs
+++ b/crates/database/tests/it/restore.rs
@@ -947,3 +947,200 @@ async fn delete_group_wide_recovers_alerts_on_every_server() {
 	})
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_detaches_reports_rather_than_being_blocked_by_them() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn, "g").await;
+		let server = insert_server(&mut conn, group).await;
+		let r = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				Some(server),
+				RestoreIntent::from("verify"),
+				"n",
+			),
+		)
+		.await
+		.expect("create");
+
+		BackupRestoreCheck::record_report(
+			&mut conn,
+			NewBackupRestoreCheck {
+				replica_id: Some(r.id),
+				..new_check(
+					consumer,
+					group,
+					server,
+					RestoreIntent::from("verify"),
+					RunOutcome::Success,
+					true,
+				)
+			},
+		)
+		.await
+		.expect("record report");
+
+		// A reported-on declaration is no harder to retire than one that never
+		// was: the report's reference is cleared instead of pinning the row.
+		RestoreReplica::delete(&mut conn, r.id)
+			.await
+			.expect("a declaration with restore-health history deletes");
+
+		let checks = BackupRestoreCheck::list_recent_for_group(&mut conn, group, 10)
+			.await
+			.expect("list checks");
+		assert_eq!(checks.len(), 1, "the report is retained");
+		assert_eq!(
+			checks[0].replica_id, None,
+			"the retained report no longer names a declaration"
+		);
+		assert_eq!(checks[0].server_id, Some(server));
+		assert_eq!(checks[0].intent, RestoreIntent::from("verify"));
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn name_is_unique_per_consumer() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let other_consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn, "g").await;
+
+		let first = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				None,
+				RestoreIntent::from("verify"),
+				"daily",
+			),
+		)
+		.await
+		.expect("create");
+
+		// A different intent is a different scope, so the scope indexes allow
+		// it — but reusing the name would leave the consumer with two replicas
+		// it can't tell apart.
+		let dup = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				None,
+				RestoreIntent::from("standby"),
+				"daily",
+			),
+		)
+		.await;
+		assert!(matches!(dup, Err(AppError::Conflict(_))), "got {dup:?}");
+
+		// Surrounding whitespace doesn't buy a way around it.
+		let padded = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				None,
+				RestoreIntent::from("standby"),
+				"  daily  ",
+			),
+		)
+		.await;
+		assert!(
+			matches!(padded, Err(AppError::Conflict(_))),
+			"got {padded:?}"
+		);
+
+		// Another consumer's declarations are named independently.
+		RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				other_consumer,
+				group,
+				None,
+				RestoreIntent::from("verify"),
+				"daily",
+			),
+		)
+		.await
+		.expect("a different consumer may reuse the name");
+
+		// Renaming onto a sibling's name is refused the same way.
+		let second = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				None,
+				RestoreIntent::from("standby"),
+				"weekly",
+			),
+		)
+		.await
+		.expect("create second");
+		let clash = RestoreReplica::update(
+			&mut conn,
+			second.id,
+			RestoreReplicaUpdate {
+				name: first.name.clone(),
+				..update_from(&second)
+			},
+		)
+		.await;
+		assert!(matches!(clash, Err(AppError::Conflict(_))), "got {clash:?}");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blank_name_is_rejected() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn, "g").await;
+
+		let blank = RestoreReplica::create(
+			&mut conn,
+			new_replica(consumer, group, None, RestoreIntent::from("verify"), "   "),
+		)
+		.await;
+		assert!(
+			matches!(blank, Err(AppError::BadRequest(_))),
+			"got {blank:?}"
+		);
+
+		let r = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				None,
+				RestoreIntent::from("verify"),
+				"  padded  ",
+			),
+		)
+		.await
+		.expect("create");
+		assert_eq!(r.name, "padded", "the stored name is trimmed");
+
+		let blanked = RestoreReplica::update(
+			&mut conn,
+			r.id,
+			RestoreReplicaUpdate {
+				name: "".into(),
+				..update_from(&r)
+			},
+		)
+		.await;
+		assert!(
+			matches!(blanked, Err(AppError::BadRequest(_))),
+			"got {blanked:?}"
+		);
+	})
+	.await;
+}

--- a/crates/private-server/src/fns/restore_replicas.rs
+++ b/crates/private-server/src/fns/restore_replicas.rs
@@ -147,7 +147,8 @@ pub struct RestoreReplicasCreateArgs {
 	/// identifier from the consumer's advertised intents, e.g. `verify`.
 	#[schema(value_type = String)]
 	pub intent: RestoreIntent,
-	/// Display name for the declaration.
+	/// Display name for the declaration, unique among the consumer's
+	/// declarations.
 	pub name: String,
 	/// Overdue bound as a human-friendly duration (jiff's "friendly" format,
 	/// e.g. `2h 30m`, `36h`, `1d 12h`); omit, null, or blank for no bound.
@@ -186,7 +187,8 @@ pub struct RestoreReplicasUpdateArgs {
 	/// identifier from the consumer's advertised intents, e.g. `verify`.
 	#[schema(value_type = String)]
 	pub intent: RestoreIntent,
-	/// New display name for the declaration.
+	/// New display name for the declaration, unique among the consumer's
+	/// declarations.
 	pub name: String,
 	/// New overdue bound as a human-friendly duration (jiff's "friendly"
 	/// format, e.g. `2h 30m`, `36h`, `1d 12h`); null or blank removes the
@@ -569,9 +571,11 @@ pub async fn checks(
 /// are resolved to raw seconds/bytes before validation against the consumer's
 /// advertised schema for the intent and stored raw. If the intent is not
 /// currently advertised, the values are accepted as-is and the declaration is
-/// created with a gap. Requires the caller to be on the admin allow-list.
-/// Responds 400 if the overdue bound or a parameter value fails to parse or
-/// validate, and 409 if a matching declaration already exists.
+/// created with a gap. The name must be unique among the consumer's
+/// declarations. Requires the caller to be on the admin allow-list. Responds
+/// 400 if the name is blank or the overdue bound or a parameter value fails to
+/// parse or validate, and 409 if a matching declaration already exists or the
+/// consumer already has a declaration with that name.
 #[utoipa::path(
 	post,
 	path = "/create",
@@ -581,7 +585,7 @@ pub async fn checks(
 	request_body = RestoreReplicasCreateArgs,
 	responses(
 		(status = 200, body = RestoreReplicaView),
-		(status = 409, description = "A matching declaration already exists.", body = ProblemDetailsSchema),
+		(status = 409, description = "A matching declaration already exists, or the consumer already has one with that name.", body = ProblemDetailsSchema),
 	),
 )]
 pub async fn create(
@@ -627,10 +631,11 @@ pub async fn create(
 /// intent the new consumer doesn't currently advertise is accepted and the
 /// values pass through unvalidated, leaving the declaration with a gap. If
 /// the scope changes, any active restore-verification alert for the
-/// declaration's old scope is recovered. Requires the caller to be on the
-/// admin allow-list. Responds 400 if the overdue bound or a parameter value
+/// declaration's old scope is recovered. The name must be unique among the
+/// consumer's declarations. Requires the caller to be on the admin allow-list.
+/// Responds 400 if the name is blank or the overdue bound or a parameter value
 /// fails to parse or validate, 404 if the declaration does not exist, and 409
-/// if the new scope collides with another declaration.
+/// if the new scope or name collides with another declaration.
 #[utoipa::path(
 	post,
 	path = "/update",
@@ -641,7 +646,7 @@ pub async fn create(
 	responses(
 		(status = 200, body = RestoreReplicaView),
 		(status = 404, body = ProblemDetailsSchema),
-		(status = 409, description = "The new scope collides with another declaration.", body = ProblemDetailsSchema),
+		(status = 409, description = "The new scope or name collides with another declaration.", body = ProblemDetailsSchema),
 	),
 )]
 pub async fn update(
@@ -682,8 +687,9 @@ pub async fn update(
 /// Removes the declaration: the consumer stops being asked to maintain the
 /// replica and loses the backup access the declaration granted. Any active
 /// restore-verification alert for the declaration's scope is recovered, since
-/// nothing tracks that scope any more. Requires the caller to be on the admin
-/// allow-list. Responds 404 if the declaration does not exist.
+/// nothing tracks that scope any more. The restore-health reports it collected
+/// are retained, detached from the deleted declaration. Requires the caller to
+/// be on the admin allow-list. Responds 404 if the declaration does not exist.
 #[utoipa::path(
 	post,
 	path = "/delete",

--- a/crates/private-server/tests/it/restore_replicas.rs
+++ b/crates/private-server/tests/it/restore_replicas.rs
@@ -653,3 +653,120 @@ async fn consumers_format_unit_param_defaults_for_display() {
 	})
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_and_update_reject_a_name_the_consumer_already_uses() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group = insert_group(&mut conn).await;
+		let consumer = insert_consumer(&mut conn).await;
+		advertise_verify_and_analytics(&mut conn, consumer).await;
+
+		private
+			.post("/api/restore_replicas/create")
+			.json(&serde_json::json!({
+				"consumer_device_id": consumer,
+				"group_id": group,
+				"server_id": null,
+				"type": "tamanu-postgres",
+				"intent": "verify",
+				"name": "nightly",
+				"overdue_after": null,
+				"params": {},
+			}))
+			.await
+			.assert_status_ok();
+
+		// A different intent is a different scope, so the scope check passes —
+		// but the name is the consumer's already, and two same-named replicas
+		// are indistinguishable to consumer and operator alike.
+		private
+			.post("/api/restore_replicas/create")
+			.json(&serde_json::json!({
+				"consumer_device_id": consumer,
+				"group_id": group,
+				"server_id": null,
+				"type": "tamanu-postgres",
+				"intent": "analytics",
+				"name": "nightly",
+				"overdue_after": null,
+				"params": {},
+			}))
+			.await
+			.assert_status_conflict();
+
+		private
+			.post("/api/restore_replicas/create")
+			.json(&serde_json::json!({
+				"consumer_device_id": consumer,
+				"group_id": group,
+				"server_id": null,
+				"type": "tamanu-postgres",
+				"intent": "analytics",
+				"name": "",
+				"overdue_after": null,
+				"params": {},
+			}))
+			.await
+			.assert_status_bad_request();
+
+		let other = create_replica(
+			&private,
+			consumer,
+			group,
+			"analytics",
+			serde_json::json!({}),
+		)
+		.await;
+		private
+			.post("/api/restore_replicas/update")
+			.json(&serde_json::json!({
+				"id": other,
+				"consumer_device_id": consumer,
+				"group_id": group,
+				"server_id": null,
+				"type": "tamanu-postgres",
+				"intent": "analytics",
+				"name": "nightly",
+				"overdue_after": null,
+				"params": {},
+				"enabled": true,
+			}))
+			.await
+			.assert_status_conflict();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_succeeds_for_a_declaration_with_restore_health_history() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let consumer = insert_consumer(&mut conn).await;
+		advertise_verify(&mut conn, consumer).await;
+		let id = create_replica(&private, consumer, group, "verify", serde_json::json!({})).await;
+
+		conn.batch_execute(&format!(
+			"INSERT INTO backup_restore_checks \
+			 (replica_id, consumer_device_id, group_id, server_id, type, intent, \
+			  snapshot_id, outcome, replica_healthy, observed_at) \
+			 VALUES ('{id}', '{consumer}', '{group}', '{server}', 'tamanu-postgres', \
+			  'verify', 'snap-1', 'success', true, now())"
+		))
+		.await
+		.expect("insert report");
+
+		private
+			.post("/api/restore_replicas/delete")
+			.json(&serde_json::json!({ "id": id }))
+			.await
+			.assert_status_ok();
+
+		let checks = database::BackupRestoreCheck::list_recent_for_group(&mut conn, group, 10)
+			.await
+			.expect("list checks");
+		assert_eq!(checks.len(), 1, "the report outlives the declaration");
+		assert_eq!(checks[0].replica_id, None);
+	})
+	.await;
+}

--- a/migrations/2026-07-28-023000-0000_restore_replica_delete_and_name_uniqueness/down.sql
+++ b/migrations/2026-07-28-023000-0000_restore_replica_delete_and_name_uniqueness/down.sql
@@ -1,0 +1,10 @@
+DROP INDEX restore_replicas_consumer_name;
+
+-- Names that were suffixed to resolve a duplicate stay as they are: the
+-- original is not recoverable, and reinstating it would recreate the ambiguity.
+
+ALTER TABLE backup_restore_checks
+	DROP CONSTRAINT backup_restore_checks_replica_id_fkey;
+ALTER TABLE backup_restore_checks
+	ADD CONSTRAINT backup_restore_checks_replica_id_fkey
+	FOREIGN KEY (replica_id) REFERENCES restore_replicas(id);

--- a/migrations/2026-07-28-023000-0000_restore_replica_delete_and_name_uniqueness/up.sql
+++ b/migrations/2026-07-28-023000-0000_restore_replica_delete_and_name_uniqueness/up.sql
@@ -1,0 +1,68 @@
+-- Two fixes to restore replica declarations, both about retiring one cleanly.
+
+-- 1. Deleting a declaration must not be blocked by its restore-health history.
+-- `backup_restore_checks.replica_id` was always meant to go NULL when the
+-- declaration it points at is retired — the column is nullable precisely "so
+-- history survives the declaration being retired", and RST says recorded
+-- restore-health history is retained when a declaration is deleted. But the FK
+-- was created with the default NO ACTION, so the first check reported against a
+-- declaration pinned it in place: deleting it failed with
+--   update or delete on table "restore_replicas" violates foreign key
+--   constraint "backup_restore_checks_replica_id_fkey"
+-- Recreate the constraint with ON DELETE SET NULL so the reports outlive the
+-- declaration, unattached, exactly as intended.
+ALTER TABLE backup_restore_checks
+	DROP CONSTRAINT backup_restore_checks_replica_id_fkey;
+ALTER TABLE backup_restore_checks
+	ADD CONSTRAINT backup_restore_checks_replica_id_fkey
+	FOREIGN KEY (replica_id) REFERENCES restore_replicas(id) ON DELETE SET NULL;
+
+-- 2. A consumer's declaration names must be distinct. The scope uniqueness
+-- indexes key on (consumer, group, type, intent, server), so two declarations
+-- differing only by intent were allowed to share a name — and the operator UI
+-- suggested the same group/server-derived name for both, making the collision
+-- the default outcome rather than an unlikely slip. The name is what the
+-- worklist hands the consumer to identify the replica, so a duplicate is
+-- ambiguous to the consumer and to the operator reading the list.
+--
+-- Existing duplicates are kept, not dropped: the oldest declaration keeps the
+-- name and each later one gets a `-2`, `-3`, … suffix, so the index can be
+-- created without losing an operator's declaration. Operators can rename them
+-- to something meaningful afterwards. Suffixing repeats because a suffixed name
+-- can itself collide with a name already in use; each round strictly lengthens
+-- the names it touches, so it converges.
+DO $$
+DECLARE
+	round INT := 0;
+BEGIN
+	LOOP
+		UPDATE restore_replicas r
+		   SET name = dup.name || '-' || dup.n
+		  FROM (
+			SELECT id, name, n
+			  FROM (
+				SELECT id,
+				       name,
+				       row_number() OVER (
+				           PARTITION BY consumer_device_id, name
+				           ORDER BY created_at, id
+				       ) AS n
+				  FROM restore_replicas
+			  ) numbered
+			 WHERE n > 1
+		  ) dup
+		 WHERE r.id = dup.id;
+		EXIT WHEN NOT FOUND;
+
+		round := round + 1;
+		IF round > 10 THEN
+			RAISE EXCEPTION
+				'restore_replicas names still collide per consumer after % rounds of suffixing',
+				round;
+		END IF;
+	END LOOP;
+END
+$$;
+
+CREATE UNIQUE INDEX restore_replicas_consumer_name
+	ON restore_replicas (consumer_device_id, name);

--- a/private-web/e2e/restore-replicas.spec.ts
+++ b/private-web/e2e/restore-replicas.spec.ts
@@ -145,11 +145,21 @@ test.describe("restore replicas", () => {
 			intents: ["verify"],
 		});
 		const groupId = await groupWithBackups(sql, "del-group");
-		await seedRestoreReplica(sql, {
+		const server = await seedServer(sql, { groupId, name: "del-srv" });
+		const replica = await seedRestoreReplica(sql, {
 			consumerDeviceId: consumer.id,
 			groupId,
 			intent: "verify",
 			name: "doomed",
+		});
+		// A declaration that has been reported on deletes like any other; its
+		// reports are kept, detached.
+		await seedRestoreCheck(sql, {
+			consumerDeviceId: consumer.id,
+			groupId,
+			serverId: server.id,
+			replicaId: replica.id,
+			snapshotId: "snap-1",
 		});
 
 		await page.goto(`/groups/${groupId}/backups`);
@@ -161,6 +171,12 @@ test.describe("restore replicas", () => {
 			"SELECT count(*) AS count FROM restore_replicas",
 		);
 		expect(Number(rows[0]!.count)).toBe(0);
+
+		const checks = await sql.query<{ replica_id: string | null }>(
+			"SELECT replica_id FROM backup_restore_checks",
+		);
+		expect(checks).toHaveLength(1);
+		expect(checks[0]!.replica_id).toBeNull();
 	});
 
 	test("toggling enabled flips the row in the database", async ({
@@ -297,19 +313,57 @@ test.describe("restore replicas", () => {
 		await page.getByRole("button", { name: /declare replica/i }).click();
 		const dialog = page.getByRole("dialog");
 
-		// Name defaults to the kebab-cased group name (whole-group scope).
-		await expect(dialog.getByLabel("Name")).toHaveValue("solo-group");
+		// Name defaults to the kebab-cased group name and intent (whole-group
+		// scope).
+		await expect(dialog.getByLabel("Name")).toHaveValue("solo-group-verify");
 		// Picking a server folds the server name into the default.
 		await dialog.getByLabel("Server").click();
 		await page.getByRole("option", { name: "srv-a" }).click();
-		await expect(dialog.getByLabel("Name")).toHaveValue("solo-group-srv-a");
+		await expect(dialog.getByLabel("Name")).toHaveValue(
+			"solo-group-srv-a-verify",
+		);
 
 		// The consumer was never picked, yet Declare succeeds — the sole consumer
 		// was auto-selected.
 		await dialog.getByRole("button", { name: /^declare$/i }).click();
 		await expect(
-			page.getByRole("row", { name: /solo-group-srv-a/ }),
+			page.getByRole("row", { name: /solo-group-srv-a-verify/ }),
 		).toBeVisible();
+	});
+
+	test("a name already used by the consumer is refused", async ({
+		page,
+		sql,
+	}) => {
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		await seedRestoreConsumerCapability(sql, {
+			deviceId: consumer.id,
+			intents: ["verify", "analytics"],
+		});
+		const groupId = await groupWithBackups(sql, "dupe-group");
+		await seedRestoreReplica(sql, {
+			consumerDeviceId: consumer.id,
+			groupId,
+			intent: "verify",
+			name: "taken",
+		});
+
+		await page.goto(`/groups/${groupId}/backups`);
+		await page.getByRole("button", { name: /declare replica/i }).click();
+
+		// A different intent is a different scope, but the name is the consumer's
+		// already — the declaration is refused rather than silently duplicated.
+		const dialog = page.getByRole("dialog");
+		await dialog.getByLabel("Intent").click();
+		await page.getByRole("option", { name: "analytics" }).click();
+		await dialog.getByLabel("Name").fill("taken");
+		await dialog.getByRole("button", { name: /^declare$/i }).click();
+
+		await expect(dialog.getByRole("alert")).toContainText(/name/i);
+		const rows = await sql.query<{ name: string }>(
+			"SELECT name FROM restore_replicas WHERE name = 'taken'",
+		);
+		expect(rows).toHaveLength(1);
 	});
 
 	test("the intent dropdown offers only intents the consumer registered", async ({

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4158,7 +4158,7 @@
           "restore_replicas"
         ],
         "summary": "Declare a managed restore replica.",
-        "description": "Creates a declaration instructing the chosen consumer to maintain a\nrestored replica of the given backup type for the given intent, and\nrecords the calling operator as its creator. The overdue bound is a\nhuman-friendly duration string (e.g. `2h 30m`); `duration` and `bytes`\nparameter values likewise accept human-unit strings (e.g. `20Gi`), which\nare resolved to raw seconds/bytes before validation against the consumer's\nadvertised schema for the intent and stored raw. If the intent is not\ncurrently advertised, the values are accepted as-is and the declaration is\ncreated with a gap. Requires the caller to be on the admin allow-list.\nResponds 400 if the overdue bound or a parameter value fails to parse or\nvalidate, and 409 if a matching declaration already exists.",
+        "description": "Creates a declaration instructing the chosen consumer to maintain a\nrestored replica of the given backup type for the given intent, and\nrecords the calling operator as its creator. The overdue bound is a\nhuman-friendly duration string (e.g. `2h 30m`); `duration` and `bytes`\nparameter values likewise accept human-unit strings (e.g. `20Gi`), which\nare resolved to raw seconds/bytes before validation against the consumer's\nadvertised schema for the intent and stored raw. If the intent is not\ncurrently advertised, the values are accepted as-is and the declaration is\ncreated with a gap. The name must be unique among the consumer's\ndeclarations. Requires the caller to be on the admin allow-list. Responds\n400 if the name is blank or the overdue bound or a parameter value fails to\nparse or validate, and 409 if a matching declaration already exists or the\nconsumer already has a declaration with that name.",
         "operationId": "restore_replicas_create",
         "requestBody": {
           "content": {
@@ -4182,7 +4182,7 @@
             }
           },
           "409": {
-            "description": "A matching declaration already exists.",
+            "description": "A matching declaration already exists, or the consumer already has one with that name.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4205,7 +4205,7 @@
           "restore_replicas"
         ],
         "summary": "Delete a restore replica declaration.",
-        "description": "Removes the declaration: the consumer stops being asked to maintain the\nreplica and loses the backup access the declaration granted. Any active\nrestore-verification alert for the declaration's scope is recovered, since\nnothing tracks that scope any more. Requires the caller to be on the admin\nallow-list. Responds 404 if the declaration does not exist.",
+        "description": "Removes the declaration: the consumer stops being asked to maintain the\nreplica and loses the backup access the declaration granted. Any active\nrestore-verification alert for the declaration's scope is recovered, since\nnothing tracks that scope any more. The restore-health reports it collected\nare retained, detached from the deleted declaration. Requires the caller to\nbe on the admin allow-list. Responds 404 if the declaration does not exist.",
         "operationId": "restore_replicas_delete",
         "requestBody": {
           "content": {
@@ -4285,7 +4285,7 @@
           "restore_replicas"
         ],
         "summary": "Update a restore replica declaration.",
-        "description": "Replaces every field, including scope: the consumer, group, server,\nbackup type, and intent can be retargeted in the same call as the name,\noverdue bound, parameter values, and enabled flag. The overdue bound and\n`duration`/`bytes` parameter values accept human-unit strings (e.g.\n`2h 30m`, `20Gi`), resolved to raw seconds/bytes and validated against the\n*new* consumer+intent's advertised parameter schema; as with `create`, an\nintent the new consumer doesn't currently advertise is accepted and the\nvalues pass through unvalidated, leaving the declaration with a gap. If\nthe scope changes, any active restore-verification alert for the\ndeclaration's old scope is recovered. Requires the caller to be on the\nadmin allow-list. Responds 400 if the overdue bound or a parameter value\nfails to parse or validate, 404 if the declaration does not exist, and 409\nif the new scope collides with another declaration.",
+        "description": "Replaces every field, including scope: the consumer, group, server,\nbackup type, and intent can be retargeted in the same call as the name,\noverdue bound, parameter values, and enabled flag. The overdue bound and\n`duration`/`bytes` parameter values accept human-unit strings (e.g.\n`2h 30m`, `20Gi`), resolved to raw seconds/bytes and validated against the\n*new* consumer+intent's advertised parameter schema; as with `create`, an\nintent the new consumer doesn't currently advertise is accepted and the\nvalues pass through unvalidated, leaving the declaration with a gap. If\nthe scope changes, any active restore-verification alert for the\ndeclaration's old scope is recovered. The name must be unique among the\nconsumer's declarations. Requires the caller to be on the admin allow-list.\nResponds 400 if the name is blank or the overdue bound or a parameter value\nfails to parse or validate, 404 if the declaration does not exist, and 409\nif the new scope or name collides with another declaration.",
         "operationId": "restore_replicas_update",
         "requestBody": {
           "content": {
@@ -4319,7 +4319,7 @@
             }
           },
           "409": {
-            "description": "The new scope collides with another declaration.",
+            "description": "The new scope or name collides with another declaration.",
             "content": {
               "application/json": {
                 "schema": {
@@ -11421,7 +11421,7 @@
           },
           "name": {
             "type": "string",
-            "description": "Display name for the declaration."
+            "description": "Display name for the declaration, unique among the consumer's\ndeclarations."
           },
           "overdue_after": {
             "type": [
@@ -11500,7 +11500,7 @@
           },
           "name": {
             "type": "string",
-            "description": "New display name for the declaration."
+            "description": "New display name for the declaration, unique among the consumer's\ndeclarations."
           },
           "overdue_after": {
             "type": [

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2088,9 +2088,11 @@ export interface paths {
          *     are resolved to raw seconds/bytes before validation against the consumer's
          *     advertised schema for the intent and stored raw. If the intent is not
          *     currently advertised, the values are accepted as-is and the declaration is
-         *     created with a gap. Requires the caller to be on the admin allow-list.
-         *     Responds 400 if the overdue bound or a parameter value fails to parse or
-         *     validate, and 409 if a matching declaration already exists.
+         *     created with a gap. The name must be unique among the consumer's
+         *     declarations. Requires the caller to be on the admin allow-list. Responds
+         *     400 if the name is blank or the overdue bound or a parameter value fails to
+         *     parse or validate, and 409 if a matching declaration already exists or the
+         *     consumer already has a declaration with that name.
          */
         post: operations["restore_replicas_create"];
         delete?: never;
@@ -2113,8 +2115,9 @@ export interface paths {
          * @description Removes the declaration: the consumer stops being asked to maintain the
          *     replica and loses the backup access the declaration granted. Any active
          *     restore-verification alert for the declaration's scope is recovered, since
-         *     nothing tracks that scope any more. Requires the caller to be on the admin
-         *     allow-list. Responds 404 if the declaration does not exist.
+         *     nothing tracks that scope any more. The restore-health reports it collected
+         *     are retained, detached from the deleted declaration. Requires the caller to
+         *     be on the admin allow-list. Responds 404 if the declaration does not exist.
          */
         post: operations["restore_replicas_delete"];
         delete?: never;
@@ -2165,10 +2168,11 @@ export interface paths {
          *     intent the new consumer doesn't currently advertise is accepted and the
          *     values pass through unvalidated, leaving the declaration with a gap. If
          *     the scope changes, any active restore-verification alert for the
-         *     declaration's old scope is recovered. Requires the caller to be on the
-         *     admin allow-list. Responds 400 if the overdue bound or a parameter value
+         *     declaration's old scope is recovered. The name must be unique among the
+         *     consumer's declarations. Requires the caller to be on the admin allow-list.
+         *     Responds 400 if the name is blank or the overdue bound or a parameter value
          *     fails to parse or validate, 404 if the declaration does not exist, and 409
-         *     if the new scope collides with another declaration.
+         *     if the new scope or name collides with another declaration.
          */
         post: operations["restore_replicas_update"];
         delete?: never;
@@ -6472,7 +6476,10 @@ export interface components {
              *     identifier from the consumer's advertised intents, e.g. `verify`.
              */
             intent: string;
-            /** @description Display name for the declaration. */
+            /**
+             * @description Display name for the declaration, unique among the consumer's
+             *     declarations.
+             */
             name: string;
             /**
              * @description Overdue bound as a human-friendly duration (jiff's "friendly" format,
@@ -6535,7 +6542,10 @@ export interface components {
              *     identifier from the consumer's advertised intents, e.g. `verify`.
              */
             intent: string;
-            /** @description New display name for the declaration. */
+            /**
+             * @description New display name for the declaration, unique among the consumer's
+             *     declarations.
+             */
             name: string;
             /**
              * @description New overdue bound as a human-friendly duration (jiff's "friendly"
@@ -10916,7 +10926,7 @@ export interface operations {
                     "application/json": components["schemas"]["RestoreReplicaView"];
                 };
             };
-            /** @description A matching declaration already exists. */
+            /** @description A matching declaration already exists, or the consumer already has one with that name. */
             409: {
                 headers: {
                     [name: string]: unknown;
@@ -11008,7 +11018,7 @@ export interface operations {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
                 };
             };
-            /** @description The new scope collides with another declaration. */
+            /** @description The new scope or name collides with another declaration. */
             409: {
                 headers: {
                     [name: string]: unknown;

--- a/private-web/src/components/RestoreReplicasSection.tsx
+++ b/private-web/src/components/RestoreReplicasSection.tsx
@@ -681,14 +681,16 @@ function CreateReplicaDialog({
 		setParamValues({});
 	}, [intent]);
 
-	// Suggest a name from the group and (if picked) server, until the operator
-	// types their own.
+	// Suggest a name from the group, (if picked) server, and intent, until the
+	// operator types their own. The intent is part of it because names are
+	// unique per consumer: without it, declaring a second intent for the same
+	// server would suggest a name already taken.
 	const selectedServer = servers.find((s) => s.id === serverId);
 	const serverName = selectedServer
 		? (selectedServer.name ?? selectedServer.display_host ?? selectedServer.id)
 		: "";
 	const suggestedName = kebabCase(
-		[groupName, serverName].filter(Boolean).join("-"),
+		[groupName, serverName, intent].filter(Boolean).join("-"),
 	);
 	useEffect(() => {
 		if (!nameEdited) setName(suggestedName);


### PR DESCRIPTION
## The bug

Deleting a restore replica declaration failed with

```
database: update or delete on table "restore_replicas" violates foreign key
constraint "backup_restore_checks_replica_id_fkey" on table "backup_restore_checks"
```

as soon as its consumer had reported a single restore-health check against it.

`backup_restore_checks.replica_id` is nullable *precisely* so history survives the declaration being retired (the column's own comment says so), and RST states the recorded restore-health history is retained on delete. But the FK was created with the default `NO ACTION`, so the history pinned the declaration in place instead of detaching from it. In practice that meant any declaration old enough to have been reported on could never be deleted.

The operator hit this after mistakenly declaring a second replica with the same **name** as an existing one but a different **intent**. That was possible because the uniqueness indexes key on `(consumer, group, type, intent, server)` only — and the declare dialog suggested the same group/server-derived name for both, so the collision was the *default* outcome rather than an unlikely slip.

## The fix

**Deleting works, history is kept.** The FK is recreated as `ON DELETE SET NULL`, so a report outlives its declaration with its group, server, type, and intent intact, no longer naming a declaration. A declaration that has been reported on is now no harder to retire than one that never was.

**Names are unique per consumer.** A new `restore_replicas_consumer_name` unique index. The name is what the worklist hands the consumer to identify the replica, so a duplicate is ambiguous to the consumer and to the operator reading the list; two declarations differing only by intent are a distinct scope but still need distinct names. Another consumer may reuse a name freely.

**The default stops steering into it.** The declare dialog's suggested name folds in the intent (`group-server-verify` rather than `group-server`), so declaring a second intent for the same server no longer pre-fills a name that's already taken.

**Better refusals.** `create`/`update` inspect the violated constraint and return a 409 naming which collision was hit — scope or name — instead of one message for both. Blank and whitespace-only names are rejected with a 400, and names are trimmed before storage, so near-identical names can't slip past the index.

**Existing duplicates are kept, not dropped.** The migration renames rather than deletes: the oldest declaration keeps the name and each later one gets a `-2`, `-3`, … suffix. Suffixing repeats because a suffixed name can itself collide with a name already in use; each round strictly lengthens the names it touches, so it converges (bounded, and it raises rather than looping if it somehow doesn't). Operators can rename afterwards.

The spec (RST) is updated to state the per-consumer name uniqueness and that reports survive their declaration's deletion.

## Testing

- `database::it restore::delete_detaches_reports_rather_than_being_blocked_by_them` — the delete that used to fail, asserting the report is retained with a null `replica_id`.
- `database::it restore::name_is_unique_per_consumer` — same name under a different intent is refused, whitespace padding doesn't evade it, another consumer may reuse it, and renaming onto a sibling's name is refused too.
- `database::it restore::blank_name_is_rejected` — blank on create and update, and trimming on store.
- `private-server::it restore_replicas::{create_and_update_reject_a_name_the_consumer_already_uses, delete_succeeds_for_a_declaration_with_restore_health_history}` — the same two behaviours over HTTP.
- Playwright: the existing "deleting a declaration removes it" test now seeds a restore check against the declaration first, so it covers the reported bug through the UI; a new spec asserts the dialog surfaces the duplicate-name refusal; the default-name spec follows the new suggestion.
- Migration dedupe loop exercised by hand against a migrated database seeded with `a`, `a`, `a-2`, `a` → `a`, `a-2`, `a-2-2`, `a-3`, index created.

Full suite: 885 passed. `cargo clippy` adds no new warnings; `cargo fmt` and `tsc -b` clean. OpenAPI spec and generated TS types regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVetxP7dot8AoSWFkzoXYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVetxP7dot8AoSWFkzoXYK)_