### PR TITLE
Group domains and per-server name-management grants (DOM)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+    ignore:
+      # TypeScript 7 is the native port, and its JS API no longer exposes
+      # `ts.factory`, which openapi-typescript calls — so `npm run gen:api-types`
+      # dies on import under TS 7. Hold at 5.x until openapi-typescript
+      # supports it, then drop this.
+      - dependency-name: typescript
+        versions: [">=6"]
     groups:
       deps-patches:
         patterns:

--- a/.workhorse/specs/private-server/self-alerts.md
+++ b/.workhorse/specs/private-server/self-alerts.md
@@ -18,6 +18,7 @@ The current conditions are:
 - An operator-notification delivery has permanently failed (stays until operator-resolved).
 - An MCP access token is within fifteen days of its expiry (see [MCP](mcp.md), "Access tokens").
 - One or more catalogued checks have gone unreported across the whole fleet for thirty days (see [CHK](../monitoring/checks.md), "Liveness and decommissioning"); it clears when no such check remains, each having been decommissioned or reported again.
+- One or more group domains fall outside the DNS zones Canopy is configured with, failing when Canopy can read no zones at all and warning when only some claims are uncovered (see [DOM](../servers/domains.md), "When the zone configuration changes"); it clears when every live group's domains sit within a configured zone again.
 
 ## Notification
 

--- a/.workhorse/specs/servers/domains.md
+++ b/.workhorse/specs/servers/domains.md
@@ -55,12 +55,31 @@ A name is claimed in the form DNS uses, so an internationalised domain is claime
 A claim is refused when the name is not a syntactically valid domain name of at least two labels.
 
 Releasing a domain ends the group's control of it and of every name beneath it.
-
-Removing a zone from Canopy's configuration does not remove the claims within it.
-Such a claim is kept and reported as unmatched: Canopy will act on no name beneath it, though it still holds its exclusivity against other claims, since the claim itself has not been given up.
-An operator resolves an unmatched claim by restoring the zone to the configuration or by releasing the claim.
+Releasing is the only way a claim goes away: nothing Canopy observes about its own configuration ever drops one.
 
 Archiving a group keeps its domains, so restoring the group restores its control of them.
+
+## When the zone configuration changes
+
+A claim outlives the zone that admitted it.
+Removing a zone from Canopy's configuration — or breaking the configuration outright — leaves every claim inside it standing, still excluding other groups from overlapping it, and still the group's to release.
+What stops is Canopy acting: no name beneath an uncovered claim resolves to a zone, so Canopy publishes and renews nothing there.
+Canopy holds the claim rather than dropping it because a claim is an operator's decision about a deployment, and a configuration Canopy cannot read is no evidence that the decision was withdrawn — inferring release from it would silently hand a live deployment's names to whoever asked next.
+
+Because the configuration is the only thing that changed, and it is a Canopy-level fault rather than any one group's, Canopy reports the shortfall as a self-alert against itself rather than as an issue on the affected groups (see [SELF](../private-server/self-alerts.md)).
+One alert covers every uncovered claim at once and names each domain with the group holding it, so an operator sees the whole blast radius in one place instead of visiting each group.
+The alert distinguishes what happened, because the two cases are fixed differently:
+
+- Some claims are uncovered while other zones remain configured, which is what removing one zone of several looks like.
+  This is a warning: the rest of the fleet is unaffected, and an operator either restores the zone or releases the claims that no longer belong.
+- The configuration cannot be read, or names no zones at all while domains stand claimed.
+  This is a failure: Canopy can act on no group's names, so it reports the parse error where there is one, and says it is treating itself as having no zones.
+
+A configuration that names no zones while nothing is claimed raises nothing, that being the feature simply not in use rather than a fault.
+An archived group's uncovered claims raise nothing either, a deployment that has been put away not being something to call an operator about.
+
+The alert recovers on its own once every live group's claims sit within a configured zone again, whether that came about by restoring the zone or by releasing the claims.
+A group's own page flags each of its uncovered claims besides, so an operator arriving from the alert sees which of that group's domains are the problem.
 
 ## Permission for a server to manage its own names
 
@@ -96,7 +115,7 @@ The permission is the trust boundary: a server permitted to manage its DNS can p
 
 ## Presentation
 
-A group presents the domains it controls, each with the managed zone it resolves to, and flags a claim no configured zone matches.
+A group presents the domains it controls, each with the managed zone it resolves to, and flags a claim no configured zone covers.
 The configured managed zones are shown to operators, so an operator claiming a domain can see which names are available to be claimed.
 
 A server presents whether it may manage its own DNS and whether it may obtain its own certificates, alongside the other permissions an operator holds over it, and an operator grants and revokes each there.

--- a/.workhorse/specs/servers/domains.md
+++ b/.workhorse/specs/servers/domains.md
@@ -117,5 +117,6 @@ The permission is the trust boundary: a server permitted to manage its DNS can p
 
 A group presents the domains it controls, each with the managed zone it resolves to, and flags a claim no configured zone covers.
 The configured managed zones are shown to operators, so an operator claiming a domain can see which names are available to be claimed.
+A group with no domains in a Canopy configured with no zones presents nothing at all, so a deployment that has not been given zones carries no standing notice about a feature it is not using.
 
 A server presents whether it may manage its own DNS and whether it may obtain its own certificates, alongside the other permissions an operator holds over it, and an operator grants and revokes each there.

--- a/.workhorse/specs/servers/domains.md
+++ b/.workhorse/specs/servers/domains.md
@@ -1,0 +1,102 @@
+---
+id: DOM
+---
+
+# Server group domains
+
+Canopy manages DNS names on its fleet's behalf.
+A *managed zone* is a DNS zone Canopy can create and change records in; a *group domain* is a name inside such a zone that a server group controls.
+Together they answer which names Canopy will act on for which deployment — the association a server's own DNS records and TLS certificates are authorised against.
+
+## Managed zones
+
+A managed zone is named by its apex domain and identified by the identifier its DNS provider knows the zone by.
+Canopy holds write access to every managed zone, and can create, change, and delete records anywhere within it.
+
+Managed zones come from Canopy's own deployment configuration, set by the infrastructure that provisions Canopy, rather than from operator-editable state.
+An operator cannot add, change, or remove a managed zone through Canopy: a zone Canopy has not actually been granted write access to would be authority Canopy could not honour, and granting that access is the provisioning infrastructure's job.
+Canopy reads the configured zones when it starts, so a change to the configuration takes effect once Canopy restarts.
+
+A managed zone is not dedicated to a single deployment.
+Zones are shared: the domains of several groups live in one zone, and names Canopy does not manage at all may live in it beside them.
+So Canopy never treats a zone as belonging to a group, and never assumes it is the only writer of records in a zone.
+
+## Group domains
+
+A group domain is a domain name that a server group controls.
+A group may control more than one domain, and controls everything beneath each of them.
+
+A group domain lies within a managed zone: it is either a zone's apex or a name beneath one.
+A name outside every managed zone cannot be claimed, because Canopy could create no records for it.
+Claiming an apex gives the group the whole zone, which is how infrastructure that means to dedicate a zone to one deployment configures it.
+
+A group domain resolves to exactly one managed zone: the longest configured apex the domain lies within, so a zone configured beneath another zone takes the names beneath itself.
+
+## Exclusivity within Canopy
+
+Within Canopy, a group domain is exclusive.
+No two group domains overlap: claiming a name already claimed, a name beneath an existing claim, or a name above an existing claim is refused, whether the existing claim belongs to the same group or to another one.
+The refusal names the overlapping domain and the group holding it, so an operator can see whom to ask.
+
+Exclusivity is Canopy's own rule and not an assertion about the wider DNS.
+A domain a group controls in Canopy may also be served by systems outside Canopy, and Canopy neither detects nor prevents that.
+What Canopy guarantees is that no other group within Canopy holds a name overlapping it.
+
+A name is controlled by a group when it is at or beneath one of that group's domains.
+Because claims never overlap, at most one group controls any given name, and that group is the one every feature acting on the name is authorised against.
+
+## Claiming and releasing
+
+An operator claims a domain for a group and releases it again; both are administrative actions, while reading a group's domains and the configured zones is open to any operator.
+A claim records the operator who made it and when.
+
+A claimed name is normalised: case and a trailing dot are not significant, and the name is held in lower case without one.
+A name is claimed in the form DNS uses, so an internationalised domain is claimed in its ASCII-compatible form rather than its unicode spelling.
+A claim is refused when the name is not a syntactically valid domain name of at least two labels.
+
+Releasing a domain ends the group's control of it and of every name beneath it.
+
+Removing a zone from Canopy's configuration does not remove the claims within it.
+Such a claim is kept and reported as unmatched: Canopy will act on no name beneath it, though it still holds its exclusivity against other claims, since the claim itself has not been given up.
+An operator resolves an unmatched claim by restoring the zone to the configuration or by releasing the claim.
+
+Archiving a group keeps its domains, so restoring the group restores its control of them.
+
+## Permission for a server to manage its own names
+
+A server manages names under its group's domains only where an operator has explicitly permitted it to.
+The permission is two separate grants, held per server and both withheld by default: one to manage the server's own DNS records, and one to obtain TLS certificates for the server's own names.
+They are separate because a deployment whose records are managed elsewhere may still want its certificates from Canopy, and a deployment may be given a name before it is trusted to hold a certificate for it.
+
+Both grants are per server rather than per group, so one member of a group may manage its names while its neighbours may not.
+
+A server that has not been granted the permission it needs is refused, and told that it is: the request is authenticated as the server it claims to be, and denied on the permission rather than ignored, so an operator reading the server's logs sees a permission to grant rather than a silence to explain.
+A server whose group controls no domain is likewise refused, but for want of a domain rather than for want of permission, so the two misconfigurations are told apart.
+
+Revoking a grant takes effect on the server's next request.
+It stops the server making further changes and leaves the records and certificates already in place, since withdrawing a live deployment's address records on a change of permission would take that deployment off the air.
+
+## Server-registered names and addresses
+
+A server permitted to manage its DNS registers a name it should be reachable at, along with the external addresses it is reachable at, and Canopy publishes that name's address records.
+
+The name must lie within one of the server's own group's domains.
+A name within another group's domain, or within no group's domain, is refused, so the group domain is the boundary of what a server can reach.
+
+Canopy publishes the IPv4 addresses given as A records and the IPv6 addresses as AAAA records, at the name registered, in the managed zone that name resolves to.
+Registering replaces the addresses previously registered for that name, so a server announces a change of address by registering again, and a registration that names no addresses at all is a request to withdraw the name.
+
+Canopy changes only the records it created itself.
+Because zones are shared, a name in a managed zone may be served by records Canopy knows nothing about, and Canopy neither rewrites nor removes those.
+
+A name is registered by one server at a time: while a registration stands, another server registering the same name is refused, so two members of a group cannot fight over one name.
+
+Canopy does not check that a registered address is really the server's.
+The permission is the trust boundary: a server permitted to manage its DNS can point a name under its group's domains at any address, and a server not permitted to can point nothing anywhere.
+
+## Presentation
+
+A group presents the domains it controls, each with the managed zone it resolves to, and flags a claim no configured zone matches.
+The configured managed zones are shown to operators, so an operator claiming a domain can see which names are available to be claimed.
+
+A server presents whether it may manage its own DNS and whether it may obtain its own certificates, alongside the other permissions an operator holds over it, and an operator grants and revokes each there.

--- a/crates/commons-tests/src/server.rs
+++ b/crates/commons-tests/src/server.rs
@@ -266,6 +266,9 @@ where
 				),
 				recovery_recipients: None,
 				recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
+				// This harness is for the tailnet-auth paths; no test on it
+				// touches group domains.
+				dns_zones: Vec::new(),
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/crates/commons-types/src/dns.rs
+++ b/crates/commons-types/src/dns.rs
@@ -1,0 +1,271 @@
+//! Managed DNS zones and domain-name handling.
+//!
+//! A [`ManagedZone`] is a DNS zone Canopy has write access to, declared by the
+//! infrastructure that provisions Canopy rather than by an operator. Group
+//! domain claims are validated against the configured zones: a claim has to sit
+//! at or under one apex, and resolves to the longest apex it sits under.
+// spec: DOM
+
+use commons_errors::{AppError, Result};
+use serde::{Deserialize, Serialize};
+
+/// Environment variable declaring the zones Canopy may write records in.
+pub const ZONES_ENV: &str = "CANOPY_DNS_ZONES";
+
+/// Environment variable declaring the role to assume for zones that don't name
+/// one of their own.
+pub const ZONE_ROLE_ENV: &str = "CANOPY_DNS_ZONE_ROLE_ARN";
+
+/// The longest a domain name may be, in its presentation form without the root
+/// dot.
+const NAME_MAX: usize = 253;
+const LABEL_MAX: usize = 63;
+
+/// A DNS zone Canopy can create, change, and delete records in.
+///
+/// Zones are shared: several groups' domains live in one zone, and names Canopy
+/// doesn't manage at all may live there beside them — so a zone is never owned
+/// by a group.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct ManagedZone {
+	/// The zone's apex domain, normalised: lower case, no trailing dot.
+	pub apex: String,
+	/// The identifier the DNS provider knows this zone by (for Route 53, the
+	/// hosted zone id).
+	pub provider_zone_id: String,
+	/// The role to assume to reach this zone, when the zone lives in another
+	/// account than Canopy's own.
+	pub role_arn: Option<String>,
+}
+
+impl ManagedZone {
+	/// Parse the zone list from the environment. `Ok(empty)` when unset or
+	/// blank — the features that need a zone report the misconfiguration
+	/// themselves rather than keeping Canopy from starting; `Err` when set but
+	/// unparseable.
+	pub fn list_from_env() -> Result<Vec<Self>> {
+		let raw = std::env::var(ZONES_ENV).unwrap_or_default();
+		let default_role = std::env::var(ZONE_ROLE_ENV)
+			.ok()
+			.map(|r| r.trim().to_string())
+			.filter(|r| !r.is_empty());
+		Self::parse_list(&raw, default_role.as_deref())
+	}
+
+	/// Parse a zone list of `apex=provider-zone-id[=role-arn]` entries separated
+	/// by commas or whitespace. An entry that names no role takes
+	/// `default_role`.
+	pub fn parse_list(raw: &str, default_role: Option<&str>) -> Result<Vec<Self>> {
+		let mut zones: Vec<Self> = Vec::new();
+		for entry in raw.split([',', ' ', '\t', '\n', '\r']) {
+			let entry = entry.trim();
+			if entry.is_empty() {
+				continue;
+			}
+
+			let mut parts = entry.split('=');
+			let apex = normalize_domain(parts.next().unwrap_or_default())?;
+			let provider_zone_id = parts.next().unwrap_or_default().trim();
+			if provider_zone_id.is_empty() {
+				return Err(AppError::BadRequest(format!(
+					"managed zone {apex:?} has no provider zone id: expected `apex=provider-zone-id[=role-arn]`"
+				)));
+			}
+			let role_arn = parts
+				.next()
+				.map(str::trim)
+				.filter(|r| !r.is_empty())
+				.map(str::to_string)
+				.or_else(|| default_role.map(str::to_string));
+			if parts.next().is_some() {
+				return Err(AppError::BadRequest(format!(
+					"managed zone entry {entry:?} has too many fields: expected `apex=provider-zone-id[=role-arn]`"
+				)));
+			}
+
+			if zones.iter().any(|z| z.apex == apex) {
+				return Err(AppError::BadRequest(format!(
+					"managed zone {apex:?} is declared more than once"
+				)));
+			}
+			zones.push(Self {
+				apex,
+				provider_zone_id: provider_zone_id.to_string(),
+				role_arn,
+			});
+		}
+		Ok(zones)
+	}
+}
+
+/// Normalise a domain name to the form Canopy holds it in: lower case, no
+/// trailing dot, no surrounding whitespace.
+///
+/// Rejects anything that isn't a syntactically valid name of at least two
+/// labels. Names are handled in the form DNS carries them, so an
+/// internationalised domain has to arrive as its ASCII-compatible (punycode)
+/// spelling.
+pub fn normalize_domain(input: &str) -> Result<String> {
+	let bad = |reason: &str| {
+		Err(AppError::BadRequest(format!(
+			"invalid domain name {input:?}: {reason}"
+		)))
+	};
+
+	let name = input.trim().trim_end_matches('.').to_ascii_lowercase();
+	if name.is_empty() {
+		return bad("it is empty");
+	}
+	if name.len() > NAME_MAX {
+		return bad(&format!("it is longer than {NAME_MAX} characters"));
+	}
+	let labels: Vec<&str> = name.split('.').collect();
+	if labels.len() < 2 {
+		return bad("it has only one label");
+	}
+	for label in labels {
+		if label.is_empty() {
+			return bad("it has an empty label");
+		}
+		if label.len() > LABEL_MAX {
+			return bad(&format!(
+				"label {label:?} is longer than {LABEL_MAX} characters"
+			));
+		}
+		if label.starts_with('-') || label.ends_with('-') {
+			return bad(&format!("label {label:?} starts or ends with a hyphen"));
+		}
+		if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+			return bad(&format!(
+				"label {label:?} has characters outside letters, digits, and hyphens"
+			));
+		}
+	}
+
+	Ok(name)
+}
+
+/// Whether `name` is at or beneath `apex`. Both must already be normalised.
+pub fn is_within(name: &str, apex: &str) -> bool {
+	name == apex
+		|| name
+			.strip_suffix(apex)
+			.is_some_and(|rest| rest.ends_with('.'))
+}
+
+/// Whether two claims overlap: the same name, or one at or beneath the other.
+/// Both must already be normalised.
+pub fn overlaps(a: &str, b: &str) -> bool {
+	is_within(a, b) || is_within(b, a)
+}
+
+/// The managed zone a name resolves to: the longest configured apex the name
+/// sits within, so a zone configured beneath another zone takes the names
+/// beneath itself. `None` when no configured zone covers the name.
+pub fn match_zone<'z>(name: &str, zones: &'z [ManagedZone]) -> Option<&'z ManagedZone> {
+	zones
+		.iter()
+		.filter(|zone| is_within(name, &zone.apex))
+		.max_by_key(|zone| zone.apex.len())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn normalises_case_and_trailing_dot() {
+		assert_eq!(
+			normalize_domain(" Fiji.Tamanu.App. ").unwrap(),
+			"fiji.tamanu.app"
+		);
+	}
+
+	#[test]
+	fn rejects_malformed_names() {
+		for input in [
+			"",
+			".",
+			"app",
+			"fiji..app",
+			"-fiji.app",
+			"fiji-.app",
+			"fiji_1.app",
+			"fidʒi.app",
+			"*.tamanu.app",
+			&format!("{}.app", "a".repeat(64)),
+		] {
+			assert!(
+				normalize_domain(input).is_err(),
+				"expected {input:?} to be rejected"
+			);
+		}
+	}
+
+	#[test]
+	fn within_needs_a_label_boundary() {
+		assert!(is_within("tamanu.app", "tamanu.app"));
+		assert!(is_within("fiji.tamanu.app", "tamanu.app"));
+		assert!(!is_within("nottamanu.app", "tamanu.app"));
+		assert!(!is_within("tamanu.app", "fiji.tamanu.app"));
+	}
+
+	#[test]
+	fn overlap_is_symmetric() {
+		assert!(overlaps("fiji.tamanu.app", "tamanu.app"));
+		assert!(overlaps("tamanu.app", "fiji.tamanu.app"));
+		assert!(overlaps("fiji.tamanu.app", "fiji.tamanu.app"));
+		assert!(!overlaps("fiji.tamanu.app", "samoa.tamanu.app"));
+	}
+
+	#[test]
+	fn longest_apex_wins() {
+		let zones = ManagedZone::parse_list("tamanu.app=Z1, demo.tamanu.app=Z2", None).unwrap();
+		assert_eq!(
+			match_zone("x.demo.tamanu.app", &zones)
+				.unwrap()
+				.provider_zone_id,
+			"Z2"
+		);
+		assert_eq!(
+			match_zone("x.prod.tamanu.app", &zones)
+				.unwrap()
+				.provider_zone_id,
+			"Z1"
+		);
+		assert!(match_zone("x.senaite.app", &zones).is_none());
+	}
+
+	#[test]
+	fn parses_roles_and_defaults() {
+		let zones = ManagedZone::parse_list(
+			"Tamanu.App.=Z1=arn:aws:iam::1:role/own\nsenaite.app=Z2",
+			Some("arn:aws:iam::9:role/default"),
+		)
+		.unwrap();
+		assert_eq!(
+			zones,
+			vec![
+				ManagedZone {
+					apex: "tamanu.app".into(),
+					provider_zone_id: "Z1".into(),
+					role_arn: Some("arn:aws:iam::1:role/own".into()),
+				},
+				ManagedZone {
+					apex: "senaite.app".into(),
+					provider_zone_id: "Z2".into(),
+					role_arn: Some("arn:aws:iam::9:role/default".into()),
+				},
+			]
+		);
+	}
+
+	#[test]
+	fn rejects_bad_config() {
+		assert!(ManagedZone::parse_list("tamanu.app", None).is_err());
+		assert!(ManagedZone::parse_list("tamanu.app=", None).is_err());
+		assert!(ManagedZone::parse_list("tamanu.app=Z1=r=extra", None).is_err());
+		assert!(ManagedZone::parse_list("tamanu.app=Z1,tamanu.app=Z2", None).is_err());
+		assert!(ManagedZone::parse_list("", None).unwrap().is_empty());
+	}
+}

--- a/crates/commons-types/src/lib.rs
+++ b/crates/commons-types/src/lib.rs
@@ -2,6 +2,7 @@ pub use uuid::Uuid;
 
 pub mod backup;
 pub mod device;
+pub mod dns;
 pub mod geo;
 pub mod issue;
 pub mod server;

--- a/crates/database/src/bin/seed.rs
+++ b/crates/database/src/bin/seed.rs
@@ -634,6 +634,8 @@ async fn seed_servers(
 			registered_at: None,
 			restore_allowed_until: None,
 			restore_allowed_by: None,
+			may_manage_dns: false,
+			may_manage_tls: false,
 		}
 	}
 

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -22,6 +22,7 @@ pub mod reported_detail;
 pub mod restore;
 pub mod schema;
 pub mod self_alerts;
+pub mod server_domains;
 pub mod server_enrollment_challenges;
 pub mod server_enrollment_tokens;
 pub mod server_groups;
@@ -58,6 +59,7 @@ pub use restore::{
 	BackupRestoreCheck, NewBackupRestoreCheck, NewRestoreReplica, RestoreConsumerCapability,
 	RestoreReplica, RestoreReplicaUpdate,
 };
+pub use server_domains::ServerGroupDomain;
 
 pub type Db = Pool<AsyncPgConnection>;
 

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -509,6 +509,17 @@ diesel::table! {
 }
 
 diesel::table! {
+	server_group_domains (id) {
+		id -> Uuid,
+		group_id -> Uuid,
+		domain -> Text,
+		created_by -> Nullable<Text>,
+		created_at -> Timestamptz,
+		updated_at -> Timestamptz,
+	}
+}
+
+diesel::table! {
 	server_groups (id) {
 		id -> Uuid,
 		created_at -> Timestamptz,
@@ -557,6 +568,8 @@ diesel::table! {
 		restore_allowed_until -> Nullable<Timestamptz>,
 		restore_allowed_by -> Nullable<Text>,
 		product -> Text,
+		may_manage_dns -> Bool,
+		may_manage_tls -> Bool,
 	}
 }
 
@@ -697,6 +710,7 @@ diesel::joinable!(server_enrollment_challenges -> servers (server_id));
 diesel::joinable!(server_enrollment_tokens -> servers (server_id));
 diesel::joinable!(server_group_backup_config -> server_groups (group_id));
 diesel::joinable!(server_group_backup_schedule -> server_groups (group_id));
+diesel::joinable!(server_group_domains -> server_groups (group_id));
 diesel::joinable!(server_reported_detail -> servers (server_id));
 diesel::joinable!(servers -> devices (device_id));
 diesel::joinable!(slack_outbox -> incident_notes (note_id));
@@ -743,6 +757,7 @@ diesel::allow_tables_to_appear_in_same_query!(
 	server_enrollment_tokens,
 	server_group_backup_config,
 	server_group_backup_schedule,
+	server_group_domains,
 	server_groups,
 	server_reported_detail,
 	servers,

--- a/crates/database/src/self_alerts.rs
+++ b/crates/database/src/self_alerts.rs
@@ -10,6 +10,7 @@
 //! [`crate::issues::raise_global_event`]).
 
 use commons_errors::Result;
+use commons_types::dns::ManagedZone;
 use commons_types::status::CheckResult;
 use diesel_async::AsyncPgConnection;
 
@@ -48,6 +49,28 @@ One or more catalogued healthchecks have not been reported by any server in the 
 ## Solve
 
 Review the checks listed in the operator UI's healthcheck settings and decommission the ones that are gone for good; a decommissioned check's stale issues are cleared fleet-wide.";
+
+/// Canopy's configured DNS zones don't cover the domains groups have been
+/// given — either the configuration is unreadable, or a zone has left it while
+/// claims inside it stand. Coalescing: one alert lists every affected group.
+/// Recovers when every live group's claims sit in a configured zone again.
+// spec: DOM#when-the-zone-configuration-changes
+pub const DNS_ZONE_COVERAGE_REF: &str = "dns-zone-coverage";
+
+pub const DNS_ZONE_COVERAGE_DOC: &str = "## Description
+
+Canopy holds the DNS zones it may write records in as deployment configuration, and a group domain is only actionable while a configured zone covers it. This alert means at least one group is now depending on a domain Canopy cannot reach — usually a zone removed from the configuration while its claims stood, or a configuration that no longer parses.
+
+Claims are never dropped for this: the group keeps the domain, and it keeps excluding other groups from overlapping it. What stops is Canopy acting on any name beneath it.
+
+## Results
+
+- **warn** — some claims fall outside the configured zones while others are covered, which is what removing one zone of several looks like. Either restore the zone to the configuration or release the claims that no longer belong.
+- **fail** — the configuration is unreadable, or there are no zones at all while domains stand claimed. Canopy can serve no DNS or TLS for any group until it is fixed.
+
+## Solve
+
+Compare the zone list in Canopy's deployment configuration against the domains reported in the alert message. Restore the missing zone if its removal was accidental; if it was deliberate, release the claims on each group's page. A configuration that does not parse is reported with the parse error — fix the entry and restart.";
 
 /// Evaluate the fleet-wide check-liveness condition and raise or recover
 /// the coalescing [`STALE_CHECKS_REF`] self-alert. Runs after liveness is
@@ -88,6 +111,109 @@ pub async fn sweep_stale_healthchecks(conn: &mut AsyncPgConnection) -> Result<Op
 	)
 	.await
 	.map(Some)
+}
+
+/// Evaluate the DNS zone coverage condition and raise or recover the coalescing
+/// [`DNS_ZONE_COVERAGE_REF`] self-alert.
+///
+/// `zones` is what Canopy managed to read from its configuration, and
+/// `config_error` is why it read nothing when the configuration was present but
+/// unparseable. The two carry different messages and different severity, because
+/// one is a Canopy fault and the other is a tidy-up after a deliberate change.
+///
+/// A deployment with no zones configured and nothing claimed is not a problem:
+/// that is the feature simply not in use.
+// spec: DOM#when-the-zone-configuration-changes
+pub async fn sweep_dns_zone_coverage(
+	conn: &mut AsyncPgConnection,
+	zones: &[ManagedZone],
+	config_error: Option<&str>,
+) -> Result<Option<Issue>> {
+	let unzoned = crate::server_domains::ServerGroupDomain::unzoned(conn, zones).await?;
+
+	if unzoned.is_empty() && config_error.is_none() {
+		return recover(
+			conn,
+			DNS_ZONE_COVERAGE_REF,
+			"every claimed group domain sits within a configured DNS zone",
+		)
+		.await;
+	}
+
+	let mut groups: Vec<&str> = unzoned.iter().map(|d| d.group_name.as_str()).collect();
+	groups.sort_unstable();
+	groups.dedup();
+	let listed: Vec<String> = unzoned
+		.iter()
+		.map(|d| format!("{} ({})", d.domain, d.group_name))
+		.collect();
+
+	let (observed, message) = if let Some(error) = config_error {
+		(
+			CheckResult::Failed,
+			format!(
+				"Canopy's managed DNS zone configuration could not be read ({error}), so it is \
+				 acting as though it has no zones. {} claimed domain(s) across {} group(s) are \
+				 unusable until it is fixed{}",
+				unzoned.len(),
+				groups.len(),
+				list_suffix(&listed),
+			),
+		)
+	} else if zones.is_empty() {
+		(
+			CheckResult::Failed,
+			format!(
+				"Canopy has no managed DNS zones configured, but {} domain(s) across {} group(s) \
+				 stand claimed{}",
+				unzoned.len(),
+				groups.len(),
+				list_suffix(&listed),
+			),
+		)
+	} else {
+		(
+			CheckResult::Warning,
+			format!(
+				"{} claimed domain(s) across {} group(s) fall outside every configured DNS zone \
+				 ({}){}",
+				unzoned.len(),
+				groups.len(),
+				zones
+					.iter()
+					.map(|z| z.apex.as_str())
+					.collect::<Vec<_>>()
+					.join(", "),
+				list_suffix(&listed),
+			),
+		)
+	};
+
+	// The ceiling registers as `fail` whatever severity this raise carries, so a
+	// warning that later becomes a fault isn't capped at warning by the policy
+	// the first sighting seeded.
+	raise(
+		conn,
+		DNS_ZONE_COVERAGE_REF,
+		observed,
+		CheckResult::Failed,
+		false,
+		Some(DNS_ZONE_COVERAGE_DOC),
+		"Group domains outside Canopy's DNS zones",
+		&message,
+	)
+	.await
+	.map(Some)
+}
+
+/// `": a, b, c"`, or nothing at all for an empty list — a broken configuration
+/// with no claims yet has nothing to name.
+fn list_suffix(listed: &[String]) -> String {
+	if listed.is_empty() {
+		String::new()
+	} else {
+		format!(": {}", listed.join(", "))
+	}
 }
 
 /// Raise (or re-affirm) a self-alert: file the coalescing canopy-wide

--- a/crates/database/src/server_domains.rs
+++ b/crates/database/src/server_domains.rs
@@ -47,6 +47,14 @@ pub struct ServerGroupDomain {
 	pub updated_at: Timestamp,
 }
 
+/// A claim no configured zone covers, with its group named for reporting.
+#[derive(Debug, Clone, Serialize)]
+pub struct UnzonedDomain {
+	pub group_id: Uuid,
+	pub group_name: String,
+	pub domain: String,
+}
+
 impl ServerGroupDomain {
 	/// Claim `domain` for a group.
 	///
@@ -127,6 +135,46 @@ impl ServerGroupDomain {
 			.load(db)
 			.await
 			.map_err(AppError::from)
+	}
+
+	/// Every live group's claims that no configured zone covers, by domain —
+	/// the deployments now depending on a domain outside Canopy's reach.
+	///
+	/// Zone matching is longest-suffix against a list that lives in
+	/// configuration rather than in the database, so the filtering happens here
+	/// rather than in SQL. The claim table is small (one row per domain a group
+	/// controls) and this runs on the monitor's sweep cadence.
+	///
+	/// Archived groups are left out: their claims are kept, but a deployment
+	/// that has been put away is not something to alert an operator about.
+	pub async fn unzoned(
+		db: &mut AsyncPgConnection,
+		zones: &[ManagedZone],
+	) -> Result<Vec<UnzonedDomain>> {
+		use crate::schema::{server_group_domains, server_groups};
+
+		let rows: Vec<(Uuid, String, String)> = server_group_domains::table
+			.inner_join(server_groups::table)
+			.filter(server_groups::deleted_at.is_null())
+			.select((
+				server_group_domains::group_id,
+				server_groups::name,
+				server_group_domains::domain,
+			))
+			.order(server_group_domains::domain.asc())
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+
+		Ok(rows
+			.into_iter()
+			.filter(|(_, _, domain)| match_zone(domain, zones).is_none())
+			.map(|(group_id, group_name, domain)| UnzonedDomain {
+				group_id,
+				group_name,
+				domain,
+			})
+			.collect())
 	}
 
 	/// Every claim in the fleet, by domain.

--- a/crates/database/src/server_domains.rs
+++ b/crates/database/src/server_domains.rs
@@ -1,0 +1,232 @@
+//! Server group domains (DOM): the DNS names each group controls.
+//!
+//! A claim is exclusive within Canopy — no two claims overlap, so at most one
+//! group controls any given name — but says nothing about the wider DNS, where
+//! the zone holding it is shared with other groups and with names Canopy doesn't
+//! manage at all.
+//!
+//! The zones Canopy may write in are deployment configuration rather than
+//! stored state (see [`commons_types::dns::ManagedZone`]), so a claim is checked
+//! against them at claim time and re-matched on read: a claim whose zone has
+//! left the configuration stays claimed, and reads report it as unmatched.
+// spec: DOM
+
+use commons_errors::{AppError, Result};
+use commons_types::dns::{ManagedZone, match_zone, normalize_domain};
+use diesel::prelude::*;
+use diesel::result::Error as DieselError;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::Timestamp;
+use serde::Serialize;
+use uuid::Uuid;
+
+/// Arbitrary constant, stable across releases: claims serialise on this so the
+/// no-overlap check can't be raced by a concurrent claim. Unlike the exact
+/// duplicate, which the unique index catches, an overlap is a read of
+/// neighbouring rows and needs the claim path to be one writer at a time.
+const CLAIM_LOCK: i64 = 818_723_002;
+
+/// A domain a server group controls, holding every name beneath it.
+#[derive(Debug, Clone, Serialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::server_group_domains)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ServerGroupDomain {
+	/// Unique identifier of this claim.
+	pub id: Uuid,
+	/// The group that controls the domain.
+	pub group_id: Uuid,
+	/// The domain, normalised: lower case, no trailing dot.
+	pub domain: String,
+	/// The operator who claimed it. `None` if not recorded.
+	pub created_by: Option<String>,
+	/// When it was claimed.
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub created_at: Timestamp,
+	/// When the claim was last modified.
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub updated_at: Timestamp,
+}
+
+impl ServerGroupDomain {
+	/// Claim `domain` for a group.
+	///
+	/// The name is normalised, then has to sit at or under one of `zones`
+	/// (`400` otherwise — Canopy could create no records for it), and must
+	/// overlap no existing claim, its own group's included (`409`, naming the
+	/// claim in the way).
+	pub async fn claim(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		domain: &str,
+		created_by: Option<String>,
+		zones: &[ManagedZone],
+	) -> Result<Self> {
+		use crate::schema::server_group_domains::dsl;
+		use diesel_async::AsyncConnection;
+
+		let domain = normalize_domain(domain)?;
+		if match_zone(&domain, zones).is_none() {
+			return Err(AppError::BadRequest(if zones.is_empty() {
+				format!(
+					"cannot claim {domain}: Canopy has no managed DNS zones configured, so it \
+					 can write no records at all"
+				)
+			} else {
+				format!(
+					"cannot claim {domain}: it is not within any of Canopy's managed DNS zones \
+					 ({})",
+					zones
+						.iter()
+						.map(|z| z.apex.as_str())
+						.collect::<Vec<_>>()
+						.join(", ")
+				)
+			}));
+		}
+
+		db.transaction::<_, AppError, _>(async |conn| {
+			diesel::sql_query(format!("SELECT pg_advisory_xact_lock({CLAIM_LOCK})"))
+				.execute(conn)
+				.await?;
+
+			if let Some(clash) = overlapping(conn, &domain).await? {
+				return Err(AppError::Conflict(if clash.group_id == group_id {
+					format!(
+						"{domain} overlaps {} which this group already claims",
+						clash.domain
+					)
+				} else {
+					format!(
+						"{domain} overlaps {}, claimed by group {}",
+						clash.domain, clash.group_id
+					)
+				}));
+			}
+
+			diesel::insert_into(dsl::server_group_domains)
+				.values((
+					dsl::group_id.eq(group_id),
+					dsl::domain.eq(&domain),
+					dsl::created_by.eq(created_by),
+				))
+				.returning(Self::as_select())
+				.get_result(conn)
+				.await
+				.map_err(AppError::from)
+		})
+		.await
+	}
+
+	/// The domains a group claims, longest-held first.
+	pub async fn list_for_group(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<Vec<Self>> {
+		use crate::schema::server_group_domains::dsl;
+		dsl::server_group_domains
+			.select(Self::as_select())
+			.filter(dsl::group_id.eq(group_id))
+			.order(dsl::created_at.asc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Every claim in the fleet, by domain.
+	pub async fn list_all(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::server_group_domains::dsl;
+		dsl::server_group_domains
+			.select(Self::as_select())
+			.order(dsl::domain.asc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	pub async fn get(db: &mut AsyncPgConnection, id: Uuid) -> Result<Self> {
+		use crate::schema::server_group_domains::dsl;
+		dsl::server_group_domains
+			.select(Self::as_select())
+			.filter(dsl::id.eq(id))
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)?
+			.ok_or(AppError::DatabaseQuery(DieselError::NotFound))
+	}
+
+	/// Release a claim, ending the group's control of every name beneath it.
+	/// `404` if there is no such claim.
+	pub async fn release(db: &mut AsyncPgConnection, id: Uuid) -> Result<()> {
+		use crate::schema::server_group_domains::dsl;
+		let deleted = diesel::delete(dsl::server_group_domains.filter(dsl::id.eq(id)))
+			.execute(db)
+			.await?;
+		if deleted == 0 {
+			return Err(AppError::DatabaseQuery(DieselError::NotFound));
+		}
+		Ok(())
+	}
+
+	/// The claim covering `name`, if any: the longest claim `name` sits at or
+	/// under. This is what authorises a server to act on a name — the group of
+	/// the returned claim is the only group that controls it.
+	pub async fn controlling(db: &mut AsyncPgConnection, name: &str) -> Result<Option<Self>> {
+		use crate::schema::server_group_domains::dsl;
+		let name = normalize_domain(name)?;
+		let mut found: Vec<Self> = dsl::server_group_domains
+			.select(Self::as_select())
+			.filter(dsl::domain.eq_any(ancestors(&name)))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		// At most one claim can match, claims being non-overlapping, but sort
+		// defensively rather than trusting the invariant with authorisation.
+		found.sort_by_key(|row| std::cmp::Reverse(row.domain.len()));
+		Ok(found.into_iter().next())
+	}
+}
+
+/// `name` itself and each of its parents down to the two-label suffix — the set
+/// of claims that would cover `name`. Hits the unique index on `domain`, unlike
+/// a suffix match.
+fn ancestors(name: &str) -> Vec<String> {
+	let labels: Vec<&str> = name.split('.').collect();
+	(0..labels.len().saturating_sub(1))
+		.map(|skip| labels[skip..].join("."))
+		.collect()
+}
+
+/// The existing claim overlapping `domain`, if any: one at or above it (an
+/// exact or ancestor match) or one beneath it (a suffix match). `domain` must be
+/// normalised, which is what makes it safe to interpolate into `LIKE` — a
+/// normalised name holds only letters, digits, hyphens, and dots, so it carries
+/// no pattern metacharacters.
+async fn overlapping(
+	db: &mut AsyncPgConnection,
+	domain: &str,
+) -> Result<Option<ServerGroupDomain>> {
+	use crate::schema::server_group_domains::dsl;
+	dsl::server_group_domains
+		.select(ServerGroupDomain::as_select())
+		.filter(
+			dsl::domain
+				.eq_any(ancestors(domain))
+				.or(dsl::domain.like(format!("%.{domain}"))),
+		)
+		.first(db)
+		.await
+		.optional()
+		.map_err(AppError::from)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn ancestors_stop_at_two_labels() {
+		assert_eq!(
+			ancestors("a.b.tamanu.app"),
+			vec!["a.b.tamanu.app", "b.tamanu.app", "tamanu.app"]
+		);
+		assert_eq!(ancestors("tamanu.app"), vec!["tamanu.app"]);
+	}
+}

--- a/crates/database/src/servers.rs
+++ b/crates/database/src/servers.rs
@@ -146,6 +146,17 @@ pub struct Server {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[diesel(treat_none_as_default_value = false)]
 	pub restore_allowed_by: Option<String>,
+	/// Whether this server may manage its own DNS records for names under its
+	/// group's domains. Withheld by default: a server without it is
+	/// authenticated and refused. Unlike the restore window this is a standing
+	/// grant, records needing maintenance for as long as the server lives.
+	// spec: DOM#permission-for-a-server-to-manage-its-own-names
+	pub may_manage_dns: bool,
+	/// Whether this server may obtain TLS certificates for names under its
+	/// group's domains. Separate from `may_manage_dns`: a deployment whose
+	/// records are managed elsewhere may still want its certificates here.
+	// spec: DOM#permission-for-a-server-to-manage-its-own-names
+	pub may_manage_tls: bool,
 }
 
 impl Server {
@@ -841,6 +852,8 @@ fn test_server_serialization() {
 		registered_at: None,
 		restore_allowed_until: None,
 		restore_allowed_by: None,
+		may_manage_dns: false,
+		may_manage_tls: false,
 	};
 
 	let serialized = serde_json::to_string_pretty(&server).unwrap();
@@ -858,7 +871,9 @@ fn test_server_serialization() {
   "is_monitored": true,
   "alert_when_down_for": 600,
   "notes": "",
-  "tags": {}
+  "tags": {},
+  "may_manage_dns": false,
+  "may_manage_tls": false
 }"#
 	);
 }
@@ -910,6 +925,8 @@ impl From<NewServer> for Server {
 			registered_at: None,
 			restore_allowed_until: None,
 			restore_allowed_by: None,
+			may_manage_dns: false,
+			may_manage_tls: false,
 		}
 	}
 }
@@ -963,4 +980,10 @@ pub struct PartialServer {
 	/// New set of key/value tags for the server. This replaces the whole
 	/// tag set.
 	pub tags: Option<TagMap>,
+	/// Whether the server may manage its own DNS records under its group's
+	/// domains.
+	pub may_manage_dns: Option<bool>,
+	/// Whether the server may obtain TLS certificates for names under its
+	/// group's domains.
+	pub may_manage_tls: Option<bool>,
 }

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -29,6 +29,7 @@ mod restore;
 mod scope;
 mod scoped_check_policies;
 mod self_alerts;
+mod server_domains;
 mod server_enrollment;
 mod server_group_archival;
 mod server_group_version_cache;

--- a/crates/database/tests/it/server_domains.rs
+++ b/crates/database/tests/it/server_domains.rs
@@ -1,0 +1,275 @@
+//! DB-layer tests for group domains (`database::server_domains`). Exercises the
+//! model helpers directly against a fresh migrated DB — no HTTP.
+
+use commons_errors::AppError;
+use commons_tests::db::TestDb;
+use commons_types::dns::ManagedZone;
+use database::ServerGroupDomain;
+use database::diesel_async::AsyncPgConnection;
+use diesel::{sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[derive(diesel::QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_group(conn: &mut AsyncPgConnection, name: &str) -> Uuid {
+	sql_query("INSERT INTO server_groups (name) VALUES ($1) RETURNING id")
+		.bind::<sql_types::Text, _>(name)
+		.get_result::<RowId>(conn)
+		.await
+		.expect("insert group")
+		.id
+}
+
+fn zones() -> Vec<ManagedZone> {
+	ManagedZone::parse_list("tamanu.app=Z1, senaite.app=Z2", None).expect("parse zones")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn claim_normalises_and_matches_a_zone() {
+	TestDb::run(async |mut conn, _url| {
+		let group = insert_group(&mut conn, "fiji").await;
+		let claim = ServerGroupDomain::claim(
+			&mut conn,
+			group,
+			" Fiji.Tamanu.App. ",
+			Some("op@example.test".into()),
+			&zones(),
+		)
+		.await
+		.expect("claim");
+
+		assert_eq!(claim.domain, "fiji.tamanu.app");
+		assert_eq!(claim.group_id, group);
+		assert_eq!(claim.created_by.as_deref(), Some("op@example.test"));
+
+		let listed = ServerGroupDomain::list_for_group(&mut conn, group)
+			.await
+			.expect("list");
+		assert_eq!(listed.len(), 1);
+		assert_eq!(listed[0].id, claim.id);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn claim_outside_every_zone_is_rejected() {
+	TestDb::run(async |mut conn, _url| {
+		let group = insert_group(&mut conn, "fiji").await;
+		let err = ServerGroupDomain::claim(&mut conn, group, "fiji.example.com", None, &zones())
+			.await
+			.expect_err("should refuse a name outside every zone");
+		assert!(matches!(err, AppError::BadRequest(_)), "got {err:?}");
+
+		// A malformed name is refused before any zone is consulted.
+		let err = ServerGroupDomain::claim(&mut conn, group, "tamanu", None, &zones())
+			.await
+			.expect_err("should refuse a single-label name");
+		assert!(matches!(err, AppError::BadRequest(_)), "got {err:?}");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn claim_with_no_zones_configured_is_rejected() {
+	TestDb::run(async |mut conn, _url| {
+		let group = insert_group(&mut conn, "fiji").await;
+		let err = ServerGroupDomain::claim(&mut conn, group, "fiji.tamanu.app", None, &[])
+			.await
+			.expect_err("should refuse when Canopy has no zones at all");
+		match err {
+			AppError::BadRequest(msg) => assert!(
+				msg.contains("no managed DNS zones"),
+				"unhelpful message: {msg}"
+			),
+			other => panic!("got {other:?}"),
+		}
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_zone_apex_may_be_claimed_whole() {
+	TestDb::run(async |mut conn, _url| {
+		let group = insert_group(&mut conn, "everything").await;
+		let claim = ServerGroupDomain::claim(&mut conn, group, "tamanu.app", None, &zones())
+			.await
+			.expect("apex claim");
+		assert_eq!(claim.domain, "tamanu.app");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn overlapping_claims_are_refused_across_groups() {
+	TestDb::run(async |mut conn, _url| {
+		let fiji = insert_group(&mut conn, "fiji").await;
+		let samoa = insert_group(&mut conn, "samoa").await;
+		ServerGroupDomain::claim(&mut conn, fiji, "fiji.tamanu.app", None, &zones())
+			.await
+			.expect("first claim");
+
+		// The same name.
+		let err = ServerGroupDomain::claim(&mut conn, samoa, "fiji.tamanu.app", None, &zones())
+			.await
+			.expect_err("duplicate should conflict");
+		assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+
+		// A name beneath it.
+		let err = ServerGroupDomain::claim(&mut conn, samoa, "sub.fiji.tamanu.app", None, &zones())
+			.await
+			.expect_err("descendant should conflict");
+		assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+
+		// A name above it.
+		let err = ServerGroupDomain::claim(&mut conn, samoa, "tamanu.app", None, &zones())
+			.await
+			.expect_err("ancestor should conflict");
+		match err {
+			AppError::Conflict(msg) => assert!(
+				msg.contains("fiji.tamanu.app"),
+				"message should name the claim in the way: {msg}"
+			),
+			other => panic!("got {other:?}"),
+		}
+
+		// A sibling is untouched by any of it.
+		ServerGroupDomain::claim(&mut conn, samoa, "samoa.tamanu.app", None, &zones())
+			.await
+			.expect("sibling claim");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn overlap_is_refused_within_one_group_too() {
+	TestDb::run(async |mut conn, _url| {
+		let group = insert_group(&mut conn, "fiji").await;
+		ServerGroupDomain::claim(&mut conn, group, "fiji.tamanu.app", None, &zones())
+			.await
+			.expect("first claim");
+		let err = ServerGroupDomain::claim(&mut conn, group, "a.fiji.tamanu.app", None, &zones())
+			.await
+			.expect_err("already covered by the group's own claim");
+		match err {
+			AppError::Conflict(msg) => assert!(
+				msg.contains("this group already claims"),
+				"message should say the group already has it: {msg}"
+			),
+			other => panic!("got {other:?}"),
+		}
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn controlling_finds_the_group_for_a_name_beneath_a_claim() {
+	TestDb::run(async |mut conn, _url| {
+		let fiji = insert_group(&mut conn, "fiji").await;
+		let samoa = insert_group(&mut conn, "samoa").await;
+		ServerGroupDomain::claim(&mut conn, fiji, "fiji.tamanu.app", None, &zones())
+			.await
+			.expect("fiji claim");
+		ServerGroupDomain::claim(&mut conn, samoa, "samoa.tamanu.app", None, &zones())
+			.await
+			.expect("samoa claim");
+
+		for name in [
+			"fiji.tamanu.app",
+			"central.fiji.tamanu.app",
+			"a.b.fiji.tamanu.app",
+		] {
+			let found = ServerGroupDomain::controlling(&mut conn, name)
+				.await
+				.expect("lookup")
+				.unwrap_or_else(|| panic!("{name} should be controlled"));
+			assert_eq!(found.group_id, fiji, "{name}");
+			assert_eq!(found.domain, "fiji.tamanu.app");
+		}
+
+		// Outside every claim: the zone apex above them, an unclaimed sibling,
+		// and a name in another zone entirely.
+		for name in ["tamanu.app", "tonga.tamanu.app", "fiji.senaite.app"] {
+			assert!(
+				ServerGroupDomain::controlling(&mut conn, name)
+					.await
+					.expect("lookup")
+					.is_none(),
+				"{name} should be controlled by nobody"
+			);
+		}
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn releasing_frees_the_name_for_another_group() {
+	TestDb::run(async |mut conn, _url| {
+		let fiji = insert_group(&mut conn, "fiji").await;
+		let samoa = insert_group(&mut conn, "samoa").await;
+		let claim = ServerGroupDomain::claim(&mut conn, fiji, "shared.tamanu.app", None, &zones())
+			.await
+			.expect("claim");
+
+		ServerGroupDomain::release(&mut conn, claim.id)
+			.await
+			.expect("release");
+		assert!(
+			ServerGroupDomain::controlling(&mut conn, "x.shared.tamanu.app")
+				.await
+				.expect("lookup")
+				.is_none()
+		);
+
+		ServerGroupDomain::claim(&mut conn, samoa, "shared.tamanu.app", None, &zones())
+			.await
+			.expect("reclaim by another group");
+
+		// Releasing a claim that isn't there is a 404, not a silent success.
+		let err = ServerGroupDomain::release(&mut conn, claim.id)
+			.await
+			.expect_err("second release should 404");
+		assert!(
+			matches!(
+				err,
+				AppError::DatabaseQuery(diesel::result::Error::NotFound)
+			),
+			"got {err:?}"
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_claim_survives_its_zone_leaving_the_configuration() {
+	TestDb::run(async |mut conn, _url| {
+		let group = insert_group(&mut conn, "fiji").await;
+		ServerGroupDomain::claim(&mut conn, group, "fiji.tamanu.app", None, &zones())
+			.await
+			.expect("claim");
+
+		// The zone is gone from the configuration: the claim stands, is still
+		// found by a name lookup, and still excludes others.
+		let listed = ServerGroupDomain::list_for_group(&mut conn, group)
+			.await
+			.expect("list");
+		assert_eq!(listed.len(), 1);
+
+		let other = insert_group(&mut conn, "samoa").await;
+		let narrowed = ManagedZone::parse_list("senaite.app=Z2", None).expect("parse");
+		let err = ServerGroupDomain::claim(&mut conn, other, "fiji.tamanu.app", None, &narrowed)
+			.await
+			.expect_err("still claimed by fiji");
+		// Refused for being outside the zones now configured, before overlap is
+		// even reached — either refusal is correct, so accept both shapes.
+		assert!(
+			matches!(err, AppError::BadRequest(_) | AppError::Conflict(_)),
+			"got {err:?}"
+		);
+	})
+	.await;
+}

--- a/crates/database/tests/it/server_domains.rs
+++ b/crates/database/tests/it/server_domains.rs
@@ -273,3 +273,166 @@ async fn a_claim_survives_its_zone_leaving_the_configuration() {
 	})
 	.await;
 }
+
+/// The DNS-zone-coverage self-alert (DOM): a claim outliving its zone is kept
+/// and reported, warning when only some claims are uncovered and failing when
+/// Canopy can read no zones at all.
+mod coverage_alert {
+	use super::*;
+	use commons_types::status::CheckResult;
+	use database::self_alerts::{self, DNS_ZONE_COVERAGE_REF};
+
+	async fn current_result(conn: &mut AsyncPgConnection) -> Option<CheckResult> {
+		self_alerts::current(conn, DNS_ZONE_COVERAGE_REF)
+			.await
+			.expect("current")
+			.filter(|issue| issue.active)
+			.and_then(|issue| issue.effective_result)
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn covered_claims_raise_nothing() {
+		TestDb::run(async |mut conn, _url| {
+			let group = insert_group(&mut conn, "fiji").await;
+			ServerGroupDomain::claim(&mut conn, group, "fiji.tamanu.app", None, &zones())
+				.await
+				.expect("claim");
+
+			self_alerts::sweep_dns_zone_coverage(&mut conn, &zones(), None)
+				.await
+				.expect("sweep");
+			assert!(current_result(&mut conn).await.is_none());
+		})
+		.await;
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn no_zones_and_no_claims_is_not_a_fault() {
+		TestDb::run(async |mut conn, _url| {
+			// The feature simply isn't in use.
+			self_alerts::sweep_dns_zone_coverage(&mut conn, &[], None)
+				.await
+				.expect("sweep");
+			assert!(current_result(&mut conn).await.is_none());
+		})
+		.await;
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn dropping_one_zone_of_several_warns_and_keeps_the_claim() {
+		TestDb::run(async |mut conn, _url| {
+			let group = insert_group(&mut conn, "fiji").await;
+			let claim =
+				ServerGroupDomain::claim(&mut conn, group, "fiji.senaite.app", None, &zones())
+					.await
+					.expect("claim");
+
+			// `senaite.app` leaves the configuration; `tamanu.app` stays.
+			let narrowed = ManagedZone::parse_list("tamanu.app=Z1", None).expect("parse");
+			self_alerts::sweep_dns_zone_coverage(&mut conn, &narrowed, None)
+				.await
+				.expect("sweep");
+
+			assert_eq!(current_result(&mut conn).await, Some(CheckResult::Warning));
+
+			// The claim itself is untouched, and still excludes other groups.
+			let listed = ServerGroupDomain::list_for_group(&mut conn, group)
+				.await
+				.expect("list");
+			assert_eq!(listed.len(), 1);
+			assert_eq!(listed[0].id, claim.id);
+
+			// Restoring the zone recovers the alert on its own.
+			self_alerts::sweep_dns_zone_coverage(&mut conn, &zones(), None)
+				.await
+				.expect("sweep");
+			assert!(current_result(&mut conn).await.is_none());
+		})
+		.await;
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn losing_every_zone_fails_rather_than_warns() {
+		TestDb::run(async |mut conn, _url| {
+			let group = insert_group(&mut conn, "fiji").await;
+			ServerGroupDomain::claim(&mut conn, group, "fiji.tamanu.app", None, &zones())
+				.await
+				.expect("claim");
+
+			self_alerts::sweep_dns_zone_coverage(&mut conn, &[], None)
+				.await
+				.expect("sweep");
+			assert_eq!(current_result(&mut conn).await, Some(CheckResult::Failed));
+		})
+		.await;
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn an_unreadable_configuration_fails_and_reports_the_error() {
+		TestDb::run(async |mut conn, _url| {
+			let issue = self_alerts::sweep_dns_zone_coverage(
+				&mut conn,
+				&[],
+				Some("managed zone \"tamanu.app\" has no provider zone id"),
+			)
+			.await
+			.expect("sweep")
+			.expect("an alert even with nothing claimed");
+
+			assert_eq!(issue.effective_result, Some(CheckResult::Failed));
+			assert!(
+				issue.message.contains("no provider zone id"),
+				"the parse error belongs in the message: {}",
+				issue.message
+			);
+		})
+		.await;
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn a_warning_can_still_escalate_to_a_failure() {
+		TestDb::run(async |mut conn, _url| {
+			let group = insert_group(&mut conn, "fiji").await;
+			ServerGroupDomain::claim(&mut conn, group, "fiji.senaite.app", None, &zones())
+				.await
+				.expect("claim");
+
+			// Warn first, so the catalog entry is seeded by that sighting...
+			let narrowed = ManagedZone::parse_list("tamanu.app=Z1", None).expect("parse");
+			self_alerts::sweep_dns_zone_coverage(&mut conn, &narrowed, None)
+				.await
+				.expect("sweep");
+			assert_eq!(current_result(&mut conn).await, Some(CheckResult::Warning));
+
+			// ...then lose everything: the seeded ceiling must not cap this at
+			// warning.
+			self_alerts::sweep_dns_zone_coverage(&mut conn, &[], None)
+				.await
+				.expect("sweep");
+			assert_eq!(current_result(&mut conn).await, Some(CheckResult::Failed));
+		})
+		.await;
+	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn an_archived_groups_uncovered_claim_is_left_alone() {
+		TestDb::run(async |mut conn, _url| {
+			let group = insert_group(&mut conn, "put-away").await;
+			ServerGroupDomain::claim(&mut conn, group, "old.senaite.app", None, &zones())
+				.await
+				.expect("claim");
+			sql_query("UPDATE server_groups SET deleted_at = now() WHERE id = $1")
+				.bind::<sql_types::Uuid, _>(group)
+				.execute(&mut conn)
+				.await
+				.expect("archive group");
+
+			let narrowed = ManagedZone::parse_list("tamanu.app=Z1", None).expect("parse");
+			self_alerts::sweep_dns_zone_coverage(&mut conn, &narrowed, None)
+				.await
+				.expect("sweep");
+			assert!(current_result(&mut conn).await.is_none());
+		})
+		.await;
+	}
+}

--- a/crates/database/tests/it/server_enrollment.rs
+++ b/crates/database/tests/it/server_enrollment.rs
@@ -29,6 +29,8 @@ fn new_server(host: &str) -> Server {
 		registered_at: None,
 		restore_allowed_until: None,
 		restore_allowed_by: None,
+		may_manage_dns: false,
+		may_manage_tls: false,
 	}
 }
 

--- a/crates/database/tests/it/server_products.rs
+++ b/crates/database/tests/it/server_products.rs
@@ -44,6 +44,8 @@ fn server(product: Product, kind: ServerKind, rank: Option<ServerRank>) -> Serve
 		registered_at: None,
 		restore_allowed_until: None,
 		restore_allowed_by: None,
+		may_manage_dns: false,
+		may_manage_tls: false,
 	}
 }
 

--- a/crates/database/tests/it/server_restore_window.rs
+++ b/crates/database/tests/it/server_restore_window.rs
@@ -26,6 +26,8 @@ fn new_server() -> Server {
 		registered_at: None,
 		restore_allowed_until: None,
 		restore_allowed_by: None,
+		may_manage_dns: false,
+		may_manage_tls: false,
 	}
 }
 

--- a/crates/database/tests/it/tag_reserved_prefix.rs
+++ b/crates/database/tests/it/tag_reserved_prefix.rs
@@ -42,6 +42,8 @@ fn new_server(host: &str) -> Server {
 		registered_at: None,
 		restore_allowed_until: None,
 		restore_allowed_by: None,
+		may_manage_dns: false,
+		may_manage_tls: false,
 	}
 }
 
@@ -84,6 +86,8 @@ async fn server_update_rejects_reserved_tag_keys() {
 			alert_when_down_for: None,
 			notes: None,
 			tags: Some(reserved_tags()),
+			may_manage_dns: None,
+			may_manage_tls: None,
 		};
 		assert_bad_request(Server::update(&mut conn, server.id, updates).await);
 	})

--- a/crates/jobs/src/bin/monitor.rs
+++ b/crates/jobs/src/bin/monitor.rs
@@ -23,6 +23,7 @@ use commons_servers::{
 	tailnet_directory::{TailnetDirectory, TailnetDirectoryConfig},
 	tailnet_sweeps,
 };
+use commons_types::dns::ManagedZone;
 use database::{issues::reconcile_open_incidents, statuses::Status};
 use lloggs::{LoggingArgs, PreArgs};
 use miette::IntoDiagnostic;
@@ -228,6 +229,26 @@ pub fn spawn() -> JoinHandle<()> {
 				Ok(0) => {}
 				Ok(n) => debug!("filed {n} mcp token-expiry events"),
 				Err(err) => error!("mcp token-expiry sweep failed: {err}"),
+			}
+
+			// Group domains left outside Canopy's configured DNS zones — a zone
+			// dropped from the configuration, or a configuration that no longer
+			// parses. Read fresh each pass so restoring the configuration (and
+			// restarting this pod) recovers the alert.
+			// spec: DOM#when-the-zone-configuration-changes
+			let (zones, zone_error) = match ManagedZone::list_from_env() {
+				Ok(zones) => (zones, None),
+				Err(err) => (Vec::new(), Some(err.to_string())),
+			};
+			match database::self_alerts::sweep_dns_zone_coverage(
+				&mut db,
+				&zones,
+				zone_error.as_deref(),
+			)
+			.await
+			{
+				Ok(_) => {}
+				Err(err) => error!("dns zone coverage sweep failed: {err}"),
 			}
 		}
 	})

--- a/crates/private-server/src/fns.rs
+++ b/crates/private-server/src/fns.rs
@@ -6,6 +6,7 @@ pub mod backups;
 pub mod bestool;
 pub mod commons;
 pub mod devices;
+pub mod domains;
 pub mod healthchecks;
 pub mod incidents;
 pub mod issues;
@@ -55,6 +56,7 @@ pub fn routes() -> OpenApiRouter<crate::state::AppState> {
 			.nest("/bestool", bestool::routes())
 			.nest("/commons", commons::routes())
 			.nest("/devices", devices::routes())
+			.nest("/domains", domains::routes())
 			.nest("/healthchecks", healthchecks::routes())
 			.nest("/incidents", incidents::routes())
 			.nest("/issues", issues::routes())

--- a/crates/private-server/src/fns/domains.rs
+++ b/crates/private-server/src/fns/domains.rs
@@ -1,0 +1,207 @@
+//! Operator-facing group-domain endpoints (private-server, admin SPA).
+//!
+//! Thin wrappers over `database::server_domains`, plus a read of the managed
+//! zones Canopy is configured with. Reads are open to any tailnet user;
+//! claiming and releasing require admin.
+// spec: DOM
+
+use axum::Json;
+use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
+use commons_errors::{ProblemDetailsSchema, Result};
+use commons_servers::tailscale_auth::TailscaleAdmin;
+use commons_types::Uuid;
+use commons_types::dns::{ManagedZone, match_zone};
+use database::ServerGroupDomain;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::fns::server_groups::GroupIdArgs;
+use crate::state::AppState;
+
+pub fn routes() -> OpenApiRouter<AppState> {
+	OpenApiRouter::new()
+		.routes(routes!(zones))
+		.routes(routes!(for_group))
+		.routes(routes!(claim))
+		.routes(routes!(release))
+}
+
+/// A DNS zone Canopy can write records in.
+///
+/// Zones come from Canopy's deployment configuration rather than from operator
+/// state: they are what the infrastructure has granted Canopy write access to,
+/// and they bound which domains a group can be given.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ManagedZoneView {
+	/// The zone's apex domain, for example `tamanu.app`.
+	pub apex: String,
+	/// The identifier the DNS provider knows this zone by.
+	pub provider_zone_id: String,
+}
+
+/// A domain a group controls, with the managed zone it resolves to.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct GroupDomainView {
+	/// Unique identifier of the claim.
+	pub id: Uuid,
+	/// The group that controls the domain.
+	pub group_id: Uuid,
+	/// The domain, normalised to lower case without a trailing dot.
+	pub domain: String,
+	/// Apex of the managed zone this domain resolves to — the longest
+	/// configured apex it sits within. Null when no configured zone covers it,
+	/// which means the zone has left Canopy's configuration since the claim was
+	/// made: the claim stands and still excludes others, but Canopy will act on
+	/// no name beneath it until the zone is restored or the claim released.
+	pub zone: Option<String>,
+	/// Login of the operator who claimed it, if recorded.
+	pub created_by: Option<String>,
+	/// When it was claimed.
+	#[schema(value_type = String)]
+	pub created_at: Timestamp,
+}
+
+fn to_view(row: ServerGroupDomain, zones: &[ManagedZone]) -> GroupDomainView {
+	GroupDomainView {
+		zone: match_zone(&row.domain, zones).map(|z| z.apex.clone()),
+		id: row.id,
+		group_id: row.group_id,
+		domain: row.domain,
+		created_by: row.created_by,
+		created_at: row.created_at,
+	}
+}
+
+/// List the managed DNS zones Canopy is configured with.
+///
+/// An operator claiming a domain for a group needs these to know which names
+/// are claimable at all: a claim has to sit at or under one of these apexes.
+/// An empty list means Canopy has been given no zones, so no domain can be
+/// claimed until its deployment configuration provides one.
+#[utoipa::path(
+	post,
+	path = "/zones",
+	operation_id = "domains_zones",
+	tag = "domains",
+	security(("tailscale-user" = [])),
+	responses((status = 200, body = Vec<ManagedZoneView>)),
+)]
+pub async fn zones(State(state): State<AppState>) -> Result<Json<Vec<ManagedZoneView>>> {
+	Ok(Json(
+		state
+			.dns_zones
+			.iter()
+			.map(|zone| ManagedZoneView {
+				apex: zone.apex.clone(),
+				provider_zone_id: zone.provider_zone_id.clone(),
+			})
+			.collect(),
+	))
+}
+
+/// List the domains a group controls.
+///
+/// Each carries the managed zone it resolves to, or null for a claim no
+/// configured zone matches.
+#[utoipa::path(
+	post,
+	path = "/for_group",
+	operation_id = "domains_for_group",
+	tag = "domains",
+	security(("tailscale-user" = [])),
+	request_body = GroupIdArgs,
+	responses((status = 200, body = Vec<GroupDomainView>)),
+)]
+pub async fn for_group(
+	State(state): State<AppState>,
+	Json(args): Json<GroupIdArgs>,
+) -> Result<Json<Vec<GroupDomainView>>> {
+	let mut conn = state.db_read.get().await?;
+	let rows = ServerGroupDomain::list_for_group(&mut conn, args.server_group_id).await?;
+	Ok(Json(
+		rows.into_iter()
+			.map(|row| to_view(row, &state.dns_zones))
+			.collect(),
+	))
+}
+
+/// Fields needed to claim a domain for a group.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DomainClaimArgs {
+	/// The group to give control of the domain.
+	pub server_group_id: Uuid,
+	/// The domain to claim. Case and a trailing dot are not significant. An
+	/// internationalised domain is claimed in its ASCII-compatible (punycode)
+	/// spelling.
+	pub domain: String,
+}
+
+/// Claim a domain for a group.
+///
+/// The group then controls the domain and every name beneath it, and no other
+/// group can claim a name overlapping it. Requires the caller to be on the
+/// admin allow-list. Responds 400 if the name is not a valid domain of at least
+/// two labels or does not sit within one of Canopy's managed zones, and 409 if
+/// it overlaps a domain already claimed — by this group or another.
+#[utoipa::path(
+	post,
+	path = "/claim",
+	operation_id = "domains_claim",
+	tag = "domains",
+	security(("tailscale-admin" = [])),
+	request_body = DomainClaimArgs,
+	responses(
+		(status = 200, body = GroupDomainView),
+		(status = 400, body = ProblemDetailsSchema),
+		(status = 409, description = "The domain overlaps one already claimed.", body = ProblemDetailsSchema),
+	),
+)]
+pub async fn claim(
+	State(state): State<AppState>,
+	TailscaleAdmin(admin): TailscaleAdmin,
+	Json(args): Json<DomainClaimArgs>,
+) -> Result<Json<GroupDomainView>> {
+	let mut conn = state.db.get().await?;
+	let row = ServerGroupDomain::claim(
+		&mut conn,
+		args.server_group_id,
+		&args.domain,
+		Some(admin.login),
+		&state.dns_zones,
+	)
+	.await?;
+	Ok(Json(to_view(row, &state.dns_zones)))
+}
+
+/// Identifies a claim.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DomainIdArgs {
+	/// The claim to release.
+	pub id: Uuid,
+}
+
+/// Release a claimed domain.
+///
+/// The group loses control of the domain and every name beneath it, and the
+/// name becomes claimable again. Requires the caller to be on the admin
+/// allow-list. Responds 404 if there is no such claim.
+#[utoipa::path(
+	post,
+	path = "/release",
+	operation_id = "domains_release",
+	tag = "domains",
+	security(("tailscale-admin" = [])),
+	request_body = DomainIdArgs,
+	responses((status = 200), (status = 404, body = ProblemDetailsSchema)),
+)]
+pub async fn release(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<DomainIdArgs>,
+) -> Result<Json<()>> {
+	let mut conn = state.db.get().await?;
+	ServerGroupDomain::release(&mut conn, args.id).await?;
+	Ok(Json(()))
+}

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -134,6 +134,12 @@ pub struct ServerInfo {
 	/// omitted-vs-present semantics as `up`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub health: Option<HealthState>,
+	/// Whether the server may manage its own DNS records for names under its
+	/// group's domains.
+	pub may_manage_dns: bool,
+	/// Whether the server may obtain TLS certificates for names under its
+	/// group's domains.
+	pub may_manage_tls: bool,
 }
 
 /// The server's most recently reported status push: version/host info plus
@@ -258,6 +264,14 @@ pub struct ServerDataUpdate {
 	/// unchanged.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub tags: Option<TagMap>,
+	/// Whether this server may manage its own DNS records for names under its
+	/// group's domains. Omit to leave unchanged.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub may_manage_dns: Option<bool>,
+	/// Whether this server may obtain TLS certificates for names under its
+	/// group's domains. Omit to leave unchanged.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub may_manage_tls: Option<bool>,
 }
 
 fn deserialize_some<'de, T, D>(deserializer: D) -> std::result::Result<Option<T>, D::Error>
@@ -293,6 +307,8 @@ pub(super) fn server_to_info(s: Server) -> ServerInfo {
 		archived: s.deleted_at.is_some(),
 		up: None,
 		health: None,
+		may_manage_dns: s.may_manage_dns,
+		may_manage_tls: s.may_manage_tls,
 	}
 }
 
@@ -868,6 +884,8 @@ pub async fn update(
 			.map(|s| database::pg_duration::PgDuration(jiff::SignedDuration::from_secs(s))),
 		notes: args.data.notes,
 		tags: args.data.tags,
+		may_manage_dns: args.data.may_manage_dns,
+		may_manage_tls: args.data.may_manage_tls,
 	};
 	Server::update(&mut conn, args.server_id, update_data).await?;
 
@@ -1028,6 +1046,10 @@ pub async fn create(
 		registered_at: None,
 		restore_allowed_until: None,
 		restore_allowed_by: None,
+		// Granted afterwards, deliberately: a server is not trusted with its
+		// own names by the act of being created.
+		may_manage_dns: false,
+		may_manage_tls: false,
 	};
 
 	let created = Server::create(&mut conn, server).await?;
@@ -1349,6 +1371,8 @@ pub async fn attach_tailscale_device(
 			alert_when_down_for: None,
 			notes: None,
 			tags: None,
+			may_manage_dns: None,
+			may_manage_tls: None,
 		},
 	)
 	.await?;

--- a/crates/private-server/src/openapi.rs
+++ b/crates/private-server/src/openapi.rs
@@ -21,6 +21,7 @@ use utoipa::{
 		(name = "bestool", description = "Bestool SQL snippet library."),
 		(name = "commons", description = "Shared configuration and identity helpers."),
 		(name = "devices", description = "Device registry, trust, and key management."),
+		(name = "domains", description = "Managed DNS zones and the domains each group controls."),
 		(name = "healthchecks", description = "Healthcheck catalog: severities, conditional rules, and sample data."),
 		(name = "incidents", description = "Operational incidents (groups of issues against a server)."),
 		(name = "issues", description = "Per-server issues raised from device events."),

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -5,6 +5,7 @@ use bestool_postgres::pool::PgPool;
 use commons_errors::Result;
 use commons_servers::recovery_vault::Recipients;
 use commons_servers::tailnet_directory::{TailnetDirectory, TailnetDirectoryConfig};
+use commons_types::dns::ManagedZone;
 use database::Db;
 use public_server::state::BackupSecrets;
 
@@ -51,6 +52,26 @@ pub struct AppState {
 	pub recovery_recipients: Option<Recipients>,
 	/// The single in-flight recovery verification challenge, if any.
 	pub recovery_challenge: RecoveryChallengeStore,
+	/// The DNS zones Canopy may write records in, from its deployment
+	/// configuration. Empty when none are configured, in which case no group
+	/// domain can be claimed — read once at startup, so a configuration change
+	/// takes effect on restart.
+	// spec: DOM#managed-zones
+	#[from_ref(skip)]
+	pub dns_zones: Vec<ManagedZone>,
+}
+
+/// Read the managed DNS zones from the environment, logging (not failing) a
+/// malformed list: the admin server should still come up, and the domain
+/// endpoints surface the misconfiguration as "no zones configured".
+fn dns_zones_from_env() -> Vec<ManagedZone> {
+	match ManagedZone::list_from_env() {
+		Ok(zones) => zones,
+		Err(e) => {
+			tracing::warn!("ignoring malformed {}: {e}", commons_types::dns::ZONES_ENV);
+			Vec::new()
+		}
+	}
 }
 
 /// Read the recovery recipients from the environment, logging (not failing) a malformed
@@ -103,6 +124,7 @@ impl AppState {
 			prober,
 			recovery_recipients: recovery_recipients_from_env(),
 			recovery_challenge: Arc::new(Mutex::new(None)),
+			dns_zones: dns_zones_from_env(),
 		})
 	}
 
@@ -129,6 +151,7 @@ impl AppState {
 			// Read from env so the e2e fixture can exercise the recovery ceremony.
 			recovery_recipients: recovery_recipients_from_env(),
 			recovery_challenge: Arc::new(Mutex::new(None)),
+			dns_zones: dns_zones_from_env(),
 		})
 	}
 }

--- a/crates/private-server/tests/it/device_admin_endpoints.rs
+++ b/crates/private-server/tests/it/device_admin_endpoints.rs
@@ -45,6 +45,7 @@ async fn private_with_directory(url: &str, directory: TailnetDirectory) -> TestS
 			),
 			recovery_recipients: None,
 			recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
+			dns_zones: Vec::new(),
 		})
 		.unwrap(),
 		ClientIpSource::RightmostForwarded,

--- a/crates/private-server/tests/it/domains.rs
+++ b/crates/private-server/tests/it/domains.rs
@@ -1,0 +1,259 @@
+//! Endpoint tests for the operator-facing `/api/domains/*` fns — the zone list
+//! read from Canopy's configuration, and claiming/releasing a group's domains
+//! against it.
+
+use commons_tests::diesel_async::{AsyncPgConnection, SimpleAsyncConnection};
+use uuid::Uuid;
+
+async fn insert_group(conn: &mut AsyncPgConnection, name: &str) -> Uuid {
+	let id = Uuid::new_v4();
+	conn.batch_execute(&format!(
+		"INSERT INTO server_groups (id, name) VALUES ('{id}', '{name}')"
+	))
+	.await
+	.expect("insert group");
+	id
+}
+
+/// Each nextest test runs in its own process, so setting the zone configuration
+/// here is isolated to this test. It has to happen before the server is built:
+/// the zones are read once, at startup.
+fn configure_zones(spec: &str) {
+	unsafe { std::env::set_var("CANOPY_DNS_ZONES", spec) };
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn zones_lists_the_configured_zones() {
+	configure_zones("tamanu.app=Z1ABC, senaite.app=Z2DEF");
+
+	commons_tests::server::run(async move |_conn, _public, private| {
+		let resp = private
+			.post("/api/domains/zones")
+			.json(&serde_json::json!({}))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		assert_eq!(body.as_array().expect("array").len(), 2);
+		assert_eq!(body[0]["apex"], "tamanu.app");
+		assert_eq!(body[0]["provider_zone_id"], "Z1ABC");
+		assert_eq!(body[1]["apex"], "senaite.app");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn claim_release_roundtrip() {
+	configure_zones("tamanu.app=Z1ABC");
+
+	commons_tests::server::run(async move |mut conn, _public, private| {
+		let group = insert_group(&mut conn, "fiji").await;
+
+		// Nothing claimed to start with.
+		let resp = private
+			.post("/api/domains/for_group")
+			.json(&serde_json::json!({"server_group_id": group}))
+			.await;
+		resp.assert_status_ok();
+		assert!(
+			resp.json::<serde_json::Value>()
+				.as_array()
+				.unwrap()
+				.is_empty()
+		);
+
+		// Claimed, normalised, and matched to its zone.
+		let resp = private
+			.post("/api/domains/claim")
+			.json(&serde_json::json!({
+				"server_group_id": group,
+				"domain": "Fiji.Tamanu.App.",
+			}))
+			.await;
+		resp.assert_status_ok();
+		let claim: serde_json::Value = resp.json();
+		assert_eq!(claim["domain"], "fiji.tamanu.app");
+		assert_eq!(claim["zone"], "tamanu.app");
+		assert_eq!(claim["group_id"], group.to_string());
+		let claim_id = claim["id"].as_str().expect("id").to_string();
+
+		// Listed against the group.
+		let resp = private
+			.post("/api/domains/for_group")
+			.json(&serde_json::json!({"server_group_id": group}))
+			.await;
+		resp.assert_status_ok();
+		let listed: serde_json::Value = resp.json();
+		assert_eq!(listed.as_array().unwrap().len(), 1);
+		assert_eq!(listed[0]["domain"], "fiji.tamanu.app");
+
+		// Released, and gone.
+		let resp = private
+			.post("/api/domains/release")
+			.json(&serde_json::json!({"id": claim_id}))
+			.await;
+		resp.assert_status_ok();
+
+		let resp = private
+			.post("/api/domains/for_group")
+			.json(&serde_json::json!({"server_group_id": group}))
+			.await;
+		resp.assert_status_ok();
+		assert!(
+			resp.json::<serde_json::Value>()
+				.as_array()
+				.unwrap()
+				.is_empty()
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn claim_outside_the_zones_is_a_400() {
+	configure_zones("tamanu.app=Z1ABC");
+
+	commons_tests::server::run(async move |mut conn, _public, private| {
+		let group = insert_group(&mut conn, "fiji").await;
+		let resp = private
+			.post("/api/domains/claim")
+			.json(&serde_json::json!({
+				"server_group_id": group,
+				"domain": "fiji.example.com",
+			}))
+			.await;
+		resp.assert_status_bad_request();
+
+		// So is a name that isn't a domain at all.
+		let resp = private
+			.post("/api/domains/claim")
+			.json(&serde_json::json!({"server_group_id": group, "domain": "nope"}))
+			.await;
+		resp.assert_status_bad_request();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn overlapping_claim_is_a_409() {
+	configure_zones("tamanu.app=Z1ABC");
+
+	commons_tests::server::run(async move |mut conn, _public, private| {
+		let fiji = insert_group(&mut conn, "fiji").await;
+		let samoa = insert_group(&mut conn, "samoa").await;
+
+		private
+			.post("/api/domains/claim")
+			.json(&serde_json::json!({
+				"server_group_id": fiji,
+				"domain": "fiji.tamanu.app",
+			}))
+			.await
+			.assert_status_ok();
+
+		for domain in ["fiji.tamanu.app", "sub.fiji.tamanu.app", "tamanu.app"] {
+			let resp = private
+				.post("/api/domains/claim")
+				.json(&serde_json::json!({
+					"server_group_id": samoa,
+					"domain": domain,
+				}))
+				.await;
+			assert_eq!(
+				resp.status_code(),
+				axum::http::StatusCode::CONFLICT,
+				"claiming {domain} should conflict"
+			);
+		}
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn releasing_an_unknown_claim_is_a_404() {
+	configure_zones("tamanu.app=Z1ABC");
+
+	commons_tests::server::run(async move |_conn, _public, private| {
+		let resp = private
+			.post("/api/domains/release")
+			.json(&serde_json::json!({"id": Uuid::new_v4()}))
+			.await;
+		resp.assert_status_not_found();
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_claim_whose_zone_left_the_configuration_reads_as_unmatched() {
+	configure_zones("tamanu.app=Z1ABC");
+
+	commons_tests::server::run(async move |mut conn, _public, private| {
+		let group = insert_group(&mut conn, "fiji").await;
+		private
+			.post("/api/domains/claim")
+			.json(&serde_json::json!({
+				"server_group_id": group,
+				"domain": "fiji.tamanu.app",
+			}))
+			.await
+			.assert_status_ok();
+
+		// Insert a claim in a zone this instance is not configured for — the
+		// state a claim lands in when its zone leaves the configuration.
+		conn.batch_execute(&format!(
+			"INSERT INTO server_group_domains (group_id, domain) \
+			 VALUES ('{group}', 'old.senaite.app')"
+		))
+		.await
+		.expect("insert stale claim");
+
+		let resp = private
+			.post("/api/domains/for_group")
+			.json(&serde_json::json!({"server_group_id": group}))
+			.await;
+		resp.assert_status_ok();
+		let listed: serde_json::Value = resp.json();
+		let by_domain: std::collections::HashMap<&str, &serde_json::Value> = listed
+			.as_array()
+			.unwrap()
+			.iter()
+			.map(|row| (row["domain"].as_str().unwrap(), row))
+			.collect();
+		assert_eq!(by_domain["fiji.tamanu.app"]["zone"], "tamanu.app");
+		assert!(
+			by_domain["old.senaite.app"]["zone"].is_null(),
+			"a claim with no configured zone should report no zone"
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn with_no_zones_configured_nothing_can_be_claimed() {
+	configure_zones("");
+
+	commons_tests::server::run(async move |mut conn, _public, private| {
+		let group = insert_group(&mut conn, "fiji").await;
+
+		let resp = private
+			.post("/api/domains/zones")
+			.json(&serde_json::json!({}))
+			.await;
+		resp.assert_status_ok();
+		assert!(
+			resp.json::<serde_json::Value>()
+				.as_array()
+				.unwrap()
+				.is_empty()
+		);
+
+		let resp = private
+			.post("/api/domains/claim")
+			.json(&serde_json::json!({
+				"server_group_id": group,
+				"domain": "fiji.tamanu.app",
+			}))
+			.await;
+		resp.assert_status_bad_request();
+	})
+	.await;
+}

--- a/crates/private-server/tests/it/main.rs
+++ b/crates/private-server/tests/it/main.rs
@@ -9,6 +9,7 @@ mod create_server;
 mod device_admin_endpoints;
 mod device_keys;
 mod devices;
+mod domains;
 mod endpoints;
 mod enrollment_ticket;
 mod group_card_version;

--- a/crates/private-server/tests/it/tailnet_device_auth.rs
+++ b/crates/private-server/tests/it/tailnet_device_auth.rs
@@ -92,6 +92,7 @@ async fn unknown_tailnet_node_is_rejected_without_creating_a_row() {
 				),
 				recovery_recipients: None,
 				recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
+				dns_zones: Vec::new(),
 			})
 			.unwrap(),
 			ClientIpSource::RightmostForwarded,

--- a/crates/private-server/tests/it/update_server.rs
+++ b/crates/private-server/tests/it/update_server.rs
@@ -398,3 +398,65 @@ async fn update_server_sets_new_device_id() {
 	})
 	.await
 }
+
+/// The per-server name-management grants (DOM) are withheld at creation and
+/// carried by the ordinary update path, one independently of the other.
+#[tokio::test(flavor = "multi_thread")]
+async fn update_server_name_management_grants() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		let id = "44444444-4444-4444-4444-444444444444";
+		conn.batch_execute(&format!(
+			"INSERT INTO servers (id, name, host, rank, kind) VALUES
+			('{id}', 'DNS Server', 'https://dns.example.com', 'production', 'central')"
+		))
+		.await
+		.unwrap();
+
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
+		assert!(!server.may_manage_dns, "withheld until granted");
+		assert!(!server.may_manage_tls, "withheld until granted");
+
+		private
+			.post("/api/servers/update")
+			.json(&json!({"server_id": id, "data": {"may_manage_dns": true}}))
+			.await
+			.assert_status_ok();
+
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
+		assert!(server.may_manage_dns);
+		assert!(!server.may_manage_tls, "granting DNS must not grant TLS");
+
+		// An update touching neither leaves both alone.
+		private
+			.post("/api/servers/update")
+			.json(&json!({"server_id": id, "data": {"name": "Renamed"}}))
+			.await
+			.assert_status_ok();
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
+		assert!(
+			server.may_manage_dns,
+			"an unrelated update must not revoke it"
+		);
+
+		// Revoked again.
+		private
+			.post("/api/servers/update")
+			.json(
+				&json!({"server_id": id, "data": {"may_manage_dns": false, "may_manage_tls": true}}),
+			)
+			.await
+			.assert_status_ok();
+		let server = Server::get_by_id(&mut conn, id.parse().unwrap())
+			.await
+			.unwrap();
+		assert!(!server.may_manage_dns);
+		assert!(server.may_manage_tls);
+	})
+	.await
+}

--- a/crates/public-server/tests/it/server_enrollment.rs
+++ b/crates/public-server/tests/it/server_enrollment.rs
@@ -43,6 +43,8 @@ fn new_server(host: &str) -> Server {
 		registered_at: None,
 		restore_allowed_until: None,
 		restore_allowed_by: None,
+		may_manage_dns: false,
+		may_manage_tls: false,
 	}
 }
 

--- a/migrations/2026-07-29-041806-0000_server_group_domains/down.sql
+++ b/migrations/2026-07-29-041806-0000_server_group_domains/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE servers
+	DROP COLUMN may_manage_tls,
+	DROP COLUMN may_manage_dns;
+
+DROP TABLE server_group_domains;

--- a/migrations/2026-07-29-041806-0000_server_group_domains/up.sql
+++ b/migrations/2026-07-29-041806-0000_server_group_domains/up.sql
@@ -1,0 +1,39 @@
+-- Server group domains (DOM): which DNS names each group controls, and which
+-- servers are trusted to manage their own names under them.
+--
+-- The zones Canopy can write records in are deployment configuration, not
+-- state, so they have no table here: a claim is validated against the
+-- configured zones at claim time and re-matched on every read, which is what
+-- lets a claim survive its zone leaving the configuration (reported as
+-- unmatched) instead of being silently actionable or silently dropped.
+--
+-- FK note: server_groups is archived (soft-deleted), never hard-deleted, so
+-- this FK is a plain REFERENCES like the other group-scoped tables.
+
+-- A domain a group controls, holding everything beneath it. Claims never
+-- overlap fleet-wide (see database::server_domains::claim), so at most one
+-- group controls any given name.
+CREATE TABLE server_group_domains (
+	id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	group_id   UUID NOT NULL REFERENCES server_groups(id),
+	-- Normalised: lower case, no trailing dot, at least two labels.
+	domain     TEXT NOT NULL,
+	created_by TEXT,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+SELECT diesel_manage_updated_at('server_group_domains');
+
+-- Exact duplicates are impossible even under a concurrent claim; the wider
+-- no-overlap rule (a claim above or below another) needs a read of neighbouring
+-- rows, so claiming serialises on an advisory lock and checks there.
+CREATE UNIQUE INDEX server_group_domains_domain ON server_group_domains (domain);
+CREATE INDEX server_group_domains_group ON server_group_domains (group_id);
+
+-- Whether this server may manage its own DNS records, and whether it may obtain
+-- its own TLS certificates, for names under its group's domains. Withheld by
+-- default: a server that has neither is authenticated and refused.
+ALTER TABLE servers
+	ADD COLUMN may_manage_dns BOOLEAN NOT NULL DEFAULT false,
+	ADD COLUMN may_manage_tls BOOLEAN NOT NULL DEFAULT false;

--- a/private-web/e2e/domains.spec.ts
+++ b/private-web/e2e/domains.spec.ts
@@ -1,0 +1,176 @@
+import { expect, test } from "./test-fixtures";
+import {
+	resetSeededTables,
+	seedServer,
+	seedServerGroup,
+	seedServerGroupDomain,
+} from "./seed";
+
+// The e2e fixture runs the private-server in a debug build, so the Tailscale
+// auth bypass treats every caller as `admin@localhost` (an admin). It also
+// configures two managed zones: `tamanu.app` and `demo.tamanu.app`.
+
+test.describe("group domains", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("empty state invites a claim and names the claimable zones", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "domainless" });
+		await page.goto(`/groups/${group.id}`);
+
+		await expect(
+			page.getByRole("heading", { name: "Domains" }),
+		).toBeVisible();
+		await expect(
+			page.getByText(/this group controls no domains yet/i),
+		).toBeVisible();
+		await expect(
+			page.getByText(/must be at or under one of: tamanu\.app, demo\.tamanu\.app/i),
+		).toBeVisible();
+	});
+
+	test("claimed domains list with the zone they resolve to", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "fiji" });
+		await seedServerGroupDomain(sql, {
+			groupId: group.id,
+			domain: "fiji.tamanu.app",
+			createdBy: "operator@example.test",
+		});
+		// Sits under the nested zone, so it resolves to the longer apex.
+		await seedServerGroupDomain(sql, {
+			groupId: group.id,
+			domain: "fiji.demo.tamanu.app",
+		});
+		// No configured zone covers this one any more.
+		await seedServerGroupDomain(sql, {
+			groupId: group.id,
+			domain: "old.senaite.app",
+		});
+
+		await page.goto(`/groups/${group.id}`);
+
+		await expect(page.getByText("fiji.tamanu.app", { exact: true })).toBeVisible();
+		await expect(page.getByText("zone tamanu.app")).toBeVisible();
+		await expect(page.getByText("zone demo.tamanu.app")).toBeVisible();
+		await expect(page.getByText("no matching zone")).toBeVisible();
+		await expect(page.getByText(/by operator@example\.test/)).toBeVisible();
+	});
+
+	test("an admin claims a domain and releases it again", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "samoa" });
+		await page.goto(`/groups/${group.id}`);
+
+		await page.getByLabel("Domain").fill("samoa.tamanu.app");
+		await page.getByRole("button", { name: "Claim" }).click();
+
+		await expect(
+			page.getByText("samoa.tamanu.app", { exact: true }),
+		).toBeVisible();
+		await expect(page.getByText("zone tamanu.app")).toBeVisible();
+
+		page.once("dialog", (dialog) => dialog.accept());
+		await page.getByRole("button", { name: "Release samoa.tamanu.app" }).click();
+
+		await expect(
+			page.getByText(/this group controls no domains yet/i),
+		).toBeVisible();
+	});
+
+	test("a domain outside every managed zone is refused", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "outside" });
+		await page.goto(`/groups/${group.id}`);
+
+		await page.getByLabel("Domain").fill("nope.example.com");
+		await page.getByRole("button", { name: "Claim" }).click();
+
+		await expect(
+			page.getByText(/not within any of Canopy's managed DNS zones/i),
+		).toBeVisible();
+		await expect(
+			page.getByText(/this group controls no domains yet/i),
+		).toBeVisible();
+	});
+
+	test("a domain overlapping another group's claim is refused", async ({
+		page,
+		sql,
+	}) => {
+		const holder = await seedServerGroup(sql, { name: "holder" });
+		await seedServerGroupDomain(sql, {
+			groupId: holder.id,
+			domain: "contested.tamanu.app",
+		});
+		const rival = await seedServerGroup(sql, { name: "rival" });
+
+		await page.goto(`/groups/${rival.id}`);
+		await page.getByLabel("Domain").fill("sub.contested.tamanu.app");
+		await page.getByRole("button", { name: "Claim" }).click();
+
+		await expect(page.getByText(/overlaps contested\.tamanu\.app/i)).toBeVisible();
+	});
+});
+
+test.describe("server name-management permissions", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("a server shows no permission until one is granted", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "perm-group" });
+		const server = await seedServer(sql, {
+			name: "unpermitted",
+			groupId: group.id,
+		});
+		await page.goto(`/servers/${server.id}`);
+
+		await expect(page.getByText("Name management")).toBeVisible();
+		await expect(page.getByText("Not permitted")).toBeVisible();
+	});
+
+	test("granting DNS in the edit form shows on the server", async ({
+		page,
+		sql,
+	}) => {
+		// The edit form requires a group, so grant on a grouped server.
+		const group = await seedServerGroup(sql, { name: "grant-group" });
+		const server = await seedServer(sql, {
+			name: "grantee",
+			groupId: group.id,
+		});
+		await page.goto(`/servers/${server.id}/edit`);
+
+		await page.getByLabel("May manage its own DNS records").check();
+		await page.getByRole("button", { name: "Save" }).click();
+
+		await expect(page.getByText("DNS only")).toBeVisible();
+
+		// And the other grant is independent of it.
+		await page.goto(`/servers/${server.id}/edit`);
+		await expect(
+			page.getByLabel("May manage its own DNS records"),
+		).toBeChecked();
+		await expect(
+			page.getByLabel("May obtain its own TLS certificates"),
+		).not.toBeChecked();
+		await page.getByLabel("May obtain its own TLS certificates").check();
+		await page.getByRole("button", { name: "Save" }).click();
+
+		await expect(page.getByText("DNS and TLS")).toBeVisible();
+	});
+});

--- a/private-web/e2e/fixture.ts
+++ b/private-web/e2e/fixture.ts
@@ -204,6 +204,10 @@ export async function startStack(opts: StartOptions = {}): Promise<StackHandle> 
 				// full decrypt round-trip is covered by the Rust endpoint tests.
 				CANOPY_RECOVERY_VAULT_KEYS:
 					"age1uy3nqmdxf4lc3sc4p32c2cp9dlqwk868gjh002gysullrgvp0cjsdg03dn",
+				// Two managed DNS zones so the group-domains UI has something to
+				// claim into; the nested one is there for the longest-apex-wins
+				// case.
+				CANOPY_DNS_ZONES: "tamanu.app=Z1E2E, demo.tamanu.app=Z2E2E",
 				// Needed by mint_enrollment to build the ticket's api_url; the
 				// setup-instructions flow auto-mints on an unregistered server.
 				PUBLIC_URL: process.env.PUBLIC_URL ?? "https://api.e2e.invalid",

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,7 +47,7 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
 	// self-alerts attach to that row, so put it back. `kind = 'canopy'` is the
@@ -140,6 +140,11 @@ export async function seedServer(
 		isMonitored?: boolean;
 		/** Threshold in seconds; defaults to 600 (10 min). Must be > 0. */
 		alertWhenDownFor?: number;
+		/** Whether the server may manage its own DNS records / obtain its own
+		 * TLS certificates under its group's domains. Both off by default, as
+		 * they are for a real server. */
+		mayManageDns?: boolean;
+		mayManageTls?: boolean;
 	} = {},
 ): Promise<SeededServer> {
 	const id = randomUUID();
@@ -153,8 +158,8 @@ export async function seedServer(
 	const isMonitored = opts.isMonitored ?? false;
 	const alertWhenDownFor = opts.alertWhenDownFor ?? 600;
 	await sql.query(
-		`INSERT INTO servers (id, name, host, product, kind, rank, group_id, device_id, is_monitored, alert_when_down_for, notes, tags)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb)`,
+		`INSERT INTO servers (id, name, host, product, kind, rank, group_id, device_id, is_monitored, alert_when_down_for, notes, tags, may_manage_dns, may_manage_tls)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14)`,
 		[
 			id,
 			name,
@@ -168,6 +173,8 @@ export async function seedServer(
 			alertWhenDownFor,
 			opts.notes ?? "",
 			JSON.stringify(opts.tags ?? {}),
+			opts.mayManageDns ?? false,
+			opts.mayManageTls ?? false,
 		],
 	);
 	return { id, name, host, product, kind, rank };
@@ -1140,4 +1147,19 @@ export async function seedRecoveryVaultWrite(
 		 VALUES (NOW() - make_interval(secs => $1), $2)`,
 		[opts.writtenAgoSecs ?? 0, opts.bytes ?? 4096],
 	);
+}
+
+/** Seed a `server_group_domains` row: a domain the group controls. Claims must
+ * not overlap, so give each seeded group its own name. */
+export async function seedServerGroupDomain(
+	sql: Sql,
+	opts: { groupId: string; domain: string; createdBy?: string },
+): Promise<{ id: string; domain: string }> {
+	const id = randomUUID();
+	await sql.query(
+		`INSERT INTO server_group_domains (id, group_id, domain, created_by)
+		 VALUES ($1, $2, $3, $4)`,
+		[id, opts.groupId, opts.domain, opts.createdBy ?? null],
+	);
+	return { id, domain: opts.domain };
 }

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -2592,6 +2592,173 @@
         ]
       }
     },
+    "/api/domains/claim": {
+      "post": {
+        "tags": [
+          "domains"
+        ],
+        "summary": "Claim a domain for a group.",
+        "description": "The group then controls the domain and every name beneath it, and no other\ngroup can claim a name overlapping it. Requires the caller to be on the\nadmin allow-list. Responds 400 if the name is not a valid domain of at least\ntwo labels or does not sit within one of Canopy's managed zones, and 409 if\nit overlaps a domain already claimed — by this group or another.",
+        "operationId": "domains_claim",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DomainClaimArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupDomainView"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The domain overlaps one already claimed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/domains/for_group": {
+      "post": {
+        "tags": [
+          "domains"
+        ],
+        "summary": "List the domains a group controls.",
+        "description": "Each carries the managed zone it resolves to, or null for a claim no\nconfigured zone matches.",
+        "operationId": "domains_for_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GroupIdArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GroupDomainView"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
+    "/api/domains/release": {
+      "post": {
+        "tags": [
+          "domains"
+        ],
+        "summary": "Release a claimed domain.",
+        "description": "The group loses control of the domain and every name beneath it, and the\nname becomes claimable again. Requires the caller to be on the admin\nallow-list. Responds 404 if there is no such claim.",
+        "operationId": "domains_release",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DomainIdArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/domains/zones": {
+      "post": {
+        "tags": [
+          "domains"
+        ],
+        "summary": "List the managed DNS zones Canopy is configured with.",
+        "description": "An operator claiming a domain for a group needs these to know which names\nare claimable at all: a claim has to sit at or under one of these apexes.\nAn empty list means Canopy has been given no zones, so no domain can be\nclaimed until its deployment configuration provides one.",
+        "operationId": "domains_zones",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManagedZoneView"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
     "/api/healthchecks/decommission": {
       "post": {
         "tags": [
@@ -8223,6 +8390,39 @@
           }
         }
       },
+      "DomainClaimArgs": {
+        "type": "object",
+        "description": "Fields needed to claim a domain for a group.",
+        "required": [
+          "server_group_id",
+          "domain"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "description": "The domain to claim. Case and a trailing dot are not significant. An\ninternationalised domain is claimed in its ASCII-compatible (punycode)\nspelling."
+          },
+          "server_group_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group to give control of the domain."
+          }
+        }
+      },
+      "DomainIdArgs": {
+        "type": "object",
+        "description": "Identifies a claim.",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The claim to release."
+          }
+        }
+      },
       "DutyBucket": {
         "type": "object",
         "description": "One hour-of-week bucket of the degradation profile.",
@@ -8567,6 +8767,50 @@
             "type": "string",
             "format": "uuid",
             "description": "Id of the server group to fetch details for."
+          }
+        }
+      },
+      "GroupDomainView": {
+        "type": "object",
+        "description": "A domain a group controls, with the managed zone it resolves to.",
+        "required": [
+          "id",
+          "group_id",
+          "domain",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When it was claimed."
+          },
+          "created_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Login of the operator who claimed it, if recorded."
+          },
+          "domain": {
+            "type": "string",
+            "description": "The domain, normalised to lower case without a trailing dot."
+          },
+          "group_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group that controls the domain."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the claim."
+          },
+          "zone": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Apex of the managed zone this domain resolves to — the longest\nconfigured apex it sits within. Null when no configured zone covers it,\nwhich means the zone has left Canopy's configuration since the claim was\nmade: the claim stands and still excludes others, but Canopy will act on\nno name beneath it until the zone is restored or the claim released."
           }
         }
       },
@@ -9944,6 +10188,24 @@
           "full"
         ]
       },
+      "ManagedZoneView": {
+        "type": "object",
+        "description": "A DNS zone Canopy can write records in.\n\nZones come from Canopy's deployment configuration rather than from operator\nstate: they are what the infrastructure has granted Canopy write access to,\nand they bound which domains a group can be given.",
+        "required": [
+          "apex",
+          "provider_zone_id"
+        ],
+        "properties": {
+          "apex": {
+            "type": "string",
+            "description": "The zone's apex domain, for example `tamanu.app`."
+          },
+          "provider_zone_id": {
+            "type": "string",
+            "description": "The identifier the DNS provider knows this zone by."
+          }
+        }
+      },
       "McpTokenView": {
         "type": "object",
         "description": "Metadata about an MCP access token. Never includes the secret value\nitself — that's only ever returned once, at minting time.",
@@ -10270,7 +10532,9 @@
                 "alert_when_down_for",
                 "notes",
                 "tags",
-                "archived"
+                "archived",
+                "may_manage_dns",
+                "may_manage_tls"
               ],
               "properties": {
                 "alert_when_down_for": {
@@ -10357,6 +10621,14 @@
                 "kind": {
                   "$ref": "#/components/schemas/ServerKind",
                   "description": "The server's role within its product's topology."
+                },
+                "may_manage_dns": {
+                  "type": "boolean",
+                  "description": "Whether the server may manage its own DNS records for names under its\ngroup's domains."
+                },
+                "may_manage_tls": {
+                  "type": "boolean",
+                  "description": "Whether the server may obtain TLS certificates for names under its\ngroup's domains."
                 },
                 "name": {
                   "type": [
@@ -12197,6 +12469,20 @@
               }
             ]
           },
+          "may_manage_dns": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether this server may manage its own DNS records for names under its\ngroup's domains. Omit to leave unchanged."
+          },
+          "may_manage_tls": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether this server may obtain TLS certificates for names under its\ngroup's domains. Omit to leave unchanged."
+          },
           "name": {
             "type": [
               "string",
@@ -12611,7 +12897,9 @@
           "alert_when_down_for",
           "notes",
           "tags",
-          "archived"
+          "archived",
+          "may_manage_dns",
+          "may_manage_tls"
         ],
         "properties": {
           "alert_when_down_for": {
@@ -12698,6 +12986,14 @@
           "kind": {
             "$ref": "#/components/schemas/ServerKind",
             "description": "The server's role within its product's topology."
+          },
+          "may_manage_dns": {
+            "type": "boolean",
+            "description": "Whether the server may manage its own DNS records for names under its\ngroup's domains."
+          },
+          "may_manage_tls": {
+            "type": "boolean",
+            "description": "Whether the server may obtain TLS certificates for names under its\ngroup's domains."
           },
           "name": {
             "type": [
@@ -14208,6 +14504,10 @@
     {
       "name": "devices",
       "description": "Device registry, trust, and key management."
+    },
+    {
+      "name": "domains",
+      "description": "Managed DNS zones and the domains each group controls."
     },
     {
       "name": "healthchecks",

--- a/private-web/package-lock.json
+++ b/private-web/package-lock.json
@@ -37,7 +37,7 @@
 				"jsdom": "^29.1.1",
 				"openapi-typescript": "^7.13.0",
 				"pg": "^8.22.0",
-				"typescript": "^7.0.2",
+				"typescript": "^5.9.3",
 				"vite": "^8.1.5",
 				"vitest": "^4.1.10"
 			}
@@ -1185,9 +1185,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1205,9 +1202,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1225,9 +1219,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1245,9 +1236,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1265,9 +1253,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1285,9 +1270,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1588,346 +1570,6 @@
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
 			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
 			"license": "MIT"
-		},
-		"node_modules/@typescript/typescript-aix-ppc64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-			"integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-darwin-arm64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-			"integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-darwin-x64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-			"integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-freebsd-arm64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-			"integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-freebsd-x64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-			"integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-linux-arm": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-			"integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-linux-arm64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-			"integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-linux-loong64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-			"integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-linux-mips64el": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-			"integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-linux-ppc64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-			"integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-linux-riscv64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-			"integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-linux-s390x": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-			"integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-linux-x64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-			"integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-netbsd-arm64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-			"integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-netbsd-x64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-			"integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-openbsd-arm64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-			"integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-openbsd-x64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-			"integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-sunos-x64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-			"integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-win32-arm64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-			"integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
-		},
-		"node_modules/@typescript/typescript-win32-x64": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-			"integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=16.20.0"
-			}
 		},
 		"node_modules/@uiw/codemirror-extensions-basic-setup": {
 			"version": "4.25.11",
@@ -5413,38 +5055,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
-				"tsc": "bin/tsc"
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=16.20.0"
-			},
-			"optionalDependencies": {
-				"@typescript/typescript-aix-ppc64": "7.0.2",
-				"@typescript/typescript-darwin-arm64": "7.0.2",
-				"@typescript/typescript-darwin-x64": "7.0.2",
-				"@typescript/typescript-freebsd-arm64": "7.0.2",
-				"@typescript/typescript-freebsd-x64": "7.0.2",
-				"@typescript/typescript-linux-arm": "7.0.2",
-				"@typescript/typescript-linux-arm64": "7.0.2",
-				"@typescript/typescript-linux-loong64": "7.0.2",
-				"@typescript/typescript-linux-mips64el": "7.0.2",
-				"@typescript/typescript-linux-ppc64": "7.0.2",
-				"@typescript/typescript-linux-riscv64": "7.0.2",
-				"@typescript/typescript-linux-s390x": "7.0.2",
-				"@typescript/typescript-linux-x64": "7.0.2",
-				"@typescript/typescript-netbsd-arm64": "7.0.2",
-				"@typescript/typescript-netbsd-x64": "7.0.2",
-				"@typescript/typescript-openbsd-arm64": "7.0.2",
-				"@typescript/typescript-openbsd-x64": "7.0.2",
-				"@typescript/typescript-sunos-x64": "7.0.2",
-				"@typescript/typescript-win32-arm64": "7.0.2",
-				"@typescript/typescript-win32-x64": "7.0.2"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/undici": {

--- a/private-web/package.json
+++ b/private-web/package.json
@@ -42,7 +42,7 @@
 		"jsdom": "^29.1.1",
 		"openapi-typescript": "^7.13.0",
 		"pg": "^8.22.0",
-		"typescript": "^7.0.2",
+		"typescript": "^5.9.3",
 		"vite": "^8.1.5",
 		"vitest": "^4.1.10"
 	}

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -1310,6 +1310,96 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/domains/claim": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Claim a domain for a group.
+         * @description The group then controls the domain and every name beneath it, and no other
+         *     group can claim a name overlapping it. Requires the caller to be on the
+         *     admin allow-list. Responds 400 if the name is not a valid domain of at least
+         *     two labels or does not sit within one of Canopy's managed zones, and 409 if
+         *     it overlaps a domain already claimed — by this group or another.
+         */
+        post: operations["domains_claim"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/domains/for_group": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * List the domains a group controls.
+         * @description Each carries the managed zone it resolves to, or null for a claim no
+         *     configured zone matches.
+         */
+        post: operations["domains_for_group"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/domains/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Release a claimed domain.
+         * @description The group loses control of the domain and every name beneath it, and the
+         *     name becomes claimable again. Requires the caller to be on the admin
+         *     allow-list. Responds 404 if there is no such claim.
+         */
+        post: operations["domains_release"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/domains/zones": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * List the managed DNS zones Canopy is configured with.
+         * @description An operator claiming a domain for a group needs these to know which names
+         *     are claimable at all: a claim has to sit at or under one of these apexes.
+         *     An empty list means Canopy has been given no zones, so no domain can be
+         *     claimed until its deployment configuration provides one.
+         */
+        post: operations["domains_zones"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/healthchecks/decommission": {
         parameters: {
             query?: never;
@@ -4439,6 +4529,28 @@ export interface components {
              */
             query: string;
         };
+        /** @description Fields needed to claim a domain for a group. */
+        DomainClaimArgs: {
+            /**
+             * @description The domain to claim. Case and a trailing dot are not significant. An
+             *     internationalised domain is claimed in its ASCII-compatible (punycode)
+             *     spelling.
+             */
+            domain: string;
+            /**
+             * Format: uuid
+             * @description The group to give control of the domain.
+             */
+            server_group_id: string;
+        };
+        /** @description Identifies a claim. */
+        DomainIdArgs: {
+            /**
+             * Format: uuid
+             * @description The claim to release.
+             */
+            id: string;
+        };
         /** @description One hour-of-week bucket of the degradation profile. */
         DutyBucket: {
             /**
@@ -4638,6 +4750,33 @@ export interface components {
              * @description Id of the server group to fetch details for.
              */
             server_group_id: string;
+        };
+        /** @description A domain a group controls, with the managed zone it resolves to. */
+        GroupDomainView: {
+            /** @description When it was claimed. */
+            created_at: string;
+            /** @description Login of the operator who claimed it, if recorded. */
+            created_by?: string | null;
+            /** @description The domain, normalised to lower case without a trailing dot. */
+            domain: string;
+            /**
+             * Format: uuid
+             * @description The group that controls the domain.
+             */
+            group_id: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier of the claim.
+             */
+            id: string;
+            /**
+             * @description Apex of the managed zone this domain resolves to — the longest
+             *     configured apex it sits within. Null when no configured zone covers it,
+             *     which means the zone has left Canopy's configuration since the claim was
+             *     made: the claim stands and still excludes others, but Canopy will act on
+             *     no name beneath it until the zone is restored or the claim released.
+             */
+            zone?: string | null;
         };
         /** @description Identifies the server group to operate on. */
         GroupIdArgs: {
@@ -5573,6 +5712,19 @@ export interface components {
          */
         MaintenanceKind: "quick" | "full";
         /**
+         * @description A DNS zone Canopy can write records in.
+         *
+         *     Zones come from Canopy's deployment configuration rather than from operator
+         *     state: they are what the infrastructure has granted Canopy write access to,
+         *     and they bound which domains a group can be given.
+         */
+        ManagedZoneView: {
+            /** @description The zone's apex domain, for example `tamanu.app`. */
+            apex: string;
+            /** @description The identifier the DNS provider knows this zone by. */
+            provider_zone_id: string;
+        };
+        /**
          * @description Metadata about an MCP access token. Never includes the secret value
          *     itself — that's only ever returned once, at minting time.
          */
@@ -5809,6 +5961,16 @@ export interface components {
                 is_monitored: boolean;
                 /** @description The server's role within its product's topology. */
                 kind: components["schemas"]["ServerKind"];
+                /**
+                 * @description Whether the server may manage its own DNS records for names under its
+                 *     group's domains.
+                 */
+                may_manage_dns: boolean;
+                /**
+                 * @description Whether the server may obtain TLS certificates for names under its
+                 *     group's domains.
+                 */
+                may_manage_tls: boolean;
                 /** @description Operator-assigned name for the server, if any. */
                 name?: string | null;
                 /** @description Free-text operator notes about the server. */
@@ -7024,6 +7186,16 @@ export interface components {
              */
             is_monitored?: boolean | null;
             kind?: null | components["schemas"]["ServerKind"];
+            /**
+             * @description Whether this server may manage its own DNS records for names under its
+             *     group's domains. Omit to leave unchanged.
+             */
+            may_manage_dns?: boolean | null;
+            /**
+             * @description Whether this server may obtain TLS certificates for names under its
+             *     group's domains. Omit to leave unchanged.
+             */
+            may_manage_tls?: boolean | null;
             /** @description New name for the server. Omit to leave unchanged. */
             name?: string | null;
             /** @description New free-text notes for the server. Omit to leave unchanged. */
@@ -7302,6 +7474,16 @@ export interface components {
             is_monitored: boolean;
             /** @description The server's role within its product's topology. */
             kind: components["schemas"]["ServerKind"];
+            /**
+             * @description Whether the server may manage its own DNS records for names under its
+             *     group's domains.
+             */
+            may_manage_dns: boolean;
+            /**
+             * @description Whether the server may obtain TLS certificates for names under its
+             *     group's domains.
+             */
+            may_manage_tls: boolean;
             /** @description Operator-assigned name for the server, if any. */
             name?: string | null;
             /** @description Free-text operator notes about the server. */
@@ -9978,6 +10160,117 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    domains_claim: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DomainClaimArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupDomainView"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            /** @description The domain overlaps one already claimed. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    domains_for_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupIdArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupDomainView"][];
+                };
+            };
+        };
+    };
+    domains_release: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DomainIdArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    domains_zones: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ManagedZoneView"][];
                 };
             };
         };

--- a/private-web/src/components/GroupDomainsSection.tsx
+++ b/private-web/src/components/GroupDomainsSection.tsx
@@ -57,10 +57,16 @@ export default function GroupDomainsSection({ groupId }: { groupId: string }) {
 	const rows = domains.data;
 	const zoneList = zones.status === "ok" ? zones.data : [];
 
-
 	// Nothing claimed and nothing an operator can do about it: stay out of the
 	// way rather than showing an empty box to every reader.
 	if (rows.length === 0 && !isAdmin) return null;
+
+	// Nothing claimed and no zone to claim into: the feature isn't in use here,
+	// so say nothing at all rather than sitting a standing warning on every
+	// group page of a deployment that hasn't been given zones yet.
+	// spec: DOM#when-the-zone-configuration-changes
+	if (rows.length === 0 && zones.status === "ok" && zoneList.length === 0)
+		return null;
 
 	return (
 		<Paper variant="outlined" sx={{ p: 2 }}>

--- a/private-web/src/components/GroupDomainsSection.tsx
+++ b/private-web/src/components/GroupDomainsSection.tsx
@@ -1,0 +1,253 @@
+import {
+	Alert,
+	Box,
+	Button,
+	Chip,
+	IconButton,
+	LinearProgress,
+	Paper,
+	Stack,
+	TextField,
+	Tooltip,
+	Typography,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import { useState } from "react";
+import { useApi, useApiAction } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
+import TimeAgo from "./TimeAgo";
+
+/// The domains this group controls, on the group detail page. A claim covers
+/// every name beneath it and excludes every other group from overlapping it,
+/// which is what authorises the group's servers to manage names there.
+/// See `database::server_domains` for the matching backend.
+// spec: DOM
+export default function GroupDomainsSection({ groupId }: { groupId: string }) {
+	const isAdmin = useIsAdmin() === true;
+	const [tick, setTick] = useState(0);
+	const reload = () => setTick((t) => t + 1);
+
+	const domains = useApi(
+		"domains",
+		"for_group",
+		{ server_group_id: groupId },
+		[groupId, tick],
+	);
+	const zones = useApi("domains", "zones", {}, []);
+
+	if (domains.status === "loading" || domains.status === "idle") {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<SectionHeading />
+				<LinearProgress />
+			</Paper>
+		);
+	}
+	if (domains.status === "error") {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<SectionHeading />
+				<Alert severity="error">{domains.error.message}</Alert>
+			</Paper>
+		);
+	}
+
+	const rows = domains.data;
+	const zoneList = zones.status === "ok" ? zones.data : [];
+
+
+	// Nothing claimed and nothing an operator can do about it: stay out of the
+	// way rather than showing an empty box to every reader.
+	if (rows.length === 0 && !isAdmin) return null;
+
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }}>
+			<SectionHeading />
+			<Stack spacing={2}>
+				{rows.length === 0 ? (
+					<Alert severity="info">
+						This group controls no domains yet.
+					</Alert>
+				) : (
+					<Stack spacing={1}>
+						{rows.map((row) => (
+							<DomainRow
+								key={row.id}
+								id={row.id}
+								domain={row.domain}
+								zone={row.zone}
+								createdAt={row.created_at}
+								createdBy={row.created_by}
+								isAdmin={isAdmin}
+								onChanged={reload}
+							/>
+						))}
+					</Stack>
+				)}
+
+				{/* Wait for the zone list before offering the form: an empty
+				    list mid-fetch would claim Canopy has no zones at all. */}
+				{isAdmin && zones.status === "ok" && (
+					<ClaimForm
+						groupId={groupId}
+						zoneApexes={zoneList.map((z) => z.apex)}
+						onClaimed={reload}
+					/>
+				)}
+			</Stack>
+		</Paper>
+	);
+}
+
+function SectionHeading() {
+	return (
+		<Typography variant="h6" component="h2" gutterBottom>
+			Domains
+			<Typography
+				component="span"
+				variant="body2"
+				color="text.secondary"
+				sx={{ ml: 1 }}
+			>
+				— this group controls every name beneath each of these, and no other
+				group can claim a name overlapping them.
+			</Typography>
+		</Typography>
+	);
+}
+
+function DomainRow({
+	id,
+	domain,
+	zone,
+	createdAt,
+	createdBy,
+	isAdmin,
+	onChanged,
+}: {
+	id: string;
+	domain: string;
+	zone: string | null;
+	createdAt: string;
+	createdBy: string | null;
+	isAdmin: boolean;
+	onChanged: () => void;
+}) {
+	const release = useApiAction("domains", "release");
+	const onRelease = async () => {
+		if (
+			!window.confirm(
+				`Release ${domain}? The group loses control of it and every name beneath it.`,
+			)
+		)
+			return;
+		try {
+			await release.call({ id });
+			onChanged();
+		} catch {
+			/* surfaced via release.error */
+		}
+	};
+
+	return (
+		<Box>
+			<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+				<Typography variant="body1" sx={{ fontFamily: "monospace" }}>
+					{domain}
+				</Typography>
+				{zone ? (
+					<Chip size="small" variant="outlined" label={`zone ${zone}`} />
+				) : (
+					<Tooltip title="No configured DNS zone covers this domain any more, so Canopy can act on no name beneath it. Restore the zone to Canopy's configuration, or release the claim.">
+						<Chip
+							size="small"
+							color="warning"
+							variant="outlined"
+							icon={<WarningAmberIcon />}
+							label="no matching zone"
+						/>
+					</Tooltip>
+				)}
+				<Box sx={{ flex: 1 }} />
+				<Typography variant="caption" color="text.secondary">
+					claimed <TimeAgo timestamp={createdAt} />
+					{createdBy && ` by ${createdBy}`}
+				</Typography>
+				{isAdmin && (
+					<IconButton
+						size="small"
+						aria-label={`Release ${domain}`}
+						onClick={onRelease}
+						disabled={release.pending}
+					>
+						<DeleteIcon fontSize="small" />
+					</IconButton>
+				)}
+			</Stack>
+			{release.error && (
+				<Alert severity="error" sx={{ mt: 1 }}>
+					{release.error.message}
+				</Alert>
+			)}
+		</Box>
+	);
+}
+
+function ClaimForm({
+	groupId,
+	zoneApexes,
+	onClaimed,
+}: {
+	groupId: string;
+	zoneApexes: string[];
+	onClaimed: () => void;
+}) {
+	const [domain, setDomain] = useState("");
+	const claim = useApiAction("domains", "claim");
+
+	const onSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (domain.trim() === "") return;
+		try {
+			await claim.call({ server_group_id: groupId, domain: domain.trim() });
+			setDomain("");
+			onClaimed();
+		} catch {
+			/* surfaced via claim.error */
+		}
+	};
+
+	return (
+		<Stack spacing={1} component="form" onSubmit={onSubmit}>
+			{zoneApexes.length === 0 ? (
+				<Alert severity="warning">
+					Canopy has no managed DNS zones configured, so no domain can be
+					claimed. Zones are set by the infrastructure that provisions Canopy.
+				</Alert>
+			) : (
+				<Stack direction="row" spacing={1} sx={{ alignItems: "flex-start" }}>
+					<TextField
+						label="Domain"
+						size="small"
+						value={domain}
+						onChange={(e) => setDomain(e.target.value)}
+						disabled={claim.pending}
+						sx={{ flex: 1, maxWidth: 420 }}
+						helperText={`Must be at or under one of: ${zoneApexes.join(", ")}`}
+					/>
+					<Button
+						type="submit"
+						variant="outlined"
+						startIcon={<AddIcon />}
+						disabled={claim.pending || domain.trim() === ""}
+					>
+						Claim
+					</Button>
+				</Stack>
+			)}
+			{claim.error && <Alert severity="error">{claim.error.message}</Alert>}
+		</Stack>
+	);
+}

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -15,6 +15,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import RestoreIcon from "@mui/icons-material/RestoreFromTrash";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
+import GroupDomainsSection from "../components/GroupDomainsSection";
 import { OperatorAvatar, connectedFor } from "../components/OperatorAvatars";
 import ServerShorty from "../components/ServerShorty";
 import SilencedRefsSection from "../components/SilencedRefsSection";
@@ -236,6 +237,8 @@ export default function GroupDetail() {
 			</Box>
 
 			<BackupsCard groupId={group.id} isAdmin={admin} />
+
+			<GroupDomainsSection groupId={group.id} />
 
 			<SilencedRefsSection scope="group" id={group.id} />
 		</Stack>

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -804,6 +804,10 @@ function InfoSection({
 						value={renderLocation(server)}
 					/>
 				)}
+				<InfoItem
+					label="Name management"
+					value={nameManagementLabel(server)}
+				/>
 			</Stack>
 			<ChecksTable
 				checks={checks}
@@ -1518,6 +1522,15 @@ function InfoItem({
 function renderLocation(server: ServerInfo): string {
 	if (!server.cloud) return "On premise";
 	return "Cloud";
+}
+
+/// What this server is trusted to do with names under its group's domains.
+// spec: DOM#permission-for-a-server-to-manage-its-own-names
+function nameManagementLabel(server: ServerInfo): string {
+	if (server.may_manage_dns && server.may_manage_tls) return "DNS and TLS";
+	if (server.may_manage_dns) return "DNS only";
+	if (server.may_manage_tls) return "TLS only";
+	return "Not permitted";
 }
 
 function SiblingServers({

--- a/private-web/src/routes/ServerEdit.tsx
+++ b/private-web/src/routes/ServerEdit.tsx
@@ -86,6 +86,8 @@ function EditForm({ info }: { info: ServerInfo }) {
 	const [lon, setLon] = useState<string>(info.geolocation?.lon?.toString() ?? "");
 	const [notes, setNotes] = useState<string>(info.notes ?? "");
 	const [tags, setTags] = useState<TagMap>(info.tags ?? {});
+	const [mayManageDns, setMayManageDns] = useState(info.may_manage_dns);
+	const [mayManageTls, setMayManageTls] = useState(info.may_manage_tls);
 
 	const onSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -116,6 +118,8 @@ function EditForm({ info }: { info: ServerInfo }) {
 			),
 			notes,
 			tags,
+			may_manage_dns: mayManageDns,
+			may_manage_tls: mayManageTls,
 		};
 		try {
 			await action.call({ server_id: info.id, data });
@@ -294,6 +298,36 @@ function EditForm({ info }: { info: ServerInfo }) {
 					it for critical servers that should page promptly. The value is
 					preserved while monitoring is off.
 				</Typography>
+
+				<Stack spacing={1}>
+					<Typography variant="subtitle1">Name management</Typography>
+					<FormControlLabel
+						control={
+							<Checkbox
+								checked={mayManageDns}
+								onChange={(e) => setMayManageDns(e.target.checked)}
+								disabled={action.pending}
+							/>
+						}
+						label="May manage its own DNS records"
+					/>
+					<FormControlLabel
+						control={
+							<Checkbox
+								checked={mayManageTls}
+								onChange={(e) => setMayManageTls(e.target.checked)}
+								disabled={action.pending}
+							/>
+						}
+						label="May obtain its own TLS certificates"
+					/>
+					<Typography variant="caption" color="text.secondary">
+						Both apply only to names under the domains this server's group
+						controls, and are off until granted: a server without the grant
+						it needs is refused. Revoking stops further changes and leaves
+						records and certificates already in place.
+					</Typography>
+				</Stack>
 
 				<TextField
 					label="Notes"

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -187,6 +187,9 @@ export type ServerBackupCapabilityView = Solidify<
 export type RestoreWindowRow = Solidify<Schemas["RestoreWindowRow"]>;
 export type RestoreWindowView = Solidify<Schemas["RestoreWindowView"]>;
 
+export type ManagedZoneView = Solidify<Schemas["ManagedZoneView"]>;
+export type GroupDomainView = Solidify<Schemas["GroupDomainView"]>;
+
 // `mode`/`status` arrive as plain strings on the wire (the Rust enums use a
 // custom Text serializer, so utoipa emits `string`). Narrow them in the UI so
 // switch/label maps are exhaustive.


### PR DESCRIPTION
The association that DNS and TLS management will be authorised against: which DNS names each server group controls, and which servers are trusted to manage their own names under them.

New spec: [DOM](../blob/claude/canopy-cert-domains-hy0ijw/.workhorse/specs/servers/domains.md).

## Managed zones

A managed zone is a DNS zone Canopy has write access to. Zones come from deployment configuration rather than operator state — granting that access is the provisioning infrastructure's job, so an operator can't invent a zone Canopy cannot actually write in:

```
CANOPY_DNS_ZONES="tamanu.app=Z1ABC,demo.tamanu.app=Z2DEF=arn:aws:iam::…:role/dns"
CANOPY_DNS_ZONE_ROLE_ARN=arn:aws:iam::…:role/default   # for entries naming no role
```

Entries are `apex=provider-zone-id[=role-arn]`, comma- or whitespace-separated. They're read once at startup into `AppState.dns_zones`; a malformed list warns and yields no zones rather than blocking boot. The monitor pod reads the same variable each sweep pass, so it needs it in its environment too.

Zones are shared: several groups' domains live in one zone, alongside names Canopy doesn't manage at all. So a zone is never owned by a group, and Canopy never assumes it is the only writer in one.

## Group domains

A claim must sit at or under a configured apex, and resolves to the longest apex it sits within (so a zone configured beneath another takes the names beneath itself). Claiming an apex outright is allowed, for infrastructure that dedicates a zone to one deployment.

Within Canopy a claim is exclusive: no two claims overlap in either direction — same name, above, or below — whether the other claim belongs to the same group or a different one. At most one group therefore controls any given name, which is what `ServerGroupDomain::controlling(name)` resolves for the endpoints to come. Claiming serialises on a transaction advisory lock so the no-overlap read can't be raced; the unique index on `domain` is the backstop.

## When the zone configuration changes

A claim outlives the zone that admitted it. Dropping a zone from the configuration — or breaking the configuration outright — leaves every claim inside it standing, still excluding other groups and still the group's to release. Only an explicit release removes a claim: a configuration Canopy cannot read is no evidence an operator withdrew the decision, and inferring release from it would silently hand a live deployment's names to whoever asked next.

What stops is Canopy acting on those names. That shortfall is reported as a coalescing self-alert (`dns-zone-coverage`) naming every uncovered domain with the group holding it, so the blast radius is visible in one place instead of group by group. Severity splits by cause, because the fixes differ:

- **warn** — some claims are uncovered while other zones remain configured, which is what removing one zone of several looks like. Restore the zone, or release the claims that no longer belong.
- **fail** — the configuration cannot be read (the parse error is reported), or it names no zones at all while domains stand claimed. Canopy can serve no group's names until it's fixed.

No zones configured and nothing claimed raises nothing — that's the feature not in use. An archived group's uncovered claims raise nothing either. The alert recovers on its own once every live group's claims are covered again, and each group's page still flags its own uncovered claims for an operator arriving from the alert.

## Per-server grants

`servers.may_manage_dns` and `may_manage_tls`, both withheld by default and held per server rather than per group. They're separate because a deployment whose records live elsewhere may still want its certificates from Canopy. Set through the ordinary server update; shown on the server page and in the edit form.

## Changes

- `crates/commons-types/src/dns.rs` — `ManagedZone`, zone-list parsing, domain normalisation, zone matching
- `crates/database/src/server_domains.rs` + migration `server_group_domains` — claims, exclusivity, name resolution, uncovered-claim lookup
- `crates/database/src/self_alerts.rs` + `crates/jobs/src/bin/monitor.rs` — the `dns-zone-coverage` condition on the minute sweep
- `crates/private-server/src/fns/domains.rs` — `/api/domains/{zones,for_group,claim,release}`; reads open to any tailnet user, mutations admin-only
- `crates/database/src/servers.rs`, `fns/servers.rs` — the two grants through `Server`/`PartialServer`/`ServerInfo`
- `private-web/` — `GroupDomainsSection` on the group page, grants in the server edit form and on the server page
- `openapi.json` + `api-types.ts` regenerated

## Not in this PR

Specced ahead of the code, as the next step: a server registering a name and its external addresses, the A/AAAA records Canopy publishes for it, and certificate issuance. The permission gates and the name → group resolution they need are in place here.

## Testing

`943 tests run: 943 passed`, clippy clean on every touched file.

- 8 unit tests over zone parsing, domain normalisation, and overlap/zone matching
- 9 model tests: normalisation, at-or-under-zone validation, apex claims, overlap across and within groups, name resolution, release, and a claim outliving its zone
- 7 tests for the coverage alert: covered claims raise nothing, no-zones-and-no-claims is not a fault, one zone of several dropped warns and keeps the claim, losing every zone fails, an unreadable configuration reports its parse error, a warning can still escalate to a failure, and an archived group is left alone
- 7 endpoint tests: the zone list, claim/release round trip, 400 outside the zones, 409 on overlap, 404 on unknown release, unmatched-zone reads, and the no-zones-configured case
- 1 endpoint test for the grants: withheld by default, independently settable, untouched by unrelated updates
- Playwright coverage in `e2e/domains.spec.ts` for the group section (empty state, zone chips, claim/release, both refusals) and the grants; the e2e fixture now configures two zones

## TypeScript pin

`typescript` is pinned to `^5.9.3`, and dependabot is told to ignore `>=6`. The bump to 7 (the native port) dropped the `ts.factory` JS API that `openapi-typescript` calls, so `npm run gen:api-types` was dying on import on `main`. With the pin it runs natively again and reproduces the committed `api-types.ts` byte for byte; `tsc -b` and `vite build` both pass on 5.9.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGPCJ1W84jn88WnYC4hBnA)_