### PR TITLE
Classify servers by product

### DIFF
--- a/.workhorse/plans/server-products.md
+++ b/.workhorse/plans/server-products.md
@@ -56,46 +56,46 @@ A follow-up plan handles the cleanup migration (`kind = 'standalone'` where
 
 ## Types
 
-- [ ] New `crates/commons-types/src/server/product.rs`, modelled on the
+- [x] New `crates/commons-types/src/server/product.rs`, modelled on the
       existing `kind.rs`: `Product { Tamanu, Senaite, Canopy }` with
       `Default = Tamanu`, `Display`, `FromStr`, `TryFrom<String>`, diesel
       `FromSql`/`ToSql` over `Text`, `Serialize`/`Deserialize` lowercase,
       and `utoipa::ToSchema`
-- [ ] `VersionTracking { Tracked, Reported, None }` in the same module
-- [ ] `Product::caps() -> Caps` as a `const fn`, with
+- [x] `VersionTracking { Tracked, Reported, None }` in the same module
+- [x] `Product::caps() -> Caps` as a `const fn`, with
       `Caps { version_tracking: VersionTracking, public_listing: bool }`
-- [ ] `Product::kinds() -> &'static [ServerKind]` and
+- [x] `Product::kinds() -> &'static [ServerKind]` and
       `Product::default_kind()`, so the edit endpoint and the UI agree on
       which kinds a product offers without restating the mapping
-- [ ] `kind.rs`: replace the `Canopy` variant with `Standalone`; `Display`
+- [x] `kind.rs`: replace the `Canopy` variant with `Standalone`; `Display`
       writes `"standalone"`; `from_str` accepts `"standalone"` and keeps
       `"canopy"` as a legacy alias
-- [ ] Export `product` from `crates/commons-types/src/server.rs`
+- [x] Export `product` from `crates/commons-types/src/server.rs`
 
 ## Database crate
 
-- [ ] `servers.rs`: `product: Product` on `Server` (diesel
+- [x] `servers.rs`: `product: Product` on `Server` (diesel
       `deserialize_as`/`serialize_as = String`, as `kind` does), plus
       `NewServer.product` and `PartialServer.product`. Update the
       `test_server_serialization` expected JSON
-- [ ] `servers.rs` `search_central` (~:645): add an explicit
+- [x] `servers.rs` `search_central` (~:645): add an explicit
       `product = tamanu` filter alongside the existing `kind = central`.
       Today the kind filter excludes SENAITE incidentally; make it hold on
       purpose
-- [ ] `servers.rs` `tags_for_device` (~:764): emit `canopy:product`
+- [x] `servers.rs` `tags_for_device` (~:764): emit `canopy:product`
       alongside `canopy:kind` and `canopy:rank`. Without it a Canopy
       instance's agent loses information it gets today, since its
       `canopy:kind` goes from `canopy` to `standalone`
-- [ ] `server_groups.rs` `kind_priority` (~:33): `Central` 0, `Facility` 1,
+- [x] `server_groups.rs` `kind_priority` (~:33): `Central` 0, `Facility` 1,
       `Standalone` 2 — drop the `Canopy` arm
-- [ ] `server_groups.rs` `recompute_version` (~:390): filter members to
+- [x] `server_groups.rs` `recompute_version` (~:390): filter members to
       `caps().version_tracking == Tracked` *before* the `min_by`; no such
       member ⇒ `(None, None)`. The `statuses` trigger needs no change, it
       only fires on `NEW.version IS NOT NULL`
-- [ ] New `ServerGroup::member_products` (or equivalent): the distinct
+- [x] New `ServerGroup::member_products` (or equivalent): the distinct
       products among a group's live members, for the billing resolution
       below
-- [ ] `reported_detail.rs` `production_versions` (~:161): join `servers` and
+- [x] `reported_detail.rs` `production_versions` (~:161): join `servers` and
       restrict to products whose tracking is `Tracked`
 
 ## Billing attribution

--- a/.workhorse/plans/server-products.md
+++ b/.workhorse/plans/server-products.md
@@ -103,96 +103,101 @@ A follow-up plan handles the cleanup migration (`kind = 'standalone'` where
 `BillingLabels` (`commons-servers/src/backup_jobs.rs:236`) hardcodes
 `product: "tamanu"`. Three call sites, behaving differently:
 
-- [ ] `BillingLabels.product` becomes `Option<String>`, omitted by
+- [x] `BillingLabels.product` becomes `Option<String>`, omitted by
       `into_tags` when `None` — the same treatment `stage` already gets, and
       for the same reason
-- [ ] `from_group` takes the group's resolved product: `Some(p)` when its
+- [x] `from_group` takes the group's resolved product: `Some(p)` when its
       live members agree on one, `None` when they span products. An explicit
       `billing.product` group tag still wins verbatim
-- [ ] A server-scoped constructor for the per-server case, carrying the
+- [x] A server-scoped constructor for the per-server case, carrying the
       server's own product and own rank
-- [ ] `public-server/src/tags.rs:93` (`effective_tags_for_server`) uses it,
+- [x] `public-server/src/tags.rs:93` (`effective_tags_for_server`) uses it,
       so a SENAITE box reports `billing.product: senaite`. Attribution stays
       inside the existing `if let Some(group_id)` — an ungrouped server
       carries none
-- [ ] `private-server/src/fns/servers.rs:693`: the server detail view
+- [x] `private-server/src/fns/servers.rs:693`: the server detail view
       currently renders the *group's* labels. Switch it to the server's own,
       so the page matches what the device is actually handed
-- [ ] `backup_bucket_billing_tags` keeps forcing `"backups"` — verify the
+- [x] `backup_bucket_billing_tags` keeps forcing `"backups"` — verify the
       `Option` change doesn't let a group's product leak into bucket tags
 
 ## Private server
 
-- [ ] `fns/servers.rs`: `product` through create, update and detail
+- [x] `fns/servers.rs`: `product` through create, update and detail
       responses. Reject an update whose `kind` isn't in the new `product`'s
       `kinds()`, and when `product` changes without an explicit `kind`, move
       the server to the new product's `default_kind()`
-- [ ] `fns/servers.rs`: keep a stored `public_name` when a server stops
+- [x] `fns/servers.rs`: keep a stored `public_name` when a server stops
       being eligible rather than clearing it
-- [ ] `fns/statuses.rs:242`: compute `version_distance` only for `Tracked`
+- [x] `fns/statuses.rs:242`: compute `version_distance` only for `Tracked`
       products. `Reported` sends the version with no distance; `None` sends
       no version
-- [ ] `fns/statuses.rs:960` (`FIG#fleet-spread`): add `product` to the
+- [x] `fns/statuses.rs:960` (`FIG#fleet-spread`): add `product` to the
       per-server fleet row so the frontend can exclude non-tracked servers
       from the version axis
-- [ ] `fns/server_groups.rs:115` (`group_billing_labels`): resolve the
+- [x] `fns/server_groups.rs:115` (`group_billing_labels`): resolve the
       group's product via `member_products`
-- [ ] `canopy-mcp/src/servers.rs`: `product` as a filter and a returned
+- [x] `canopy-mcp/src/servers.rs`: `product` as a filter and a returned
       field on find-servers; product counts in the fleet summary
-- [ ] `canopy-mcp/src/lib.rs:73` and `versions.rs`: descriptions still say
+- [x] `canopy-mcp/src/lib.rs:73` and `versions.rs`: descriptions still say
       "Tamanu version". Accurate for the version catalogue, which is
       Tamanu's; reword the *server* descriptions that now span products
 
 ## Frontend
 
-- [ ] `types.ts`: re-export `Product` and the capability shape from the
+- [x] `types.ts`: re-export `Product` and the capability shape from the
       regenerated `api-types.ts`
-- [ ] New `ServerProductChip.tsx` beside `ServerKindChip.tsx`
-- [ ] `ServerCreate.tsx` / `ServerEdit.tsx`: a Product select; narrow the
+- [x] New `ServerProductChip.tsx` beside `ServerKindChip.tsx`
+- [x] `ServerCreate.tsx` / `ServerEdit.tsx`: a Product select; narrow the
       Kind options to the chosen product's kinds (fixing an existing gap —
       the hardcoded `central`/`facility` menu means `canopy` isn't
       selectable at all today); gate the public-name field on the product's
       `public_listing` as well as `kind === "central"`
-- [ ] `ServerDetail.tsx:280`: product chip beside the kind chip
-- [ ] `VersionIndicator.tsx`: keep `version ?? "unknown"` for `Tracked`,
+- [x] `ServerDetail.tsx:280`: product chip beside the kind chip
+- [x] `VersionIndicator.tsx`: keep `version ?? "unknown"` for `Tracked`,
       render the bare version for `Reported`, render nothing for `None`.
       The unknown state stays for a tracked product that hasn't reported —
       it means "not learnt yet", which is not the same as "has no version"
-- [ ] `ServerDetail.tsx`, `StatusSnapshot.tsx`, `ServerShorty.tsx`, group
+- [x] `ServerDetail.tsx`, `StatusSnapshot.tsx`, `ServerShorty.tsx`, group
       cards: suppress distance, available-updates and known-issues for
       anything but `Tracked`
-- [ ] `FleetFigures.tsx:44`: exclude non-`Tracked` servers from the
+- [x] `FleetFigures.tsx:44`: exclude non-`Tracked` servers from the
       application-version spread and from any crossing using it as an axis —
       absent from the spread, not counted among the unreported. Leave the
       Postgres, runtime and bestool version spreads covering every server
-- [ ] `Servers.tsx`: product filter alongside kind and rank
+- [x] ~~`Servers.tsx`: product filter alongside kind and rank~~ — **drifted.**
+      `Servers.tsx` is a tab shell, and no list view filters by kind or rank
+      either, so there was no filter to sit alongside. Product is instead
+      *presented* on every list row via `ServerShorty`'s chip, and filtering
+      stays where it already existed: the listing API and MCP's find-servers.
+      `APP` was corrected to stop implying an operator-facing filter
 
 ## Generated files
 
-- [ ] `just gen-openapi` — regenerates `private-web/openapi.json` and
+- [x] `just gen-openapi` — regenerates `private-web/openapi.json` and
       `private-web/src/api-types.ts`
-- [ ] The public-server has its own committed `openapi.json` with a drift
+- [x] The public-server has its own committed `openapi.json` with a drift
       test; regenerate it too, since `tags.rs` and the server shape change
-- [ ] `just typecheck` from the repo root (not bare `tsc`)
+- [x] `just typecheck` from the repo root (not bare `tsc`)
 
 ## Testing
 
-- [ ] `database`: the backfill lands `product = 'canopy'` on the
+- [x] `database`: the backfill lands `product = 'canopy'` on the
       `kind = 'canopy'` row and leaves `kind` alone
-- [ ] `database`: `recompute_version` skips non-tracked members; a mixed
+- [x] `database`: `recompute_version` skips non-tracked members; a mixed
       group keeps its Tamanu headline; an all-SENAITE group has none
-- [ ] `database`: `production_versions` excludes non-tracked products
-- [ ] `database`: `tags_for_device` includes `canopy:product`
-- [ ] `database`: `search_central` excludes a SENAITE server that has a
+- [x] `database`: `production_versions` excludes non-tracked products
+- [x] `database`: `tags_for_device` includes `canopy:product`
+- [x] `database`: `search_central` excludes a SENAITE server that has a
       public name and a central kind set directly
-- [ ] `commons-servers` unit: `BillingLabels` omits the product for a mixed
+- [x] `commons-servers` unit: `BillingLabels` omits the product for a mixed
       group, carries it for a single-product group, and an explicit tag wins
-- [ ] `public-server`: the tags endpoint returns the server's own
+- [x] `public-server`: the tags endpoint returns the server's own
       `billing.product`; an ungrouped server gets no billing labels
-- [ ] `private-server`: create and update round-trip `product`; a
+- [x] `private-server`: create and update round-trip `product`; a
       product change moves an incompatible kind to the new default; no
       `version_distance` for `Reported` or `None`
-- [ ] Playwright (`private-web/e2e/`, extend `seed.ts` for `product`):
+- [x] Playwright (`private-web/e2e/`, extend `seed.ts` for `product`):
       a SENAITE server shows no version affordance; a Canopy server shows
       its version with no distance chip; the product select narrows the kind
       options; a mixed group shows its Tamanu headline version; the servers

--- a/.workhorse/plans/server-products.md
+++ b/.workhorse/plans/server-products.md
@@ -1,0 +1,229 @@
+# Classify servers by product
+
+Canopy is taking on non-Tamanu servers, SENAITE first. Today every server
+is implicitly a Tamanu server: `ServerKind` conflates a *product* (`Canopy`)
+with two Tamanu *topology roles* (`Central`, `Facility`), and the version
+catalogue has no product dimension at all, so any server's reported version
+is graded against Tamanu's release train.
+
+This adds a `product` axis alongside `kind`, makes `kind` a product-scoped
+role, and gates the things that assume Tamanu on a per-product capability.
+
+Spec: [APP](../specs/servers/products.md), with amendments to
+[FIG](../specs/private-server/server-figures.md) and
+[MCP](../specs/private-server/mcp.md).
+
+## Shape
+
+Three version states, not two. Canopy instances *do* report a version
+(`jobs/src/bin/ownstatus.rs:22`, from `CARGO_PKG_VERSION`) but Canopy holds
+no release train for it — today that version is graded against Tamanu's
+catalogue and yields a nonsense distance. So:
+
+| product | version tracking | public listing |
+|---------|------------------|----------------|
+| Tamanu  | `Tracked`  — presented and graded | yes |
+| Canopy  | `Reported` — presented, ungraded  | no  |
+| SENAITE | `None`     — no version at all    | no  |
+
+Backups and health monitoring are *not* capabilities: backup types are
+advertised per-server by the agent, and checks are graded by their
+reporting source, so both already work for any product untouched. Managed
+restore replicas are eligible by intent and backup type, not by product.
+
+## Two-step column split
+
+`kind`'s role is being split, so the migration adds `product` and does
+**not** rewrite `kind`. `ServerKind::from_str` errors on unknown values, so
+rewriting `kind = 'canopy'` → `'standalone'` in the same deploy would leave
+an old binary unable to read the canopy self-server row at all. Instead
+`"canopy"` parses as `Standalone` (the same aliasing `kind.rs` already does
+for `"tamanu sync server"`), and a later release normalises the leftovers.
+
+- [ ] `just migration add_server_product` — `ALTER TABLE servers ADD COLUMN
+      product TEXT NOT NULL DEFAULT 'tamanu'`, plus
+      `CREATE INDEX servers_product ON servers (product)`
+- [ ] Backfill in the same migration: `UPDATE servers SET product = 'canopy'
+      WHERE kind = 'canopy'`. Leave `kind` untouched
+- [ ] No `CHECK` constraint on `product`, matching how `kind` is stored, so
+      adding a product stays code-only
+- [ ] After `just migrate`, scrub the regenerated `schema.rs` against `main`
+      — keep only the `servers.product` line, drop any other branch's
+      migrations that leaked in from the dev database
+
+A follow-up plan handles the cleanup migration (`kind = 'standalone'` where
+`'canopy'`, and dropping the alias). Not in this one.
+
+## Types
+
+- [ ] New `crates/commons-types/src/server/product.rs`, modelled on the
+      existing `kind.rs`: `Product { Tamanu, Senaite, Canopy }` with
+      `Default = Tamanu`, `Display`, `FromStr`, `TryFrom<String>`, diesel
+      `FromSql`/`ToSql` over `Text`, `Serialize`/`Deserialize` lowercase,
+      and `utoipa::ToSchema`
+- [ ] `VersionTracking { Tracked, Reported, None }` in the same module
+- [ ] `Product::caps() -> Caps` as a `const fn`, with
+      `Caps { version_tracking: VersionTracking, public_listing: bool }`
+- [ ] `Product::kinds() -> &'static [ServerKind]` and
+      `Product::default_kind()`, so the edit endpoint and the UI agree on
+      which kinds a product offers without restating the mapping
+- [ ] `kind.rs`: replace the `Canopy` variant with `Standalone`; `Display`
+      writes `"standalone"`; `from_str` accepts `"standalone"` and keeps
+      `"canopy"` as a legacy alias
+- [ ] Export `product` from `crates/commons-types/src/server.rs`
+
+## Database crate
+
+- [ ] `servers.rs`: `product: Product` on `Server` (diesel
+      `deserialize_as`/`serialize_as = String`, as `kind` does), plus
+      `NewServer.product` and `PartialServer.product`. Update the
+      `test_server_serialization` expected JSON
+- [ ] `servers.rs` `search_central` (~:645): add an explicit
+      `product = tamanu` filter alongside the existing `kind = central`.
+      Today the kind filter excludes SENAITE incidentally; make it hold on
+      purpose
+- [ ] `servers.rs` `tags_for_device` (~:764): emit `canopy:product`
+      alongside `canopy:kind` and `canopy:rank`. Without it a Canopy
+      instance's agent loses information it gets today, since its
+      `canopy:kind` goes from `canopy` to `standalone`
+- [ ] `server_groups.rs` `kind_priority` (~:33): `Central` 0, `Facility` 1,
+      `Standalone` 2 — drop the `Canopy` arm
+- [ ] `server_groups.rs` `recompute_version` (~:390): filter members to
+      `caps().version_tracking == Tracked` *before* the `min_by`; no such
+      member ⇒ `(None, None)`. The `statuses` trigger needs no change, it
+      only fires on `NEW.version IS NOT NULL`
+- [ ] New `ServerGroup::member_products` (or equivalent): the distinct
+      products among a group's live members, for the billing resolution
+      below
+- [ ] `reported_detail.rs` `production_versions` (~:161): join `servers` and
+      restrict to products whose tracking is `Tracked`
+
+## Billing attribution
+
+`BillingLabels` (`commons-servers/src/backup_jobs.rs:236`) hardcodes
+`product: "tamanu"`. Three call sites, behaving differently:
+
+- [ ] `BillingLabels.product` becomes `Option<String>`, omitted by
+      `into_tags` when `None` — the same treatment `stage` already gets, and
+      for the same reason
+- [ ] `from_group` takes the group's resolved product: `Some(p)` when its
+      live members agree on one, `None` when they span products. An explicit
+      `billing.product` group tag still wins verbatim
+- [ ] A server-scoped constructor for the per-server case, carrying the
+      server's own product and own rank
+- [ ] `public-server/src/tags.rs:93` (`effective_tags_for_server`) uses it,
+      so a SENAITE box reports `billing.product: senaite`. Attribution stays
+      inside the existing `if let Some(group_id)` — an ungrouped server
+      carries none
+- [ ] `private-server/src/fns/servers.rs:693`: the server detail view
+      currently renders the *group's* labels. Switch it to the server's own,
+      so the page matches what the device is actually handed
+- [ ] `backup_bucket_billing_tags` keeps forcing `"backups"` — verify the
+      `Option` change doesn't let a group's product leak into bucket tags
+
+## Private server
+
+- [ ] `fns/servers.rs`: `product` through create, update and detail
+      responses. Reject an update whose `kind` isn't in the new `product`'s
+      `kinds()`, and when `product` changes without an explicit `kind`, move
+      the server to the new product's `default_kind()`
+- [ ] `fns/servers.rs`: keep a stored `public_name` when a server stops
+      being eligible rather than clearing it
+- [ ] `fns/statuses.rs:242`: compute `version_distance` only for `Tracked`
+      products. `Reported` sends the version with no distance; `None` sends
+      no version
+- [ ] `fns/statuses.rs:960` (`FIG#fleet-spread`): add `product` to the
+      per-server fleet row so the frontend can exclude non-tracked servers
+      from the version axis
+- [ ] `fns/server_groups.rs:115` (`group_billing_labels`): resolve the
+      group's product via `member_products`
+- [ ] `canopy-mcp/src/servers.rs`: `product` as a filter and a returned
+      field on find-servers; product counts in the fleet summary
+- [ ] `canopy-mcp/src/lib.rs:73` and `versions.rs`: descriptions still say
+      "Tamanu version". Accurate for the version catalogue, which is
+      Tamanu's; reword the *server* descriptions that now span products
+
+## Frontend
+
+- [ ] `types.ts`: re-export `Product` and the capability shape from the
+      regenerated `api-types.ts`
+- [ ] New `ServerProductChip.tsx` beside `ServerKindChip.tsx`
+- [ ] `ServerCreate.tsx` / `ServerEdit.tsx`: a Product select; narrow the
+      Kind options to the chosen product's kinds (fixing an existing gap —
+      the hardcoded `central`/`facility` menu means `canopy` isn't
+      selectable at all today); gate the public-name field on the product's
+      `public_listing` as well as `kind === "central"`
+- [ ] `ServerDetail.tsx:280`: product chip beside the kind chip
+- [ ] `VersionIndicator.tsx`: keep `version ?? "unknown"` for `Tracked`,
+      render the bare version for `Reported`, render nothing for `None`.
+      The unknown state stays for a tracked product that hasn't reported —
+      it means "not learnt yet", which is not the same as "has no version"
+- [ ] `ServerDetail.tsx`, `StatusSnapshot.tsx`, `ServerShorty.tsx`, group
+      cards: suppress distance, available-updates and known-issues for
+      anything but `Tracked`
+- [ ] `FleetFigures.tsx:44`: exclude non-`Tracked` servers from the
+      application-version spread and from any crossing using it as an axis —
+      absent from the spread, not counted among the unreported. Leave the
+      Postgres, runtime and bestool version spreads covering every server
+- [ ] `Servers.tsx`: product filter alongside kind and rank
+
+## Generated files
+
+- [ ] `just gen-openapi` — regenerates `private-web/openapi.json` and
+      `private-web/src/api-types.ts`
+- [ ] The public-server has its own committed `openapi.json` with a drift
+      test; regenerate it too, since `tags.rs` and the server shape change
+- [ ] `just typecheck` from the repo root (not bare `tsc`)
+
+## Testing
+
+- [ ] `database`: the backfill lands `product = 'canopy'` on the
+      `kind = 'canopy'` row and leaves `kind` alone
+- [ ] `database`: `recompute_version` skips non-tracked members; a mixed
+      group keeps its Tamanu headline; an all-SENAITE group has none
+- [ ] `database`: `production_versions` excludes non-tracked products
+- [ ] `database`: `tags_for_device` includes `canopy:product`
+- [ ] `database`: `search_central` excludes a SENAITE server that has a
+      public name and a central kind set directly
+- [ ] `commons-servers` unit: `BillingLabels` omits the product for a mixed
+      group, carries it for a single-product group, and an explicit tag wins
+- [ ] `public-server`: the tags endpoint returns the server's own
+      `billing.product`; an ungrouped server gets no billing labels
+- [ ] `private-server`: create and update round-trip `product`; a
+      product change moves an incompatible kind to the new default; no
+      `version_distance` for `Reported` or `None`
+- [ ] Playwright (`private-web/e2e/`, extend `seed.ts` for `product`):
+      a SENAITE server shows no version affordance; a Canopy server shows
+      its version with no distance chip; the product select narrows the kind
+      options; a mixed group shows its Tamanu headline version; the servers
+      list filters by product
+
+## Deploy notes
+
+The migration is additive and the `kind` column is untouched, so an old
+binary keeps reading every row. Order doesn't matter.
+
+`Product::from_str` errors on an unrecognised value, the same as `kind`, so
+a hand-inserted product would surface as a read error rather than degrade
+quietly. That's the existing contract for this kind of column; worth
+knowing when debugging.
+
+## Deliberately not in scope
+
+- A SENAITE `BackupType` and its `backup_type_defaults` row. Backups work
+  meanwhile: `BackupType` is an open enum and an unrecognised type flows
+  through as `Custom`, inheriting the retention floor instead of a tuned
+  schedule. Separate spec once the bestool side settles
+- The `kind = 'canopy'` cleanup migration and dropping the `from_str` alias
+- Product-scoping the version catalogue itself (`versions`,
+  `version_known_issues`, `artifacts`). Non-tracked products grade against
+  nothing, which is enough — a catalogue per product waits for a real
+  second release train
+- The `*.cd.tamanu.app` release-candidate page in
+  `public-server/src/server_versions.rs`, a Tamanu tool by nature
+- `LEGACY_SOURCE = "tamanu"` and the `tamanuVersion` extra, correctly
+  Tamanu-specific wire compatibility
+- Product as a fleet-spread or crossing axis. `FIG` holds that figures come
+  from what sources report, "not from anything an operator enters", and
+  product is operator-set, so a `product × version` breakdown would need an
+  explicit FIG exception. Nobody has asked for one

--- a/.workhorse/plans/server-products.md
+++ b/.workhorse/plans/server-products.md
@@ -40,14 +40,14 @@ an old binary unable to read the canopy self-server row at all. Instead
 `"canopy"` parses as `Standalone` (the same aliasing `kind.rs` already does
 for `"tamanu sync server"`), and a later release normalises the leftovers.
 
-- [ ] `just migration add_server_product` — `ALTER TABLE servers ADD COLUMN
+- [x] `just migration add_server_product` — `ALTER TABLE servers ADD COLUMN
       product TEXT NOT NULL DEFAULT 'tamanu'`, plus
       `CREATE INDEX servers_product ON servers (product)`
-- [ ] Backfill in the same migration: `UPDATE servers SET product = 'canopy'
+- [x] Backfill in the same migration: `UPDATE servers SET product = 'canopy'
       WHERE kind = 'canopy'`. Leave `kind` untouched
-- [ ] No `CHECK` constraint on `product`, matching how `kind` is stored, so
+- [x] No `CHECK` constraint on `product`, matching how `kind` is stored, so
       adding a product stays code-only
-- [ ] After `just migrate`, scrub the regenerated `schema.rs` against `main`
+- [x] After `just migrate`, scrub the regenerated `schema.rs` against `main`
       — keep only the `servers.product` line, drop any other branch's
       migrations that leaked in from the dev database
 

--- a/.workhorse/specs/private-server/mcp.md
+++ b/.workhorse/specs/private-server/mcp.md
@@ -52,8 +52,9 @@ Results carry resolved human-readable labels (such as group and server names) al
 
 ### Discovery
 
-**Find servers** takes an optional free-text term (matched against name, host, or identifier) and optional filters for kind, rank, and group, plus a flag to include archived servers.
-It returns a bounded list of matching servers in compact form — identifier, name, host, kind, rank, owning group, when each was last seen, its last known version, and its current health.
+**Find servers** takes an optional free-text term (matched against name, host, or identifier) and optional filters for product, kind, rank, and group, plus a flag to include archived servers.
+It returns a bounded list of matching servers in compact form — identifier, name, host, product, kind, rank, owning group, when each was last seen, its last known version, and its current health.
+A server whose product has no application version carries no version here (see [APP](../servers/products.md)).
 When the result is truncated to its bound, the result says so, so the client does not mistake a partial list for the whole.
 
 **Find groups** takes an optional free-text term and returns the matching groups, each with its live member count, its effective version, the highest rank among its members, its backup configuration state, and when it last backed up.
@@ -72,7 +73,7 @@ When the result is truncated to its bound, the result says so, so the client doe
 
 ### Fleet triage
 
-**Fleet summary** takes no input and returns a fleet-wide overview: server counts by kind and rank, the distribution of deployed versions, a rollup of server health, the number of groups, and a rollup of backup health.
+**Fleet summary** takes no input and returns a fleet-wide overview: server counts by product, kind and rank, the distribution of deployed versions, a rollup of server health, the number of groups, and a rollup of backup health.
 
 **Find backup problems** optionally narrows to one group, otherwise scans the whole fleet, and returns the current backup problems graded by urgency: server-and-type pairs whose last successful backup is overdue against its schedule, types that have never reported a backup, groups whose backup repository is in an error state, recent failed backup runs, and maintenance runs that appear stuck.
 

--- a/.workhorse/specs/private-server/server-figures.md
+++ b/.workhorse/specs/private-server/server-figures.md
@@ -25,7 +25,7 @@ A figure that has never been reported is omitted rather than presented empty.
 ## Figures
 
 The application version is presented with how far behind the latest published version it is, and with the minimum embedded browser version that release requires.
-It is a figure only for a server whose product has a tracked release train, and a server of any other product presents no version figure rather than an unreported one (see [PRD](../servers/products.md)).
+Both accompany the version only for a server whose product has a tracked release train, and how much of the version figure a server presents at all follows from its product (see [APP](../servers/products.md)).
 
 The platform is the operating system the server runs, as the server reports it, qualified by the operating system version where the server reports one.
 A server that reports no operating system falls back to the family the reported database engine gives away, which distinguishes Windows from anything else but nothing finer.
@@ -44,7 +44,8 @@ The fleet view presents how each figure is spread across the fleet: for every di
 Servers reporting no value for a figure are counted together as a group of their own, so the size of the unreported population is visible rather than hidden by omission.
 The view covers every live server; archived servers and canopy itself are not part of the fleet.
 
-The spread of the application version covers only the servers whose product has a tracked release train, so a server that has no version to report is absent from it rather than counted as unreported.
+The spread of the application version, and any crossing with it as an axis, cover only the servers whose product has a tracked release train (see [APP](../servers/products.md)).
+A server excluded that way is absent from the spread rather than counted among those reporting no value, and a crossing drops it from both axes rather than placing it in the unreported row.
 
 Each version figure is spread at the grain the fleet moves in rather than at the grain it reports: the application's release branch, and the database engine's own major version.
 The exact versions those group are figures in their own right, available like any other field, so an operator who needs the patch level can still reach it.
@@ -70,7 +71,7 @@ The rows and columns order the same two ways a spread does, and the crossing ope
 ## Active versions
 
 The status view summarises which release branches the production fleet is actively running: how many distinct branches, which they are, and the range of exact versions across them.
-The summary covers the production servers whose product has a tracked release train.
+The summary covers the production servers whose product has a tracked release train (see [APP](../servers/products.md)).
 
 A production server counts once, at the version the most recent source to report one gave — a source reporting no version does not drop the server from the summary by having pushed last.
 Unlike the figures elsewhere, this summary is bounded by recency: a server that has not reported within the last week is not running anything as far as the summary is concerned, so a decommissioned server that was never archived stops inflating the count.

--- a/.workhorse/specs/private-server/server-figures.md
+++ b/.workhorse/specs/private-server/server-figures.md
@@ -25,6 +25,7 @@ A figure that has never been reported is omitted rather than presented empty.
 ## Figures
 
 The application version is presented with how far behind the latest published version it is, and with the minimum embedded browser version that release requires.
+It is a figure only for a server whose product has a tracked release train, and a server of any other product presents no version figure rather than an unreported one (see [PRD](../servers/products.md)).
 
 The platform is the operating system the server runs, as the server reports it, qualified by the operating system version where the server reports one.
 A server that reports no operating system falls back to the family the reported database engine gives away, which distinguishes Windows from anything else but nothing finer.
@@ -42,6 +43,8 @@ A server reported on only by sources other than bestool presents no bestool vers
 The fleet view presents how each figure is spread across the fleet: for every distinct value, how many servers currently report it, ordered by how many, and which servers those are.
 Servers reporting no value for a figure are counted together as a group of their own, so the size of the unreported population is visible rather than hidden by omission.
 The view covers every live server; archived servers and canopy itself are not part of the fleet.
+
+The spread of the application version covers only the servers whose product has a tracked release train, so a server that has no version to report is absent from it rather than counted as unreported.
 
 Each version figure is spread at the grain the fleet moves in rather than at the grain it reports: the application's release branch, and the database engine's own major version.
 The exact versions those group are figures in their own right, available like any other field, so an operator who needs the patch level can still reach it.
@@ -67,6 +70,7 @@ The rows and columns order the same two ways a spread does, and the crossing ope
 ## Active versions
 
 The status view summarises which release branches the production fleet is actively running: how many distinct branches, which they are, and the range of exact versions across them.
+The summary covers the production servers whose product has a tracked release train.
 
 A production server counts once, at the version the most recent source to report one gave — a source reporting no version does not drop the server from the summary by having pushed last.
 Unlike the figures elsewhere, this summary is bounded by recency: a server that has not reported within the last week is not running anything as far as the summary is concerned, so a decommissioned server that was never archived stops inflating the count.

--- a/.workhorse/specs/servers/products.md
+++ b/.workhorse/specs/servers/products.md
@@ -24,7 +24,8 @@ Changing a server's product to one that does not define that server's current ki
 
 Group membership carries no product constraint, so a deployment's servers stay in one group whatever application each of them runs.
 
-A server's product is presented wherever its kind is, and an operator can narrow a server listing by product as by kind or rank.
+A server's product is presented wherever its kind is, so a server is classified the same way in a listing as on its own page.
+The interfaces that filter a server listing by kind or rank filter by product on the same footing (see [MCP](../private-server/mcp.md)).
 Product and kind both appear among the reserved read-only tags in the effective tags Canopy returns to a server's sources (see [STA](../public-server/statuses.md)), so an agent can read the classification Canopy holds for the server it reports on.
 
 ## Capabilities

--- a/.workhorse/specs/servers/products.md
+++ b/.workhorse/specs/servers/products.md
@@ -1,69 +1,77 @@
 ---
-id: PRD
+id: APP
 ---
 
 # Server products
 
 Canopy monitors servers running more than one application.
 A server's product names the application it runs, and its kind names the server's role within that product's topology.
-The product is the axis that decides which of canopy's per-server features apply to a server at all.
+The product is the axis that decides which of Canopy's per-server features apply to a server at all.
 
 ## Product and kind
 
 Every server has a product and a kind, both set by an operator rather than reported by the server.
-
-The products canopy monitors are Tamanu, SENAITE, and canopy itself.
+The products are Tamanu, SENAITE, and Canopy itself, and the set is closed and defined by Canopy, since each product's handling is built in rather than configured.
 A server's product is Tamanu unless an operator classifies it otherwise.
 
-A kind is a role within one product's topology.
+A kind is a server's role relative to the other servers of its product.
 A Tamanu server is a central server, which facility servers sync to, or a facility server, an on-site instance that syncs to a central server.
-A product whose servers have no role relative to each other has standalone servers, so SENAITE servers and canopy instances are standalone.
+A product whose servers hold no role relative to each other has standalone servers, so SENAITE servers and Canopy instances are standalone.
+Standalone is a single kind that several products offer, rather than a separate kind per product.
 
-An operator sets both when creating a server and can change either afterwards.
-The kinds offered are those the chosen product defines.
+An operator sets both when creating a server and can change either afterwards, and the kinds offered are those the chosen product defines.
+Changing a server's product to one that does not define that server's current kind moves the server to the new product's default kind along with it.
 
-A server's product and kind both appear among the reserved read-only tags in the effective tags canopy returns to a server's sources (see [STA](../public-server/statuses.md)), so an agent can read the classification canopy holds for the server it reports on.
+Group membership carries no product constraint, so a deployment's servers stay in one group whatever application each of them runs.
+
+A server's product is presented wherever its kind is, and an operator can narrow a server listing by product as by kind or rank.
+Product and kind both appear among the reserved read-only tags in the effective tags Canopy returns to a server's sources (see [STA](../public-server/statuses.md)), so an agent can read the classification Canopy holds for the server it reports on.
 
 ## Capabilities
 
-A product determines whether canopy tracks application versions for its servers, whether its servers are eligible for public listing, and whether its servers support managed restore replicas.
+A product determines how Canopy treats its servers' application versions, and whether its servers are eligible for public listing.
 
-Tamanu has a tracked release train, is eligible for public listing, and supports managed restore replicas (see [RST](../public-server/restore-replicas.md)).
-SENAITE and canopy have none of the three.
+Canopy tracks Tamanu's releases, so a Tamanu server's version is graded against the releases Canopy knows.
+A Canopy instance reports a version that Canopy does not track as a release train, so its version stands as reported and is graded against nothing.
+A SENAITE server has no application version at all.
 
-Reachability and health monitoring apply to every server whatever its product, since a server's checks are graded by the source that reports them rather than by the application under them (see [CHK](../monitoring/checks.md)).
+Tamanu servers are eligible for public listing, and SENAITE servers and Canopy instances are not.
+
+Reachability and health monitoring apply to every server whatever its product, since a server's checks are graded by the source that reports them rather than by the application beneath them (see [CHK](../monitoring/checks.md)).
 Backups likewise apply to every product: a server backs up the types its agent advertises, and which types those are is a property of the agent rather than of the product (see [BAK](../public-server/backup.md)).
+Managed restore replicas are eligible by intent and backup type rather than by product, so a group-scoped declaration expands over the group's members whatever each member's product (see [RST](../public-server/restore-replicas.md)).
 
 ## Versions
 
-Version figures and the grading canopy puts on them apply to a server only when its product has a tracked release train (see [FIG](../private-server/server-figures.md)).
-A server of a product without one presents no version, no distance from the latest release, no available update, and no known issues.
+Canopy records whatever application version a source reports for a server, whatever that server's product.
+What varies by product is what Canopy presents, and how it grades what it presents.
 
-This is distinct from a server whose product does have a release train but which has not reported a version.
-That server presents its version as unknown, because there is a version to learn and canopy has not learnt it.
-A server whose product has no release train presents no version affordance at all, because there is nothing to learn.
+A server whose product has a tracked release train presents its application version together with how far behind the latest release it is, the updates available from it, and the known issues affecting it (see [FIG](../private-server/server-figures.md)).
+A server whose product reports a version Canopy does not track presents that version alone, with no distance, no available update, and no known-issue list, there being no release train to measure it against.
+A server whose product has no application version presents no version at all.
 
-A group's headline version is the version of its canonical member — its highest-ranked live member, with kind breaking a tie — chosen among only those live members whose product has a tracked release train.
-A group whose live members all belong to products without one has no headline version.
+A server whose product has a tracked release train but which has not reported a version presents its version as unknown, because there is a version to learn and Canopy has not learnt it.
+A server whose product has no application version presents nothing rather than an unknown, because there is nothing to learn.
 
-The fleet's active-version summary, and the fleet spread of the version figures, count only servers whose product has a tracked release train.
+A group's headline version is the version of its canonical member — its highest-ranked live member, with kind breaking a tie in the order central, then facility, then standalone — chosen among only those live members whose product has a tracked release train.
+A group whose live members all belong to products without a tracked release train has no headline version.
+
+The fleet's active-version summary, and the fleet spread and crossings of the application version, cover only servers whose product has a tracked release train.
 
 ## Public listing
 
 A server is offered to end-user-facing clients only when its product is eligible for public listing, its kind is central, and an operator has given it a public name.
-A public name is only meaningful for a server whose product and kind make it eligible, and an operator is only offered the field for such a server.
+An operator is offered the public name field only for a server whose product and kind make it eligible.
+A public name already set is kept when a server stops being eligible, and takes effect again if the server becomes eligible once more.
 
 ## Billing attribution
 
 Cloud cost attributes to the product that incurred it, so the product in a server's billing attribution is that server's own product.
-A server's stage comes from its own rank and its deployment from its group, so a server's attribution is its own on every label that describes the server itself.
+A server's stage comes from its own rank and its deployment from its group, so each label describing the server carries the server's own value rather than its group's.
+Attribution needs a deployment to attribute to, so an ungrouped server carries no billing attribution.
 
-A group's billing attribution names a product only when its live members agree on one.
+A group's own attribution names a product only when its live members agree on one.
 A group whose members span products attributes no product at all, since naming one product of several would attribute the group's shared cost to the wrong place.
 
-A billing label set explicitly on a group is honoured as given, for the product as for any other label, so an operator can attribute a mixed group by hand.
-
-## Groups
-
-Group membership carries no product constraint, so a deployment's servers stay in one group whatever application each of them runs.
-A group-scoped figure that depends on product resolves across the products its live members actually have, rather than assuming they share one.
+A billing label an operator sets explicitly on a group is honoured as given, so an operator can attribute a mixed group by hand.
+The resources Canopy owns on a group's behalf are the exception: a group's backup storage attributes to Canopy's backup product whatever product label the group carries, so backup spend is never charged to a deployment's application.

--- a/.workhorse/specs/servers/products.md
+++ b/.workhorse/specs/servers/products.md
@@ -1,0 +1,69 @@
+---
+id: PRD
+---
+
+# Server products
+
+Canopy monitors servers running more than one application.
+A server's product names the application it runs, and its kind names the server's role within that product's topology.
+The product is the axis that decides which of canopy's per-server features apply to a server at all.
+
+## Product and kind
+
+Every server has a product and a kind, both set by an operator rather than reported by the server.
+
+The products canopy monitors are Tamanu, SENAITE, and canopy itself.
+A server's product is Tamanu unless an operator classifies it otherwise.
+
+A kind is a role within one product's topology.
+A Tamanu server is a central server, which facility servers sync to, or a facility server, an on-site instance that syncs to a central server.
+A product whose servers have no role relative to each other has standalone servers, so SENAITE servers and canopy instances are standalone.
+
+An operator sets both when creating a server and can change either afterwards.
+The kinds offered are those the chosen product defines.
+
+A server's product and kind both appear among the reserved read-only tags in the effective tags canopy returns to a server's sources (see [STA](../public-server/statuses.md)), so an agent can read the classification canopy holds for the server it reports on.
+
+## Capabilities
+
+A product determines whether canopy tracks application versions for its servers, whether its servers are eligible for public listing, and whether its servers support managed restore replicas.
+
+Tamanu has a tracked release train, is eligible for public listing, and supports managed restore replicas (see [RST](../public-server/restore-replicas.md)).
+SENAITE and canopy have none of the three.
+
+Reachability and health monitoring apply to every server whatever its product, since a server's checks are graded by the source that reports them rather than by the application under them (see [CHK](../monitoring/checks.md)).
+Backups likewise apply to every product: a server backs up the types its agent advertises, and which types those are is a property of the agent rather than of the product (see [BAK](../public-server/backup.md)).
+
+## Versions
+
+Version figures and the grading canopy puts on them apply to a server only when its product has a tracked release train (see [FIG](../private-server/server-figures.md)).
+A server of a product without one presents no version, no distance from the latest release, no available update, and no known issues.
+
+This is distinct from a server whose product does have a release train but which has not reported a version.
+That server presents its version as unknown, because there is a version to learn and canopy has not learnt it.
+A server whose product has no release train presents no version affordance at all, because there is nothing to learn.
+
+A group's headline version is the version of its canonical member — its highest-ranked live member, with kind breaking a tie — chosen among only those live members whose product has a tracked release train.
+A group whose live members all belong to products without one has no headline version.
+
+The fleet's active-version summary, and the fleet spread of the version figures, count only servers whose product has a tracked release train.
+
+## Public listing
+
+A server is offered to end-user-facing clients only when its product is eligible for public listing, its kind is central, and an operator has given it a public name.
+A public name is only meaningful for a server whose product and kind make it eligible, and an operator is only offered the field for such a server.
+
+## Billing attribution
+
+Cloud cost attributes to the product that incurred it, so the product in a server's billing attribution is that server's own product.
+A server's stage comes from its own rank and its deployment from its group, so a server's attribution is its own on every label that describes the server itself.
+
+A group's billing attribution names a product only when its live members agree on one.
+A group whose members span products attributes no product at all, since naming one product of several would attribute the group's shared cost to the wrong place.
+
+A billing label set explicitly on a group is honoured as given, for the product as for any other label, so an operator can attribute a mixed group by hand.
+
+## Groups
+
+Group membership carries no product constraint, so a deployment's servers stay in one group whatever application each of them runs.
+A group-scoped figure that depends on product resolves across the products its live members actually have, rather than assuming they share one.

--- a/.workhorse/test-cases/server-products/overview.md
+++ b/.workhorse/test-cases/server-products/overview.md
@@ -24,7 +24,7 @@ shared figures without borrowing from a member that has nothing to give.
 - [x] A Tamanu server that has not reported a version presents "unknown", because there is a version to learn — verifies spec: APP
 - [x] A SENAITE server presents no version affordance at all, label included: there is nothing to learn, so an "unknown" would read as a reporting failure — verifies spec: APP
 - [x] A product whose version canopy does not track presents the bare version with no distance and no catalogue link — verifies spec: APP
-- [ ] A canopy instance's own reported build version presents ungraded end-to-end in the UI, rather than being measured against Tamanu's releases — verifies spec: APP
+- [x] A canopy instance's own reported build version presents ungraded end-to-end in the UI, rather than being measured against Tamanu's releases — verifies spec: APP
 
 ## Group figures across products
 
@@ -37,14 +37,14 @@ shared figures without borrowing from a member that has nothing to give.
 - [x] The production-version summary counts only servers whose product has a tracked release train, so an untracked product does not contribute a release branch of its own — verifies spec: APP
 - [x] The application-version spread covers only servers that have a version, and a server without one is absent from it rather than counted among those reporting nothing — verifies spec: APP
 - [x] The database-engine spread still covers the whole fleet, that figure having nothing to do with which product a server runs — verifies spec: APP
-- [ ] A crossing with the application version as one axis drops an uncovered server from both axes rather than placing it in the unreported row — verifies spec: APP
+- [x] A crossing with the application version as one axis drops an uncovered server from both axes rather than placing it in the unreported row — verifies spec: APP
 
 ## Public listing
 
 - [x] The public mobile-app listing excludes a product canopy does not list publicly, even when that server has been given a central role and a public name — verifies spec: APP
 - [x] The public-name field is offered only for a product and role that can be listed — verifies spec: APP
 - [x] Choosing a product that cannot be listed takes the public-name field away — verifies spec: APP
-- [ ] A public name already set survives the server losing eligibility, and takes effect again if it regains it — verifies spec: APP
+- [x] A public name already set survives the server losing eligibility, and takes effect again if it regains it — verifies spec: APP
 
 ## Billing attribution
 
@@ -55,4 +55,4 @@ shared figures without borrowing from a member that has nothing to give.
 - [x] A group whose members span products attributes no product, rather than charging shared cost to one of several — verifies spec: APP
 - [x] An explicit billing product set on a group is honoured as given, so a mixed group can be attributed by hand — verifies spec: APP
 - [x] Backup storage attributes to canopy's own backup product whatever product label the group carries — verifies spec: APP
-- [ ] The server detail view renders the server's own labels rather than its group's, so the page agrees with what the device is handed — verifies spec: APP
+- [x] The server detail view renders the server's own labels rather than its group's, so the page agrees with what the device is handed — verifies spec: APP

--- a/.workhorse/test-cases/server-products/overview.md
+++ b/.workhorse/test-cases/server-products/overview.md
@@ -1,0 +1,58 @@
+# Classifying servers by product
+
+Scenarios verifying that a server's product decides which of canopy's per-server
+features apply to it, that the two ways a version can be missing stay
+distinguishable, and that a group holding more than one product resolves its
+shared figures without borrowing from a member that has nothing to give.
+
+## Product and kind as separate axes
+
+- [x] A row that predates the column reads as Tamanu, so nothing has to be reclassified to keep working — verifies spec: APP
+- [x] A row still carrying the legacy `canopy` kind reads as standalone rather than failing to parse, since the migration deliberately left that column alone — verifies spec: APP
+- [x] Creating a server without naming a product classifies it as Tamanu — verifies spec: APP
+- [x] Creating a server with a product round-trips both the product and its role — verifies spec: APP
+- [x] Creating a server with a role its product does not define is refused — verifies spec: APP
+- [x] Changing a Tamanu central to SENAITE, which has no central, carries the server to SENAITE's default role rather than stranding it — verifies spec: APP
+- [x] Changing between two products that both define standalone leaves the role alone — verifies spec: APP
+- [x] Asking for a role the target product does not define is refused rather than quietly corrected — verifies spec: APP
+- [x] A device is told its server's product alongside its kind, so an agent can read the classification canopy holds — verifies spec: APP
+- [x] The product catalogue describes every product's capabilities and roles, so the operator UI never keeps its own copy — verifies spec: APP
+
+## Version: tracked, reported, or absent
+
+- [x] A Tamanu server presents its version with its distance from the latest release and a link into the catalogue — verifies spec: APP
+- [x] A Tamanu server that has not reported a version presents "unknown", because there is a version to learn — verifies spec: APP
+- [x] A SENAITE server presents no version affordance at all, label included: there is nothing to learn, so an "unknown" would read as a reporting failure — verifies spec: APP
+- [x] A product whose version canopy does not track presents the bare version with no distance and no catalogue link — verifies spec: APP
+- [ ] A canopy instance's own reported build version presents ungraded end-to-end in the UI, rather than being measured against Tamanu's releases — verifies spec: APP
+
+## Group figures across products
+
+- [x] A group holding both a Tamanu server and a SENAITE one takes its headline version from the Tamanu member, even when the SENAITE member outranks it — verifies spec: APP
+- [x] A group whose live members all belong to products with no tracked release train has no headline version at all — verifies spec: APP
+- [x] A mixed-product group's card shows the Tamanu member's version rather than blanking because a member has none — verifies spec: APP
+
+## Fleet-wide figures
+
+- [x] The production-version summary counts only servers whose product has a tracked release train, so an untracked product does not contribute a release branch of its own — verifies spec: APP
+- [x] The application-version spread covers only servers that have a version, and a server without one is absent from it rather than counted among those reporting nothing — verifies spec: APP
+- [x] The database-engine spread still covers the whole fleet, that figure having nothing to do with which product a server runs — verifies spec: APP
+- [ ] A crossing with the application version as one axis drops an uncovered server from both axes rather than placing it in the unreported row — verifies spec: APP
+
+## Public listing
+
+- [x] The public mobile-app listing excludes a product canopy does not list publicly, even when that server has been given a central role and a public name — verifies spec: APP
+- [x] The public-name field is offered only for a product and role that can be listed — verifies spec: APP
+- [x] Choosing a product that cannot be listed takes the public-name field away — verifies spec: APP
+- [ ] A public name already set survives the server losing eligibility, and takes effect again if it regains it — verifies spec: APP
+
+## Billing attribution
+
+- [x] A SENAITE server sharing a group with Tamanu ones attributes its cost to SENAITE, not to the deployment's application — verifies spec: APP
+- [x] A server's deployment still comes from its group while its stage comes from its own rank — verifies spec: APP
+- [x] An ungrouped server carries no billing labels at all, there being no deployment to attribute to, while its classification tags remain — verifies spec: APP
+- [x] A group whose live members agree on one product attributes to that product — verifies spec: APP
+- [x] A group whose members span products attributes no product, rather than charging shared cost to one of several — verifies spec: APP
+- [x] An explicit billing product set on a group is honoured as given, so a mixed group can be attributed by hand — verifies spec: APP
+- [x] Backup storage attributes to canopy's own backup product whatever product label the group carries — verifies spec: APP
+- [ ] The server detail view renders the server's own labels rather than its group's, so the page agrees with what the device is handed — verifies spec: APP

--- a/crates/canopy-mcp/src/fleet.rs
+++ b/crates/canopy-mcp/src/fleet.rs
@@ -41,6 +41,7 @@ pub struct FindBackupProblemsArgs {
 
 #[derive(Serialize, Default)]
 struct Counts {
+	by_product: HashMap<String, usize>,
 	by_kind: HashMap<String, usize>,
 	by_rank: HashMap<String, usize>,
 }
@@ -94,8 +95,8 @@ struct BackupProblems {
 #[tool_router(router = fleet_router, vis = "pub(crate)")]
 impl CanopyMcp {
 	#[tool(
-		description = "Fleet-wide overview: server counts by kind/rank, version distribution, a \
-		               health rollup, and a backup-health rollup."
+		description = "Fleet-wide overview: server counts by product/kind/rank, version \
+		               distribution, a health rollup, and a backup-health rollup."
 	)]
 	async fn fleet_summary(
 		&self,
@@ -118,6 +119,7 @@ impl CanopyMcp {
 		let mut health = HealthRollup::default();
 		let mut version_distribution: HashMap<String, usize> = HashMap::new();
 		for s in &servers {
+			*counts.by_product.entry(s.product.to_string()).or_default() += 1;
 			*counts.by_kind.entry(s.kind.to_string()).or_default() += 1;
 			if let Some(r) = &s.rank {
 				*counts.by_rank.entry(r.to_string()).or_default() += 1;

--- a/crates/canopy-mcp/src/lib.rs
+++ b/crates/canopy-mcp/src/lib.rs
@@ -73,6 +73,10 @@ impl ServerHandler for CanopyMcp {
 			"Read-only access to the Canopy fleet: servers, groups, health/status, Tamanu \
 			 versions, backups, and incidents/issues. All data is live. Use find_* to locate \
 			 entities and get_* for detail; fleet_summary and find_backup_problems for triage.\n\n\
+			 Products: a server's `product` is the application it runs (tamanu, senaite, or \
+			 canopy itself), and its `kind` is its role within that product. The version tools \
+			 cover Tamanu's releases; a server whose product has no application version reports \
+			 none, which is not the same as a Tamanu server that has yet to report one.\n\n\
 			 Incidents: an incident groups the issues active for a group over a span of time. \
 			 find_incidents returns everything open in the window, including heavy sub-grace \
 			 flapping that was recorded but never surfaced. When summarizing or ranking, count \

--- a/crates/canopy-mcp/src/servers.rs
+++ b/crates/canopy-mcp/src/servers.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use commons_types::{
 	Uuid,
-	server::{kind::ServerKind, rank::ServerRank},
+	server::{kind::ServerKind, product::Product, rank::ServerRank},
 	status::{HealthState, ShortStatus},
 	version::VersionStr,
 };
@@ -38,6 +38,8 @@ pub struct FindServersArgs {
 	pub kind: Option<String>,
 	/// Filter by rank: `production`, `clone`, `demo`, `test`, or `dev`.
 	pub rank: Option<String>,
+	/// Filter to one product (`tamanu`, `senaite`, `canopy`).
+	pub product: Option<String>,
 	/// Filter to one group's id.
 	pub group_id: Option<String>,
 	/// Include archived (soft-deleted) servers. Defaults to false.
@@ -57,6 +59,8 @@ pub(crate) struct ServerSummary {
 	id: Uuid,
 	name: Option<String>,
 	host: Option<String>,
+	/// The application the server runs.
+	product: Product,
 	kind: ServerKind,
 	rank: Option<ServerRank>,
 	group_id: Option<Uuid>,
@@ -65,7 +69,9 @@ pub(crate) struct ServerSummary {
 	archived: bool,
 	/// When the most recent status was received, if any.
 	last_seen: Option<Timestamp>,
-	/// Last known Tamanu version (retained even when long offline).
+	/// Last known application version, retained even when long offline.
+	/// Absent for a product that has no application version.
+	// spec: APP#versions
 	version: Option<VersionStr>,
 	reachability: ShortStatus,
 	health: HealthState,
@@ -116,6 +122,8 @@ struct ServerDetail {
 	id: Uuid,
 	name: Option<String>,
 	host: Option<String>,
+	/// The application the server runs.
+	product: Product,
 	kind: ServerKind,
 	rank: Option<ServerRank>,
 	cloud: Option<bool>,
@@ -138,14 +146,16 @@ struct ServerDetail {
 #[tool_router(router = servers_router, vis = "pub(crate)")]
 impl CanopyMcp {
 	#[tool(
-		description = "Find servers by name/host/id substring, optionally filtered by kind, rank, \
-		               or group. Returns compact records with last-seen, version, and health."
+		description = "Find servers by name/host/id substring, optionally filtered by product, \
+		               kind, rank, or group. Returns compact records with last-seen, version, and \
+		               health. A server whose product has no application version carries none."
 	)]
 	async fn find_servers(
 		&self,
 		Parameters(args): Parameters<FindServersArgs>,
 	) -> Result<CallToolResult, McpError> {
 		let mut conn = self.conn().await?;
+		let product = parse_opt::<Product>(&args.product, "product")?;
 		let kind = parse_opt::<ServerKind>(&args.kind, "kind")?;
 		let rank = parse_opt::<ServerRank>(&args.rank, "rank")?;
 		let group = parse_opt_uuid(&args.group_id, "group_id")?;
@@ -158,7 +168,8 @@ impl CanopyMcp {
 
 		let q = args.query.as_deref().map(str::to_lowercase);
 		servers.retain(|s| {
-			kind.as_ref().is_none_or(|k| &s.kind == k)
+			product.as_ref().is_none_or(|p| &s.product == p)
+				&& kind.as_ref().is_none_or(|k| &s.kind == k)
 				&& rank.as_ref().is_none_or(|r| s.rank.as_ref() == Some(r))
 				&& group
 					.as_ref()
@@ -295,6 +306,7 @@ impl CanopyMcp {
 			id: server.id,
 			name: server.name.clone(),
 			host: server.host.as_ref().map(|h| h.0.to_string()),
+			product: server.product,
 			kind: server.kind,
 			rank: server.rank,
 			cloud: server.cloud,
@@ -329,6 +341,7 @@ pub(crate) fn summarize(
 		id: s.id,
 		name: s.name.clone(),
 		host: s.host.as_ref().map(|h| h.0.to_string()),
+		product: s.product,
 		kind: s.kind,
 		rank: s.rank,
 		group_id: s.group_id,
@@ -336,7 +349,12 @@ pub(crate) fn summarize(
 		is_monitored: s.is_monitored,
 		archived: s.deleted_at.is_some(),
 		last_seen: st.map(|s| s.created_at),
-		version: st.and_then(|s| s.version.clone()),
+		// A product with no application version carries none rather than a
+		// stale value from a status that predates its classification.
+		// spec: APP#versions
+		version: st
+			.and_then(|st| st.version.clone())
+			.filter(|_| s.product.has_versions()),
 		reachability: st.map_or(ShortStatus::Gone, |s| s.short_status()),
 		health,
 	}

--- a/crates/commons-servers/src/backup_jobs.rs
+++ b/crates/commons-servers/src/backup_jobs.rs
@@ -9,7 +9,7 @@ use commons_errors::Result;
 use commons_types::{
 	Uuid,
 	backup::{BackupConfigStatus, BackupPurpose, BackupType},
-	server::{rank::ServerRank, tags::TagMap},
+	server::{product::Product, rank::ServerRank, tags::TagMap},
 };
 use database::{
 	BackupRequest, BackupRun, BackupTypeDefault, ServerBackupCapability, ServerGroupBackupConfig,
@@ -234,7 +234,12 @@ pub async fn backups_due_now_for_server(
 /// The three `billing.*` pod labels spawned Jobs carry for AWS cost allocation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BillingLabels {
-	pub product: String,
+	/// `None` ⇒ omit the `billing.product` label. A group whose members span
+	/// products has no single product to attribute its shared cost to, and
+	/// naming one of several would charge it to the wrong place — the same
+	/// reasoning as `stage`.
+	// spec: APP#billing-attribution
+	pub product: Option<String>,
 	pub deployment: String,
 	/// `None` ⇒ omit the `billing.stage` label (group with no ranked members);
 	/// a wrong `prod` would mis-attribute cost.
@@ -256,18 +261,27 @@ pub fn stage_for_rank(rank: ServerRank) -> &'static str {
 }
 
 impl BillingLabels {
-	/// Derive labels from a group's tags, name, and highest member rank.
-	/// Explicit `billing.*` tags are honored **verbatim**; computed fallbacks are
-	/// lower-kebab-cased — `product = "tamanu"`, `deployment = lower_kebab(group
-	/// name)`, `stage = mapped highest rank` (omitted when the group has no ranked
+	/// Derive labels from a group's tags, name, resolved product, and highest
+	/// member rank. Explicit `billing.*` tags are honored **verbatim**; computed
+	/// fallbacks are lower-kebab-cased — `deployment = lower_kebab(group name)`,
+	/// `stage = mapped highest rank` (omitted when the group has no ranked
 	/// members).
-	pub fn from_group(tags: &TagMap, group_name: &str, highest_rank: Option<ServerRank>) -> Self {
+	///
+	/// `product` is the one its live members agree on, or `None` when they span
+	/// products; see [`Self::product`].
+	// spec: APP#billing-attribution
+	pub fn from_group(
+		tags: &TagMap,
+		group_name: &str,
+		product: Option<Product>,
+		highest_rank: Option<ServerRank>,
+	) -> Self {
 		BillingLabels {
 			product: tags
 				.0
 				.get("billing.product")
 				.cloned()
-				.unwrap_or_else(|| "tamanu".to_string()),
+				.or_else(|| product.map(String::from)),
 			deployment: tags
 				.0
 				.get("billing.deployment")
@@ -281,21 +295,41 @@ impl BillingLabels {
 		}
 	}
 
+	/// Labels for one server's own resources: its own product and its own rank,
+	/// against the deployment its group names.
+	///
+	/// Every label describing the server carries the server's value rather than
+	/// its group's — a `rank = clone` server must report `stage = clone` and
+	/// never the group's `prod`, and a SENAITE server in a Tamanu group must
+	/// report `product = senaite`.
+	// spec: APP#billing-attribution
+	pub fn for_server(
+		tags: &TagMap,
+		group_name: &str,
+		product: Product,
+		rank: Option<ServerRank>,
+	) -> Self {
+		Self::from_group(tags, group_name, Some(product), rank)
+	}
+
 	/// Override the `product` label — e.g. `"backups"` for a backup bucket, which
 	/// should attribute to the backups product regardless of the group's own
 	/// `billing.product`. (Reusable for other canopy-owned resources later.)
 	pub fn with_product(mut self, product: impl Into<String>) -> Self {
-		self.product = product.into();
+		self.product = Some(product.into());
 		self
 	}
 
-	/// Render as AWS `billing.*` resource tags. `billing.stage` is omitted when
-	/// the group has no ranked members (no stage to attribute to).
+	/// Render as AWS `billing.*` resource tags. A label with nothing to
+	/// attribute to is omitted rather than guessed: `billing.stage` when the
+	/// group has no ranked members, `billing.product` when its members span
+	/// products.
 	pub fn into_tags(self) -> Vec<(String, String)> {
-		let mut tags = vec![
-			("billing.product".to_string(), self.product),
-			("billing.deployment".to_string(), self.deployment),
-		];
+		let mut tags = Vec::with_capacity(3);
+		if let Some(product) = self.product {
+			tags.push(("billing.product".to_string(), product));
+		}
+		tags.push(("billing.deployment".to_string(), self.deployment));
 		if let Some(stage) = self.stage {
 			tags.push(("billing.stage".to_string(), stage));
 		}
@@ -397,7 +431,7 @@ pub fn backup_bucket_billing_tags(
 	group_name: &str,
 	highest_rank: Option<ServerRank>,
 ) -> Vec<(String, String)> {
-	BillingLabels::from_group(group_tags, group_name, highest_rank)
+	BillingLabels::from_group(group_tags, group_name, None, highest_rank)
 		.with_product("backups")
 		.into_tags()
 }
@@ -693,33 +727,89 @@ mod tests {
 	fn billing_labels_defaults_and_overrides() {
 		// All-unranked group: no stage label, defaults for the rest.
 		let empty = TagMap::default();
-		let b = BillingLabels::from_group(&empty, "my-group", None);
-		assert_eq!(b.product, "tamanu");
+		let b = BillingLabels::from_group(&empty, "my-group", Some(Product::Tamanu), None);
+		assert_eq!(b.product.as_deref(), Some("tamanu"));
 		assert_eq!(b.deployment, "my-group");
 		assert_eq!(b.stage, None);
 
 		// A computed deployment (group name) is lower-kebab-cased.
-		let b = BillingLabels::from_group(&empty, "Acme Prod", None);
+		let b = BillingLabels::from_group(&empty, "Acme Prod", Some(Product::Tamanu), None);
 		assert_eq!(b.deployment, "acme-prod");
 
 		// An explicit billing.deployment tag is honored verbatim (not kebab'd).
 		let mut dep = TagMap::default();
 		dep.0
 			.insert("billing.deployment".into(), "Acme Prod".into());
-		let b = BillingLabels::from_group(&dep, "ignored", None);
+		let b = BillingLabels::from_group(&dep, "ignored", Some(Product::Tamanu), None);
 		assert_eq!(b.deployment, "Acme Prod");
 
 		// Highest rank maps in when present.
-		let b = BillingLabels::from_group(&empty, "g", Some(ServerRank::Production));
+		let b = BillingLabels::from_group(
+			&empty,
+			"g",
+			Some(Product::Tamanu),
+			Some(ServerRank::Production),
+		);
 		assert_eq!(b.stage.as_deref(), Some("prod"));
 
 		// Explicit billing.* tags win.
 		let mut tags = TagMap::default();
 		tags.0.insert("billing.product".into(), "pgro".into());
 		tags.0.insert("billing.stage".into(), "staging".into());
-		let b = BillingLabels::from_group(&tags, "g", Some(ServerRank::Production));
-		assert_eq!(b.product, "pgro");
+		let b = BillingLabels::from_group(
+			&tags,
+			"g",
+			Some(Product::Tamanu),
+			Some(ServerRank::Production),
+		);
+		assert_eq!(b.product.as_deref(), Some("pgro"));
 		assert_eq!(b.stage.as_deref(), Some("staging"));
+	}
+
+	#[test]
+	fn mixed_product_group_attributes_no_product() {
+		// Members spanning products: nothing to attribute the group's shared
+		// cost to, so the label is omitted rather than guessed at.
+		let empty = TagMap::default();
+		let b = BillingLabels::from_group(&empty, "pacific", None, Some(ServerRank::Production));
+		assert_eq!(b.product, None);
+		let tags = b.into_tags();
+		assert!(!tags.iter().any(|(k, _)| k == "billing.product"));
+		// The labels that *are* unambiguous still land.
+		assert!(tags.contains(&("billing.deployment".to_string(), "pacific".to_string())));
+		assert!(tags.contains(&("billing.stage".to_string(), "prod".to_string())));
+	}
+
+	#[test]
+	fn explicit_group_product_tag_pins_a_mixed_group() {
+		// An operator can always attribute a mixed group by hand.
+		let mut tags = TagMap::default();
+		tags.0.insert("billing.product".into(), "tamanu".into());
+		let b = BillingLabels::from_group(&tags, "pacific", None, None);
+		assert_eq!(b.product.as_deref(), Some("tamanu"));
+	}
+
+	#[test]
+	fn server_labels_use_the_servers_own_product_and_rank() {
+		// A SENAITE server in a Tamanu group attributes to senaite, and to its
+		// own stage rather than the group's highest.
+		let empty = TagMap::default();
+		let b =
+			BillingLabels::for_server(&empty, "Pacific", Product::Senaite, Some(ServerRank::Clone));
+		assert_eq!(b.product.as_deref(), Some("senaite"));
+		assert_eq!(b.deployment, "pacific");
+		assert_eq!(b.stage.as_deref(), Some("clone"));
+	}
+
+	#[test]
+	fn backup_bucket_tags_attribute_to_the_backups_product() {
+		// Backup spend never charges to the deployment's application, and a
+		// group's own product label must not leak through.
+		let mut tags = TagMap::default();
+		tags.0.insert("billing.product".into(), "tamanu".into());
+		let out = backup_bucket_billing_tags(&tags, "pacific", Some(ServerRank::Production));
+		assert!(out.contains(&("billing.product".to_string(), "backups".to_string())));
+		assert!(!out.contains(&("billing.product".to_string(), "tamanu".to_string())));
 	}
 
 	#[test]

--- a/crates/commons-types/src/server.rs
+++ b/crates/commons-types/src/server.rs
@@ -1,5 +1,6 @@
 pub mod cards;
 pub mod kind;
+pub mod product;
 pub mod rank;
 pub mod tags;
 

--- a/crates/commons-types/src/server/cards.rs
+++ b/crates/commons-types/src/server/cards.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-	server::{kind::ServerKind, rank::ServerRank},
+	server::{kind::ServerKind, product::Product, rank::ServerRank},
 	status::{HealthState, OperatorPresence, ShortStatus},
 	version::VersionStr,
 };
@@ -29,7 +29,11 @@ pub struct FacilityServerStatus {
 	/// rank (e.g. production before clone, demo, and so on) in a consistent
 	/// order.
 	pub rank: Option<ServerRank>,
-	/// The server's kind (central, facility, or canopy).
+	/// The application the server runs, presented alongside its role.
+	// spec: APP#product-and-kind
+	pub product: Product,
+	/// The server's role within its product's topology (for Tamanu, central
+	/// or facility; standalone for a product with no internal roles).
 	pub kind: ServerKind,
 }
 

--- a/crates/commons-types/src/server/kind.rs
+++ b/crates/commons-types/src/server/kind.rs
@@ -9,7 +9,11 @@ use diesel::{
 };
 use serde::{Deserialize, Serialize};
 
-/// What kind of server this is within a deployment.
+/// A server's role relative to the other servers of its product.
+///
+/// Which kinds are available depends on the server's product; see
+/// [`Product::kinds`](super::product::Product::kinds).
+// spec: APP#product-and-kind
 #[derive(
 	Debug,
 	Clone,
@@ -31,8 +35,8 @@ pub enum ServerKind {
 	Central,
 	/// A facility server: an on-site instance that syncs to a central server.
 	Facility,
-	/// A canopy instance itself, monitored like any other server.
-	Canopy,
+	/// A server that holds no role relative to its product's other servers.
+	Standalone,
 }
 
 impl Display for ServerKind {
@@ -40,7 +44,7 @@ impl Display for ServerKind {
 		match self {
 			ServerKind::Central => write!(f, "central"),
 			ServerKind::Facility => write!(f, "facility"),
-			ServerKind::Canopy => write!(f, "canopy"),
+			ServerKind::Standalone => write!(f, "standalone"),
 		}
 	}
 }
@@ -62,7 +66,10 @@ impl FromStr for ServerKind {
 		match value.to_ascii_lowercase().as_ref() {
 			"tamanu sync server" | "central" => Ok(Self::Central),
 			"tamanu lan server" | "facility" => Ok(Self::Facility),
-			"canopy" => Ok(Self::Canopy),
+			// `canopy` is what a canopy instance's kind was before product
+			// became its own axis. Stored rows still carry it until a later
+			// migration normalises them.
+			"standalone" | "canopy" => Ok(Self::Standalone),
 			s => Err(ServerKindFromStringError(s.into())),
 		}
 	}

--- a/crates/commons-types/src/server/product.rs
+++ b/crates/commons-types/src/server/product.rs
@@ -1,0 +1,244 @@
+use std::{fmt::Display, str::FromStr};
+
+use diesel::{
+	backend::Backend,
+	deserialize::{self, FromSql},
+	expression::AsExpression,
+	serialize::{self, Output, ToSql},
+	sql_types::Text,
+};
+use serde::{Deserialize, Serialize};
+
+use super::kind::ServerKind;
+
+/// Which application a server runs.
+///
+/// The set is closed and defined here rather than configured, because each
+/// product's handling — what canopy tracks for it, what it presents — is
+/// built in. See [`Product::caps`].
+// spec: APP
+#[derive(
+	Debug,
+	Clone,
+	Copy,
+	Default,
+	Eq,
+	PartialEq,
+	Hash,
+	Serialize,
+	Deserialize,
+	AsExpression,
+	utoipa::ToSchema,
+)]
+#[diesel(sql_type = Text)]
+#[serde(rename_all = "lowercase")]
+pub enum Product {
+	/// Tamanu, the product canopy was built to monitor. The default.
+	#[default]
+	Tamanu,
+	/// SENAITE, a laboratory information management system.
+	Senaite,
+	/// A canopy instance itself, monitored like any other server.
+	Canopy,
+}
+
+/// How canopy treats a product's application version.
+// spec: APP#versions
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum VersionTracking {
+	/// Canopy holds this product's release train, so a server's version is
+	/// graded against it: how far behind, what updates are available, which
+	/// known issues apply.
+	Tracked,
+	/// The server reports a version canopy holds no release train for, so it
+	/// stands as reported and is graded against nothing.
+	Reported,
+	/// The product has no application version at all.
+	Absent,
+}
+
+/// What canopy does for a product's servers.
+///
+/// Reachability, health checks and backups are deliberately absent: checks
+/// are graded by the source that reports them, and backup types are
+/// advertised per-server by the agent, so both already work for any product.
+// spec: APP#capabilities
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct Caps {
+	/// How this product's application version is treated.
+	pub version_tracking: VersionTracking,
+	/// Whether this product's servers can be listed for end-user-facing
+	/// clients.
+	pub public_listing: bool,
+}
+
+impl Product {
+	pub const ALL: &'static [Self] = &[Self::Tamanu, Self::Senaite, Self::Canopy];
+
+	/// What canopy does for this product's servers.
+	pub const fn caps(self) -> Caps {
+		match self {
+			Self::Tamanu => Caps {
+				version_tracking: VersionTracking::Tracked,
+				public_listing: true,
+			},
+			// A canopy instance reports its own build version, which canopy
+			// holds no release train for: presented, but graded against
+			// nothing.
+			Self::Canopy => Caps {
+				version_tracking: VersionTracking::Reported,
+				public_listing: false,
+			},
+			Self::Senaite => Caps {
+				version_tracking: VersionTracking::Absent,
+				public_listing: false,
+			},
+		}
+	}
+
+	/// Whether a server's version is graded against a release train canopy
+	/// holds. False both for a product with no version and for one whose
+	/// version canopy doesn't track.
+	pub const fn tracks_versions(self) -> bool {
+		matches!(self.caps().version_tracking, VersionTracking::Tracked)
+	}
+
+	/// Whether this product's servers have an application version at all.
+	/// A server of a product without one presents nothing, as against the
+	/// `unknown` a versioned server shows before it has reported.
+	pub const fn has_versions(self) -> bool {
+		!matches!(self.caps().version_tracking, VersionTracking::Absent)
+	}
+
+	/// The kinds this product defines, in the order they rank for a group's
+	/// canonical member.
+	pub const fn kinds(self) -> &'static [ServerKind] {
+		match self {
+			Self::Tamanu => &[ServerKind::Central, ServerKind::Facility],
+			Self::Senaite | Self::Canopy => &[ServerKind::Standalone],
+		}
+	}
+
+	/// The kind a server of this product takes when none is chosen, and the
+	/// one it moves to when reclassifying leaves its current kind undefined
+	/// for the new product.
+	pub const fn default_kind(self) -> ServerKind {
+		match self {
+			Self::Tamanu => ServerKind::Central,
+			Self::Senaite | Self::Canopy => ServerKind::Standalone,
+		}
+	}
+
+	/// Whether this product defines `kind` as one of its roles.
+	pub fn defines_kind(self, kind: ServerKind) -> bool {
+		self.kinds().contains(&kind)
+	}
+
+	/// The stored values of every product satisfying `predicate`, for
+	/// filtering a query on a capability rather than restating which products
+	/// happen to have it. Keeps [`Self::caps`] the only place the mapping
+	/// lives, so a new product is picked up by every such query at once.
+	pub fn stored_values_where(predicate: fn(Self) -> bool) -> Vec<String> {
+		Self::ALL
+			.iter()
+			.copied()
+			.filter(|p| predicate(*p))
+			.map(String::from)
+			.collect()
+	}
+}
+
+impl Display for Product {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Product::Tamanu => write!(f, "tamanu"),
+			Product::Senaite => write!(f, "senaite"),
+			Product::Canopy => write!(f, "canopy"),
+		}
+	}
+}
+
+impl From<Product> for String {
+	fn from(product: Product) -> Self {
+		product.to_string()
+	}
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("invalid server product: {0}")]
+pub struct ProductFromStringError(String);
+
+impl FromStr for Product {
+	type Err = ProductFromStringError;
+
+	fn from_str(value: &str) -> Result<Self, Self::Err> {
+		match value.to_ascii_lowercase().as_ref() {
+			"tamanu" => Ok(Self::Tamanu),
+			"senaite" => Ok(Self::Senaite),
+			"canopy" => Ok(Self::Canopy),
+			s => Err(ProductFromStringError(s.into())),
+		}
+	}
+}
+
+impl TryFrom<String> for Product {
+	type Error = ProductFromStringError;
+	fn try_from(value: String) -> Result<Self, Self::Error> {
+		value.parse()
+	}
+}
+
+impl<DB> FromSql<Text, DB> for Product
+where
+	DB: Backend,
+	String: FromSql<Text, DB>,
+{
+	fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
+		let s = String::from_sql(bytes)?;
+		Ok(Product::try_from(s)?)
+	}
+}
+
+impl ToSql<Text, diesel::pg::Pg> for Product
+where
+	String: ToSql<Text, diesel::pg::Pg>,
+{
+	fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, diesel::pg::Pg>) -> serialize::Result {
+		let v = String::from(*self);
+		<String as ToSql<Text, diesel::pg::Pg>>::to_sql(&v, &mut out.reborrow())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn roundtrips_through_string() {
+		for product in Product::ALL {
+			assert_eq!(product.to_string().parse::<Product>().unwrap(), *product);
+		}
+	}
+
+	#[test]
+	fn default_kind_is_one_the_product_defines() {
+		for product in Product::ALL {
+			assert!(product.defines_kind(product.default_kind()));
+		}
+	}
+
+	#[test]
+	fn only_tamanu_is_graded_against_a_release_train() {
+		assert!(Product::Tamanu.tracks_versions());
+		assert!(!Product::Canopy.tracks_versions());
+		assert!(!Product::Senaite.tracks_versions());
+	}
+
+	#[test]
+	fn canopy_has_a_version_even_though_it_is_ungraded() {
+		assert!(Product::Canopy.has_versions());
+		assert!(Product::Tamanu.has_versions());
+		assert!(!Product::Senaite.has_versions());
+	}
+}

--- a/crates/database/src/bin/seed.rs
+++ b/crates/database/src/bin/seed.rs
@@ -17,7 +17,7 @@ use commons_types::{
 	device::DeviceRole,
 	geo::GeoPoint,
 	issue::ResolvedReason,
-	server::{TagMap, kind::ServerKind, rank::ServerRank},
+	server::{TagMap, kind::ServerKind, product::Product, rank::ServerRank},
 	status::CheckResult,
 	version::{VersionStatus, VersionStr},
 };
@@ -592,6 +592,9 @@ struct SeededServers {
 	pending_with_token: Uuid,
 	/// Pending enrollment, no token yet.
 	pending_no_token: Uuid,
+	/// A non-Tamanu server sharing a group with Tamanu ones: no version at
+	/// all, and it must not become the group's headline version.
+	senaite_lims: Uuid,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -607,10 +610,15 @@ async fn seed_servers(
 	}
 
 	fn base(host: &str, kind: ServerKind) -> Server {
+		base_of(Product::Tamanu, host, kind)
+	}
+
+	fn base_of(product: Product, host: &str, kind: ServerKind) -> Server {
 		Server {
 			id: Uuid::new_v4(),
 			name: None,
 			host: Some(url(host)),
+			product,
 			kind,
 			rank: None,
 			device_id: None,
@@ -772,6 +780,26 @@ async fn seed_servers(
 	.await?;
 
 	// Archived (soft-deleted) server. Insert it live, then soft_delete so the
+	// A SENAITE server in the same group as the Tamanu ones: the mixed-product
+	// group the version rollup and billing attribution have to cope with.
+	let senaite_lims = insert(
+		conn,
+		Server {
+			name: Some("Pacific LIMS".to_string()),
+			rank: Some(ServerRank::Production),
+			group_id: Some(groups.pacific),
+			cloud: Some(true),
+			notes: "SENAITE laboratory system for the Pacific region.".to_string(),
+			registered_at: Some(now),
+			..base_of(
+				Product::Senaite,
+				"https://pacific-lims.example.com/",
+				ServerKind::Standalone,
+			)
+		},
+	)
+	.await?;
+
 	// real archival path runs (releases device, deactivates keys).
 	let archived = insert(
 		conn,
@@ -803,6 +831,7 @@ async fn seed_servers(
 		ungrouped,
 		pending_with_token,
 		pending_no_token,
+		senaite_lims,
 	})
 }
 
@@ -958,6 +987,29 @@ async fn seed_statuses(
 		true,
 		serde_json::json!([{"check": "database_connectivity", "healthy": true}]),
 		extra("PostgreSQL 13.12", "2.8.0", 50_000),
+	)
+	.await?;
+
+	// SENAITE server — healthy, and reporting no version at all. Its extra
+	// deliberately carries no `tamanuVersion`, so the detail view has to
+	// present nothing rather than "unknown", and the group's headline version
+	// has to come from a Tamanu member.
+	insert_status(
+		conn,
+		servers.senaite_lims,
+		None,
+		now,
+		None,
+		true,
+		serde_json::json!([
+			{"check": "database_connectivity", "healthy": true},
+			{"check": "disk_space", "healthy": true, "free_pct": 71},
+		]),
+		serde_json::json!({
+			"pgVersion": "PostgreSQL 16.2, compiled by gcc",
+			"bestoolVersion": "2.10.5",
+			"uptimeSecs": 604_800,
+		}),
 	)
 	.await?;
 

--- a/crates/database/src/reported_detail.rs
+++ b/crates/database/src/reported_detail.rs
@@ -12,7 +12,10 @@
 //! record of what stands.
 
 use commons_errors::{AppError, Result};
-use commons_types::{server::rank::ServerRank, version::VersionStr};
+use commons_types::{
+	server::{product::Product, rank::ServerRank},
+	version::VersionStr,
+};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use jiff::Timestamp;
@@ -164,6 +167,11 @@ impl ReportedDetail {
 		let rows: Vec<Option<VersionStr>> = detail::table
 			.inner_join(servers::table.on(servers::id.eq(detail::server_id)))
 			.filter(servers::rank.eq(ServerRank::Production))
+			// A release branch only means something for a product canopy holds
+			// a release train for. Others would each contribute a branch of
+			// their own to a count of what the fleet is running.
+			// spec: APP#versions
+			.filter(servers::product.eq_any(Product::stored_values_where(Product::tracks_versions)))
 			.filter(servers::deleted_at.is_null())
 			.filter(detail::version.is_not_null())
 			.filter(detail::reported_at.ge(diesel::dsl::sql(ACTIVE_LOOKBACK_SQL)))

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -556,6 +556,7 @@ diesel::table! {
 		registered_at -> Nullable<Timestamptz>,
 		restore_allowed_until -> Nullable<Timestamptz>,
 		restore_allowed_by -> Nullable<Text>,
+		product -> Text,
 	}
 }
 

--- a/crates/database/src/server_groups.rs
+++ b/crates/database/src/server_groups.rs
@@ -2,7 +2,7 @@
 //! purposes of incident roll-up, shared tags, and shared operator notes.
 
 use commons_errors::{AppError, Result};
-use commons_types::server::{TagMap, kind::ServerKind, rank::ServerRank};
+use commons_types::server::{TagMap, kind::ServerKind, product::Product, rank::ServerRank};
 use commons_types::version::VersionStr;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -29,12 +29,13 @@ pub fn rank_priority(rank: Option<ServerRank>) -> u8 {
 }
 
 /// Ordering key for a server's kind — lower is higher priority. Central servers
-/// are the headline of a group; facility ties below them, canopy-kind last.
+/// are the headline of a group; facility ties below them, standalone last.
+// spec: APP#versions
 pub fn kind_priority(kind: ServerKind) -> u8 {
 	match kind {
 		ServerKind::Central => 0,
 		ServerKind::Facility => 1,
-		ServerKind::Canopy => 2,
+		ServerKind::Standalone => 2,
 	}
 }
 
@@ -358,6 +359,52 @@ impl ServerGroup {
 		Ok(out)
 	}
 
+	/// The product each group's live members agree on, keyed by group id.
+	///
+	/// A group whose members span products is absent from the map, as is one
+	/// with no live members: in both cases there is no single product to
+	/// attribute the group's shared resources to, and naming one of several
+	/// would attribute its cost to the wrong place.
+	// spec: APP#billing-attribution
+	pub async fn sole_member_products(
+		db: &mut AsyncPgConnection,
+		group_ids: &[Uuid],
+	) -> Result<std::collections::HashMap<Uuid, Product>> {
+		use crate::schema::servers::dsl;
+		use std::collections::HashMap;
+
+		if group_ids.is_empty() {
+			return Ok(HashMap::new());
+		}
+		let rows: Vec<(Uuid, String)> = dsl::servers
+			.select((dsl::group_id.assume_not_null(), dsl::product))
+			.filter(dsl::group_id.eq_any(group_ids))
+			.filter(dsl::deleted_at.is_null())
+			.load(db)
+			.await?;
+
+		// Two passes rather than one: a group has to be *removed* once a
+		// second product shows up, which a running "first wins" insert can't
+		// express.
+		let mut seen: HashMap<Uuid, Vec<Product>> = HashMap::new();
+		for (gid, product) in rows {
+			let Ok(product) = product.parse::<Product>() else {
+				continue;
+			};
+			let products = seen.entry(gid).or_default();
+			if !products.contains(&product) {
+				products.push(product);
+			}
+		}
+		Ok(seen
+			.into_iter()
+			.filter_map(|(gid, products)| match products.as_slice() {
+				[sole] => Some((gid, *sole)),
+				_ => None,
+			})
+			.collect())
+	}
+
 	/// Count of live (non-archived) servers in each group, keyed by group id.
 	/// Groups with no live members are absent (callers default to 0).
 	pub async fn live_server_counts(
@@ -382,11 +429,12 @@ impl ServerGroup {
 
 	/// Recompute the cached canonical member and its version for `group_id`.
 	///
-	/// Loads every member of the group, picks the canonical one (lowest
+	/// Loads every member of the group, picks the canonical one among those
+	/// whose product canopy tracks versions for (lowest
 	/// `(rank_priority, kind_priority)`, tie-broken by `id`), and caches that
-	/// member's last reported version. No members → both cache columns are
-	/// cleared. The `statuses` trigger handles the hot path (canonical member
-	/// reporting a new version) without touching this.
+	/// member's last reported version. No such members → both cache columns
+	/// are cleared. The `statuses` trigger handles the hot path (canonical
+	/// member reporting a new version) without touching this.
 	pub async fn recompute_version(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<()> {
 		use crate::schema::server_groups::dsl;
 
@@ -400,13 +448,20 @@ impl ServerGroup {
 				.await?
 		};
 
-		let canonical = members.into_iter().min_by(|a, b| {
-			(rank_priority(a.rank), kind_priority(a.kind), a.id).cmp(&(
-				rank_priority(b.rank),
-				kind_priority(b.kind),
-				b.id,
-			))
-		});
+		// Only a member whose product canopy holds a release train for can
+		// speak for the group's version. A group of products canopy doesn't
+		// track has no headline version rather than one that means nothing.
+		// spec: APP#versions
+		let canonical = members
+			.into_iter()
+			.filter(|s| s.product.tracks_versions())
+			.min_by(|a, b| {
+				(rank_priority(a.rank), kind_priority(a.kind), a.id).cmp(&(
+					rank_priority(b.rank),
+					kind_priority(b.kind),
+					b.id,
+				))
+			});
 
 		let (version_server_id, effective_version) = match canonical {
 			None => (None, None),

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -1,7 +1,7 @@
 use commons_errors::{AppError, Result};
 use commons_types::{
 	geo::GeoPoint,
-	server::{RESERVED_TAG_PREFIX, TagMap, kind::ServerKind, rank::ServerRank},
+	server::{RESERVED_TAG_PREFIX, TagMap, kind::ServerKind, product::Product, rank::ServerRank},
 };
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -60,7 +60,13 @@ pub struct Server {
 	#[diesel(treat_none_as_default_value = false)]
 	pub host: Option<UrlField>,
 
-	/// The server's role, for example central or facility.
+	/// The application this server runs, for example tamanu or senaite.
+	/// Decides which of canopy's per-server features apply to it at all.
+	// spec: APP#product-and-kind
+	#[diesel(deserialize_as = String, serialize_as = String)]
+	pub product: Product,
+	/// The server's role within its product's topology, for example central
+	/// or facility. Which roles are available depends on the product.
 	#[diesel(deserialize_as = String, serialize_as = String)]
 	pub kind: ServerKind,
 	/// The server's environment tier, for example production, test, or dev.
@@ -650,8 +656,14 @@ impl Server {
 		use crate::schema::servers::dsl::*;
 		let search_pattern = format!("%{}%", query);
 
+		// Both halves of eligibility, stated rather than implied: only a
+		// product canopy lists publicly, and only its central servers. The
+		// kind filter alone would exclude other products today, but by
+		// accident of their having no central role rather than on purpose.
+		// spec: APP#public-listing
 		let mut query_builder = servers
 			.select(Self::as_select())
+			.filter(product.eq_any(Product::stored_values_where(|p| p.caps().public_listing)))
 			.filter(kind.eq(ServerKind::Central.to_string()))
 			.filter(public_name.is_not_null())
 			.filter(deleted_at.is_null())
@@ -755,6 +767,7 @@ impl Server {
 	/// read-only tags describing the server itself, under the reserved
 	/// [`RESERVED_TAG_PREFIX`] namespace:
 	///
+	/// - `canopy:product` — the server's [`Product`] (always present).
 	/// - `canopy:kind` — the server's [`ServerKind`] (always present).
 	/// - `canopy:rank` — the server's [`ServerRank`], only when one is set.
 	/// - `canopy:group-id` / `canopy:group-name` — only when grouped.
@@ -772,6 +785,10 @@ impl Server {
 			None => self.tags.clone(),
 		};
 
+		tags.0.insert(
+			format!("{RESERVED_TAG_PREFIX}product"),
+			self.product.to_string(),
+		);
 		tags.0
 			.insert(format!("{RESERVED_TAG_PREFIX}kind"), self.kind.to_string());
 		if let Some(rank) = self.rank {
@@ -807,6 +824,7 @@ fn test_server_serialization() {
 	let server = Server {
 		id: Uuid::nil(),
 		name: Some("Test Server".to_string()),
+		product: Product::Tamanu,
 		kind: ServerKind::Central,
 		rank: Some(ServerRank::Production),
 		host: Some(UrlField("https://example.com/".parse().unwrap())),
@@ -832,6 +850,7 @@ fn test_server_serialization() {
   "id": "00000000-0000-0000-0000-000000000000",
   "name": "Test Server",
   "host": "https://example.com",
+  "product": "tamanu",
   "kind": "central",
   "rank": "production",
   "device_id": "00000000-0000-0000-0000-000000000000",
@@ -854,7 +873,11 @@ pub struct NewServer {
 	/// The server's URL, if known up front.
 	#[serde(default)]
 	pub host: Option<UrlField>,
-	/// The server's role, for example central or facility.
+	/// The application this server runs. Defaults to tamanu.
+	#[serde(default)]
+	pub product: Product,
+	/// The server's role within its product's topology, for example central
+	/// or facility.
 	pub kind: ServerKind,
 	/// The server's environment tier, for example production, test, or dev.
 	pub rank: Option<ServerRank>,
@@ -870,6 +893,7 @@ impl From<NewServer> for Server {
 		Server {
 			id: Uuid::new_v4(),
 			name: server.name,
+			product: server.product,
 			kind: server.kind,
 			rank: server.rank,
 			host: server.host,
@@ -903,6 +927,11 @@ pub struct PartialServer {
 	pub id: Uuid,
 	/// New display name for the server.
 	pub name: Option<String>,
+	/// New application for the server. When this changes to a product that
+	/// does not define the server's current kind, the caller settles the kind
+	/// too — the endpoint moves it to the new product's default.
+	#[diesel(deserialize_as = String, serialize_as = String)]
+	pub product: Option<Product>,
 	/// New role for the server, for example central or facility.
 	pub kind: Option<ServerKind>,
 	/// New environment tier for the server, for example production, test,

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -32,6 +32,7 @@ mod self_alerts;
 mod server_enrollment;
 mod server_group_archival;
 mod server_group_version_cache;
+mod server_products;
 mod server_restore_window;
 mod silenced_health_checks;
 mod slack_outbox_enqueue;

--- a/crates/database/tests/it/server_enrollment.rs
+++ b/crates/database/tests/it/server_enrollment.rs
@@ -1,6 +1,6 @@
 //! Model-level tests for server archival and enrollment-token lifecycle.
 
-use commons_types::server::{TagMap, kind::ServerKind};
+use commons_types::server::{TagMap, kind::ServerKind, product::Product};
 use database::{
 	Device, DeviceKey, pg_duration::PgDuration, server_enrollment_tokens::ServerEnrollmentToken,
 	servers::Server, url_field::UrlField,
@@ -13,6 +13,7 @@ fn new_server(host: &str) -> Server {
 		id: Uuid::new_v4(),
 		name: Some("t".into()),
 		host: Some(UrlField(host.parse().unwrap())),
+		product: Product::Tamanu,
 		kind: ServerKind::Central,
 		rank: None,
 		device_id: None,

--- a/crates/database/tests/it/server_products.rs
+++ b/crates/database/tests/it/server_products.rs
@@ -1,0 +1,364 @@
+//! Model-level tests for the product axis: what the migration backfilled, what
+//! a mixed-product group's figures resolve to, and which servers a
+//! version-bearing query covers.
+//!
+//! spec: APP
+
+use commons_types::server::{
+	RESERVED_TAG_PREFIX, TagMap, kind::ServerKind, product::Product, rank::ServerRank,
+};
+use database::{
+	pg_duration::PgDuration,
+	reported_detail::ReportedDetail,
+	server_groups::{NewServerGroup, ServerGroup},
+	servers::Server,
+	url_field::UrlField,
+};
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::SignedDuration;
+use uuid::Uuid;
+
+fn server(product: Product, kind: ServerKind, rank: Option<ServerRank>) -> Server {
+	Server {
+		id: Uuid::new_v4(),
+		name: Some(format!("{product}-{kind}")),
+		host: Some(UrlField(
+			format!("https://{product}-{}.example/", Uuid::new_v4())
+				.parse()
+				.unwrap(),
+		)),
+		product,
+		kind,
+		rank,
+		device_id: None,
+		group_id: None,
+		public_name: None,
+		cloud: None,
+		geolocation: None,
+		is_monitored: true,
+		alert_when_down_for: PgDuration(SignedDuration::from_secs(600)),
+		notes: String::new(),
+		tags: TagMap::default(),
+		deleted_at: None,
+		registered_at: None,
+		restore_allowed_until: None,
+		restore_allowed_by: None,
+	}
+}
+
+async fn group(conn: &mut AsyncPgConnection, name: &str) -> ServerGroup {
+	ServerGroup::create(
+		conn,
+		NewServerGroup {
+			name: name.into(),
+			notes: String::new(),
+			tags: TagMap::default(),
+			slack_open_delay: None,
+			slack_close_delay: None,
+		},
+	)
+	.await
+	.unwrap()
+}
+
+/// A server's product defaults to Tamanu, so every row that predates the
+/// column reads as one.
+#[tokio::test(flavor = "multi_thread")]
+async fn product_defaults_to_tamanu() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		use database::schema::servers;
+
+		let id = Uuid::new_v4();
+		diesel::sql_query(
+			"INSERT INTO servers (id, host, kind) VALUES ($1, 'https://legacy.example', 'central')",
+		)
+		.bind::<diesel::sql_types::Uuid, _>(id)
+		.execute(&mut conn)
+		.await
+		.unwrap();
+
+		let stored: String = servers::table
+			.select(servers::product)
+			.filter(servers::id.eq(id))
+			.first(&mut conn)
+			.await
+			.unwrap();
+		assert_eq!(stored, "tamanu");
+		assert_eq!(
+			Server::get_by_id(&mut conn, id).await.unwrap().product,
+			Product::Tamanu
+		);
+	})
+	.await
+}
+
+/// The migration lifted canopy instances onto `product` and deliberately left
+/// `kind` alone, so a row still carrying the old kind value has to read as
+/// standalone rather than fail to parse.
+#[tokio::test(flavor = "multi_thread")]
+async fn legacy_canopy_kind_still_reads() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		let id = Uuid::new_v4();
+		diesel::sql_query(
+			"INSERT INTO servers (id, host, kind, product) \
+			 VALUES ($1, 'https://canopy.example', 'canopy', 'canopy')",
+		)
+		.bind::<diesel::sql_types::Uuid, _>(id)
+		.execute(&mut conn)
+		.await
+		.unwrap();
+
+		let loaded = Server::get_by_id(&mut conn, id).await.unwrap();
+		assert_eq!(loaded.product, Product::Canopy);
+		assert_eq!(loaded.kind, ServerKind::Standalone);
+	})
+	.await
+}
+
+/// A group holding both a Tamanu server and a SENAITE one takes its headline
+/// version from the Tamanu member: the SENAITE server has no version, and
+/// letting it speak for the group would blank a figure an operator relies on.
+#[tokio::test(flavor = "multi_thread")]
+async fn mixed_group_headline_version_comes_from_the_tamanu_member() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		let g = group(&mut conn, "pacific").await;
+
+		// The SENAITE server outranks nothing, but it sorts first by kind
+		// priority among equals if product isn't considered — standalone would
+		// still lose to central, so give it the higher rank to make the test
+		// bite on product rather than on the ordering.
+		let lims = Server::create(
+			&mut conn,
+			Server {
+				group_id: Some(g.id),
+				..server(
+					Product::Senaite,
+					ServerKind::Standalone,
+					Some(ServerRank::Production),
+				)
+			},
+		)
+		.await
+		.unwrap();
+		let central = Server::create(
+			&mut conn,
+			Server {
+				group_id: Some(g.id),
+				..server(Product::Tamanu, ServerKind::Central, Some(ServerRank::Test))
+			},
+		)
+		.await
+		.unwrap();
+
+		ReportedDetail::record(
+			&mut conn,
+			central.id,
+			"alertd",
+			&serde_json::json!({}),
+			Some(&"2.34.1".parse().unwrap()),
+		)
+		.await
+		.unwrap();
+		ServerGroup::recompute_version(&mut conn, g.id)
+			.await
+			.unwrap();
+
+		let after = ServerGroup::get_by_id(&mut conn, g.id).await.unwrap();
+		assert_eq!(
+			after.version_server_id,
+			Some(central.id),
+			"the versioned member speaks for the group even when outranked"
+		);
+		assert_eq!(
+			after.effective_version.map(|v| v.to_string()),
+			Some("2.34.1".to_string())
+		);
+		let _ = lims;
+	})
+	.await
+}
+
+/// A group of nothing but products canopy holds no release train for has no
+/// headline version at all, rather than one borrowed from a member that has
+/// none to give.
+#[tokio::test(flavor = "multi_thread")]
+async fn group_without_a_versioned_member_has_no_headline_version() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		let g = group(&mut conn, "labs-only").await;
+		Server::create(
+			&mut conn,
+			Server {
+				group_id: Some(g.id),
+				..server(
+					Product::Senaite,
+					ServerKind::Standalone,
+					Some(ServerRank::Production),
+				)
+			},
+		)
+		.await
+		.unwrap();
+
+		ServerGroup::recompute_version(&mut conn, g.id)
+			.await
+			.unwrap();
+
+		let after = ServerGroup::get_by_id(&mut conn, g.id).await.unwrap();
+		assert_eq!(after.version_server_id, None);
+		assert_eq!(after.effective_version, None);
+	})
+	.await
+}
+
+/// The production-version summary answers what the fleet is running, so it
+/// counts only the servers whose product canopy holds a release train for.
+#[tokio::test(flavor = "multi_thread")]
+async fn production_versions_skip_untracked_products() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		let tamanu = Server::create(
+			&mut conn,
+			server(
+				Product::Tamanu,
+				ServerKind::Central,
+				Some(ServerRank::Production),
+			),
+		)
+		.await
+		.unwrap();
+		let canopy = Server::create(
+			&mut conn,
+			server(
+				Product::Canopy,
+				ServerKind::Standalone,
+				Some(ServerRank::Production),
+			),
+		)
+		.await
+		.unwrap();
+
+		ReportedDetail::record(
+			&mut conn,
+			tamanu.id,
+			"alertd",
+			&serde_json::json!({}),
+			Some(&"2.34.1".parse().unwrap()),
+		)
+		.await
+		.unwrap();
+		// A canopy instance does report a version — its own build — which would
+		// otherwise land in the fleet's release count as a branch of its own.
+		ReportedDetail::record(
+			&mut conn,
+			canopy.id,
+			"alertd",
+			&serde_json::json!({}),
+			Some(&"1.8.0".parse().unwrap()),
+		)
+		.await
+		.unwrap();
+
+		let versions: Vec<String> = ReportedDetail::production_versions(&mut conn)
+			.await
+			.unwrap()
+			.into_iter()
+			.map(|v| v.to_string())
+			.collect();
+		assert_eq!(versions, vec!["2.34.1".to_string()]);
+	})
+	.await
+}
+
+/// The device gets its server's product alongside its kind, so an agent can
+/// read the classification canopy holds for it.
+#[tokio::test(flavor = "multi_thread")]
+async fn device_tags_carry_the_product() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		let s = Server::create(
+			&mut conn,
+			server(Product::Senaite, ServerKind::Standalone, None),
+		)
+		.await
+		.unwrap();
+
+		let tags = s.tags_for_device(&mut conn).await.unwrap();
+		assert_eq!(
+			tags.0.get(&format!("{RESERVED_TAG_PREFIX}product")),
+			Some(&"senaite".to_string())
+		);
+		assert_eq!(
+			tags.0.get(&format!("{RESERVED_TAG_PREFIX}kind")),
+			Some(&"standalone".to_string())
+		);
+	})
+	.await
+}
+
+/// The public mobile-app listing covers only a product canopy lists publicly,
+/// stated rather than left to fall out of the kind filter.
+#[tokio::test(flavor = "multi_thread")]
+async fn public_search_excludes_products_that_are_not_listed() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		// Deliberately give the SENAITE server the central kind and a public
+		// name, so only the product filter can keep it out.
+		Server::create(
+			&mut conn,
+			Server {
+				name: Some("Lab Portal".into()),
+				public_name: Some("Lab Portal".into()),
+				..server(Product::Senaite, ServerKind::Central, None)
+			},
+		)
+		.await
+		.unwrap();
+		Server::create(
+			&mut conn,
+			Server {
+				name: Some("Lab Central".into()),
+				public_name: Some("Lab Central".into()),
+				..server(Product::Tamanu, ServerKind::Central, None)
+			},
+		)
+		.await
+		.unwrap();
+
+		let found = Server::search_central(&mut conn, "Lab", 50).await.unwrap();
+		let names: Vec<String> = found.into_iter().filter_map(|s| s.public_name).collect();
+		assert_eq!(names, vec!["Lab Central".to_string()]);
+	})
+	.await
+}
+
+/// A group's shared cost can only be attributed to one product when its
+/// members agree on one.
+#[tokio::test(flavor = "multi_thread")]
+async fn sole_member_product_is_absent_for_a_mixed_group() {
+	commons_tests::db::TestDb::run(|mut conn, _url| async move {
+		let pure = group(&mut conn, "tamanu-only").await;
+		let mixed = group(&mut conn, "mixed").await;
+
+		for (g, product) in [
+			(pure.id, Product::Tamanu),
+			(mixed.id, Product::Tamanu),
+			(mixed.id, Product::Senaite),
+		] {
+			let kind = product.default_kind();
+			Server::create(
+				&mut conn,
+				Server {
+					group_id: Some(g),
+					..server(product, kind, None)
+				},
+			)
+			.await
+			.unwrap();
+		}
+
+		let sole = ServerGroup::sole_member_products(&mut conn, &[pure.id, mixed.id])
+			.await
+			.unwrap();
+		assert_eq!(sole.get(&pure.id), Some(&Product::Tamanu));
+		assert_eq!(sole.get(&mixed.id), None, "members span products");
+	})
+	.await
+}

--- a/crates/database/tests/it/server_restore_window.rs
+++ b/crates/database/tests/it/server_restore_window.rs
@@ -1,6 +1,6 @@
 //! Model-level tests for the per-server restore window.
 
-use commons_types::server::{TagMap, kind::ServerKind};
+use commons_types::server::{TagMap, kind::ServerKind, product::Product};
 use database::{pg_duration::PgDuration, servers::Server, url_field::UrlField};
 use jiff::{SignedDuration, Timestamp};
 use uuid::Uuid;
@@ -10,6 +10,7 @@ fn new_server() -> Server {
 		id: Uuid::new_v4(),
 		name: Some("t".into()),
 		host: Some(UrlField("https://restore.example/".parse().unwrap())),
+		product: Product::Tamanu,
 		kind: ServerKind::Central,
 		rank: None,
 		device_id: None,

--- a/crates/database/tests/it/tag_reserved_prefix.rs
+++ b/crates/database/tests/it/tag_reserved_prefix.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeMap;
 
 use commons_errors::AppError;
-use commons_types::server::{TagMap, kind::ServerKind};
+use commons_types::server::{TagMap, kind::ServerKind, product::Product};
 use database::{
 	pg_duration::PgDuration,
 	server_groups::{NewServerGroup, PartialServerGroup, ServerGroup},
@@ -26,6 +26,7 @@ fn new_server(host: &str) -> Server {
 		id: Uuid::new_v4(),
 		name: Some("t".into()),
 		host: Some(UrlField(host.parse().unwrap())),
+		product: Product::Tamanu,
 		kind: ServerKind::Central,
 		rank: None,
 		device_id: None,
@@ -70,6 +71,7 @@ async fn server_update_rejects_reserved_tag_keys() {
 		let updates = PartialServer {
 			id: server.id,
 			name: None,
+			product: None,
 			kind: None,
 			rank: None,
 			host: None,

--- a/crates/private-server/src/fns/commons.rs
+++ b/crates/private-server/src/fns/commons.rs
@@ -2,6 +2,12 @@ use axum::Json;
 use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
+use commons_types::server::{
+	kind::ServerKind,
+	product::{Caps, Product},
+};
+use serde::Serialize;
+use utoipa::ToSchema;
 
 use crate::state::AppState;
 
@@ -10,6 +16,53 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(public_url))
 		.routes(routes!(server_versions_url))
 		.routes(routes!(is_current_user_admin))
+		.routes(routes!(products))
+}
+
+/// One product canopy monitors, with what canopy does for its servers and the
+/// roles it defines.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ProductInfo {
+	/// The product itself.
+	pub product: Product,
+	/// What canopy does for this product's servers.
+	pub caps: Caps,
+	/// The roles this product defines, in the order they rank when choosing a
+	/// group's canonical member.
+	pub kinds: Vec<ServerKind>,
+	/// The role a server of this product takes when none is chosen.
+	pub default_kind: ServerKind,
+}
+
+/// Describe every product canopy monitors.
+///
+/// The operator UI reads this to decide what to present for a server — which
+/// roles to offer, whether a version applies and whether it can be graded,
+/// whether the public-name field is meaningful — rather than restating the
+/// mapping client-side, where it would drift as products are added.
+// spec: APP#capabilities
+#[utoipa::path(
+	post,
+	path = "/products",
+	tag = "commons",
+	responses(
+		(status = 200, description = "Every product, its capabilities, and the roles it defines.", body = Vec<ProductInfo>),
+		(status = 500, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn products() -> Result<Json<Vec<ProductInfo>>> {
+	Ok(Json(
+		Product::ALL
+			.iter()
+			.copied()
+			.map(|product| ProductInfo {
+				product,
+				caps: product.caps(),
+				kinds: product.kinds().to_vec(),
+				default_kind: product.default_kind(),
+			})
+			.collect(),
+	))
 }
 
 /// Get the configured public API base URL.

--- a/crates/private-server/src/fns/server_groups.rs
+++ b/crates/private-server/src/fns/server_groups.rs
@@ -99,10 +99,13 @@ pub struct GroupIdArgs {
 /// One effective billing label attributed to a group's cloud resources.
 ///
 /// Labels are computed from the group's configuration: explicit `billing.*`
-/// tags on the group are honoured verbatim; otherwise the product defaults to
-/// `tamanu`, the deployment to the group name in lower-kebab-case, and the
-/// stage to the group's highest-ranked live member (for example `prod`). The
-/// stage label is omitted entirely when the group has no ranked members.
+/// tags on the group are honoured verbatim; otherwise the product comes from
+/// the one its live members agree on, the deployment from the group name in
+/// lower-kebab-case, and the stage from the group's highest-ranked live member
+/// (for example `prod`). A label with nothing to attribute to is omitted
+/// entirely: the stage when the group has no ranked members, and the product
+/// when its members span products.
+// spec: APP#billing-attribution
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct BillingTag {
 	/// Label key, for example `billing.product`.
@@ -120,8 +123,12 @@ pub(crate) async fn group_billing_labels(
 		.await?
 		.get(&group.id)
 		.copied();
+	let product = ServerGroup::sole_member_products(conn, &[group.id])
+		.await?
+		.get(&group.id)
+		.copied();
 	Ok(
-		BillingLabels::from_group(&group.tags, &group.name, highest_rank)
+		BillingLabels::from_group(&group.tags, &group.name, product, highest_rank)
 			.into_tags()
 			.into_iter()
 			.map(|(key, value)| BillingTag { key, value })

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -8,7 +8,7 @@ use commons_types::{
 	Uuid,
 	device::DeviceRole,
 	geo::GeoPoint,
-	server::{TagMap, kind::ServerKind, rank::ServerRank},
+	server::{TagMap, kind::ServerKind, product::Product, rank::ServerRank},
 	status::{HealthState, ShortStatus},
 	version::VersionStr,
 };
@@ -74,7 +74,11 @@ pub struct ServerInfo {
 	pub id: Uuid,
 	/// Operator-assigned name for the server, if any.
 	pub name: Option<String>,
-	/// The kind of deployment this server represents.
+	/// The application this server runs. Decides which of canopy's
+	/// per-server features apply to it.
+	// spec: APP#product-and-kind
+	pub product: Product,
+	/// The server's role within its product's topology.
 	pub kind: ServerKind,
 	/// Where this server sits in its deployment's promotion order (e.g.
 	/// production vs. staging), if applicable.
@@ -175,7 +179,13 @@ pub struct ServerDataUpdate {
 	/// New name for the server. Omit to leave unchanged.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
-	/// New deployment kind for the server. Omit to leave unchanged.
+	/// New application for the server. Omit to leave unchanged. Changing it
+	/// to a product that does not define the server's kind moves the kind to
+	/// the new product's default, unless this request sets one too.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub product: Option<Product>,
+	/// New role for the server within its product's topology. Omit to leave
+	/// unchanged. Rejected when the product does not define it.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub kind: Option<ServerKind>,
 	/// New promotion rank for the server. Omit to leave unchanged.
@@ -254,6 +264,7 @@ pub(super) fn server_to_info(s: Server) -> ServerInfo {
 	ServerInfo {
 		id: s.id,
 		name: s.name,
+		product: s.product,
 		kind: s.kind,
 		rank: s.rank,
 		host: s.host.as_ref().map(|h| h.0.to_string()),
@@ -720,13 +731,53 @@ pub struct ServerUpdateArgs {
 	pub data: ServerDataUpdate,
 }
 
+/// Settle the product/kind pair an update leaves behind.
+///
+/// A product defines which roles exist, so the two can't move independently:
+/// a kind the target product doesn't define is a bad request, and a product
+/// change that leaves the stored kind undefined carries the server to the new
+/// product's default role rather than stranding it on a role its product
+/// doesn't have.
+///
+/// Reads the stored server only when the answer depends on it.
+// spec: APP#product-and-kind
+async fn settle_kind(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	product: Option<Product>,
+	kind: Option<ServerKind>,
+) -> Result<Option<ServerKind>> {
+	let target = match product {
+		Some(product) => product,
+		None => match kind {
+			// Nothing to check: neither half of the pair is moving.
+			None => return Ok(None),
+			// The stored product has to define the requested kind.
+			Some(_) => Server::get_by_id(conn, server_id).await?.product,
+		},
+	};
+
+	match kind {
+		Some(kind) if !target.defines_kind(kind) => Err(AppError::BadRequest(format!(
+			"{target} servers have no {kind} role"
+		))),
+		Some(kind) => Ok(Some(kind)),
+		// A product change with no kind: keep the stored kind when the new
+		// product defines it, else move to that product's default.
+		None => {
+			let current = Server::get_by_id(conn, server_id).await?;
+			Ok((!target.defines_kind(current.kind)).then(|| target.default_kind()))
+		}
+	}
+}
+
 /// Update a server's fields.
 ///
 /// Applies a partial update — only the fields present in `data` are
 /// changed. Moving a previously-ungrouped server into a group, or toggling
 /// `is_monitored`, re-evaluates the server's open issues so incidents catch
 /// up with the new state. Returns 400 if the update is rejected (e.g. an
-/// invalid host value).
+/// invalid host value, or a role the target product doesn't define).
 #[utoipa::path(
 	post,
 	path = "/update",
@@ -759,10 +810,13 @@ pub async fn update(
 	};
 	let new_group_id = args.data.group_id;
 
+	let kind = settle_kind(&mut conn, args.server_id, args.data.product, args.data.kind).await?;
+
 	let update_data = PartialServer {
 		id: args.server_id,
 		name: args.data.name,
-		kind: args.data.kind,
+		product: args.data.product,
+		kind,
 		rank: args.data.rank,
 		// `Some(Some(url))` sets, `Some(None)` clears, `None` leaves unchanged.
 		// The form always sends `host`; an empty string clears it.
@@ -813,7 +867,11 @@ pub struct CreateServerArgs {
 	/// URL for the server, if known. Can be added or changed later.
 	#[serde(default)]
 	pub host: Option<String>,
-	/// The kind of deployment this server represents.
+	/// The application this server runs. Defaults to tamanu.
+	#[serde(default)]
+	pub product: Product,
+	/// The server's role within its product's topology. Rejected when the
+	/// product does not define it.
 	pub kind: ServerKind,
 	/// Where this server sits in its deployment's promotion order (e.g.
 	/// production vs. staging), if applicable.
@@ -907,10 +965,21 @@ pub async fn create(
 		None
 	};
 
+	// A role its product doesn't define would leave the server misclassified
+	// from the moment it exists.
+	// spec: APP#product-and-kind
+	if !args.product.defines_kind(args.kind) {
+		return Err(AppError::BadRequest(format!(
+			"{} servers have no {} role",
+			args.product, args.kind
+		)));
+	}
+
 	let server = Server {
 		id: Uuid::new_v4(),
 		name: args.name,
 		host,
+		product: args.product,
 		kind: args.kind,
 		rank: args.rank,
 		device_id,
@@ -1236,6 +1305,7 @@ pub async fn attach_tailscale_device(
 		PartialServer {
 			id: args.server_id,
 			name: None,
+			product: None,
 			kind: None,
 			rank: None,
 			host: None,

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -144,6 +144,11 @@ pub struct ServerLastStatusData {
 	pub id: Uuid,
 	/// When this status was reported.
 	pub created_at: Timestamp,
+	/// The application the server runs. Travels with the version so a
+	/// consumer can tell a product with no version from one that has yet to
+	/// report one.
+	// spec: APP#versions
+	pub product: Product,
 	/// Software version the server reported running, if known.
 	pub version: Option<VersionStr>,
 	/// How many releases behind the latest known version this server's
@@ -651,13 +656,19 @@ pub async fn get_detail(
 		let nodejs = figures
 			.node_version()
 			.or_else(|| connection.and_then(|d| d.nodejs_version()));
+		// Grading a version means measuring it against a release train canopy
+		// holds, so both the distance and the embedded-browser floor apply only
+		// to a product that has one. A canopy instance reports its own build
+		// version and would otherwise be measured against Tamanu's releases.
+		// spec: APP#versions
+		let graded = server.product.tracks_versions();
 		let version_distance = latest_version
 			.as_ref()
+			.filter(|_| graded)
 			.and_then(|lv| st.distance_from_version(lv));
-		let min_chrome_version = if let Some(ref version) = st.version {
-			compute_min_chrome_version(&mut conn, version).await
-		} else {
-			None
+		let min_chrome_version = match &st.version {
+			Some(version) if graded => compute_min_chrome_version(&mut conn, version).await,
+			_ => None,
 		};
 		let mut operators = st.operators();
 		super::statuses::enrich_operators(&mut conn, operators.iter_mut()).await?;
@@ -665,7 +676,11 @@ pub async fn get_detail(
 		Some(ServerLastStatusData {
 			id: st.id,
 			created_at: st.created_at,
-			version: st.version.clone(),
+			product: server.product,
+			// A product with no application version presents none, as against
+			// the `unknown` a versioned server shows before it has reported.
+			// spec: APP#versions
+			version: st.version.clone().filter(|_| server.product.has_versions()),
 			version_distance,
 			min_chrome_version,
 			platform: figures.platform(),

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -56,8 +56,11 @@ pub struct ServerDetailData {
 	/// server is ungrouped or alone in its group. Each entry carries its
 	/// own `up` / `health` so the UI can render a status dot per sibling.
 	pub siblings: Vec<ServerInfo>,
-	/// The server's effective `billing.*` labels — i.e. its group's
-	/// (product/deployment/stage). Empty when the server is ungrouped.
+	/// The server's own effective `billing.*` labels
+	/// (product/deployment/stage) — the ones canopy hands the server's device,
+	/// carrying its own product and rank rather than its group's. Empty when
+	/// the server is ungrouped, there being no deployment to attribute to.
+	// spec: APP#billing-attribution
 	pub billing_labels: Vec<super::server_groups::BillingTag>,
 	/// Whether the server is known to run Munin, from the most recent source
 	/// to report the flag. The UI offers a Munin link only when this is true.
@@ -700,8 +703,21 @@ pub async fn get_detail(
 		Vec::new()
 	};
 
+	// This server's own attribution, not its group's: for a server whose
+	// product or rank differs from the group's, the page would otherwise show
+	// labels the device is never handed.
+	// spec: APP#billing-attribution
 	let billing_labels = match group.as_ref() {
-		Some(g) => super::server_groups::group_billing_labels(&mut conn, g).await?,
+		Some(g) => commons_servers::backup_jobs::BillingLabels::for_server(
+			&g.tags,
+			&g.name,
+			server.product,
+			server.rank,
+		)
+		.into_tags()
+		.into_iter()
+		.map(|(key, value)| super::server_groups::BillingTag { key, value })
+		.collect(),
 		None => Vec::new(),
 	};
 

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -584,6 +584,11 @@ pub struct StatusSnapshotData {
 	pub server_id: Uuid,
 	/// Id of the device that sent this status push, if known.
 	pub device_id: Option<Uuid>,
+	/// The application the server runs. Travels with the version so a
+	/// consumer can tell a product with no version from one that has yet to
+	/// report one.
+	// spec: APP#versions
+	pub product: Product,
 	/// Software version reported in this push.
 	pub version: Option<VersionStr>,
 	/// How many releases behind the latest published version this push's
@@ -728,6 +733,7 @@ pub async fn snapshot(
 		created_at: status.created_at,
 		server_id: status.server_id,
 		device_id: status.device_id,
+		product: server.product,
 		// A product with no application version presents none, as against the
 		// `unknown` a versioned server shows before it has reported one.
 		// spec: APP#versions

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -9,6 +9,7 @@ use commons_types::{
 	server::{
 		cards::{FacilityServerStatus, ServerGroupCard},
 		kind::ServerKind,
+		product::Product,
 		rank::ServerRank,
 	},
 	status::{CheckResult, OperatorPresence, ShortStatus},
@@ -264,6 +265,7 @@ pub async fn group_details(
 				health: member_health.get(&s.id).copied().unwrap_or_default(),
 				operators,
 				rank: s.rank,
+				product: s.product,
 				kind: s.kind,
 			}
 		})
@@ -663,12 +665,22 @@ pub async fn snapshot(
 	};
 	let server = Server::get_by_id(&mut conn, args.server_id).await?;
 
+	// Grading a version means measuring it against a release train canopy
+	// holds, so it applies only to a product that has one. A canopy instance
+	// reports its own build version and would otherwise be measured against
+	// Tamanu's releases, yielding a distance that means nothing.
+	//
 	// If the deployment has no published versions yet, we just skip
 	// the distance computation rather than 404'ing the whole
 	// snapshot — the call still wants to surface everything else.
-	let version_distance = match Version::get_latest_matching(&mut conn, "*".parse()?).await {
-		Ok(v) => status.distance_from_version(&v.as_semver()),
-		Err(_) => None,
+	// spec: APP#versions
+	let version_distance = if server.product.tracks_versions() {
+		match Version::get_latest_matching(&mut conn, "*".parse()?).await {
+			Ok(v) => status.distance_from_version(&v.as_semver()),
+			Err(_) => None,
+		}
+	} else {
+		None
 	};
 	// The consolidated checks as of this snapshot: every source's most
 	// recent report at-or-before `at`, re-graded through current policy,
@@ -699,10 +711,14 @@ pub async fn snapshot(
 			}
 		}
 	};
-	let min_chrome_version = if let Some(ref v) = status.version {
-		super::servers::compute_min_chrome_version(&mut conn, v).await
-	} else {
-		None
+	// The embedded-browser floor is a property of a Tamanu release, so it too
+	// only means something for a product whose releases canopy holds.
+	// spec: APP#versions
+	let min_chrome_version = match &status.version {
+		Some(v) if server.product.tracks_versions() => {
+			super::servers::compute_min_chrome_version(&mut conn, v).await
+		}
+		_ => None,
 	};
 	let mut operators = status.operators();
 	enrich_operators(&mut conn, operators.iter_mut()).await?;
@@ -712,7 +728,10 @@ pub async fn snapshot(
 		created_at: status.created_at,
 		server_id: status.server_id,
 		device_id: status.device_id,
-		version: status.version,
+		// A product with no application version presents none, as against the
+		// `unknown` a versioned server shows before it has reported one.
+		// spec: APP#versions
+		version: status.version.filter(|_| server.product.has_versions()),
 		version_distance,
 		min_chrome_version,
 		platform: figures.platform(),
@@ -919,7 +938,11 @@ pub struct FleetServerDetailData {
 	pub group_name: Option<String>,
 	/// Where the server sits in its deployment's promotion order, if set.
 	pub rank: Option<ServerRank>,
-	/// The kind of deployment the server represents.
+	/// The application the server runs. The fleet view reads it to keep the
+	/// application-version spread to servers that have one to report.
+	// spec: APP#versions
+	pub product: Product,
+	/// The server's role within its product's topology.
 	pub kind: ServerKind,
 	/// Application version the server reports running, if any.
 	pub version: Option<VersionStr>,
@@ -1011,8 +1034,12 @@ pub async fn fleet_detail(
 				group_id: server.group_id,
 				group_name: server.group_id.and_then(|g| group_names.get(&g).cloned()),
 				rank: server.rank,
+				product: server.product,
 				kind: server.kind,
-				version,
+				// A product with no application version reports none, so the
+				// row carries nothing for the fleet view to count.
+				// spec: APP#versions
+				version: version.filter(|_| server.product.has_versions()),
 				platform: figures.platform(),
 				postgres: figures.postgres_version(),
 				nodejs: figures.node_version(),

--- a/crates/private-server/tests/it/main.rs
+++ b/crates/private-server/tests/it/main.rs
@@ -22,6 +22,7 @@ mod operator_presence;
 mod private_statuses;
 mod provision_credential;
 mod restore_replicas;
+mod server_products;
 mod server_version_distance;
 mod tagged_device_guard;
 mod tailnet_device_auth;

--- a/crates/private-server/tests/it/server_products.rs
+++ b/crates/private-server/tests/it/server_products.rs
@@ -1,0 +1,181 @@
+//! Product classification through the admin API: how the product/kind pair is
+//! settled on create and update, and how the version is presented for a
+//! product that has none.
+//!
+//! spec: APP
+
+use commons_types::server::{kind::ServerKind, product::Product};
+use database::servers::Server;
+use serde_json::json;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_defaults_to_tamanu_and_round_trips_a_product() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		// Omitting the product classifies the server as Tamanu, so an existing
+		// caller that never heard of the field keeps working.
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({ "kind": "central" }))
+			.await;
+		response.assert_status_ok();
+		let id: String = response.json();
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
+		assert_eq!(server.product, Product::Tamanu);
+
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({ "product": "senaite", "kind": "standalone" }))
+			.await;
+		response.assert_status_ok();
+		let id: String = response.json();
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
+		assert_eq!(server.product, Product::Senaite);
+		assert_eq!(server.kind, ServerKind::Standalone);
+	})
+	.await
+}
+
+/// A role its product doesn't define would leave the server misclassified from
+/// the moment it exists, so creation refuses it outright.
+#[tokio::test(flavor = "multi_thread")]
+async fn create_rejects_a_role_the_product_does_not_define() {
+	commons_tests::server::run(async |_conn, _, private| {
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({ "product": "senaite", "kind": "central" }))
+			.await;
+		response.assert_status_bad_request();
+	})
+	.await
+}
+
+/// Reclassifying a Tamanu central as SENAITE, which has no central role,
+/// carries the server to the new product's default role rather than stranding
+/// it on one its product doesn't have.
+#[tokio::test(flavor = "multi_thread")]
+async fn changing_product_moves_an_orphaned_kind_to_the_new_default() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({ "kind": "central" }))
+			.await;
+		response.assert_status_ok();
+		let id: String = response.json();
+
+		let response = private
+			.post("/api/servers/update")
+			.json(&json!({
+				"server_id": id,
+				"data": { "product": "senaite" },
+			}))
+			.await;
+		response.assert_status_ok();
+
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
+		assert_eq!(server.product, Product::Senaite);
+		assert_eq!(
+			server.kind,
+			ServerKind::Standalone,
+			"the kind follows the product rather than staying central"
+		);
+	})
+	.await
+}
+
+/// A product change that keeps a role the new product also defines leaves the
+/// role alone.
+#[tokio::test(flavor = "multi_thread")]
+async fn changing_product_keeps_a_kind_the_new_product_defines() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({ "product": "senaite", "kind": "standalone" }))
+			.await;
+		response.assert_status_ok();
+		let id: String = response.json();
+
+		// Canopy also defines standalone, so nothing has to move.
+		let response = private
+			.post("/api/servers/update")
+			.json(&json!({
+				"server_id": id,
+				"data": { "product": "canopy" },
+			}))
+			.await;
+		response.assert_status_ok();
+
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
+		assert_eq!(server.product, Product::Canopy);
+		assert_eq!(server.kind, ServerKind::Standalone);
+	})
+	.await
+}
+
+/// An explicitly requested role the target product doesn't define is a bad
+/// request rather than something quietly corrected.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_rejects_a_role_the_product_does_not_define() {
+	commons_tests::server::run(async |_conn, _, private| {
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({ "product": "senaite", "kind": "standalone" }))
+			.await;
+		response.assert_status_ok();
+		let id: String = response.json();
+
+		let response = private
+			.post("/api/servers/update")
+			.json(&json!({
+				"server_id": id,
+				"data": { "kind": "facility" },
+			}))
+			.await;
+		response.assert_status_bad_request();
+	})
+	.await
+}
+
+/// The product catalogue is what the UI reads to decide what to present, so it
+/// has to describe every product's capabilities and roles.
+#[tokio::test(flavor = "multi_thread")]
+async fn products_endpoint_describes_every_product() {
+	commons_tests::server::run(async |_conn, _, private| {
+		let response = private.post("/api/commons/products").json(&json!({})).await;
+		response.assert_status_ok();
+		let body: serde_json::Value = response.json();
+		let products = body.as_array().expect("array of products");
+
+		let find = |name: &str| {
+			products
+				.iter()
+				.find(|p| p["product"] == name)
+				.unwrap_or_else(|| panic!("{name} missing from the catalogue"))
+				.clone()
+		};
+
+		let tamanu = find("tamanu");
+		assert_eq!(tamanu["caps"]["version_tracking"], "tracked");
+		assert_eq!(tamanu["caps"]["public_listing"], true);
+		assert_eq!(tamanu["kinds"], json!(["central", "facility"]));
+		assert_eq!(tamanu["default_kind"], "central");
+
+		// A canopy instance reports its own build version, which canopy holds no
+		// release train for: presented, but graded against nothing.
+		let canopy = find("canopy");
+		assert_eq!(canopy["caps"]["version_tracking"], "reported");
+		assert_eq!(canopy["caps"]["public_listing"], false);
+
+		let senaite = find("senaite");
+		assert_eq!(senaite["caps"]["version_tracking"], "absent");
+		assert_eq!(senaite["kinds"], json!(["standalone"]));
+	})
+	.await
+}

--- a/crates/private-server/tests/it/server_products.rs
+++ b/crates/private-server/tests/it/server_products.rs
@@ -179,3 +179,143 @@ async fn products_endpoint_describes_every_product() {
 	})
 	.await
 }
+
+/// A public name already set survives the server becoming ineligible to be
+/// listed: reclassification shouldn't destroy operator data, and the name takes
+/// effect again if the server becomes eligible once more.
+#[tokio::test(flavor = "multi_thread")]
+async fn public_name_survives_losing_eligibility() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({
+				"kind": "central",
+				"public_name": "Island Central",
+			}))
+			.await;
+		response.assert_status_ok();
+		let id: String = response.json();
+		let server_id: uuid::Uuid = id.parse().unwrap();
+
+		// Reclassifying to SENAITE makes it ineligible: no public listing, and
+		// the role moves to standalone.
+		let response = private
+			.post("/api/servers/update")
+			.json(&json!({
+				"server_id": id,
+				"data": { "product": "senaite" },
+			}))
+			.await;
+		response.assert_status_ok();
+
+		let server = Server::get_by_id(&mut conn, server_id).await.unwrap();
+		assert_eq!(server.product, Product::Senaite);
+		assert_eq!(
+			server.public_name.as_deref(),
+			Some("Island Central"),
+			"the stored name is kept rather than cleared"
+		);
+		// It is nonetheless not listed while ineligible.
+		let listed = Server::search_central(&mut conn, "Island", 50)
+			.await
+			.unwrap();
+		assert!(listed.is_empty(), "ineligible servers are not offered");
+
+		// Back to Tamanu central, and the name takes effect again.
+		let response = private
+			.post("/api/servers/update")
+			.json(&json!({
+				"server_id": id,
+				"data": { "product": "tamanu", "kind": "central", "name": "Island Central" },
+			}))
+			.await;
+		response.assert_status_ok();
+
+		let listed = Server::search_central(&mut conn, "Island", 50)
+			.await
+			.unwrap();
+		assert_eq!(
+			listed
+				.into_iter()
+				.filter_map(|s| s.public_name)
+				.collect::<Vec<_>>(),
+			vec!["Island Central".to_string()],
+		);
+	})
+	.await
+}
+
+/// The server detail view renders the server's *own* billing labels, so the page
+/// agrees with what canopy hands that server's device. Rendering its group's
+/// would show a SENAITE server in a Tamanu group an attribution it never gets.
+#[tokio::test(flavor = "multi_thread")]
+async fn detail_billing_labels_are_the_servers_own() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		let group = private
+			.post("/api/server_groups/create")
+			.json(&json!({ "name": "Pacific" }))
+			.await;
+		group.assert_status_ok();
+		let group_body: serde_json::Value = group.json();
+		let group_id = group_body["id"].as_str().unwrap().to_string();
+
+		// A production Tamanu member, so the group's highest rank is production
+		// and its members span products.
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({
+				"kind": "central",
+				"rank": "production",
+				"group_id": group_id,
+			}))
+			.await;
+		response.assert_status_ok();
+
+		let response = private
+			.post("/api/servers/create")
+			.json(&json!({
+				"product": "senaite",
+				"kind": "standalone",
+				"rank": "clone",
+				"group_id": group_id,
+			}))
+			.await;
+		response.assert_status_ok();
+		let lims_id: String = response.json();
+
+		let response = private
+			.post("/api/servers/get_detail")
+			.json(&json!({ "server_id": lims_id }))
+			.await;
+		response.assert_status_ok();
+		let body: serde_json::Value = response.json();
+		let labels: std::collections::HashMap<String, String> = body["billing_labels"]
+			.as_array()
+			.expect("billing labels")
+			.iter()
+			.map(|t| {
+				(
+					t["key"].as_str().unwrap().to_string(),
+					t["value"].as_str().unwrap().to_string(),
+				)
+			})
+			.collect();
+
+		assert_eq!(
+			labels.get("billing.product").map(String::as_str),
+			Some("senaite")
+		);
+		// Its own rank, not the group's highest.
+		assert_eq!(
+			labels.get("billing.stage").map(String::as_str),
+			Some("clone")
+		);
+		// The deployment still comes from the group.
+		assert_eq!(
+			labels.get("billing.deployment").map(String::as_str),
+			Some("pacific")
+		);
+		let _ = &mut conn;
+	})
+	.await
+}

--- a/crates/public-server/src/tags.rs
+++ b/crates/public-server/src/tags.rs
@@ -79,18 +79,24 @@ pub async fn effective_tags_for_server(
 ) -> Result<TagMap> {
 	let mut merged = server.tags_for_device(conn).await?;
 
-	// Fill in the group's effective billing labels where the server doesn't
-	// already carry one, matching what canopy attributes to the group's cloud
+	// Fill in the effective billing labels where the server doesn't already
+	// carry one, matching what canopy attributes to the group's cloud
 	// resources. `merged` already holds server tags overlaid on group tags, so a
 	// stored `billing.*` tag (server's own first, then the group's) is honoured
-	// and only the missing labels fall back to computed values. `billing.stage`
-	// is computed from *this* server's own rank, not the group's highest — a
-	// rank=clone server must report `billing.stage=clone`, never the group's
-	// `prod`, so its cost attributes to the right stage.
+	// and only the missing labels fall back to computed values.
+	//
+	// Every computed label describes *this* server, not its group: the stage
+	// comes from the server's own rank, so a rank=clone server reports
+	// `billing.stage=clone` and never the group's `prod`; and the product comes
+	// from the server's own product, so a SENAITE server in a Tamanu group
+	// reports `billing.product=senaite`. Attribution needs a deployment to
+	// attribute to, so an ungrouped server carries none.
+	// spec: APP#billing-attribution
 	if let Some(group_id) = server.group_id {
 		let group = ServerGroup::get_by_id(conn, group_id).await?;
 		for (key, value) in
-			BillingLabels::from_group(&group.tags, &group.name, server.rank).into_tags()
+			BillingLabels::for_server(&group.tags, &group.name, server.product, server.rank)
+				.into_tags()
 		{
 			merged.0.entry(key).or_insert(value);
 		}

--- a/crates/public-server/tests/it/server_enrollment.rs
+++ b/crates/public-server/tests/it/server_enrollment.rs
@@ -9,7 +9,7 @@
 
 use base64::Engine;
 use commons_tests::server::{make_signing_certificate, run, run_with_tailnet_device_auth};
-use commons_types::server::{TagMap, kind::ServerKind};
+use commons_types::server::{TagMap, kind::ServerKind, product::Product};
 use database::{
 	pg_duration::PgDuration, server_enrollment_tokens::ServerEnrollmentToken, servers::Server,
 	url_field::UrlField,
@@ -27,6 +27,7 @@ fn new_server(host: &str) -> Server {
 		id: Uuid::new_v4(),
 		name: Some("test".into()),
 		host: Some(UrlField(host.parse().unwrap())),
+		product: Product::Tamanu,
 		kind: ServerKind::Central,
 		rank: None,
 		device_id: None,

--- a/crates/public-server/tests/it/statuses.rs
+++ b/crates/public-server/tests/it/statuses.rs
@@ -243,14 +243,14 @@ async fn submit_status() {
 
 			// The response carries only the return-path fields; the stored
 			// status record is not echoed back. Tags for this bare ungrouped
-			// server are just the synthetic `canopy:kind`.
+			// server are just the synthetic `canopy:product` and `canopy:kind`.
 			let body: serde_json::Value = response.json();
 			assert_eq!(
 				body,
 				serde_json::json!({
 					"backup_now": [],
 					"check_severities": {},
-					"tags": {"canopy:kind": "facility"},
+					"tags": {"canopy:product": "tamanu", "canopy:kind": "facility"},
 				}),
 			);
 

--- a/crates/public-server/tests/it/tags.rs
+++ b/crates/public-server/tests/it/tags.rs
@@ -444,3 +444,93 @@ async fn tags_endpoint_412_when_device_has_no_server() {
 	)
 	.await
 }
+
+/// A server's billing product is its own, not its group's: a SENAITE server
+/// sharing a group with Tamanu ones attributes its cloud cost to SENAITE, since
+/// charging it to the deployment's application would put the spend in the wrong
+/// place.
+// spec: APP#billing-attribution
+#[tokio::test(flavor = "multi_thread")]
+async fn tags_endpoint_billing_product_is_the_servers_own() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let group_id = Uuid::new_v4();
+			let server_id = Uuid::new_v4();
+			sql_query("INSERT INTO server_groups (id, name) VALUES ($1, 'Pacific')")
+				.bind::<sql_types::Uuid, _>(group_id)
+				.execute(&mut conn)
+				.await
+				.unwrap();
+			// A Tamanu member alongside it, so the group genuinely spans products.
+			sql_query(
+				"INSERT INTO servers (id, host, kind, rank, group_id) \
+				 VALUES ($1, 'https://central.example.com', 'central', 'production', $2)",
+			)
+			.bind::<sql_types::Uuid, _>(Uuid::new_v4())
+			.bind::<sql_types::Uuid, _>(group_id)
+			.execute(&mut conn)
+			.await
+			.unwrap();
+			sql_query(
+				"INSERT INTO servers (id, host, product, kind, rank, device_id, group_id) \
+				 VALUES ($1, 'https://lims.example.com', 'senaite', 'standalone', 'clone', $2, $3)",
+			)
+			.bind::<sql_types::Uuid, _>(server_id)
+			.bind::<sql_types::Uuid, _>(device_id)
+			.bind::<sql_types::Uuid, _>(group_id)
+			.execute(&mut conn)
+			.await
+			.unwrap();
+
+			let response = public
+				.get("/tags")
+				.add_header("mtls-certificate", &cert)
+				.await;
+			response.assert_status_ok();
+			let tags: HashMap<String, String> = response.json();
+			assert_eq!(tags.get("billing.product"), Some(&"senaite".to_string()));
+			// The deployment still comes from the group it belongs to...
+			assert_eq!(tags.get("billing.deployment"), Some(&"pacific".to_string()));
+			// ...and the stage from its own rank, not the group's highest.
+			assert_eq!(tags.get("billing.stage"), Some(&"clone".to_string()));
+		},
+	)
+	.await
+}
+
+/// Billing attribution needs a deployment to attribute to, so an ungrouped
+/// server carries no `billing.*` labels at all — not even the product it could
+/// name on its own.
+// spec: APP#billing-attribution
+#[tokio::test(flavor = "multi_thread")]
+async fn tags_endpoint_ungrouped_server_has_no_billing_product() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			sql_query(
+				"INSERT INTO servers (id, host, product, kind, device_id) \
+				 VALUES ($1, 'https://lone-lims.example.com', 'senaite', 'standalone', $2)",
+			)
+			.bind::<sql_types::Uuid, _>(Uuid::new_v4())
+			.bind::<sql_types::Uuid, _>(device_id)
+			.execute(&mut conn)
+			.await
+			.unwrap();
+
+			let response = public
+				.get("/tags")
+				.add_header("mtls-certificate", &cert)
+				.await;
+			response.assert_status_ok();
+			let tags: HashMap<String, String> = response.json();
+			assert_eq!(tags.get("billing.product"), None);
+			assert_eq!(tags.get("billing.deployment"), None);
+			assert_eq!(tags.get("billing.stage"), None);
+			// The classification tags are still there — those describe the
+			// server, not what its cost attributes to.
+			assert_eq!(tags.get("canopy:product"), Some(&"senaite".to_string()));
+		},
+	)
+	.await
+}

--- a/crates/public-server/tests/it/tags.rs
+++ b/crates/public-server/tests/it/tags.rs
@@ -113,13 +113,15 @@ async fn tags_endpoint_returns_server_tags_when_ungrouped() {
 			response.assert_status_ok();
 			let tags: HashMap<String, String> = response.json();
 			assert_eq!(tags.get("role"), Some(&"primary".to_string()));
-			// Synthetic kind tag is always present; ungrouped, so no group tags.
+			// Synthetic product and kind tags are always present; ungrouped, so
+			// no group tags.
+			assert_eq!(tags.get("canopy:product"), Some(&"tamanu".to_string()));
 			assert_eq!(tags.get("canopy:kind"), Some(&"central".to_string()));
 			assert_eq!(tags.get("canopy:group-id"), None);
 			assert_eq!(tags.get("canopy:group-name"), None);
 			// No rank set on this server, so no synthetic rank tag.
 			assert_eq!(tags.get("canopy:rank"), None);
-			assert_eq!(tags.len(), 2);
+			assert_eq!(tags.len(), 3);
 		},
 	)
 	.await

--- a/migrations/2026-07-28-023053-0000_add_server_product/down.sql
+++ b/migrations/2026-07-28-023053-0000_add_server_product/down.sql
@@ -1,0 +1,5 @@
+-- `kind` was never rewritten, so Canopy instances are still identifiable by
+-- `kind = 'canopy'` and nothing needs restoring before the column goes.
+DROP INDEX servers_product;
+
+ALTER TABLE servers DROP COLUMN product;

--- a/migrations/2026-07-28-023053-0000_add_server_product/up.sql
+++ b/migrations/2026-07-28-023053-0000_add_server_product/up.sql
@@ -1,0 +1,15 @@
+-- A server's product: which application it runs. `kind` remains the server's
+-- role within that product's topology.
+--
+-- No CHECK constraint, matching how `kind` is stored: the valid set is code's
+-- to define, so adding a product stays a code-only change.
+ALTER TABLE servers ADD COLUMN product TEXT NOT NULL DEFAULT 'tamanu';
+
+CREATE INDEX servers_product ON servers (product);
+
+-- Canopy instances were classified by kind, the one product that had smuggled
+-- itself onto that axis. Lift them onto `product` and leave `kind` as it is:
+-- the kind column's role is being split over two releases, and rewriting it
+-- here would leave a not-yet-upgraded binary unable to read these rows at all.
+-- A later migration normalises the leftover `kind = 'canopy'` values.
+UPDATE servers SET product = 'canopy' WHERE kind = 'canopy';

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -50,9 +50,12 @@ export async function resetSeededTables(sql: Sql): Promise<void> {
 		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
-	// self-alerts attach to that row, so put it back.
+	// self-alerts attach to that row, so put it back. `kind = 'canopy'` is the
+	// legacy value the product migration deliberately left in place, so this
+	// also keeps the read alias exercised; `product` has to be set explicitly
+	// since that migration's backfill has already run by now.
 	await sql.query(
-		"INSERT INTO servers (id, kind, name, host) VALUES ('00000000-0000-0000-0000-000000000000', 'canopy', 'Canopy', 'http://localhost')",
+		"INSERT INTO servers (id, product, kind, name, host) VALUES ('00000000-0000-0000-0000-000000000000', 'canopy', 'canopy', 'Canopy', 'http://localhost')",
 	);
 	// Same for the migration's one seeded source policy: tamanu reports on
 	// its own schedule, so its silence is not a reachability signal.
@@ -107,12 +110,15 @@ export async function seedServerGroup(
 }
 
 export type ServerRank = "production" | "clone" | "demo" | "test" | "dev";
+export type Product = "tamanu" | "senaite" | "canopy";
+export type ServerKind = "central" | "facility" | "standalone";
 
 export interface SeededServer {
 	id: string;
 	name: string;
 	host: string;
-	kind: "central" | "facility";
+	product: Product;
+	kind: ServerKind;
 	rank: ServerRank | null;
 }
 
@@ -121,7 +127,9 @@ export async function seedServer(
 	opts: {
 		name?: string;
 		host?: string;
-		kind?: "central" | "facility";
+		/** Which application the server runs. Defaults to tamanu. */
+		product?: Product;
+		kind?: ServerKind;
 		rank?: ServerRank | null;
 		groupId?: string | null;
 		deviceId?: string;
@@ -137,17 +145,21 @@ export async function seedServer(
 	const id = randomUUID();
 	const name = opts.name ?? randomLabel("srv");
 	const host = opts.host ?? `https://${randomLabel("host")}.e2e.invalid`;
-	const kind = opts.kind ?? "central";
+	const product = opts.product ?? "tamanu";
+	// Default the role to one the chosen product actually defines, so a seed
+	// that only names a product doesn't produce a misclassified server.
+	const kind = opts.kind ?? (product === "tamanu" ? "central" : "standalone");
 	const rank = opts.rank ?? "production";
 	const isMonitored = opts.isMonitored ?? false;
 	const alertWhenDownFor = opts.alertWhenDownFor ?? 600;
 	await sql.query(
-		`INSERT INTO servers (id, name, host, kind, rank, group_id, device_id, is_monitored, alert_when_down_for, notes, tags)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)`,
+		`INSERT INTO servers (id, name, host, product, kind, rank, group_id, device_id, is_monitored, alert_when_down_for, notes, tags)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb)`,
 		[
 			id,
 			name,
 			host,
+			product,
 			kind,
 			rank,
 			opts.groupId ?? null,
@@ -158,7 +170,7 @@ export async function seedServer(
 			JSON.stringify(opts.tags ?? {}),
 		],
 	);
-	return { id, name, host, kind, rank };
+	return { id, name, host, product, kind, rank };
 }
 
 export interface SeededDevice {

--- a/private-web/e2e/server-products.spec.ts
+++ b/private-web/e2e/server-products.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test } from "./test-fixtures";
+import {
+	resetSeededTables,
+	seedServer,
+	seedServerGroup,
+	seedStatus,
+	seedVersion,
+} from "./seed";
+
+/// Coverage for the product axis: how a product is presented, and how its
+/// version is presented given what the product actually has.
+///
+/// spec: APP
+test.describe("server products", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("a Tamanu server presents its version graded against the catalogue", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 2, minor: 34, patch: 1, status: "published" });
+		const server = await seedServer(sql, {
+			name: "central-graded",
+			product: "tamanu",
+			kind: "central",
+		});
+		await seedStatus(sql, { serverId: server.id, version: "2.34.1" });
+
+		await page.goto(`/servers/${server.id}`);
+
+		// Graded: the version links into the catalogue and carries its distance
+		// from the latest release.
+		await expect(
+			page.getByRole("link", { name: /2\.34\.1 0 versions behind latest/ }),
+		).toBeVisible();
+	});
+
+	test("a SENAITE server presents no version at all", async ({ page, sql }) => {
+		await seedVersion(sql, { major: 2, minor: 34, patch: 1, status: "published" });
+		const server = await seedServer(sql, {
+			name: "lims-box",
+			product: "senaite",
+		});
+		// A SENAITE agent reports health and figures but no application version.
+		await seedStatus(sql, {
+			serverId: server.id,
+			version: null,
+			extra: { pgVersion: "PostgreSQL 16.2", bestoolVersion: "2.10.5" },
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		// The product chip identifies it, and its role is the standalone one
+		// SENAITE defines.
+		await expect(page.getByText("SENAITE", { exact: true })).toBeVisible();
+		await expect(page.getByText("standalone", { exact: true })).toBeVisible();
+		// There is no version affordance at all — not even "unknown". There is no
+		// version to learn, so an unknown would read as a reporting failure.
+		await expect(page.getByText("unknown")).toHaveCount(0);
+		await expect(page.getByRole("link", { name: /versions behind/ })).toHaveCount(
+			0,
+		);
+	});
+
+	test("a Tamanu server that has not reported a version presents unknown", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 2, minor: 34, patch: 1, status: "published" });
+		const server = await seedServer(sql, {
+			name: "silent-central",
+			product: "tamanu",
+			kind: "central",
+		});
+		// Reported, but carrying no version — the agent couldn't read it.
+		await seedStatus(sql, { serverId: server.id, version: null });
+
+		await page.goto(`/servers/${server.id}`);
+
+		// There *is* a version to learn here, so the indicator says so.
+		await expect(page.getByText("unknown")).toBeVisible();
+	});
+
+	test("a mixed-product group takes its headline version from the Tamanu member", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 2, minor: 34, patch: 1, status: "published" });
+		const group = await seedServerGroup(sql, { name: "pacific-mixed" });
+		const central = await seedServer(sql, {
+			name: "pacific-central",
+			product: "tamanu",
+			kind: "central",
+			groupId: group.id,
+		});
+		await seedServer(sql, {
+			name: "pacific-lims",
+			product: "senaite",
+			groupId: group.id,
+			rank: "production",
+		});
+		await seedStatus(sql, { serverId: central.id, version: "2.34.1" });
+
+		await page.goto("/status");
+
+		// The group card shows the Tamanu member's version rather than blanking
+		// because one of its members has none to give.
+		await expect(page.getByText(group.name)).toBeVisible();
+		await expect(page.getByText("2.34.1")).toBeVisible();
+	});
+
+	test("the create form offers a product and narrows the roles to match", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "target-group" });
+
+		await page.goto(`/groups/${group.id}/servers/new`);
+
+		// Tamanu is the default product, and offers both of its roles.
+		const kindField = page.getByRole("combobox", { name: "Kind" });
+		await expect(kindField).toHaveText("facility");
+		await kindField.click();
+		await expect(page.getByRole("option", { name: "central" })).toBeVisible();
+		await expect(page.getByRole("option", { name: "facility" })).toBeVisible();
+		await expect(page.getByRole("option", { name: "standalone" })).toHaveCount(
+			0,
+		);
+		await page.keyboard.press("Escape");
+
+		// Choosing SENAITE moves the role to the one it defines, since it has no
+		// central.
+		await page.getByRole("combobox", { name: "Product" }).click();
+		await page.getByRole("option", { name: "SENAITE" }).click();
+		await expect(kindField).toHaveText("standalone");
+	});
+
+	test("the public-name field is only offered for a publicly-listable product", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "listing-group" });
+
+		await page.goto(`/groups/${group.id}/servers/new`);
+
+		// The form opens on facility, which is not listed either; a central is.
+		await expect(page.getByLabel("Name in Tamanu Mobile app")).toHaveCount(0);
+		await page.getByRole("combobox", { name: "Kind" }).click();
+		await page.getByRole("option", { name: "central" }).click();
+		await expect(page.getByLabel("Name in Tamanu Mobile app")).toBeVisible();
+
+		// SENAITE cannot be listed at all, so choosing it takes the field away
+		// even though the role moves to standalone rather than staying central.
+		await page.getByRole("combobox", { name: "Product" }).click();
+		await page.getByRole("option", { name: "SENAITE" }).click();
+		await expect(page.getByLabel("Name in Tamanu Mobile app")).toHaveCount(0);
+	});
+
+	test("the fleet version spread covers only servers that have a version", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 2, minor: 34, patch: 1, status: "published" });
+		const central = await seedServer(sql, {
+			name: "fleet-central",
+			product: "tamanu",
+			kind: "central",
+		});
+		const lims = await seedServer(sql, {
+			name: "fleet-lims",
+			product: "senaite",
+		});
+		await seedStatus(sql, { serverId: central.id, version: "2.34.1" });
+		await seedStatus(sql, {
+			serverId: lims.id,
+			version: null,
+			extra: { pgVersion: "PostgreSQL 16.2" },
+		});
+
+		await page.goto("/servers/figures");
+
+		// The release spread counts the one server that has a release, and the
+		// SENAITE server is absent from it rather than counted as having failed
+		// to report one.
+		const release = page.getByRole("group", { name: "Tamanu release" });
+		await expect(release.getByRole("button", { name: "2.34: 1" })).toBeVisible();
+		await expect(
+			release.getByRole("button", { name: /not reported/ }),
+		).toHaveCount(0);
+
+		// The database-engine spread still covers the whole fleet: that figure
+		// has nothing to do with which product a server runs.
+		const postgres = page.getByRole("group", { name: "PostgreSQL major" });
+		await expect(postgres.getByRole("button", { name: "16: 1" })).toBeVisible();
+	});
+});

--- a/private-web/e2e/server-products.spec.ts
+++ b/private-web/e2e/server-products.spec.ts
@@ -195,4 +195,71 @@ test.describe("server products", () => {
 		const postgres = page.getByRole("group", { name: "PostgreSQL major" });
 		await expect(postgres.getByRole("button", { name: "16: 1" })).toBeVisible();
 	});
+
+	test("a canopy instance presents its own version ungraded", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 2, minor: 34, patch: 1, status: "published" });
+		const server = await seedServer(sql, {
+			name: "canopy-self",
+			product: "canopy",
+		});
+		// A canopy instance reports its own build version, which is nowhere near
+		// Tamanu's release numbering.
+		await seedStatus(sql, { serverId: server.id, version: "1.8.0" });
+
+		await page.goto(`/servers/${server.id}`);
+
+		// The version it reports is presented...
+		await expect(page.getByText("1.8.0")).toBeVisible();
+		// ...but graded against nothing: no distance from Tamanu's latest release,
+		// and no link into a catalogue that doesn't describe it.
+		await expect(
+			page.getByRole("link", { name: /versions behind/ }),
+		).toHaveCount(0);
+		await expect(page.getByRole("link", { name: /1\.8\.0/ })).toHaveCount(0);
+	});
+
+	test("a crossing on the application version drops uncovered servers from both axes", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 2, minor: 34, patch: 1, status: "published" });
+		const central = await seedServer(sql, {
+			name: "cross-central",
+			product: "tamanu",
+			kind: "central",
+		});
+		const lims = await seedServer(sql, {
+			name: "cross-lims",
+			product: "senaite",
+		});
+		await seedStatus(sql, {
+			serverId: central.id,
+			version: "2.34.1",
+			extra: { pgVersion: "PostgreSQL 16.2" },
+		});
+		// Distinct database major, so its presence or absence in the crossing is
+		// unambiguous.
+		await seedStatus(sql, {
+			serverId: lims.id,
+			version: null,
+			extra: { pgVersion: "PostgreSQL 13.12" },
+		});
+
+		await page.goto("/servers/figures");
+
+		// The crossing opens on the coarse version figures: database major
+		// against release.
+		const crossTab = page.getByRole("group", { name: "Cross two fields" });
+		await expect(crossTab.getByRole("rowheader").first()).toHaveText("16");
+		// The SENAITE server is dropped from the table entirely rather than
+		// occupying an unreported column, so its database major never appears as
+		// a row of its own.
+		await expect(crossTab.getByRole("rowheader", { name: "13" })).toHaveCount(0);
+		await expect(
+			crossTab.getByRole("columnheader", { name: "not reported" }),
+		).toHaveCount(0);
+	});
 });

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1722,6 +1722,41 @@
         }
       }
     },
+    "/api/commons/products": {
+      "post": {
+        "tags": [
+          "commons"
+        ],
+        "summary": "Describe every product canopy monitors.",
+        "description": "The operator UI reads this to decide what to present for a server — which\nroles to offer, whether a version applies and whether it can be graded,\nwhether the public-name field is meaningful — rather than restating the\nmapping client-side, where it would drift as products are added.",
+        "operationId": "products",
+        "responses": {
+          "200": {
+            "description": "Every product, its capabilities, and the roles it defines.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProductInfo"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/commons/public_url": {
       "post": {
         "tags": [
@@ -5438,7 +5473,7 @@
           "servers"
         ],
         "summary": "Update a server's fields.",
-        "description": "Applies a partial update — only the fields present in `data` are\nchanged. Moving a previously-ungrouped server into a group, or toggling\n`is_monitored`, re-evaluates the server's open issues so incidents catch\nup with the new state. Returns 400 if the update is rejected (e.g. an\ninvalid host value).",
+        "description": "Applies a partial update — only the fields present in `data` are\nchanged. Moving a previously-ungrouped server into a group, or toggling\n`is_monitored`, re-evaluates the server's open issues so incidents catch\nup with the new state. Returns 400 if the update is rejected (e.g. an\ninvalid host value, or a role the target product doesn't define).",
         "operationId": "server_update",
         "requestBody": {
           "content": {
@@ -7196,7 +7231,7 @@
       },
       "BillingTag": {
         "type": "object",
-        "description": "One effective billing label attributed to a group's cloud resources.\n\nLabels are computed from the group's configuration: explicit `billing.*`\ntags on the group are honoured verbatim; otherwise the product defaults to\n`tamanu`, the deployment to the group name in lower-kebab-case, and the\nstage to the group's highest-ranked live member (for example `prod`). The\nstage label is omitted entirely when the group has no ranked members.",
+        "description": "One effective billing label attributed to a group's cloud resources.\n\nLabels are computed from the group's configuration: explicit `billing.*`\ntags on the group are honoured verbatim; otherwise the product comes from\nthe one its live members agree on, the deployment from the group name in\nlower-kebab-case, and the stage from the group's highest-ranked live member\n(for example `prod`). A label with nothing to attribute to is omitted\nentirely: the stage when the group has no ranked members, and the product\nwhen its members span products.",
         "required": [
           "key",
           "value"
@@ -7209,6 +7244,24 @@
           "value": {
             "type": "string",
             "description": "Label value."
+          }
+        }
+      },
+      "Caps": {
+        "type": "object",
+        "description": "What canopy does for a product's servers.\n\nReachability, health checks and backups are deliberately absent: checks\nare graded by the source that reports them, and backup types are\nadvertised per-server by the agent, so both already work for any product.",
+        "required": [
+          "version_tracking",
+          "public_listing"
+        ],
+        "properties": {
+          "public_listing": {
+            "type": "boolean",
+            "description": "Whether this product's servers can be listed for end-user-facing\nclients."
+          },
+          "version_tracking": {
+            "$ref": "#/components/schemas/VersionTracking",
+            "description": "How this product's application version is treated."
           }
         }
       },
@@ -7847,7 +7900,7 @@
           },
           "kind": {
             "$ref": "#/components/schemas/ServerKind",
-            "description": "The kind of deployment this server represents."
+            "description": "The server's role within its product's topology. Rejected when the\nproduct does not define it."
           },
           "name": {
             "type": [
@@ -7862,6 +7915,10 @@
               "null"
             ],
             "description": "Free-text operator notes about the server."
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product",
+            "description": "The application this server runs. Defaults to tamanu."
           },
           "public_name": {
             "type": [
@@ -8262,6 +8319,7 @@
           "up",
           "health",
           "operators",
+          "product",
           "kind"
         ],
         "properties": {
@@ -8276,7 +8334,7 @@
           },
           "kind": {
             "$ref": "#/components/schemas/ServerKind",
-            "description": "The server's kind (central, facility, or canopy)."
+            "description": "The server's role within its product's topology (for Tamanu, central\nor facility; standalone for a product with no internal roles)."
           },
           "name": {
             "type": "string",
@@ -8288,6 +8346,10 @@
               "$ref": "#/components/schemas/OperatorPresence"
             },
             "description": "People currently connected to this server, from its latest status\nupdate. Always empty unless the server is actively reporting (`up`\nor `blip`) — a stale report can't be trusted to reflect who is\nconnected right now."
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product",
+            "description": "The application the server runs, presented alongside its role."
           },
           "rank": {
             "oneOf": [
@@ -8312,6 +8374,7 @@
         "required": [
           "server_id",
           "server_name",
+          "product",
           "kind",
           "detail",
           "checks"
@@ -8349,7 +8412,7 @@
           },
           "kind": {
             "$ref": "#/components/schemas/ServerKind",
-            "description": "The kind of deployment the server represents."
+            "description": "The server's role within its product's topology."
           },
           "nodejs": {
             "type": [
@@ -8371,6 +8434,10 @@
               "null"
             ],
             "description": "Reported database engine version."
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product",
+            "description": "The application the server runs. The fleet view reads it to keep the\napplication-version spread to servers that have one to report."
           },
           "rank": {
             "oneOf": [
@@ -10196,6 +10263,7 @@
               "description": "A server in the fleet inventory: its identity, classification, network\naddress, monitoring configuration, and (when requested by the endpoint)\ncurrent reachability/health.",
               "required": [
                 "id",
+                "product",
                 "kind",
                 "display_host",
                 "is_monitored",
@@ -10288,7 +10356,7 @@
                 },
                 "kind": {
                   "$ref": "#/components/schemas/ServerKind",
-                  "description": "The kind of deployment this server represents."
+                  "description": "The server's role within its product's topology."
                 },
                 "name": {
                   "type": [
@@ -10300,6 +10368,10 @@
                 "notes": {
                   "type": "string",
                   "description": "Free-text operator notes about the server."
+                },
+                "product": {
+                  "$ref": "#/components/schemas/Product",
+                  "description": "The application this server runs. Decides which of canopy's\nper-server features apply to it."
                 },
                 "public_name": {
                   "type": [
@@ -10627,6 +10699,46 @@
             "format": "uri",
             "description": "A URI reference identifying the problem type. Stable across\noccurrences of the same error, so callers can match on it.",
             "example": "/errors/resource-not-found"
+          }
+        }
+      },
+      "Product": {
+        "type": "string",
+        "description": "Which application a server runs.\n\nThe set is closed and defined here rather than configured, because each\nproduct's handling — what canopy tracks for it, what it presents — is\nbuilt in. See [`Product::caps`].",
+        "enum": [
+          "tamanu",
+          "senaite",
+          "canopy"
+        ]
+      },
+      "ProductInfo": {
+        "type": "object",
+        "description": "One product canopy monitors, with what canopy does for its servers and the\nroles it defines.",
+        "required": [
+          "product",
+          "caps",
+          "kinds",
+          "default_kind"
+        ],
+        "properties": {
+          "caps": {
+            "$ref": "#/components/schemas/Caps",
+            "description": "What canopy does for this product's servers."
+          },
+          "default_kind": {
+            "$ref": "#/components/schemas/ServerKind",
+            "description": "The role a server of this product takes when none is chosen."
+          },
+          "kinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServerKind"
+            },
+            "description": "The roles this product defines, in the order they rank when choosing a\ngroup's canonical member."
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product",
+            "description": "The product itself."
           }
         }
       },
@@ -12081,7 +12193,7 @@
               },
               {
                 "$ref": "#/components/schemas/ServerKind",
-                "description": "New deployment kind for the server. Omit to leave unchanged."
+                "description": "New role for the server within its product's topology. Omit to leave\nunchanged. Rejected when the product does not define it."
               }
             ]
           },
@@ -12098,6 +12210,17 @@
               "null"
             ],
             "description": "New free-text notes for the server. Omit to leave unchanged."
+          },
+          "product": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Product",
+                "description": "New application for the server. Omit to leave unchanged. Changing it\nto a product that does not define the server's kind moves the kind to\nthe new product's default, unless this request sets one too."
+              }
+            ]
           },
           "public_name": {
             "type": [
@@ -12148,7 +12271,7 @@
             "items": {
               "$ref": "#/components/schemas/BillingTag"
             },
-            "description": "The server's effective `billing.*` labels — i.e. its group's\n(product/deployment/stage). Empty when the server is ungrouped."
+            "description": "The server's own effective `billing.*` labels\n(product/deployment/stage) — the ones canopy hands the server's device,\ncarrying its own product and rank rather than its group's. Empty when\nthe server is ungrouped, there being no deployment to attribute to."
           },
           "checks": {
             "$ref": "#/components/schemas/ConsolidatedChecks",
@@ -12481,6 +12604,7 @@
         "description": "A server in the fleet inventory: its identity, classification, network\naddress, monitoring configuration, and (when requested by the endpoint)\ncurrent reachability/health.",
         "required": [
           "id",
+          "product",
           "kind",
           "display_host",
           "is_monitored",
@@ -12573,7 +12697,7 @@
           },
           "kind": {
             "$ref": "#/components/schemas/ServerKind",
-            "description": "The kind of deployment this server represents."
+            "description": "The server's role within its product's topology."
           },
           "name": {
             "type": [
@@ -12585,6 +12709,10 @@
           "notes": {
             "type": "string",
             "description": "Free-text operator notes about the server."
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product",
+            "description": "The application this server runs. Decides which of canopy's\nper-server features apply to it."
           },
           "public_name": {
             "type": [
@@ -12631,11 +12759,11 @@
       },
       "ServerKind": {
         "type": "string",
-        "description": "What kind of server this is within a deployment.",
+        "description": "A server's role relative to the other servers of its product.\n\nWhich kinds are available depends on the server's product; see\n[`Product::kinds`](super::product::Product::kinds).",
         "enum": [
           "central",
           "facility",
-          "canopy"
+          "standalone"
         ]
       },
       "ServerLastStatusData": {
@@ -12644,6 +12772,7 @@
         "required": [
           "id",
           "created_at",
+          "product",
           "source",
           "extra",
           "operators"
@@ -12706,6 +12835,10 @@
               "null"
             ],
             "description": "PostgreSQL version the server reported, if any."
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product",
+            "description": "The application the server runs. Travels with the version so a\nconsumer can tell a product with no version from one that has yet to\nreport one."
           },
           "source": {
             "type": "string",
@@ -13314,6 +13447,7 @@
           "id",
           "created_at",
           "server_id",
+          "product",
           "extra",
           "operators",
           "checks"
@@ -13387,6 +13521,10 @@
               "null"
             ],
             "description": "Reported database engine version."
+          },
+          "product": {
+            "$ref": "#/components/schemas/Product",
+            "description": "The application the server runs. Travels with the version so a\nconsumer can tell a product with no version from one that has yet to\nreport one."
           },
           "server_id": {
             "type": "string",
@@ -14024,6 +14162,15 @@
             "description": "Exact version string to look up (e.g. `\"1.2.3\"`)."
           }
         }
+      },
+      "VersionTracking": {
+        "type": "string",
+        "description": "How canopy treats a product's application version.",
+        "enum": [
+          "tracked",
+          "reported",
+          "absent"
+        ]
       }
     },
     "securitySchemes": {

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -12,6 +12,7 @@ import { NavLink, Navigate, Route, Routes } from "react-router-dom";
 import { useApi } from "./api";
 import AdminProbeBanner from "./components/AdminProbeBanner";
 import { AdminProvider } from "./hooks/useIsAdmin";
+import { ProductsProvider } from "./hooks/useProducts";
 import { useReloadInterval } from "./hooks/useReloadInterval";
 import Admins from "./routes/Admins";
 import BackupConfig from "./routes/BackupConfig";
@@ -100,6 +101,7 @@ export default function App() {
 
 	return (
 		<AdminProvider>
+		<ProductsProvider>
 		<Box>
 			<AppBar position="static" color="default" elevation={1}>
 				<Toolbar variant="dense" sx={{ gap: 2 }}>
@@ -255,6 +257,7 @@ export default function App() {
 				</Routes>
 			</Container>
 		</Box>
+		</ProductsProvider>
 		</AdminProvider>
 	);
 }

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -849,6 +849,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/commons/products": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Describe every product canopy monitors.
+         * @description The operator UI reads this to decide what to present for a server — which
+         *     roles to offer, whether a version applies and whether it can be graded,
+         *     whether the public-name field is meaningful — rather than restating the
+         *     mapping client-side, where it would drift as products are added.
+         */
+        post: operations["products"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/commons/public_url": {
         parameters: {
             query?: never;
@@ -2745,7 +2768,7 @@ export interface paths {
          *     changed. Moving a previously-ungrouped server into a group, or toggling
          *     `is_monitored`, re-evaluates the server's open issues so incidents catch
          *     up with the new state. Returns 400 if the update is rejected (e.g. an
-         *     invalid host value).
+         *     invalid host value, or a role the target product doesn't define).
          */
         post: operations["server_update"];
         delete?: never;
@@ -3797,16 +3820,34 @@ export interface components {
          * @description One effective billing label attributed to a group's cloud resources.
          *
          *     Labels are computed from the group's configuration: explicit `billing.*`
-         *     tags on the group are honoured verbatim; otherwise the product defaults to
-         *     `tamanu`, the deployment to the group name in lower-kebab-case, and the
-         *     stage to the group's highest-ranked live member (for example `prod`). The
-         *     stage label is omitted entirely when the group has no ranked members.
+         *     tags on the group are honoured verbatim; otherwise the product comes from
+         *     the one its live members agree on, the deployment from the group name in
+         *     lower-kebab-case, and the stage from the group's highest-ranked live member
+         *     (for example `prod`). A label with nothing to attribute to is omitted
+         *     entirely: the stage when the group has no ranked members, and the product
+         *     when its members span products.
          */
         BillingTag: {
             /** @description Label key, for example `billing.product`. */
             key: string;
             /** @description Label value. */
             value: string;
+        };
+        /**
+         * @description What canopy does for a product's servers.
+         *
+         *     Reachability, health checks and backups are deliberately absent: checks
+         *     are graded by the source that reports them, and backup types are
+         *     advertised per-server by the agent, so both already work for any product.
+         */
+        Caps: {
+            /**
+             * @description Whether this product's servers can be listed for end-user-facing
+             *     clients.
+             */
+            public_listing: boolean;
+            /** @description How this product's application version is treated. */
+            version_tracking: components["schemas"]["VersionTracking"];
         };
         /** @description Request body for [`check_detail`]. */
         CheckDetailArgs: {
@@ -4217,12 +4258,17 @@ export interface components {
              *     true.
              */
             is_monitored?: boolean | null;
-            /** @description The kind of deployment this server represents. */
+            /**
+             * @description The server's role within its product's topology. Rejected when the
+             *     product does not define it.
+             */
             kind: components["schemas"]["ServerKind"];
             /** @description Name for the server, if any. */
             name?: string | null;
             /** @description Free-text operator notes about the server. */
             notes?: string | null;
+            /** @description The application this server runs. Defaults to tamanu. */
+            product?: components["schemas"]["Product"];
             /**
              * @description Name to list the server under in the public mobile-app server list.
              *     Omit to keep it unlisted.
@@ -4465,7 +4511,10 @@ export interface components {
              * @description Unique identifier of the server.
              */
             id: string;
-            /** @description The server's kind (central, facility, or canopy). */
+            /**
+             * @description The server's role within its product's topology (for Tamanu, central
+             *     or facility; standalone for a product with no internal roles).
+             */
             kind: components["schemas"]["ServerKind"];
             /** @description Name of the server. */
             name: string;
@@ -4476,6 +4525,8 @@ export interface components {
              *     connected right now.
              */
             operators: components["schemas"]["OperatorPresence"][];
+            /** @description The application the server runs, presented alongside its role. */
+            product: components["schemas"]["Product"];
             rank?: null | components["schemas"]["ServerRank"];
             /**
              * @description Reachability of the server, based on how recently it last reported a
@@ -4509,7 +4560,7 @@ export interface components {
             group_id?: string | null;
             /** @description Display name of that group, if any. */
             group_name?: string | null;
-            /** @description The kind of deployment the server represents. */
+            /** @description The server's role within its product's topology. */
             kind: components["schemas"]["ServerKind"];
             /** @description Reported runtime version. */
             nodejs?: string | null;
@@ -4517,6 +4568,11 @@ export interface components {
             platform?: string | null;
             /** @description Reported database engine version. */
             postgres?: string | null;
+            /**
+             * @description The application the server runs. The fleet view reads it to keep the
+             *     application-version spread to servers that have one to report.
+             */
+            product: components["schemas"]["Product"];
             rank?: null | components["schemas"]["ServerRank"];
             /**
              * Format: uuid
@@ -5747,12 +5803,17 @@ export interface components {
                  *     incidents.
                  */
                 is_monitored: boolean;
-                /** @description The kind of deployment this server represents. */
+                /** @description The server's role within its product's topology. */
                 kind: components["schemas"]["ServerKind"];
                 /** @description Operator-assigned name for the server, if any. */
                 name?: string | null;
                 /** @description Free-text operator notes about the server. */
                 notes: string;
+                /**
+                 * @description The application this server runs. Decides which of canopy's
+                 *     per-server features apply to it.
+                 */
+                product: components["schemas"]["Product"];
                 /**
                  * @description Name this server appears under in the public mobile-app server list.
                  *     `None` means the server is not listed publicly.
@@ -5950,6 +6011,32 @@ export interface components {
              * @example /errors/resource-not-found
              */
             type: string;
+        };
+        /**
+         * @description Which application a server runs.
+         *
+         *     The set is closed and defined here rather than configured, because each
+         *     product's handling — what canopy tracks for it, what it presents — is
+         *     built in. See [`Product::caps`].
+         * @enum {string}
+         */
+        Product: "tamanu" | "senaite" | "canopy";
+        /**
+         * @description One product canopy monitors, with what canopy does for its servers and the
+         *     roles it defines.
+         */
+        ProductInfo: {
+            /** @description What canopy does for this product's servers. */
+            caps: components["schemas"]["Caps"];
+            /** @description The role a server of this product takes when none is chosen. */
+            default_kind: components["schemas"]["ServerKind"];
+            /**
+             * @description The roles this product defines, in the order they rank when choosing a
+             *     group's canonical member.
+             */
+            kinds: components["schemas"]["ServerKind"][];
+            /** @description The product itself. */
+            product: components["schemas"]["Product"];
         };
         /** @description Request to mint a new device credential. */
         ProvisionArgs: {
@@ -6931,6 +7018,7 @@ export interface components {
             name?: string | null;
             /** @description New free-text notes for the server. Omit to leave unchanged. */
             notes?: string | null;
+            product?: null | components["schemas"]["Product"];
             /**
              * @description New public-facing name for the server, or `null` to unlist it. Omit
              *     to leave unchanged.
@@ -6945,8 +7033,10 @@ export interface components {
          */
         ServerDetailData: {
             /**
-             * @description The server's effective `billing.*` labels — i.e. its group's
-             *     (product/deployment/stage). Empty when the server is ungrouped.
+             * @description The server's own effective `billing.*` labels
+             *     (product/deployment/stage) — the ones canopy hands the server's device,
+             *     carrying its own product and rank rather than its group's. Empty when
+             *     the server is ungrouped, there being no deployment to attribute to.
              */
             billing_labels: components["schemas"]["BillingTag"][];
             /**
@@ -7200,12 +7290,17 @@ export interface components {
              *     incidents.
              */
             is_monitored: boolean;
-            /** @description The kind of deployment this server represents. */
+            /** @description The server's role within its product's topology. */
             kind: components["schemas"]["ServerKind"];
             /** @description Operator-assigned name for the server, if any. */
             name?: string | null;
             /** @description Free-text operator notes about the server. */
             notes: string;
+            /**
+             * @description The application this server runs. Decides which of canopy's
+             *     per-server features apply to it.
+             */
+            product: components["schemas"]["Product"];
             /**
              * @description Name this server appears under in the public mobile-app server list.
              *     `None` means the server is not listed publicly.
@@ -7223,10 +7318,13 @@ export interface components {
             up?: null | components["schemas"]["ShortStatus"];
         };
         /**
-         * @description What kind of server this is within a deployment.
+         * @description A server's role relative to the other servers of its product.
+         *
+         *     Which kinds are available depends on the server's product; see
+         *     [`Product::kinds`](super::product::Product::kinds).
          * @enum {string}
          */
-        ServerKind: "central" | "facility" | "canopy";
+        ServerKind: "central" | "facility" | "standalone";
         /**
          * @description The server's most recently reported status push: version/host info plus
          *     health.
@@ -7267,6 +7365,12 @@ export interface components {
             platform?: string | null;
             /** @description PostgreSQL version the server reported, if any. */
             postgres?: string | null;
+            /**
+             * @description The application the server runs. Travels with the version so a
+             *     consumer can tell a product with no version from one that has yet to
+             *     report one.
+             */
+            product: components["schemas"]["Product"];
             /** @description The source that pushed this status (e.g. `alertd`). */
             source: string;
             /** @description Timezone the server reported, if any. */
@@ -7696,6 +7800,12 @@ export interface components {
             /** @description Reported database engine version. */
             postgres?: string | null;
             /**
+             * @description The application the server runs. Travels with the version so a
+             *     consumer can tell a product with no version from one that has yet to
+             *     report one.
+             */
+            product: components["schemas"]["Product"];
+            /**
              * Format: uuid
              * @description Id of the server this status was reported by.
              */
@@ -8083,6 +8193,11 @@ export interface components {
             /** @description Exact version string to look up (e.g. `"1.2.3"`). */
             version: string;
         };
+        /**
+         * @description How canopy treats a product's application version.
+         * @enum {string}
+         */
+        VersionTracking: "tracked" | "reported" | "absent";
     };
     responses: never;
     parameters: never;
@@ -9258,6 +9373,34 @@ export interface operations {
                 };
             };
             /** @description The caller's admin status could not be determined. Distinct from a `false` answer: retry rather than treating the caller as a non-admin. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    products: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Every product, its capabilities, and the roles it defines. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProductInfo"][];
+                };
+            };
             500: {
                 headers: {
                     [name: string]: unknown;

--- a/private-web/src/components/ServerKindChip.tsx
+++ b/private-web/src/components/ServerKindChip.tsx
@@ -4,7 +4,7 @@ import type { ServerKind } from "../types";
 const COLORS: Record<ServerKind, "primary" | "info" | "default"> = {
 	central: "primary",
 	facility: "info",
-	canopy: "default",
+	standalone: "default",
 };
 
 export default function ServerKindChip({ kind }: { kind: ServerKind }) {

--- a/private-web/src/components/ServerProductChip.tsx
+++ b/private-web/src/components/ServerProductChip.tsx
@@ -1,0 +1,19 @@
+import { Chip } from "@mui/material";
+import { PRODUCT_LABELS, type Product } from "../types";
+
+const COLORS: Record<Product, "success" | "secondary" | "default"> = {
+	tamanu: "success",
+	senaite: "secondary",
+	canopy: "default",
+};
+
+export default function ServerProductChip({ product }: { product: Product }) {
+	return (
+		<Chip
+			size="small"
+			variant="outlined"
+			color={COLORS[product]}
+			label={PRODUCT_LABELS[product]}
+		/>
+	);
+}

--- a/private-web/src/components/ServerShorty.tsx
+++ b/private-web/src/components/ServerShorty.tsx
@@ -1,7 +1,14 @@
 import { Box, Chip, Link as MuiLink, Stack, Tooltip, Typography } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
-import type { HealthState, ServerKind, ServerRank, ShortStatus } from "../types";
+import type {
+	HealthState,
+	Product,
+	ServerKind,
+	ServerRank,
+	ShortStatus,
+} from "../types";
 import ServerKindChip from "./ServerKindChip";
+import ServerProductChip from "./ServerProductChip";
 import ServerNameWithGroup from "./ServerNameWithGroup";
 import ServerRankChip from "./ServerRankChip";
 import StatusDot from "./StatusDot";
@@ -11,6 +18,7 @@ export interface ServerInfo {
 	name: string | null;
 	host?: string | null;
 	display_host: string;
+	product: Product;
 	kind: ServerKind;
 	rank: ServerRank | null;
 	group_name?: string | null;
@@ -50,6 +58,7 @@ export default function ServerShorty({ server }: { server: ServerInfo }) {
 				/>
 			</MuiLink>
 			{server.rank && <ServerRankChip rank={server.rank} />}
+			<ServerProductChip product={server.product} />
 			<ServerKindChip kind={server.kind} />
 			{unmonitored && (
 				<Tooltip title="Status alerts are off for this server — canopy isn't watching it.">

--- a/private-web/src/components/StatusSnapshot.tsx
+++ b/private-web/src/components/StatusSnapshot.tsx
@@ -24,6 +24,8 @@ import HealthChip from "./HealthChip";
 import TimeAgo from "./TimeAgo";
 import TimezoneTooltip from "./TimezoneTooltip";
 import VersionIndicator from "./VersionIndicator";
+import { useProductCaps } from "../hooks/useProducts";
+import { PRODUCT_LABELS } from "../types";
 import {
 	CHECK_RESULT_INTENT,
 	type CheckResult,
@@ -120,14 +122,23 @@ function PanelBody({
 }
 
 function CuratedFields({ snap }: { snap: StatusSnapshotData }) {
+	const caps = useProductCaps(snap.product);
+	const tracking = caps?.version_tracking;
 	return (
 		<Stack direction="row" spacing={3} sx={{ flexWrap: "wrap" }} useFlexGap>
-			<Field label="Tamanu">
-				<VersionIndicator
-					version={snap.version}
-					distance={snap.version_distance}
-				/>
-			</Field>
+			{/* A product with no application version shows no version field at
+			    all — label included, since an empty "Version" reads as a
+			    reporting failure rather than an absence.
+			    spec: APP#versions */}
+			{tracking !== undefined && tracking !== "absent" && (
+				<Field label={PRODUCT_LABELS[snap.product]}>
+					<VersionIndicator
+						version={snap.version}
+						tracking={tracking}
+						distance={snap.version_distance}
+					/>
+				</Field>
+			)}
 			{snap.platform && <Field label="Platform" value={snap.platform} />}
 			{snap.timezone && (
 				<Field label="Timezone">

--- a/private-web/src/components/VersionIndicator.tsx
+++ b/private-web/src/components/VersionIndicator.tsx
@@ -1,19 +1,38 @@
 import { Link as MuiLink, Stack } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
-import type { VersionStr } from "../types";
+import type { VersionStr, VersionTracking } from "../types";
 import VersionSquare from "./VersionSquare";
 
 interface VersionIndicatorProps {
 	version: VersionStr | null;
+	/// How the server's product treats versions. `absent` renders nothing at
+	/// all — there is no version to learn, so an "unknown" would read as a
+	/// reporting failure. `reported` renders the bare version: canopy holds no
+	/// release train to measure it against, so there is nothing to grade or to
+	/// link to. Only `tracked` gets the distance square and the catalogue link.
+	/// `undefined` while the product catalogue is still loading, which also
+	/// renders nothing — better a momentarily blank cell than an "unknown" for
+	/// a server that has no version.
+	// spec: APP#versions
+	tracking: VersionTracking | undefined;
 	distance?: number | null;
 	addLink?: boolean;
 }
 
 export default function VersionIndicator({
 	version,
+	tracking,
 	distance = null,
 	addLink = true,
 }: VersionIndicatorProps) {
+	if (tracking === undefined || tracking === "absent") {
+		return null;
+	}
+
+	if (tracking === "reported") {
+		return <span>{version ?? "unknown"}</span>;
+	}
+
 	const inner = (
 		<Stack direction="row" spacing={0.5} component="span" sx={{ alignItems: "center" }}>
 			<span>{version ?? "unknown"}</span>

--- a/private-web/src/hooks/useProducts.tsx
+++ b/private-web/src/hooks/useProducts.tsx
@@ -1,0 +1,106 @@
+import { type ReactNode, createContext, useContext, useMemo } from "react";
+import { useApi } from "../api";
+import type {
+	Caps,
+	Product,
+	ProductInfo,
+	ServerKind,
+	VersionTracking,
+} from "../types";
+
+// `null` (not `undefined`) so consumers can tell "no provider mounted" apart
+// from "provider mounted, not yet loaded".
+const ProductsContext = createContext<ProductInfo[] | null | undefined>(null);
+
+/** Loads the product catalogue once per session and shares it with the tree.
+ *
+ * What canopy does for a product — whether its servers have a version, whether
+ * that version can be graded, which roles it defines — is decided in the
+ * backend's capability table. The UI reads it from there rather than keeping
+ * its own copy, which would drift the moment a product is added. */
+export function ProductsProvider({ children }: { children: ReactNode }) {
+	// The catalogue is compiled into the backend, so it can't change under a
+	// running session: fetch once, no reload interval.
+	const probe = useApi("commons", "products", {});
+	const products = probe.status === "ok" ? probe.data : undefined;
+	return (
+		<ProductsContext.Provider value={products}>
+			{children}
+		</ProductsContext.Provider>
+	);
+}
+
+function useProductCatalogue(): ProductInfo[] | undefined {
+	const ctx = useContext(ProductsContext);
+	if (ctx === null) {
+		throw new Error("useProducts must be used inside <ProductsProvider>");
+	}
+	return ctx;
+}
+
+/** Every product, for pickers. Empty until the catalogue loads. */
+export function useProducts(): ProductInfo[] {
+	return useProductCatalogue() ?? [];
+}
+
+/** One product's capabilities, or `undefined` until the catalogue loads.
+ *
+ * Callers render nothing rather than guessing while this is `undefined`: a
+ * version cell that assumes "tracked" would flash an "unknown" for a product
+ * that has no version at all. */
+export function useProductCaps(product: Product): Caps | undefined {
+	const catalogue = useProductCatalogue();
+	return useMemo(
+		() => catalogue?.find((p) => p.product === product)?.caps,
+		[catalogue, product],
+	);
+}
+
+/** How versions should be treated across a set of servers' products — for a
+ * figure that summarises several servers at once, like a group's headline
+ * version.
+ *
+ * The strongest treatment present wins: a group with one Tamanu member has a
+ * version to grade whatever else it holds, and only a group where nothing has
+ * a version at all shows none. `undefined` until the catalogue loads. */
+export function useVersionTrackingAcross(
+	products: readonly Product[],
+): VersionTracking | undefined {
+	const catalogue = useProductCatalogue();
+	return useMemo(() => {
+		if (!catalogue) return undefined;
+		const tracking = products.map(
+			(p) => catalogue.find((c) => c.product === p)?.caps.version_tracking,
+		);
+		if (tracking.includes("tracked")) return "tracked";
+		if (tracking.includes("reported")) return "reported";
+		return "absent";
+	}, [catalogue, products]);
+}
+
+/** A predicate for whether a product's version is graded against a release
+ * train canopy holds — for filtering a fleet-wide spread down to the servers a
+ * version figure actually covers.
+ *
+ * Reports `true` for every product until the catalogue loads, so the spread
+ * starts from what it has always shown and narrows once the answer arrives,
+ * rather than briefly dropping rows. */
+export function useIsVersionTracked(): (product: Product) => boolean {
+	const catalogue = useProductCatalogue();
+	return useMemo(
+		() => (product: Product) => {
+			const found = catalogue?.find((p) => p.product === product);
+			return found === undefined || found.caps.version_tracking === "tracked";
+		},
+		[catalogue],
+	);
+}
+
+/** The roles a product defines, in rank order. Empty until loaded. */
+export function useProductKinds(product: Product): ServerKind[] {
+	const catalogue = useProductCatalogue();
+	return useMemo(
+		() => catalogue?.find((p) => p.product === product)?.kinds ?? [],
+		[catalogue, product],
+	);
+}

--- a/private-web/src/routes/FleetFigures.tsx
+++ b/private-web/src/routes/FleetFigures.tsx
@@ -29,8 +29,9 @@ import { Link as RouterLink } from "react-router-dom";
 import { useApi } from "../api";
 import { usePageTitle } from "../hooks/usePageTitle";
 import { useReloadInterval } from "../hooks/useReloadInterval";
+import { useIsVersionTracked } from "../hooks/useProducts";
 import { valueComparator } from "../lib/valueOrder";
-import type { FleetServerDetailData } from "../types";
+import type { FleetServerDetailData, Product } from "../types";
 
 /// How many distinct values a distribution card shows before collapsing the
 /// rest. A field like `uptimeSecs` is near-unique across the fleet, and a
@@ -92,6 +93,25 @@ const FIGURES: Figure[] = [
 	{ key: "nodejs", label: "Node.js", card: true, pick: (s) => s.nodejs },
 	{ key: "timezone", label: "Timezone", card: true, pick: (s) => s.timezone },
 ];
+
+/// The fields whose spread covers only the servers whose product canopy holds
+/// a release train for. A server that has no application version to report is
+/// absent from these spreads rather than counted among those reporting nothing
+/// — it isn't a server that failed to report, it's a server with nothing to
+/// report. Every other field, including the database-engine and bestool
+/// versions, still covers the whole fleet.
+// spec: APP#versions
+const VERSION_TRACKED_FIELDS = new Set(["release", "version"]);
+
+/// Narrow a server list to the ones a field's spread covers.
+function coveredBy(
+	field: string,
+	servers: FleetServerDetailData[],
+	isVersionTracked: (product: Product) => boolean,
+): FleetServerDetailData[] {
+	if (!VERSION_TRACKED_FIELDS.has(field)) return servers;
+	return servers.filter((s) => isVersionTracked(s.product));
+}
 
 /// The name to present a field under: a figure's own label, or the field
 /// name as an operator typed it.
@@ -216,6 +236,7 @@ export default function FleetFigures() {
 	usePageTitle("Fleet figures");
 	const tick = useReloadInterval(60_000, "canopy-data-changed");
 	const result = useApi("statuses", "fleet_detail", {}, [tick]);
+	const isVersionTracked = useIsVersionTracked();
 
 	const servers = result.status === "ok" ? result.data : [];
 
@@ -266,14 +287,21 @@ export default function FleetFigures() {
 					},
 				}}
 			>
-				{FIGURES.filter((figure) => figure.card).map((figure) => (
-					<DistributionCard
-						key={figure.key}
-						label={figure.label}
-						groups={distribution(servers, figure.pick)}
-						total={servers.length}
-					/>
-				))}
+				{FIGURES.filter((figure) => figure.card).map((figure) => {
+					// Each card's total is the population it actually covers, so
+					// the version cards read against the servers that have a
+					// version rather than the whole fleet.
+					// spec: APP#versions
+					const covered = coveredBy(figure.key, servers, isVersionTracked);
+					return (
+						<DistributionCard
+							key={figure.key}
+							label={figure.label}
+							groups={distribution(covered, figure.pick)}
+							total={covered.length}
+						/>
+					);
+				})}
 			</Box>
 
 			<LookupCard servers={servers} keys={reportedKeys} />
@@ -439,9 +467,16 @@ function LookupCard({
 	keys: string[];
 }) {
 	const [field, setField] = useState<string | null>(null);
+	const isVersionTracked = useIsVersionTracked();
 	const groups = useMemo(
-		() => (field === null ? [] : distribution(servers, picker(field))),
-		[servers, field],
+		() =>
+			field === null
+				? []
+				: distribution(
+						coveredBy(field, servers, isVersionTracked),
+						picker(field),
+					),
+		[servers, field, isVersionTracked],
 	);
 	// The figures the page doesn't lead with — the exact versions behind the
 	// coarse groupings, mostly — are only reachable here and in the crossing.
@@ -513,13 +548,23 @@ function CrossTab({
 	const [cell, setCell] = useState<string | null>(null);
 	const [sort, setSort] = useState<SortMode>("popularity");
 
+	const isVersionTracked = useIsVersionTracked();
 	const { rows, cols, counts } = useMemo(() => {
 		const pickRow = picker(rowField);
 		const pickCol = picker(colField);
-		const rowGroups = orderGroups(distribution(servers, pickRow), sort);
-		const colGroups = orderGroups(distribution(servers, pickCol), sort);
+		// A server absent from either axis is dropped from the table rather
+		// than placed in an unreported row, so a crossing never implies it
+		// failed to report a figure it doesn't have.
+		// spec: APP#versions
+		const covered = coveredBy(
+			colField,
+			coveredBy(rowField, servers, isVersionTracked),
+			isVersionTracked,
+		);
+		const rowGroups = orderGroups(distribution(covered, pickRow), sort);
+		const colGroups = orderGroups(distribution(covered, pickCol), sort);
 		const counts = new Map<string, FleetServerDetailData[]>();
-		for (const server of servers) {
+		for (const server of covered) {
 			const key = `${bucket(pickRow(server))} ${bucket(pickCol(server))}`;
 			const existing = counts.get(key);
 			if (existing) existing.push(server);
@@ -530,7 +575,7 @@ function CrossTab({
 			cols: colGroups.map((g) => g.value),
 			counts,
 		};
-	}, [servers, rowField, colField, sort]);
+	}, [servers, rowField, colField, sort, isVersionTracked]);
 
 	const label = (value: string | null) => value ?? "not reported";
 

--- a/private-web/src/routes/ServerCreate.tsx
+++ b/private-web/src/routes/ServerCreate.tsx
@@ -15,7 +15,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { callApi, useApi, useApiAction } from "../api";
 import TagsEditor from "../components/TagsEditor";
 import { usePageTitle } from "../hooks/usePageTitle";
+import {
+	useProductCaps,
+	useProductKinds,
+	useProducts,
+} from "../hooks/useProducts";
+import { PRODUCT_LABELS } from "../types";
 import type {
+	Product,
 	ServerGroup,
 	ServerKind,
 	ServerRank,
@@ -44,7 +51,12 @@ export default function ServerCreate() {
 
 	const [name, setName] = useState("");
 	const [host, setHost] = useState("");
+	const [product, setProduct] = useState<Product>("tamanu");
 	const [kind, setKind] = useState<ServerKind>("facility");
+	const products = useProducts();
+	const kinds = useProductKinds(product);
+	const caps = useProductCaps(product);
+	const canListPublicly = caps?.public_listing === true && kind === "central";
 	const [rank, setRank] = useState<ServerRank | "">("");
 	const [publicName, setPublicName] = useState("");
 	const [isMonitored, setIsMonitored] = useState(true);
@@ -63,9 +75,14 @@ export default function ServerCreate() {
 		const data: Record<string, unknown> = {
 			name: name.trim(),
 			host: host.trim(),
+			product,
 			kind,
 			rank: rank === "" ? null : rank,
-			public_name: publicName.trim() === "" ? null : publicName.trim(),
+			// Only a product/kind combination that can be listed carries a
+			// public name; the field isn't offered otherwise.
+			// spec: APP#public-listing
+			public_name:
+				canListPublicly && publicName.trim() !== "" ? publicName.trim() : null,
 			group_id: groupId,
 			tailscale_identifier:
 				tailscaleIdentifier.trim() === "" ? null : tailscaleIdentifier.trim(),
@@ -110,13 +127,44 @@ export default function ServerCreate() {
 				/>
 				<TextField
 					select
+					label="Product"
+					value={product}
+					onChange={(e) => {
+						const next = e.target.value as Product;
+						setProduct(next);
+						// A role its new product doesn't define would leave the
+						// server misclassified, so follow the product.
+						// spec: APP#product-and-kind
+						const info = products.find((p) => p.product === next);
+						if (info && !info.kinds.includes(kind)) {
+							setKind(info.default_kind);
+						}
+					}}
+					disabled={action.pending}
+				>
+					{products.map((p) => (
+						<MenuItem key={p.product} value={p.product}>
+							{PRODUCT_LABELS[p.product]}
+						</MenuItem>
+					))}
+				</TextField>
+				<TextField
+					select
 					label="Kind"
 					value={kind}
 					onChange={(e) => setKind(e.target.value as ServerKind)}
-					disabled={action.pending}
+					disabled={action.pending || kinds.length < 2}
+					helperText={
+						kinds.length < 2
+							? `${PRODUCT_LABELS[product]} servers have one role`
+							: undefined
+					}
 				>
-					<MenuItem value="central">central</MenuItem>
-					<MenuItem value="facility">facility</MenuItem>
+					{kinds.map((k) => (
+						<MenuItem key={k} value={k}>
+							{k}
+						</MenuItem>
+					))}
 				</TextField>
 				<TextField
 					select
@@ -174,7 +222,7 @@ export default function ServerCreate() {
 					/>
 				</Stack>
 
-				{kind === "central" && (
+				{canListPublicly && (
 					<TextField
 						label="Name in Tamanu Mobile app"
 						value={publicName}

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -65,6 +65,9 @@ import { BackupProcessingChip } from "../components/BackupProcessingChip";
 import { BackupLiveProgress } from "../components/BackupLiveProgress";
 import TimezoneTooltip from "../components/TimezoneTooltip";
 import VersionIndicator from "../components/VersionIndicator";
+import ServerProductChip from "../components/ServerProductChip";
+import { useProductCaps } from "../hooks/useProducts";
+import { PRODUCT_LABELS } from "../types";
 import { HealthLegend, StatusLegend, VersionLegend } from "../components/Legends";
 import ServerKindChip from "../components/ServerKindChip";
 import ServerRankChip from "../components/ServerRankChip";
@@ -277,6 +280,7 @@ function Header({
 				useFlexGap
 			>
 				{data.server.rank && <ServerRankChip rank={data.server.rank} />}
+				<ServerProductChip product={data.server.product} />
 				<ServerKindChip kind={data.server.kind} />
 				<Typography variant="h4" component="h1" sx={{ ml: 1 }}>
 					<SiblingDotStrip
@@ -1422,6 +1426,7 @@ function SilenceScopeRow({
 }
 
 function StatusInfoFields({ status }: { status: ServerLastStatusData }) {
+	const tracking = useProductCaps(status.product)?.version_tracking;
 	return (
 		<>
 			<Stack spacing={0.25}>
@@ -1442,15 +1447,22 @@ function StatusInfoFields({ status }: { status: ServerLastStatusData }) {
 					</Typography>
 				</InfoItem>
 			)}
-			<Stack spacing={0.25}>
-				<Typography variant="caption" color="text.secondary">
-					Tamanu
-				</Typography>
-				<VersionIndicator
-					version={status.version}
-					distance={status.version_distance}
-				/>
-			</Stack>
+			{/* A product with no application version shows no version block at
+			    all — the caption included, since an empty one reads as a
+			    reporting failure rather than an absence.
+			    spec: APP#versions */}
+			{tracking !== undefined && tracking !== "absent" && (
+				<Stack spacing={0.25}>
+					<Typography variant="caption" color="text.secondary">
+						{PRODUCT_LABELS[status.product]}
+					</Typography>
+					<VersionIndicator
+						version={status.version}
+						tracking={tracking}
+						distance={status.version_distance}
+					/>
+				</Stack>
+			)}
 			{status.postgres && (
 				<InfoItem
 					label="PostgreSQL"

--- a/private-web/src/routes/ServerEdit.tsx
+++ b/private-web/src/routes/ServerEdit.tsx
@@ -16,7 +16,14 @@ import { useNavigate, useParams } from "react-router-dom";
 import { callApi, useApi, useApiAction } from "../api";
 import TagsEditor from "../components/TagsEditor";
 import { usePageTitle } from "../hooks/usePageTitle";
+import {
+	useProductCaps,
+	useProductKinds,
+	useProducts,
+} from "../hooks/useProducts";
+import { PRODUCT_LABELS } from "../types";
 import type {
+	Product,
 	ServerGroup,
 	ServerInfo,
 	ServerKind,
@@ -55,7 +62,12 @@ function EditForm({ info }: { info: ServerInfo }) {
 
 	const [name, setName] = useState(info.name ?? "");
 	const [host, setHost] = useState(info.host ?? "");
+	const [product, setProduct] = useState<Product>(info.product);
 	const [kind, setKind] = useState<ServerKind>(info.kind);
+	const products = useProducts();
+	const kinds = useProductKinds(product);
+	const caps = useProductCaps(product);
+	const canListPublicly = caps?.public_listing === true && kind === "central";
 	const [rank, setRank] = useState<ServerRank | "">(info.rank ?? "");
 	const [publicName, setPublicName] = useState<string>(info.public_name ?? "");
 	// `is_monitored` carries the on/off toggle; `alert_when_down_for` is the
@@ -82,8 +94,13 @@ function EditForm({ info }: { info: ServerInfo }) {
 			name: name.trim(),
 			// Empty string clears the URL (server identified by its device only).
 			host: host.trim(),
+			product,
 			kind,
 			rank: rank === "" ? null : rank,
+			// Sent whether or not the field is currently offered: a public name
+			// already set survives the server losing eligibility, and takes effect
+			// again if it regains it.
+			// spec: APP#public-listing
 			public_name: publicName.trim() === "" ? null : publicName.trim(),
 			group_id: groupId,
 			device_id: deviceId.trim() === "" ? null : deviceId.trim(),
@@ -130,13 +147,45 @@ function EditForm({ info }: { info: ServerInfo }) {
 				/>
 				<TextField
 					select
+					label="Product"
+					value={product}
+					onChange={(e) => {
+						const next = e.target.value as Product;
+						setProduct(next);
+						// A role its new product doesn't define would leave the
+						// server misclassified, so follow the product. The
+						// endpoint applies the same rule if we don't.
+						// spec: APP#product-and-kind
+						const info = products.find((p) => p.product === next);
+						if (info && !info.kinds.includes(kind)) {
+							setKind(info.default_kind);
+						}
+					}}
+					disabled={action.pending}
+				>
+					{products.map((p) => (
+						<MenuItem key={p.product} value={p.product}>
+							{PRODUCT_LABELS[p.product]}
+						</MenuItem>
+					))}
+				</TextField>
+				<TextField
+					select
 					label="Kind"
 					value={kind}
 					onChange={(e) => setKind(e.target.value as ServerKind)}
-					disabled={action.pending}
+					disabled={action.pending || kinds.length < 2}
+					helperText={
+						kinds.length < 2
+							? `${PRODUCT_LABELS[product]} servers have one role`
+							: undefined
+					}
 				>
-					<MenuItem value="central">central</MenuItem>
-					<MenuItem value="facility">facility</MenuItem>
+					{kinds.map((k) => (
+						<MenuItem key={k} value={k}>
+							{k}
+						</MenuItem>
+					))}
 				</TextField>
 				<TextField
 					select
@@ -195,7 +244,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 					/>
 				</Stack>
 
-				{kind === "central" && (
+				{canListPublicly && (
 					<TextField
 						label="Name in Tamanu Mobile app"
 						value={publicName}

--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -13,9 +13,11 @@ import {
 } from "@mui/material";
 import BarChartIcon from "@mui/icons-material/BarChart";
 import PersonIcon from "@mui/icons-material/Person";
+import { useMemo } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import StatusDot from "../components/StatusDot";
 import VersionIndicator from "../components/VersionIndicator";
+import { useVersionTrackingAcross } from "../hooks/useProducts";
 import {
 	HealthLegend,
 	OperatorLegend,
@@ -300,6 +302,13 @@ function GroupCard({
 	operators: AggregatedOperator[];
 	openIncident: IncidentLoudness | null;
 }) {
+	// The headline version comes from whichever member speaks for the group, so
+	// how to present it follows from the products its members actually have: a
+	// group with no versioned member shows no version rather than an "unknown".
+	// spec: APP#versions
+	const tracking = useVersionTrackingAcross(
+		useMemo(() => group.members.map((m) => m.product), [group.members]),
+	);
 	return (
 		<Stack spacing={1}>
 			<Stack
@@ -322,6 +331,7 @@ function GroupCard({
 				<Box sx={{ flexShrink: 0 }}>
 					<VersionIndicator
 						version={group.version}
+						tracking={tracking}
 						distance={group.version_distance}
 						addLink={false}
 					/>

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -74,6 +74,10 @@ export type Solidify<T> = T extends readonly unknown[]
 export type ShortStatus = Solidify<Schemas["ShortStatus"]>;
 export type HealthState = Solidify<Schemas["HealthState"]>;
 export type ServerKind = Solidify<Schemas["ServerKind"]>;
+export type Product = Solidify<Schemas["Product"]>;
+export type VersionTracking = Solidify<Schemas["VersionTracking"]>;
+export type Caps = Solidify<Schemas["Caps"]>;
+export type ProductInfo = Solidify<Schemas["ProductInfo"]>;
 export type ServerRank = Solidify<Schemas["ServerRank"]>;
 export type VersionStatus = Solidify<Schemas["VersionStatus"]>;
 export type DeviceRole = Solidify<Schemas["DeviceRole"]>;
@@ -215,10 +219,22 @@ export const SERVER_RANK_ORDER: ServerRank[] = [
 	"dev",
 ];
 
+/// Human-readable product names. The wire values are lowercase identifiers;
+/// these are how a product is written in the UI.
+export const PRODUCT_LABELS: Record<Product, string> = {
+	tamanu: "Tamanu",
+	senaite: "SENAITE",
+	canopy: "Canopy",
+};
+
 /// Display order for server kinds — centrals first, then facilities,
-/// then canopy's own. Used as a tiebreak within a single rank in
+/// then standalone. Used as a tiebreak within a single rank in
 /// status-dot lists / group detail views.
-export const SERVER_KIND_ORDER: ServerKind[] = ["central", "facility", "canopy"];
+export const SERVER_KIND_ORDER: ServerKind[] = [
+	"central",
+	"facility",
+	"standalone",
+];
 
 /// Sort key combining rank index (with `null` ranks pushed last) and
 /// kind index. Stable per-rank ordering matches what the UI grouping


### PR DESCRIPTION
🤖 Canopy is taking on non-Tamanu servers, SENAITE being the first. Until now every server was implicitly a Tamanu server: `ServerKind` conflated a *product* (`Canopy`) with two Tamanu *topology roles* (`Central`, `Facility`), and the version catalogue has no product dimension at all, so any server's reported version was graded against Tamanu's release train.

This adds a `product` axis alongside `kind`, makes `kind` a role scoped to its product, and gates the things that assumed Tamanu on a per-product capability.

Spec: `.workhorse/specs/servers/products.md` (`APP`), with amendments to `FIG` and `MCP`.

## Three version states, not two

The interesting finding. Canopy instances *do* report a version — `jobs/src/bin/ownstatus.rs` sends `CARGO_PKG_VERSION` — but canopy holds no release train for it, so that version is currently graded against Tamanu's catalogue and yields a meaningless distance. Nobody noticed because `FIG` already excludes canopy from fleet views.

| product | version tracking | public listing |
|---------|------------------|----------------|
| Tamanu  | `Tracked` — presented and graded | yes |
| Canopy  | `Reported` — presented, ungraded | no |
| SENAITE | `Absent` — no version at all | no |

So "this product has no version" stays distinguishable from "this Tamanu server hasn't reported one yet". The first presents nothing, label included; the second presents `unknown`. Collapsing them would either strip a canopy instance of the version it reports or keep grading it against Tamanu releases.

Backups and health monitoring are deliberately *not* capabilities: backup types are advertised per-server by the agent, and checks are graded by their reporting source, so both already work for any product untouched. Managed restore replicas are eligible by intent and backup type rather than by product, so a group-scoped declaration expands over every member.

## The column split ships over two deploys

The migration adds `product` and backfills canopy instances onto it **without touching `kind`**. `ServerKind::from_str` errors on unknown values, so rewriting `kind = 'canopy'` to `'standalone'` in the same deploy would leave a not-yet-upgraded binary unable to read the canopy self-server row at all. Instead `"canopy"` parses as `Standalone`, the same aliasing `kind.rs` already does for `"tamanu sync server"`. Deploy order doesn't matter.

A follow-up handles the cleanup migration and drops the alias.

## Billing attribution

`BillingLabels` hardcoded `product: "tamanu"`. A server's labels now carry its own product alongside its own rank, so a SENAITE server in a Tamanu group reports `billing.product: senaite`. Product joins stage in being omitted rather than guessed when there's nothing to attribute to — naming one product of several would charge a mixed group's shared cost to the wrong place. An explicit `billing.product` group tag still wins, and backup buckets keep forcing the backups product.

This also fixes an inconsistency it exposed: the server detail view rendered the *group's* labels, which for a mixed group showed the operator something the device is never handed.

## Two pre-existing bugs fixed as fallout

- Canopy's own version is no longer graded against Tamanu's catalogue.
- `canopy` is now selectable in the create form. The hardcoded menu only ever listed central and facility, so that product was unreachable.

## Scope notes

The plan called for a product filter in `Servers.tsx` "alongside kind and rank". That rested on a false premise: it's a tab shell, and no list view filters by kind or rank either. So the spec sentence I'd written described a filter that exists for no axis. I corrected `APP` to point at the query interfaces where filtering actually lives, and added the product chip to every list row instead. Building a new filtering UI across four list views would be separate work.

Deliberately out of scope, and recorded in the plan:

- A SENAITE `BackupType` and its schedule defaults. Backups work meanwhile — `BackupType` is an open enum, so an unrecognised type flows through as `Custom` and inherits the retention floor rather than a tuned schedule. Separate spec once the bestool side settles.
- Product-scoping the version catalogue itself. Untracked products grade against nothing, which is enough until there's a real second release train.
- The release-candidate page in `public-server/src/server_versions.rs` and the `tamanuVersion` wire field, both correctly Tamanu-specific.
- Product as a fleet-spread axis. `FIG` holds that figures come from what sources report rather than what an operator enters, so that would need an explicit exception nobody has asked for.

## One judgement call

I added a `commons/products` endpoint so the frontend reads the capability table rather than duplicating it in TypeScript. It costs a round trip and a provider, but adding a product stays one `caps()` arm instead of two places that drift. `SERVER_KIND_ORDER` in `types.ts` already duplicates `kind_priority`, which is the failure mode being avoided.

Every scenario in `.workhorse/test-cases/server-products/overview.md` has automated coverage. Two of the later additions are worth knowing about because they'd pass vacuously if written carelessly: the canopy-version test asserts the *absence* of a "versions behind latest" link, and the crossing test asserts the SENAITE server's distinct database major never appears as a row. Both fail without the gates this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
