### PR TITLE
Reachability presents always; unmonitored servers are marked

### DIFF
--- a/.workhorse/specs/monitoring/checks.md
+++ b/.workhorse/specs/monitoring/checks.md
@@ -188,6 +188,6 @@ Server-targeted checks on a server that is not monitored are recorded and presen
 Canopy's own per-server determinations are made for unmonitored servers just as for monitored ones, so an unmonitored server that has gone away still presents as unreachable and unhealthy — it simply raises nothing.
 Group and Canopy-wide checks are not subject to any server's monitoring gate.
 
-Because an unmonitored server can present as failing while nothing is being alerted on, every surface that presents its health or its reachability marks it as unmonitored.
+Because an unmonitored server can present as failing while nothing is being alerted on, every surface presenting its health or reachability as they currently stand marks it as unmonitored.
 Its health is presented muted and accompanied by a silenced indicator explaining that alerting is off for the server, and its status indicator is struck through with a diagonal cut, so the distinction survives at the size of a single dot.
 The status legend names the mark.

--- a/.workhorse/specs/monitoring/checks.md
+++ b/.workhorse/specs/monitoring/checks.md
@@ -134,6 +134,10 @@ It keeps one `reachability` check per server, under the `canopy` source, reflect
 A stale source degrades the server rather than silently dropping its checks, so a reporter going quiet is never mistaken for health.
 There is no per-source staleness check; the one reachability check carries the full picture.
 
+Every server presents a reachability check as it currently stands, whether or not a reporter has ever gone quiet: a server with nothing stale presents it as passed, and a server whose reachability is silenced presents it as skipped.
+So the check — and the controls on it — are reachable before anything has gone wrong.
+A server's checks as they stood at a past time carry reachability only where it was recorded at that time.
+
 ## Liveness and decommissioning
 
 Reachability is a per-server signal about reporters that have gone quiet; check liveness is a fleet-wide signal about a (source, check) that has gone away everywhere.
@@ -163,6 +167,8 @@ No surface presents one source's checks in isolation, and none exposes a source'
 ## Operator controls
 
 **Silences** are the scoped policy described above.
+A server's own settings additionally carry its reachability silence, presented alongside its monitoring switch so the two are read together: with monitoring off no check on the server alerts at all, while with unreachability alerting off every other check alerts as normal and only the server going away is quiet.
+That control is the same server-scoped silence of the reachability check reached from the check itself, and each surface reflects what the other did.
 
 **Snoozes** suppress one state until a chosen time, after which it contributes again if still degraded.
 
@@ -179,4 +185,9 @@ A manual condition behaves as a reported check whose reporter is the operator: i
 ## Monitoring gate
 
 Server-targeted checks on a server that is not monitored are recorded and presented for visibility but do not contribute to incidents.
+Canopy's own per-server determinations are made for unmonitored servers just as for monitored ones, so an unmonitored server that has gone away still presents as unreachable and unhealthy — it simply raises nothing.
 Group and Canopy-wide checks are not subject to any server's monitoring gate.
+
+Because an unmonitored server can present as failing while nothing is being alerted on, every surface that presents its health or its reachability marks it as unmonitored.
+Its health is presented muted and accompanied by a silenced indicator explaining that alerting is off for the server, and its status indicator is struck through with a diagonal cut, so the distinction survives at the size of a single dot.
+The status legend names the mark.

--- a/crates/commons-types/src/server/cards.rs
+++ b/crates/commons-types/src/server/cards.rs
@@ -20,6 +20,12 @@ pub struct FacilityServerStatus {
 	pub up: ShortStatus,
 	/// The server's self-reported health.
 	pub health: HealthState,
+	/// Whether canopy alerts on this server's checks. An unmonitored
+	/// server's reachability and health are determined and presented as
+	/// normal, but raise nothing — so consumers mark it, rather than
+	/// showing a failure that nobody is being paged about.
+	// spec: CHK#monitoring-gate
+	pub is_monitored: bool,
 	/// People currently connected to this server, from its latest status
 	/// update. Always empty unless the server is actively reporting (`up`
 	/// or `blip`) — a stale report can't be trusted to reflect who is

--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -350,6 +350,29 @@ impl CheckPolicy {
 		Ok(())
 	}
 
+	/// Register the canopy checks that exist for every server regardless of
+	/// whether anything has gone wrong, so their catalog row — policy,
+	/// documentation, liveness — is there from the start rather than
+	/// appearing the first time some server degrades.
+	///
+	/// Today that's reachability alone: it is presented for every server
+	/// whether or not a reporter has ever gone quiet (see
+	/// [`crate::issues::consolidated_checks_latest`]), and that presentation
+	/// is gated on a live catalog row. Idempotent, so it's safe to call on
+	/// every startup; operator edits to the policy or documentation stick.
+	// spec: CHK#reachability
+	pub async fn seed_own_checks(db: &mut AsyncPgConnection) -> Result<()> {
+		Self::register(
+			db,
+			crate::statuses::CANOPY_SOURCE,
+			crate::statuses::REACHABILITY_REF,
+			CheckResult::Failed,
+			false,
+			Some(crate::statuses::REACHABILITY_DOC),
+		)
+		.await
+	}
+
 	/// Apply the `(source, check_name)` policy to an `observed` result:
 	/// if the entry has a `rules` ladder and a branch matches the
 	/// supplied evaluation context, that branch's result wins (any

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -1354,6 +1354,38 @@ pub async fn consolidated_checks_latest(
 			})
 		})
 		.collect();
+	// Reachability presents for every server, whether or not a reporter has
+	// ever gone quiet. The sweep only files this check while it's degraded
+	// (or when it has a degradation to close), so a server that has never
+	// had a problem carries no state row for it — fill that in as passing,
+	// so the check and its silence control are there before anything is
+	// red. Gated on a live catalog row so decommissioning still removes it,
+	// and graded through the same silence pass as everything else.
+	// spec: CHK#reachability
+	let reachability = (
+		crate::statuses::CANOPY_SOURCE.to_string(),
+		crate::statuses::REACHABILITY_REF.to_string(),
+	);
+	if cataloged.contains(&reachability)
+		&& !checks
+			.iter()
+			.any(|c| c.source == reachability.0 && c.check == reachability.1)
+	{
+		let is_silenced = silenced.contains(&reachability);
+		checks.push(ConsolidatedCheck {
+			silenced: is_silenced,
+			observed: Some(CheckResult::Passed),
+			source: reachability.0,
+			check: reachability.1,
+			effective: if is_silenced {
+				CheckResult::Skipped
+			} else {
+				CheckResult::Passed
+			},
+			detail: serde_json::json!({}),
+		});
+	}
+
 	checks.sort_by(|a, b| {
 		a.effective
 			.urgency_rank()

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -35,6 +35,7 @@ Tracks whether the sources canopy expects to report on this server are actually 
 
 ## Results
 
+- **pass** — every source canopy expects to report on this server is reporting within the server's down threshold.
 - **warn** — a source in reachability mode `on` has gone quiet past the server's down threshold while others still report; the quiet sources are listed in the detail.
 - **fail** — every expected source is stale, or the server has never reported: nothing is reaching canopy, and the server is unreachable.
 
@@ -252,7 +253,7 @@ impl Status {
 		Ok(())
 	}
 
-	/// File (or update) each monitored server's single `reachability` check
+	/// File (or update) each server's single `reachability` check
 	/// from the freshness of the sources it is expected to report, against
 	/// its per-server `alert_when_down_for` threshold. Passed when every
 	/// expected source is fresh; warning when an `on`-mode source has gone
@@ -263,20 +264,24 @@ impl Status {
 	/// toward unreachable, or is ignored. Servers with no counted source
 	/// fall back to whether anything at all has reached canopy.
 	///
+	/// Unmonitored servers are swept alongside the rest: their reachability
+	/// is recorded and presented, and the monitoring gate in
+	/// [`crate::issues::NewEvent::save_with_state`] is what keeps it out of
+	/// incidents. The UI marks them so an operator reads "unreachable and
+	/// nobody is being paged" rather than "unreachable".
+	///
 	/// Returns the number of events filed in this pass.
+	// spec: CHK#monitoring-gate
 	pub async fn sweep_staleness(db: &mut AsyncPgConnection) -> Result<usize> {
 		use commons_types::source::ReachabilityMode;
 		use std::collections::HashMap;
 
 		let servers = Server::get_all(db, 0, None).await?;
-		let monitored: Vec<&Server> = servers
-			.iter()
-			.filter(|s| s.is_monitored && s.id != Uuid::nil())
-			.collect();
-		if monitored.is_empty() {
+		let swept: Vec<&Server> = servers.iter().filter(|s| s.id != Uuid::nil()).collect();
+		if swept.is_empty() {
 			return Ok(0);
 		}
-		let server_ids: Vec<Uuid> = monitored.iter().map(|s| s.id).collect();
+		let server_ids: Vec<Uuid> = swept.iter().map(|s| s.id).collect();
 
 		// Per-source freshness (already excludes canopy/manual and
 		// decommissioned checks), grouped by server, plus each source's
@@ -304,7 +309,7 @@ impl Status {
 
 		let now = Timestamp::now();
 		let mut filed = 0usize;
-		for server in &monitored {
+		for server in &swept {
 			let threshold = server.alert_when_down_for.0;
 			let label = server_label(server);
 

--- a/crates/database/tests/it/consolidated_checks.rs
+++ b/crates/database/tests/it/consolidated_checks.rs
@@ -2,7 +2,9 @@
 //! every source, graded, with the health rollup matching the headline.
 
 use commons_types::status::{CheckResult, HealthState};
+use database::check_policies::CheckPolicy;
 use database::issues::{CheckFiling, Scope, consolidated_checks_latest, file_check};
+use database::statuses::{CANOPY_SOURCE, REACHABILITY_REF};
 use diesel::{QueryableByName, sql_query, sql_types};
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
@@ -176,6 +178,133 @@ async fn latest_excludes_decommissioned_and_flags_silenced() {
 		// observed result still records what was reported.
 		assert_eq!(consolidated.checks[0].effective, CheckResult::Skipped);
 		assert_eq!(consolidated.checks[0].observed, Some(CheckResult::Warning));
+	})
+	.await
+}
+
+/// Find the reachability entry among a server's consolidated checks.
+fn reachability(
+	consolidated: &commons_types::status::ConsolidatedChecks,
+) -> Option<&commons_types::status::ConsolidatedCheck> {
+	consolidated
+		.checks
+		.iter()
+		.find(|c| c.source == CANOPY_SOURCE && c.check == REACHABILITY_REF)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reachability_presents_as_passed_when_it_has_never_degraded() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		// The sweep files reachability only while it's degraded, so a server
+		// that has never had a reporter go quiet carries no state for it. It
+		// still presents — green — so the check and its silence control are
+		// there before anything is red.
+		CheckPolicy::seed_own_checks(&mut conn)
+			.await
+			.expect("seed canopy's own checks");
+		let server_id = insert_server(&mut conn).await;
+
+		let consolidated = consolidated_checks_latest(&mut conn, server_id, None)
+			.await
+			.expect("consolidated");
+
+		let check = reachability(&consolidated).expect("reachability presents");
+		assert_eq!(check.effective, CheckResult::Passed);
+		assert_eq!(check.observed, Some(CheckResult::Passed));
+		assert!(!check.silenced);
+		// A passing check doesn't count against the server.
+		assert_eq!(consolidated.health_state, HealthState::Healthy);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn synthesised_reachability_reflects_a_silence() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		CheckPolicy::seed_own_checks(&mut conn)
+			.await
+			.expect("seed canopy's own checks");
+		let server_id = insert_server(&mut conn).await;
+		sql_query(
+			"INSERT INTO scoped_check_policies (server_id, source, check_name, ceiling, created_by) \
+			 VALUES ($1, $2, $3, 'skipped', 'op')",
+		)
+		.bind::<sql_types::Uuid, _>(server_id)
+		.bind::<sql_types::Text, _>(CANOPY_SOURCE)
+		.bind::<sql_types::Text, _>(REACHABILITY_REF)
+		.execute(&mut conn)
+		.await
+		.expect("silence reachability");
+
+		let consolidated = consolidated_checks_latest(&mut conn, server_id, None)
+			.await
+			.expect("consolidated");
+
+		// Silenced reads skipped rather than green: the operator turned
+		// alerting off, and the check says so.
+		let check = reachability(&consolidated).expect("reachability presents");
+		assert_eq!(check.effective, CheckResult::Skipped);
+		assert!(check.silenced);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_filed_reachability_wins_over_the_synthesised_one() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		CheckPolicy::seed_own_checks(&mut conn)
+			.await
+			.expect("seed canopy's own checks");
+		let server_id = insert_server(&mut conn).await;
+		file_check(
+			&mut conn,
+			filing(
+				server_id,
+				CANOPY_SOURCE,
+				REACHABILITY_REF,
+				CheckResult::Failed,
+			),
+		)
+		.await
+		.expect("file");
+
+		let consolidated = consolidated_checks_latest(&mut conn, server_id, None)
+			.await
+			.expect("consolidated");
+
+		// One entry, not two: the recorded state is the check.
+		assert_eq!(consolidated.checks.len(), 1);
+		let check = reachability(&consolidated).expect("reachability presents");
+		assert_eq!(check.effective, CheckResult::Failed);
+		assert_eq!(consolidated.health_state, HealthState::Unhealthy);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decommissioning_reachability_removes_it() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		CheckPolicy::seed_own_checks(&mut conn)
+			.await
+			.expect("seed canopy's own checks");
+		let server_id = insert_server(&mut conn).await;
+		sql_query(
+			"UPDATE check_policies SET decommissioned_at = now() \
+			 WHERE source = $1 AND check_name = $2",
+		)
+		.bind::<sql_types::Text, _>(CANOPY_SOURCE)
+		.bind::<sql_types::Text, _>(REACHABILITY_REF)
+		.execute(&mut conn)
+		.await
+		.expect("decommission");
+
+		let consolidated = consolidated_checks_latest(&mut conn, server_id, None)
+			.await
+			.expect("consolidated");
+
+		// Presentation follows the catalog: a retired check stays retired
+		// rather than being conjured back by the fill-in.
+		assert!(reachability(&consolidated).is_none());
 	})
 	.await
 }

--- a/crates/database/tests/it/reachability_sweep.rs
+++ b/crates/database/tests/it/reachability_sweep.rs
@@ -47,6 +47,57 @@ async fn insert_server_full(
 	row.id
 }
 
+/// Insert a server in a group, so incident membership is actually on the
+/// table: the incident flow is skipped outright for ungrouped servers, and
+/// a gate assertion against one would pass for the wrong reason.
+async fn insert_grouped_server(
+	conn: &mut diesel_async::AsyncPgConnection,
+	host: &str,
+	alert_when_down_for_secs: i64,
+	is_monitored: bool,
+) -> Uuid {
+	let group: RowId = sql_query("INSERT INTO server_groups (name) VALUES ('sweep') RETURNING id")
+		.get_result(conn)
+		.await
+		.expect("insert group");
+	let row: RowId = sql_query(
+		r#"
+			INSERT INTO servers (host, alert_when_down_for, is_monitored, group_id)
+			VALUES ($1, ($2 || ' seconds')::INTERVAL, $3, $4)
+			RETURNING id
+		"#,
+	)
+	.bind::<sql_types::Text, _>(host)
+	.bind::<sql_types::Text, _>(alert_when_down_for_secs.to_string())
+	.bind::<sql_types::Bool, _>(is_monitored)
+	.bind::<sql_types::Uuid, _>(group.id)
+	.get_result(conn)
+	.await
+	.expect("insert server");
+	row.id
+}
+
+/// Count open (`left_at IS NULL`) incident links for a server's reachability
+/// check.
+async fn open_incident_links(conn: &mut diesel_async::AsyncPgConnection, server_id: Uuid) -> i64 {
+	#[derive(QueryableByName)]
+	struct CountRow {
+		#[diesel(sql_type = sql_types::BigInt)]
+		n: i64,
+	}
+	sql_query(
+		"SELECT COUNT(*) AS n FROM incident_issues ii \
+		 JOIN issues i ON i.id = ii.issue_id \
+		 WHERE i.server_id = $1 AND i.\"ref\" = $2 AND ii.left_at IS NULL",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(REACHABILITY_REF)
+	.get_result::<CountRow>(conn)
+	.await
+	.expect("count incident links")
+	.n
+}
+
 async fn insert_status_at(
 	conn: &mut diesel_async::AsyncPgConnection,
 	server_id: Uuid,
@@ -163,16 +214,39 @@ async fn sweep_files_when_no_status_ever() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn sweep_skips_unmonitored_server() {
+async fn sweep_files_for_unmonitored_server_without_alerting() {
 	commons_tests::db::TestDb::run(async |mut conn, _| {
-		// is_monitored = false: never file regardless of how stale the status
-		// is. The threshold is preserved so flipping monitoring back on
-		// resumes with the chosen value.
-		let id = insert_server_full(&mut conn, "http://silenced.invalid/", 600, false).await;
+		// is_monitored = false doesn't change what's true about the server:
+		// its reachability is determined and recorded like everyone else's,
+		// so an operator can see it's away. The monitoring gate is what
+		// keeps the filing out of incidents.
+		let id = insert_grouped_server(&mut conn, "http://silenced.invalid/", 600, false).await;
 		insert_status_at(&mut conn, id, 120).await;
 		let filed = Status::sweep_staleness(&mut conn).await.expect("sweep");
-		assert_eq!(filed, 0);
-		assert!(issue_for(&mut conn, id).await.is_none());
+		assert_eq!(filed, 1);
+		let issue = issue_for(&mut conn, id).await.expect("issue exists");
+		assert_eq!(issue.effective_result, Some(CheckResult::Failed));
+		assert!(issue.active);
+		assert_eq!(
+			open_incident_links(&mut conn, id).await,
+			0,
+			"an unmonitored server's reachability must not join an incident",
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sweep_opens_an_incident_for_a_monitored_server() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		// The counterpart to the unmonitored case: same filing, same group,
+		// and here it does reach an incident — so that test's zero is the
+		// monitoring gate rather than something else swallowing it.
+		let id = insert_grouped_server(&mut conn, "http://watched.invalid/", 600, true).await;
+		insert_status_at(&mut conn, id, 120).await;
+		let filed = Status::sweep_staleness(&mut conn).await.expect("sweep");
+		assert_eq!(filed, 1);
+		assert_eq!(open_incident_links(&mut conn, id).await, 1);
 	})
 	.await
 }

--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -263,6 +263,7 @@ pub async fn group_details(
 				name: s.name.clone().unwrap_or_default(),
 				up,
 				health: member_health.get(&s.id).copied().unwrap_or_default(),
+				is_monitored: s.is_monitored,
 				operators,
 				rank: s.rank,
 				product: s.product,

--- a/crates/private-server/src/state.rs
+++ b/crates/private-server/src/state.rs
@@ -90,6 +90,24 @@ fn recovery_recipients_from_env() -> Option<Recipients> {
 	}
 }
 
+/// Put canopy's own always-present checks in the catalog at startup, so
+/// the reachability check presents (and can be silenced) on a fleet where
+/// nothing has ever gone wrong. Best-effort: a database that isn't up yet
+/// shouldn't stop the server from starting, and the monitor registers the
+/// same row the first time it files.
+async fn seed_own_checks(db: &database::Db) {
+	let seeded = match db.get().await {
+		Ok(mut conn) => database::check_policies::CheckPolicy::seed_own_checks(&mut conn).await,
+		Err(err) => {
+			tracing::warn!("seeding canopy's own checks: no database connection: {err}");
+			return;
+		}
+	};
+	if let Err(err) = seeded {
+		tracing::warn!("seeding canopy's own checks failed: {err}");
+	}
+}
+
 impl AppState {
 	pub async fn init() -> Result<Self> {
 		let ro_pool = if let Ok(url) = std::env::var("RO_DATABASE_URL") {
@@ -113,6 +131,7 @@ impl AppState {
 
 		let db = database::init();
 		let db_read = database::init_ro().unwrap_or_else(|| db.clone());
+		seed_own_checks(&db).await;
 
 		Ok(Self {
 			db,
@@ -134,6 +153,7 @@ impl AppState {
 	#[cfg(debug_assertions)]
 	pub async fn from_db_url(url: &str) -> Result<Self> {
 		let db = database::init_to(url);
+		seed_own_checks(&db).await;
 		Ok(Self {
 			db_read: db.clone(),
 			db,

--- a/crates/private-server/tests/it/healthchecks.rs
+++ b/crates/private-server/tests/it/healthchecks.rs
@@ -24,9 +24,11 @@ async fn list_returns_catalog_rows_with_pending_review_flag() {
 		response.assert_status_ok();
 
 		let body: Vec<serde_json::Value> = response.json();
-		assert_eq!(body.len(), 2);
+		// The two seeded rows, plus canopy's own reachability check, which
+		// the server catalogues at startup so it exists before anything has
+		// gone wrong. Ordered by source then check_name.
+		assert_eq!(body.len(), 3);
 
-		// Ordered by source then check_name.
 		assert_eq!(body[0]["source"], "alertd");
 		assert_eq!(body[0]["check_name"], "disk_space");
 		assert_eq!(body[0]["ceiling"], "warning");
@@ -37,6 +39,13 @@ async fn list_returns_catalog_rows_with_pending_review_flag() {
 		assert_eq!(body[1]["ceiling"], "failed");
 		assert_eq!(body[1]["pending_review"], false);
 		assert_eq!(body[1]["reviewed_by"], "alice@example.com");
+
+		// Canopy's own checks register already reviewed, at the policy their
+		// condition warrants rather than the default warning ceiling.
+		assert_eq!(body[2]["source"], "canopy");
+		assert_eq!(body[2]["check_name"], "reachability");
+		assert_eq!(body[2]["ceiling"], "failed");
+		assert_eq!(body[2]["pending_review"], false);
 	})
 	.await
 }

--- a/crates/public-server/tests/it/statuses.rs
+++ b/crates/public-server/tests/it/statuses.rs
@@ -2504,11 +2504,15 @@ async fn submit_status_result_all_kinds_upsert_catalog() {
 				#[diesel(sql_type = sql_types::Text)]
 				check_name: String,
 			}
-			let rows: Vec<NameRow> =
-				sql_query("SELECT check_name FROM check_policies ORDER BY check_name")
-					.get_results(&mut conn)
-					.await
-					.expect("list catalog");
+			// Reported checks only: canopy's own checks are catalogued at
+			// startup and aren't what this push is being judged on.
+			let rows: Vec<NameRow> = sql_query(
+				"SELECT check_name FROM check_policies WHERE source <> 'canopy' \
+				 ORDER BY check_name",
+			)
+			.get_results(&mut conn)
+			.await
+			.expect("list catalog");
 			let names: Vec<&str> = rows.iter().map(|r| r.check_name.as_str()).collect();
 			assert_eq!(names, vec!["a_passed", "b_skipped", "c_broken"]);
 		},

--- a/private-web/e2e/reachability-presentation.spec.ts
+++ b/private-web/e2e/reachability-presentation.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "./test-fixtures";
+import {
+	resetSeededTables,
+	seedServer,
+	seedServerGroup,
+	seedServerSilencedRef,
+	seedStatus,
+	seedVersion,
+} from "./seed";
+
+// spec: CHK#reachability
+test.describe("reachability presents before anything is wrong", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("a server that has never gone quiet shows a passing reachability check", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const server = await seedServer(sql, { name: "never-quiet" });
+		await seedStatus(sql, { serverId: server.id, healthy: true });
+
+		await page.goto(`/servers/${server.id}`);
+
+		// The check is there with nothing filed against it, so its silence
+		// control is reachable before the server has ever gone away.
+		await expect(
+			page.getByRole("link", { name: "reachability", exact: true }),
+		).toBeVisible();
+		// Passing, so it doesn't drag the headline.
+		await expect(page.getByText("Healthy", { exact: true })).toBeVisible();
+	});
+
+	test("a silenced reachability presents as silenced rather than green", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const server = await seedServer(sql, { name: "hushed-reach" });
+		await seedStatus(sql, { serverId: server.id, healthy: true });
+		// Canopy's own checks are silenced at a bare ref, not under `health/`.
+		await seedServerSilencedRef(sql, {
+			serverId: server.id,
+			source: "canopy",
+			ref: "reachability",
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		await expect(
+			page.getByRole("link", { name: "reachability", exact: true }),
+		).toBeVisible();
+		// The chip only matches if the UI builds canopy's ref the same way the
+		// backend stores it.
+		await expect(page.getByText("silenced (server)")).toBeVisible();
+	});
+});
+
+// spec: CHK#monitoring-gate
+test.describe("unmonitored servers are marked", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("an unmonitored server's health chip carries the silence marker", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const server = await seedServer(sql, {
+			name: "off-the-radar",
+			isMonitored: false,
+		});
+		await seedStatus(sql, {
+			serverId: server.id,
+			healthy: false,
+			health: [{ check: "database", result: "failed" }],
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		// The state is still true and still says Unhealthy — what's off is the
+		// alerting, and the marker is what says so.
+		await expect(page.getByText("Unhealthy", { exact: true })).toBeVisible();
+		await expect(page.getByTestId("unmonitored-marker")).toBeVisible();
+	});
+
+	test("a monitored server's health chip carries no marker", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const server = await seedServer(sql, {
+			name: "on-the-radar",
+			isMonitored: true,
+		});
+		await seedStatus(sql, {
+			serverId: server.id,
+			healthy: false,
+			health: [{ check: "database", result: "failed" }],
+		});
+
+		await page.goto(`/servers/${server.id}`);
+
+		await expect(page.getByText("Unhealthy", { exact: true })).toBeVisible();
+		await expect(page.getByTestId("unmonitored-marker")).toHaveCount(0);
+	});
+
+	test("the status page cuts through an unmonitored server's dot", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const group = await seedServerGroup(sql, { name: "mixed-monitoring" });
+		const watched = await seedServer(sql, {
+			name: "watched",
+			kind: "central",
+			rank: "production",
+			groupId: group.id,
+			isMonitored: true,
+		});
+		const ignored = await seedServer(sql, {
+			name: "ignored",
+			kind: "facility",
+			rank: "production",
+			groupId: group.id,
+			isMonitored: false,
+		});
+		await seedStatus(sql, { serverId: watched.id, healthy: true });
+		await seedStatus(sql, { serverId: ignored.id, healthy: true });
+
+		await page.goto("/status");
+
+		const strip = page
+			.locator(`a[href="/groups/${group.id}"]`)
+			.first()
+			.getByTestId("dot-strip");
+		await expect(strip).toBeVisible();
+
+		// The cut is a mask on the dot itself, so assert on computed style
+		// rather than a marker element: at a single dot's size there's no room
+		// for anything else to carry the distinction. Both servers are
+		// production, and centrals sort first within a rank, so the watched
+		// central is dot 0 and the ignored facility is dot 1.
+		const masks = await strip
+			.locator("> span > span")
+			.evaluateAll((els) => els.map((el) => getComputedStyle(el).maskImage));
+		expect(masks).toHaveLength(2);
+		expect(masks[0]).toBe("none");
+		expect(masks[1]).not.toBe("none");
+
+		// And the dot says why, for anyone who hovers it. The cell carries its
+		// own tooltip alongside the dot's, so match on the one we mean.
+		await strip.locator("> span").nth(1).hover();
+		await expect(
+			page.getByRole("tooltip", { name: /unmonitored/ }),
+		).toBeVisible();
+	});
+});

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -62,6 +62,13 @@ export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
 		"INSERT INTO source_policies (source, reachability) VALUES ('tamanu', 'quiet')",
 	);
+	// And the catalog row the server registers at startup for canopy's own
+	// reachability check: every server presents a passing reachability, and
+	// that presentation is gated on this row existing.
+	await sql.query(
+		"INSERT INTO check_policies (source, check_name, ceiling, reviewed_at, reviewed_by) \
+		 VALUES ('canopy', 'reachability', 'failed', NOW(), 'canopy')",
+	);
 }
 
 export interface SeededServerGroup {

--- a/private-web/e2e/server-reachability-silence.spec.ts
+++ b/private-web/e2e/server-reachability-silence.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "./test-fixtures";
+import {
+	resetSeededTables,
+	seedServer,
+	seedServerGroup,
+	seedServerSilencedRef,
+	seedStatus,
+	seedVersion,
+	type Sql,
+} from "./seed";
+
+/** The server-scoped silences on a server's reachability check — what the
+ * form's "alert when this server is unreachable" switch writes, and what
+ * the check's own silence button writes. */
+async function reachabilitySilences(sql: Sql, serverId: string): Promise<number> {
+	const rows = await sql.query<{ n: string }>(
+		"SELECT COUNT(*) AS n FROM scoped_check_policies \
+		 WHERE server_id = $1 AND source = 'canopy' AND check_name = 'reachability' \
+		 AND ceiling = 'skipped'",
+		[serverId],
+	);
+	return Number(rows[0]!.n);
+}
+
+const SWITCH = "Alert when this server is unreachable";
+
+// spec: CHK#operator-controls
+test.describe("reachability alerting switch on the server form", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("creating with the switch off silences the new server's reachability", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const group = await seedServerGroup(sql, { name: "comes-and-goes" });
+
+		await page.goto(`/groups/${group.id}/servers/new`);
+		await page.getByLabel(/^Name(\s*\*)?$/i).fill("expected-to-vanish");
+		// On by default: a new server alerts when it goes away unless told not to.
+		await expect(page.getByLabel(SWITCH)).toBeChecked();
+		await page.getByLabel(SWITCH).uncheck();
+		await page.getByRole("button", { name: "Create server" }).click();
+
+		await expect(page).toHaveURL(/\/servers\/[0-9a-f-]{36}$/);
+		const id = page.url().split("/").pop()!;
+		expect(await reachabilitySilences(sql, id)).toBe(1);
+	});
+
+	test("creating with the switch on leaves reachability alerting", async ({
+		page,
+		sql,
+	}) => {
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const group = await seedServerGroup(sql, { name: "should-stay-up" });
+
+		await page.goto(`/groups/${group.id}/servers/new`);
+		await page.getByLabel(/^Name(\s*\*)?$/i).fill("expected-to-stay");
+		await page.getByRole("button", { name: "Create server" }).click();
+
+		await expect(page).toHaveURL(/\/servers\/[0-9a-f-]{36}$/);
+		const id = page.url().split("/").pop()!;
+		expect(await reachabilitySilences(sql, id)).toBe(0);
+	});
+
+	test("the edit form reflects an existing silence and clearing it re-enables alerting", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "edit-reach-group" });
+		const server = await seedServer(sql, {
+			name: "already-hushed",
+			groupId: group.id,
+		});
+		// As the check's own silence button would have left it.
+		await seedServerSilencedRef(sql, {
+			serverId: server.id,
+			source: "canopy",
+			ref: "reachability",
+		});
+
+		await page.goto(`/servers/${server.id}/edit`);
+		// The switch reads the silence, so the form doesn't quietly write the
+		// operator's earlier decision away on the next unrelated save.
+		await expect(page.getByLabel(SWITCH)).not.toBeChecked();
+
+		await page.getByLabel(SWITCH).check();
+		await page.getByRole("button", { name: /^save$/i }).click();
+		await page.waitForURL(`**/servers/${server.id}`);
+
+		expect(await reachabilitySilences(sql, server.id)).toBe(0);
+	});
+
+	test("turning the switch off from the edit form silences reachability", async ({
+		page,
+		sql,
+	}) => {
+		// Seeded with a version and a status so the detail page it lands on
+		// renders the checks table we then assert against.
+		await seedVersion(sql, { major: 1, minor: 0, patch: 0 });
+		const group = await seedServerGroup(sql, { name: "edit-hush-group" });
+		const server = await seedServer(sql, {
+			name: "about-to-be-hushed",
+			groupId: group.id,
+		});
+		await seedStatus(sql, { serverId: server.id, healthy: true });
+
+		await page.goto(`/servers/${server.id}/edit`);
+		await expect(page.getByLabel(SWITCH)).toBeChecked();
+		await page.getByLabel(SWITCH).uncheck();
+		await page.getByRole("button", { name: /^save$/i }).click();
+		await page.waitForURL(`**/servers/${server.id}`);
+
+		expect(await reachabilitySilences(sql, server.id)).toBe(1);
+		// And the check itself now shows as silenced, so the two surfaces agree.
+		await expect(page.getByText("silenced (server)")).toBeVisible();
+	});
+
+	test("saving with the switch untouched leaves the silence alone", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "untouched-group" });
+		const server = await seedServer(sql, {
+			name: "leave-me-be",
+			groupId: group.id,
+		});
+		await seedServerSilencedRef(sql, {
+			serverId: server.id,
+			source: "canopy",
+			ref: "reachability",
+		});
+
+		await page.goto(`/servers/${server.id}/edit`);
+		await page.getByLabel(/^Name(\s*\*)?$/i).fill("leave-me-be-renamed");
+		await page.getByRole("button", { name: /^save$/i }).click();
+		await page.waitForURL(`**/servers/${server.id}`);
+
+		expect(await reachabilitySilences(sql, server.id)).toBe(1);
+	});
+});

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -8518,6 +8518,7 @@
           "name",
           "up",
           "health",
+          "is_monitored",
           "operators",
           "product",
           "kind"
@@ -8531,6 +8532,10 @@
             "type": "string",
             "format": "uuid",
             "description": "Unique identifier of the server."
+          },
+          "is_monitored": {
+            "type": "boolean",
+            "description": "Whether canopy alerts on this server's checks. An unmonitored\nserver's reachability and health are determined and presented as\nnormal, but raise nothing — so consumers mark it, rather than\nshowing a failure that nobody is being paged about."
           },
           "kind": {
             "$ref": "#/components/schemas/ServerKind",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -4628,6 +4628,13 @@ export interface components {
              */
             id: string;
             /**
+             * @description Whether canopy alerts on this server's checks. An unmonitored
+             *     server's reachability and health are determined and presented as
+             *     normal, but raise nothing — so consumers mark it, rather than
+             *     showing a failure that nobody is being paged about.
+             */
+            is_monitored: boolean;
+            /**
              * @description The server's role within its product's topology (for Tamanu, central
              *     or facility; standalone for a product with no internal roles).
              */

--- a/private-web/src/components/HealthChip.tsx
+++ b/private-web/src/components/HealthChip.tsx
@@ -1,8 +1,12 @@
-import { Chip, Tooltip } from "@mui/material";
+import { Box, Chip, Stack, Tooltip } from "@mui/material";
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import type { HealthState } from "../types";
+
+const UNMONITORED_TOOLTIP =
+	"This server is unmonitored — its checks are recorded and shown, but nothing alerts on them.";
 
 const LABEL: Record<HealthState, string> = {
 	healthy: "Healthy",
@@ -29,38 +33,62 @@ const COLOR: Record<HealthState, "success" | "warning" | "error"> = {
  *
  * `stale` recolours to an outlined variant for servers that aren't
  * currently reporting, so an operator isn't misled into thinking a stale
- * "Healthy" still holds. */
+ * "Healthy" still holds.
+ *
+ * `monitored={false}` fades the chip and sets a silence icon beside it:
+ * canopy determines an unmonitored server's health the same way it does
+ * everyone else's, so it can read Unhealthy while nobody is being paged.
+ * The chip keeps its real colour and label underneath — the state is
+ * true, it's the alerting that's off. */
+// spec: CHK#monitoring-gate
 export default function HealthChip({
 	health,
 	stale = false,
+	monitored = true,
 }: {
 	health: HealthState;
 	stale?: boolean;
+	monitored?: boolean;
 }) {
-	if (stale) {
-		return (
-			<Tooltip title="Server isn't currently reporting status; this reflects its most recent received report.">
-				<Chip
-					size="small"
-					variant="outlined"
-					color="warning"
-					icon={<WarningAmberIcon />}
-					label={`Last reported ${LABEL[health].toLowerCase()}`}
+	const chip = stale ? (
+		<Tooltip title="Server isn't currently reporting status; this reflects its most recent received report.">
+			<Chip
+				size="small"
+				variant="outlined"
+				color="warning"
+				icon={<WarningAmberIcon />}
+				label={`Last reported ${LABEL[health].toLowerCase()}`}
+			/>
+		</Tooltip>
+	) : (
+		<Tooltip title={TOOLTIP[health]}>
+			<Chip
+				size="small"
+				color={COLOR[health]}
+				icon={
+					health === "healthy" ? (
+						<CheckCircleIcon />
+					) : health === "warning" ? (
+						<WarningAmberIcon />
+					) : (
+						<CancelIcon />
+					)
+				}
+				label={LABEL[health]}
+			/>
+		</Tooltip>
+	);
+	if (monitored) return chip;
+	return (
+		<Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+			<Box sx={{ opacity: 0.5, display: "inline-flex" }}>{chip}</Box>
+			<Tooltip title={UNMONITORED_TOOLTIP}>
+				<NotificationsOffIcon
+					fontSize="small"
+					color="info"
+					data-testid="unmonitored-marker"
 				/>
 			</Tooltip>
-		);
-	}
-	const icon =
-		health === "healthy" ? (
-			<CheckCircleIcon />
-		) : health === "warning" ? (
-			<WarningAmberIcon />
-		) : (
-			<CancelIcon />
-		);
-	return (
-		<Tooltip title={TOOLTIP[health]}>
-			<Chip size="small" color={COLOR[health]} icon={icon} label={LABEL[health]} />
-		</Tooltip>
+		</Stack>
 	);
 }

--- a/private-web/src/components/Legends.tsx
+++ b/private-web/src/components/Legends.tsx
@@ -52,6 +52,12 @@ export function StatusLegend() {
 					</Typography>
 				</Stack>
 			))}
+			<Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+				<StatusDot up="down" monitored={false} />
+				<Typography variant="body2" color="text.secondary">
+					Cut through: unmonitored (state shown, nothing alerts)
+				</Typography>
+			</Stack>
 		</Stack>
 	);
 }

--- a/private-web/src/components/ServerShorty.tsx
+++ b/private-web/src/components/ServerShorty.tsx
@@ -43,7 +43,11 @@ export default function ServerShorty({ server }: { server: ServerInfo }) {
 			}}
 		>
 			{server.up && (
-				<StatusDot up={server.up} health={server.health ?? undefined} />
+				<StatusDot
+					up={server.up}
+					health={server.health ?? undefined}
+					monitored={!unmonitored}
+				/>
 			)}
 			<MuiLink
 				component={RouterLink}

--- a/private-web/src/components/StatusDot.tsx
+++ b/private-web/src/components/StatusDot.tsx
@@ -20,6 +20,13 @@ const HEALTH_OUTLINE: Record<HealthState, string | null> = {
 
 const REACHABLE: ReadonlySet<ShortStatus> = new Set(["up", "blip"]);
 
+// Diagonal cut for unmonitored servers. A mask punches the band out of the
+// dot rather than painting over it, so the surface behind shows through
+// whatever it is — these dots sit on plain paper, on operator-tinted group
+// cards, and on hover backgrounds.
+const UNMONITORED_MASK =
+	"linear-gradient(135deg, #000 0 42%, transparent 42% 58%, #000 58% 100%)";
+
 interface StatusDotProps {
 	up: ShortStatus;
 	/** Server's self-reported health from its most recent status push.
@@ -30,6 +37,12 @@ interface StatusDotProps {
 	dim?: boolean;
 	/** Size relative to the surrounding font size. Defaults to "1em". */
 	size?: string;
+	/** Whether canopy alerts on this server. Unmonitored servers are cut
+	 * through with a diagonal so a red dot doesn't read as "someone is
+	 * being paged about this" — their checks are determined and shown as
+	 * normal but raise nothing. Defaults to monitored. */
+	// spec: CHK#monitoring-gate
+	monitored?: boolean;
 }
 
 export default function StatusDot({
@@ -38,6 +51,7 @@ export default function StatusDot({
 	title,
 	dim,
 	size = "1em",
+	monitored = true,
 }: StatusDotProps) {
 	const outlineColor =
 		health && REACHABLE.has(up) ? HEALTH_OUTLINE[health] : null;
@@ -65,11 +79,16 @@ export default function StatusDot({
 				outline: outlineColor ? "0.2em solid" : "none",
 				outlineColor,
 				outlineOffset: outlineColor ? "-0.2em" : 0,
+				maskImage: monitored ? undefined : UNMONITORED_MASK,
+				WebkitMaskImage: monitored ? undefined : UNMONITORED_MASK,
 			}}
 		/>
 	);
-	if (title) {
-		return <Tooltip title={title}>{dot}</Tooltip>;
+	const tooltip = monitored
+		? title
+		: [title, "unmonitored"].filter(Boolean).join(" · ");
+	if (tooltip) {
+		return <Tooltip title={tooltip}>{dot}</Tooltip>;
 	}
 	return dot;
 }

--- a/private-web/src/routes/ServerCreate.tsx
+++ b/private-web/src/routes/ServerCreate.tsx
@@ -20,7 +20,7 @@ import {
 	useProductKinds,
 	useProducts,
 } from "../hooks/useProducts";
-import { PRODUCT_LABELS } from "../types";
+import { PRODUCT_LABELS, REACHABILITY_CHECK } from "../types";
 import type {
 	Product,
 	ServerGroup,
@@ -48,6 +48,7 @@ export default function ServerCreate() {
 	// group to default-select.
 	const { id: presetGroupId } = useParams<{ id?: string }>();
 	const action = useApiAction("servers", "create");
+	const silence = useApiAction("silenced_refs", "silence_server");
 
 	const [name, setName] = useState("");
 	const [host, setHost] = useState("");
@@ -60,6 +61,12 @@ export default function ServerCreate() {
 	const [rank, setRank] = useState<ServerRank | "">("");
 	const [publicName, setPublicName] = useState("");
 	const [isMonitored, setIsMonitored] = useState(true);
+	// Off means "alert on everything else, just not this server going away".
+	// Written as the server-scoped silence on canopy's reachability check,
+	// the same one the check itself offers — so it can only be applied once
+	// the server exists.
+	// spec: CHK#operator-controls
+	const [alertWhenUnreachable, setAlertWhenUnreachable] = useState(true);
 	const [alertWhenDownMinutes, setAlertWhenDownMinutes] = useState("10");
 	const [groupId, setGroupId] = useState<string | null>(presetGroupId ?? null);
 	const [tailscaleIdentifier, setTailscaleIdentifier] = useState("");
@@ -68,6 +75,9 @@ export default function ServerCreate() {
 	const [lon, setLon] = useState("");
 	const [notes, setNotes] = useState("");
 	const [tags, setTags] = useState<TagMap>({});
+
+	const pending = action.pending || silence.pending;
+	const error = action.error ?? silence.error;
 
 	const onSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -99,9 +109,16 @@ export default function ServerCreate() {
 		};
 		try {
 			const serverId = await action.call(data);
+			if (!alertWhenUnreachable) {
+				await silence.call({
+					server_id: serverId,
+					source: REACHABILITY_CHECK.source,
+					ref: REACHABILITY_CHECK.ref,
+				});
+			}
 			navigate(`/servers/${serverId}`);
 		} catch {
-			/* surfaced via action.error */
+			/* surfaced via the actions' errors */
 		}
 	};
 
@@ -116,14 +133,14 @@ export default function ServerCreate() {
 					label="Name"
 					value={name}
 					onChange={(e) => setName(e.target.value)}
-					disabled={action.pending}
+					disabled={pending}
 					required
 				/>
 				<TextField
 					label="URL"
 					value={host}
 					onChange={(e) => setHost(e.target.value)}
-					disabled={action.pending}
+					disabled={pending}
 				/>
 				<TextField
 					select
@@ -140,7 +157,7 @@ export default function ServerCreate() {
 							setKind(info.default_kind);
 						}
 					}}
-					disabled={action.pending}
+					disabled={pending}
 				>
 					{products.map((p) => (
 						<MenuItem key={p.product} value={p.product}>
@@ -153,7 +170,7 @@ export default function ServerCreate() {
 					label="Kind"
 					value={kind}
 					onChange={(e) => setKind(e.target.value as ServerKind)}
-					disabled={action.pending || kinds.length < 2}
+					disabled={pending || kinds.length < 2}
 					helperText={
 						kinds.length < 2
 							? `${PRODUCT_LABELS[product]} servers have one role`
@@ -171,7 +188,7 @@ export default function ServerCreate() {
 					label="Rank"
 					value={rank}
 					onChange={(e) => setRank(e.target.value as ServerRank | "")}
-					disabled={action.pending}
+					disabled={pending}
 				>
 					{RANK_OPTIONS.map((o) => (
 						<MenuItem key={o.value} value={o.value}>
@@ -183,13 +200,13 @@ export default function ServerCreate() {
 				<TailscaleIdentityField
 					value={tailscaleIdentifier}
 					onChange={setTailscaleIdentifier}
-					disabled={action.pending}
+					disabled={pending}
 				/>
 
 				<GroupControl
 					currentGroupId={groupId}
 					onChange={setGroupId}
-					disabled={action.pending}
+					disabled={pending}
 					required
 				/>
 
@@ -199,7 +216,7 @@ export default function ServerCreate() {
 						label="Location"
 						value={cloud}
 						onChange={(e) => setCloud(e.target.value as "" | "true" | "false")}
-						disabled={action.pending}
+						disabled={pending}
 						sx={{ minWidth: 180 }}
 					>
 						<MenuItem value="">unknown</MenuItem>
@@ -210,14 +227,14 @@ export default function ServerCreate() {
 						label="Latitude"
 						value={lat}
 						onChange={(e) => setLat(e.target.value)}
-						disabled={action.pending}
+						disabled={pending}
 						sx={{ flex: 1 }}
 					/>
 					<TextField
 						label="Longitude"
 						value={lon}
 						onChange={(e) => setLon(e.target.value)}
-						disabled={action.pending}
+						disabled={pending}
 						sx={{ flex: 1 }}
 					/>
 				</Stack>
@@ -227,7 +244,7 @@ export default function ServerCreate() {
 						label="Name in Tamanu Mobile app"
 						value={publicName}
 						onChange={(e) => setPublicName(e.target.value)}
-						disabled={action.pending}
+						disabled={pending}
 						helperText="Leave empty to hide this server from the public mobile-app list."
 					/>
 				)}
@@ -237,16 +254,34 @@ export default function ServerCreate() {
 						<Checkbox
 							checked={isMonitored}
 							onChange={(e) => setIsMonitored(e.target.checked)}
-							disabled={action.pending}
+							disabled={pending}
 						/>
 					}
 					label="Monitor this server"
 				/>
 				<Typography variant="caption" color="text.secondary">
-					When off, canopy stops watching this server: reachability sweeps
-					skip it and its events/issues no longer trigger or join incidents.
-					Use this for test environments and ad-hoc demos that are expected
-					to be down.
+					When off, no check on this server alerts: its checks are still
+					determined and shown, and its health and reachability are marked
+					as unmonitored wherever they appear, but nothing triggers or joins
+					an incident. Use this for test environments and ad-hoc demos that
+					are expected to be down.
+				</Typography>
+
+				<FormControlLabel
+					control={
+						<Checkbox
+							checked={alertWhenUnreachable}
+							onChange={(e) => setAlertWhenUnreachable(e.target.checked)}
+							disabled={pending}
+						/>
+					}
+					label="Alert when this server is unreachable"
+				/>
+				<Typography variant="caption" color="text.secondary">
+					When off, every other check alerts as normal and only the server
+					going away is quiet. This is the same as silencing the
+					reachability check on this server, and either place reflects the
+					other.
 				</Typography>
 
 				<Stack
@@ -262,7 +297,7 @@ export default function ServerCreate() {
 						type="number"
 						value={alertWhenDownMinutes}
 						onChange={(e) => setAlertWhenDownMinutes(e.target.value)}
-						disabled={action.pending || !isMonitored}
+						disabled={pending || !isMonitored || !alertWhenUnreachable}
 						slotProps={{ htmlInput: { min: 1, step: 1 } }}
 						sx={{ width: 140 }}
 					/>
@@ -274,33 +309,31 @@ export default function ServerCreate() {
 					minRows={3}
 					value={notes}
 					onChange={(e) => setNotes(e.target.value)}
-					disabled={action.pending}
+					disabled={pending}
 					helperText="Operator notes shown on the server's detail page. Plain text."
 				/>
 
 				<Stack spacing={1}>
 					<Typography variant="subtitle1">Tags</Typography>
-					<TagsEditor value={tags} onChange={setTags} disabled={action.pending} />
+					<TagsEditor value={tags} onChange={setTags} disabled={pending} />
 				</Stack>
 
-				{action.error && (
-					<Alert severity="error">{action.error.message}</Alert>
-				)}
+				{error && <Alert severity="error">{error.message}</Alert>}
 
 				<Stack direction="row" spacing={1}>
 					<Button
 						type="submit"
 						variant="contained"
-						disabled={action.pending || !groupId || !name.trim()}
+						disabled={pending || !groupId || !name.trim()}
 					>
-						{action.pending ? "Creating…" : "Create server"}
+						{pending ? "Creating…" : "Create server"}
 					</Button>
 					<Button
 						type="button"
 						variant="outlined"
 						color="error"
 						onClick={() => navigate(-1)}
-						disabled={action.pending}
+						disabled={pending}
 					>
 						Cancel
 					</Button>

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -82,6 +82,7 @@ import {
 	compareServersByRankThenKind,
 	groupServersByRank,
 	healthcheckPath,
+	silenceRef,
 	type CheckResult,
 	type ConsolidatedCheck,
 	type ConsolidatedChecks,
@@ -982,8 +983,9 @@ function ChecksTableBody({
 				{visible.map((entry) => {
 					// Match the silence refs to this entry's own source — a
 					// silence on another source's same-named check is a
-					// different check.
-					const refName = `health/${entry.check}`;
+					// different check, and canopy's own checks are silenced
+					// at a bare ref rather than under `health/`.
+					const refName = silenceRef(entry.source, entry.check);
 					const serverSilence =
 						serverSilences.find(
 							(s) => s.source === entry.source && s.ref === refName,
@@ -1270,7 +1272,7 @@ function SilenceCheckButton({
 		silenceGroup.error ??
 		unsilenceServer.error ??
 		unsilenceGroup.error;
-	const refName = `health/${check}`;
+	const refName = silenceRef(source, check);
 	const silenced = !!serverSilence || !!groupSilence;
 	const handle = async (fn: () => Promise<unknown>) => {
 		try {

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -774,6 +774,7 @@ function InfoSection({
 				<HealthIndicator
 					health={health}
 					up={up}
+					monitored={server.is_monitored !== false}
 					operators={status.operators}
 				/>
 			)}
@@ -854,10 +855,12 @@ function InfoSection({
 function HealthIndicator({
 	health,
 	up,
+	monitored,
 	operators,
 }: {
 	health: HealthState;
 	up: ShortStatus;
+	monitored: boolean;
 	operators: OperatorPresence[];
 }) {
 	const reporting = up === "up" || up === "blip";
@@ -868,7 +871,7 @@ function HealthIndicator({
 			useFlexGap
 			sx={{ mb: 1.5, alignItems: "center", flexWrap: "wrap" }}
 		>
-			<HealthChip health={health} stale={!reporting} />
+			<HealthChip health={health} stale={!reporting} monitored={monitored} />
 			{reporting && operators.length > 0 && (
 				<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
 					<OperatorAvatars operators={operators} size={24} />
@@ -1598,6 +1601,7 @@ function SiblingServers({
 									<StatusDot
 										up={sib.up ?? "gone"}
 										health={sib.health ?? undefined}
+										monitored={sib.is_monitored !== false}
 									/>
 									<MuiLink
 										component={RouterLink}
@@ -2101,6 +2105,7 @@ function SiblingDotStrip({
 							key={m.entry.id}
 							up={(m.entry.up as ShortStatus | undefined) ?? "gone"}
 							health={(m.entry.health as HealthState | undefined) ?? undefined}
+							monitored={m.entry.is_monitored !== false}
 							title={m.entry.name ?? ""}
 							dim={!m.focused}
 							size="0.8em"

--- a/private-web/src/routes/ServerEdit.tsx
+++ b/private-web/src/routes/ServerEdit.tsx
@@ -21,7 +21,7 @@ import {
 	useProductKinds,
 	useProducts,
 } from "../hooks/useProducts";
-import { PRODUCT_LABELS } from "../types";
+import { PRODUCT_LABELS, REACHABILITY_CHECK } from "../types";
 import type {
 	Product,
 	ServerGroup,
@@ -49,16 +49,50 @@ export default function ServerEdit() {
 		{ server_id: id },
 		[id],
 	);
+	// The unreachability toggle *is* the server-scoped silence on canopy's
+	// reachability check, so the form can't render until we know whether one
+	// exists — a wrong initial value would be written back on save.
+	const silences = useApi(
+		"silenced_refs",
+		"list_for_server",
+		{ server_id: id },
+		[id],
+	);
 
-	if (info.status === "loading" || info.status === "idle") return <LinearProgress />;
+	if (
+		info.status === "loading" ||
+		info.status === "idle" ||
+		silences.status === "loading" ||
+		silences.status === "idle"
+	)
+		return <LinearProgress />;
 	if (info.status === "error")
 		return <Alert severity="error">{info.error.message}</Alert>;
-	return <EditForm info={info.data} />;
+	if (silences.status === "error")
+		return <Alert severity="error">{silences.error.message}</Alert>;
+	return (
+		<EditForm
+			info={info.data}
+			reachabilitySilenced={silences.data.some(
+				(s) =>
+					s.source === REACHABILITY_CHECK.source &&
+					s.ref === REACHABILITY_CHECK.ref,
+			)}
+		/>
+	);
 }
 
-function EditForm({ info }: { info: ServerInfo }) {
+function EditForm({
+	info,
+	reachabilitySilenced,
+}: {
+	info: ServerInfo;
+	reachabilitySilenced: boolean;
+}) {
 	const navigate = useNavigate();
 	const action = useApiAction("servers", "update");
+	const silence = useApiAction("silenced_refs", "silence_server");
+	const unsilence = useApiAction("silenced_refs", "unsilence_server");
 
 	const [name, setName] = useState(info.name ?? "");
 	const [host, setHost] = useState(info.host ?? "");
@@ -74,6 +108,14 @@ function EditForm({ info }: { info: ServerInfo }) {
 	// (always-positive) threshold to use when monitored. Stored separately
 	// so muting doesn't lose the chosen threshold. UI works in minutes.
 	const [isMonitored, setIsMonitored] = useState(info.is_monitored);
+	// Off means "alert on everything else, just not this server going away".
+	// Stored as the server-scoped silence on canopy's reachability check, the
+	// same one the check itself offers, so the two surfaces are one state.
+	// spec: CHK#operator-controls
+	const alertsWhenUnreachableInitially = !reachabilitySilenced;
+	const [alertWhenUnreachable, setAlertWhenUnreachable] = useState(
+		alertsWhenUnreachableInitially,
+	);
 	const [alertWhenDownMinutes, setAlertWhenDownMinutes] = useState<string>(
 		Math.max(1, Math.round(info.alert_when_down_for / 60)).toString(),
 	);
@@ -88,6 +130,9 @@ function EditForm({ info }: { info: ServerInfo }) {
 	const [tags, setTags] = useState<TagMap>(info.tags ?? {});
 	const [mayManageDns, setMayManageDns] = useState(info.may_manage_dns);
 	const [mayManageTls, setMayManageTls] = useState(info.may_manage_tls);
+
+	const pending = action.pending || silence.pending || unsilence.pending;
+	const error = action.error ?? silence.error ?? unsilence.error;
 
 	const onSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -123,9 +168,19 @@ function EditForm({ info }: { info: ServerInfo }) {
 		};
 		try {
 			await action.call({ server_id: info.id, data });
+			if (alertWhenUnreachable !== alertsWhenUnreachableInitially) {
+				const ref = {
+					server_id: info.id,
+					source: REACHABILITY_CHECK.source,
+					ref: REACHABILITY_CHECK.ref,
+				};
+				await (alertWhenUnreachable
+					? unsilence.call(ref)
+					: silence.call(ref));
+			}
 			navigate(`/servers/${info.id}`);
 		} catch {
-			/* surfaced via action.error */
+			/* surfaced via the actions' errors */
 		}
 	};
 
@@ -140,14 +195,14 @@ function EditForm({ info }: { info: ServerInfo }) {
 					label="Name"
 					value={name}
 					onChange={(e) => setName(e.target.value)}
-					disabled={action.pending}
+					disabled={pending}
 					required
 				/>
 				<TextField
 					label="URL"
 					value={host}
 					onChange={(e) => setHost(e.target.value)}
-					disabled={action.pending}
+					disabled={pending}
 				/>
 				<TextField
 					select
@@ -165,7 +220,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 							setKind(info.default_kind);
 						}
 					}}
-					disabled={action.pending}
+					disabled={pending}
 				>
 					{products.map((p) => (
 						<MenuItem key={p.product} value={p.product}>
@@ -178,7 +233,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 					label="Kind"
 					value={kind}
 					onChange={(e) => setKind(e.target.value as ServerKind)}
-					disabled={action.pending || kinds.length < 2}
+					disabled={pending || kinds.length < 2}
 					helperText={
 						kinds.length < 2
 							? `${PRODUCT_LABELS[product]} servers have one role`
@@ -196,7 +251,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 					label="Rank"
 					value={rank}
 					onChange={(e) => setRank(e.target.value as ServerRank | "")}
-					disabled={action.pending}
+					disabled={pending}
 				>
 					{RANK_OPTIONS.map((o) => (
 						<MenuItem key={o.value} value={o.value}>
@@ -209,13 +264,13 @@ function EditForm({ info }: { info: ServerInfo }) {
 					placeholder="UUID"
 					value={deviceId}
 					onChange={(e) => setDeviceId(e.target.value)}
-					disabled={action.pending}
+					disabled={pending}
 				/>
 
 				<GroupControl
 					currentGroupId={groupId}
 					onChange={setGroupId}
-					disabled={action.pending}
+					disabled={pending}
 					required
 				/>
 
@@ -225,7 +280,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 						label="Location"
 						value={cloud}
 						onChange={(e) => setCloud(e.target.value as "" | "true" | "false")}
-						disabled={action.pending}
+						disabled={pending}
 						sx={{ minWidth: 180 }}
 					>
 						<MenuItem value="">unknown</MenuItem>
@@ -236,14 +291,14 @@ function EditForm({ info }: { info: ServerInfo }) {
 						label="Latitude"
 						value={lat}
 						onChange={(e) => setLat(e.target.value)}
-						disabled={action.pending}
+						disabled={pending}
 						sx={{ flex: 1 }}
 					/>
 					<TextField
 						label="Longitude"
 						value={lon}
 						onChange={(e) => setLon(e.target.value)}
-						disabled={action.pending}
+						disabled={pending}
 						sx={{ flex: 1 }}
 					/>
 				</Stack>
@@ -253,7 +308,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 						label="Name in Tamanu Mobile app"
 						value={publicName}
 						onChange={(e) => setPublicName(e.target.value)}
-						disabled={action.pending}
+						disabled={pending}
 						helperText="Leave empty to hide this server from the public mobile-app list."
 					/>
 				)}
@@ -263,16 +318,34 @@ function EditForm({ info }: { info: ServerInfo }) {
 						<Checkbox
 							checked={isMonitored}
 							onChange={(e) => setIsMonitored(e.target.checked)}
-							disabled={action.pending}
+							disabled={pending}
 						/>
 					}
 					label="Monitor this server"
 				/>
 				<Typography variant="caption" color="text.secondary">
-					When off, canopy stops watching this server: reachability sweeps
-					skip it and its events/issues no longer trigger or join incidents.
-					Existing issues are kept for the record. Use this for test
-					environments and ad-hoc demos that are expected to be down.
+					When off, no check on this server alerts: its checks are still
+					determined and shown, and its health and reachability are marked
+					as unmonitored wherever they appear, but nothing triggers or joins
+					an incident. Use this for test environments and ad-hoc demos that
+					are expected to be down.
+				</Typography>
+
+				<FormControlLabel
+					control={
+						<Checkbox
+							checked={alertWhenUnreachable}
+							onChange={(e) => setAlertWhenUnreachable(e.target.checked)}
+							disabled={pending}
+						/>
+					}
+					label="Alert when this server is unreachable"
+				/>
+				<Typography variant="caption" color="text.secondary">
+					When off, every other check alerts as normal and only the server
+					going away is quiet. This is the same as silencing the
+					reachability check on this server, and either place reflects the
+					other.
 				</Typography>
 
 				<Stack
@@ -288,7 +361,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 						type="number"
 						value={alertWhenDownMinutes}
 						onChange={(e) => setAlertWhenDownMinutes(e.target.value)}
-						disabled={action.pending || !isMonitored}
+						disabled={pending || !isMonitored || !alertWhenUnreachable}
 						slotProps={{ htmlInput: { min: 1, step: 1 } }}
 						sx={{ width: 140 }}
 					/>
@@ -296,7 +369,7 @@ function EditForm({ info }: { info: ServerInfo }) {
 				<Typography variant="caption" color="text.secondary">
 					Raise this for flappy servers (so brief blips don't fire) or lower
 					it for critical servers that should page promptly. The value is
-					preserved while monitoring is off.
+					preserved while either switch above is off.
 				</Typography>
 
 				<Stack spacing={1}>
@@ -335,33 +408,31 @@ function EditForm({ info }: { info: ServerInfo }) {
 					minRows={3}
 					value={notes}
 					onChange={(e) => setNotes(e.target.value)}
-					disabled={action.pending}
+					disabled={pending}
 					helperText="Operator notes shown on the server's detail page. Plain text."
 				/>
 
 				<Stack spacing={1}>
 					<Typography variant="subtitle1">Tags</Typography>
-					<TagsEditor value={tags} onChange={setTags} disabled={action.pending} />
+					<TagsEditor value={tags} onChange={setTags} disabled={pending} />
 				</Stack>
 
-				{action.error && (
-					<Alert severity="error">{action.error.message}</Alert>
-				)}
+				{error && <Alert severity="error">{error.message}</Alert>}
 
 				<Stack direction="row" spacing={1}>
 					<Button
 						type="submit"
 						variant="contained"
-						disabled={action.pending || !groupId || !name.trim()}
+						disabled={pending || !groupId || !name.trim()}
 					>
-						{action.pending ? "Saving…" : "Save"}
+						{pending ? "Saving…" : "Save"}
 					</Button>
 					<Button
 						type="button"
 						variant="outlined"
 						color="error"
 						onClick={() => navigate(`/servers/${info.id}`)}
-						disabled={action.pending}
+						disabled={pending}
 					>
 						Cancel
 					</Button>

--- a/private-web/src/routes/Status.tsx
+++ b/private-web/src/routes/Status.tsx
@@ -462,6 +462,7 @@ export function RankedDotStrip({ members }: { members: FacilityServerStatus[] })
 					<StatusDot
 						up={m.up}
 						health={m.health}
+						monitored={m.is_monitored}
 						title={`${m.name}: ${m.up}${
 							m.health !== "healthy" ? ` (${m.health})` : ""
 						}`}

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -396,6 +396,28 @@ export function healthcheckNameFromRef(
 	return ref.slice(prefix.length);
 }
 
+/// Sources canopy reserves for its own conditions. They file at bare
+/// refs; every other source's checks are namespaced under `health/`.
+export const RESERVED_SOURCES = ["canopy", "manual"];
+
+/// The silence ref for a check, which is what the silence endpoints and
+/// the silence listings speak. Mirrors `database::silenced_refs`: bare
+/// for the reserved sources, `health/`-prefixed for reported checks.
+/// Building it by hand gets the reserved sources wrong, and a mismatched
+/// ref silently fails to match an existing silence.
+export function silenceRef(source: string, check: string): string {
+	return RESERVED_SOURCES.includes(source) ? check : `health/${check}`;
+}
+
+/// Canopy's per-server reachability check, with the ref its silence is
+/// keyed by. The server form's "alert when unreachable" switch and the
+/// check's own silence button both write this one silence.
+export const REACHABILITY_CHECK = {
+	source: "canopy",
+	check: "reachability",
+	ref: silenceRef("canopy", "reachability"),
+} as const;
+
 /// One person connected somewhere in a server group, with the names of
 /// the member servers they're on. Produced by [`aggregateOperators`].
 export type AggregatedOperator = {


### PR DESCRIPTION
🤖 The reachability check only existed while it was failing, so the check — and the silence control on it — first appeared once a server was already red. And silencing reachability meant finding the check to silence it, which is backwards when the whole point is a server you already know comes and goes.

## Reachability presents for every server

The sweep still files this check only while it's degraded: writing a passing state per server per minute would take the per-group incident lock on every tick, which is the convoy shape that was fixed earlier. Instead the consolidated view fills in a passing `canopy/reachability` where no state exists, so the check reads green rather than being absent. It's gated on a live catalog row, which the private-server registers at startup, so decommissioning still removes the check and the documentation is there to link.

Live view only. The point-in-time snapshot path still reconstructs from history — inventing a green for a past moment nothing was recorded for would be a lie.

## Unmonitored servers are determined and marked

The sweep no longer skips unmonitored servers. The monitoring gate already keeps their filings out of incidents, so their reachability is now determined and presented like everyone else's — which means an unmonitored server that is genuinely off reads Unhealthy where it previously showed nothing at all.

So the presentation says which it is: the health chip fades and gains an info-coloured silence icon, and the status dot is cut through with a diagonal that the status legend names. The cut is a mask punched through the dot rather than a stripe painted over it, so it works on the operator-tinted group cards as well as plain paper. `FacilityServerStatus` carries the monitored flag for the status page; every other dot call site already had it.

## The switch on the server form

Create and edit carry \"alert when this server is unreachable\" next to the monitoring switch, so the two read together: monitoring off silences every check on the server, this one silences only its going away. It writes the same server-scoped silence the check's own button writes, and the edit form reads the existing silence before rendering so an unrelated save can't write an operator's earlier decision away.

That button was building canopy's refs under the \`health/\` namespace. Canopy and manual file at bare refs, so the silence stored correctly but never matched on the way back, and the silenced chip never showed for canopy's own checks. Both surfaces now go through one helper.

## Notes for review

- `just gen-openapi` is broken on main, independently of this branch: private-web is on `typescript@^7` but `openapi-typescript@7.13.0` needs `^5.x` and dies with `ts.factory` undefined. `api-types.ts` here was generated by running the generator against `typescript@5.9.3` from outside the project, and the diff is the one new field. The recipe needs either a pinned TS5 for that step or an `openapi-typescript` that supports TS7 — not decided here.
- Two existing catalog assertions counted every `check_policies` row, so registering canopy's own check at startup broke them; both are now scoped to what they were actually about.
- The historical status-snapshot panel is not marked for unmonitored servers — it's reached from a context with no monitoring info, and the spec sentence is scoped to health and reachability as they currently stand.