### PR TITLE
Pre-upgrade migration testing (RST)

### DIFF
--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -218,10 +218,13 @@ Canopy decides which versions are tested against which servers, rather than an o
 A published version is a candidate for a server when that server could upgrade to it: the version is newer than the one the server reports running, and it lies on the upgrade path Canopy would serve that server.
 Where that path passes through several versions of one minor series, only the newest of the series is a candidate, because that is the version an upgrade applies.
 
-An operator may also nominate a version for a group or a server, including a version not yet published, so a release candidate is tested against the largest deployments' data before it ships.
-A nomination ends when the operator withdraws it.
+Only a published version is a candidate, because a version's migrations reach a consumer as its published artefacts, and an unpublished version has none to fetch.
+Publication is what makes a version testable and what makes it reachable by a server, so the two arrive together.
 
 A server with no successful backup of a restorable type has no candidates, because there is nothing to restore and migrate.
+
+Testing therefore sits between a version being available and a deployment being told to take it.
+That window is where the answer is still cheap: the fleet is not moving yet, and a version found to break a deployment's data can be held back before anyone schedules its upgrade.
 
 ### Dispatching a migration test
 
@@ -274,12 +277,8 @@ For an intent carrying `once`, the expectation is measured against the latest sn
 For an intent without `once`, it is measured against wall-clock time since the last healthy report.
 Overdue applies only to intents carrying `check`.
 
-A failed migration test against a published candidate version raises a migration-test check on the affected server, under the same gates, because that server is on the upgrade path to the version that failed.
+A failed migration test raises a migration-test check on the affected server, under the same gates, because that server is on the upgrade path to the version that failed.
 The check names the target version as well as the type and intent, so a failure against one candidate version does not mask a pass against another.
-
-A failed test against a nominated version that is not yet published raises no check on the server.
-The server lent its data; nothing running on it is at risk from a version that has not shipped.
-That failure lands on the version's readiness instead, for whoever owns the release.
 
 ## Out of scope
 

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -6,10 +6,11 @@ id: RST
 
 Canopy is the control plane for a fleet's *managed restore replicas*: standing replicas that Canopy decides should exist and keeps restored from the latest backups, driven through a restore consumer.
 An external restore consumer — first-party infrastructure that restores backups into working Postgres replicas — is driven entirely by Canopy: Canopy declares which replicas should exist, hands out the snapshot to restore and short-lived read-only credentials for each, and records the restorability of every replica as the strongest backup-health signal.
+A replica restored from real data is also the substrate for testing a Tamanu version's schema migrations before that version reaches the deployment, so the same machinery carries both a backup-health signal and a version-readiness one.
 
 ## Scope
 
-This spec covers *managed* restore replicas only: the standing replicas Canopy decides should exist and keeps current, and the restore-health signal they produce.
+This spec covers *managed* restore replicas only: the standing replicas Canopy decides should exist and keeps current, the restore-health signal they produce, and the pre-upgrade migration testing they carry.
 
 It does not cover an operator restoring a backup by hand.
 An operator performing disaster recovery or an ad-hoc restore selects a specific snapshot for a specific server and restores it through that server's own device tooling and credentials — the existing per-server restore path, unchanged by this spec.
@@ -92,6 +93,7 @@ The recognised semantics are:
 - **once** — a given snapshot is dispatched to the intent at most once.
   Canopy omits a replica from the worklist once the intent has a healthy report for that replica's current snapshot, and reinstates it only when a newer snapshot exists.
   Without `once`, the intent is always pointed at the latest snapshot and manages its own refresh.
+  An intent whose result depends on more than the snapshot keys `once` to that wider input as well, and may treat a failure as settled rather than retryable (see [Pre-upgrade migration testing](#pre-upgrade-migration-testing)).
 - **url** — the intent's health report carries a link to the running replica within its attached health data, which Canopy surfaces to operators.
 
 ### Parameters
@@ -201,6 +203,62 @@ Reports are retained indefinitely as an audit trail.
 Canopy derives each restore's duration from the interval between its first credential issuance and its report.
 A restore for which credentials were issued but no report has arrived is shown as in progress while the credentials remain valid, otherwise as a restore whose outcome is unknown; this surfaces in-flight and terminated-without-report restores in the operator view, including those under intents that produce no health report.
 
+## Pre-upgrade migration testing
+
+An intent may apply a Tamanu version's schema migrations to the replica it restores, so a version's effect on a deployment's real data is known ahead of an upgrade window rather than discovered inside one.
+
+An upgrade applies schema migrations to the live database with the deployment down for the duration.
+A migration that fails against real data, and one that succeeds but runs far longer than the window allowed for, are both properties of that deployment's data rather than of the migration alone, so neither shows against a small or synthetic database.
+Canopy knows the version each server reports running and the upgrade path it would be served, and already holds the authority over replicas made from real backups, so it is where the question can be posed ahead of the window.
+
+### Candidate versions
+
+Canopy decides which versions are tested against which servers, rather than an operator naming each pair.
+
+A published version is a candidate for a server when that server could upgrade to it: the version is newer than the one the server reports running, and it lies on the upgrade path Canopy would serve that server.
+Where that path passes through several versions of one minor series, only the newest of the series is a candidate, because that is the version an upgrade applies.
+
+An operator may also nominate a version for a group or a server, including a version not yet published, so a release candidate is tested against the largest deployments' data before it ships.
+A nomination ends when the operator withdraws it.
+
+A server with no successful backup of a restorable type has no candidates, because there is nothing to restore and migrate.
+
+### Dispatching a migration test
+
+A migration-testing entry carries the target version alongside the snapshot, and a reference to that version's migrations in the same form Canopy publishes a version's artefacts to devices, so a consumer obtains them the way a server being upgraded does.
+
+`once` is keyed to the pair of snapshot and target version: an entry is omitted once that pair has a verdict, and reinstated when either a newer snapshot or a new candidate version appears.
+A failed verdict settles that pair rather than leaving it retryable.
+A restore can fail for transient reasons and is worth retrying, but a migration failing against a fixed snapshot fails the same way every time, and a retry costs a full restore for an answer already held.
+
+### What a migration test reports
+
+Beyond the fields every report carries, a migration-testing report carries:
+
+- the **target version** whose migrations were applied;
+- whether **every migration applied**, or which one failed and the error it produced;
+- the **total elapsed time** of the migration run;
+- the **elapsed time of each migration** that ran;
+- the **size of the data** the migrations ran against.
+
+Per-migration timings are a primary result rather than diagnostic detail.
+A version whose migrations all apply but whose slowest migration takes hours against a large deployment is a finding, and a report carries enough detail to name the migration to attend to.
+Recording the data size alongside the timings is what lets a duration be read against the volume that produced it, and compared across deployments of different sizes.
+
+### Verdicts
+
+Canopy derives a verdict for each candidate pair of server and version: not yet tested, passed, or failed.
+Verdicts are presented per group, as the set of versions tested against that group's servers, so whether a version is safe for a deployment is answered in one place instead of by assembling reports.
+
+A verdict names the snapshot it was reached against and when that was, because a pass against a month-old snapshot is a weaker statement than one against last night's.
+A newer test of the same pair supersedes the previous verdict, and the superseded reports remain.
+
+### Version readiness
+
+A failed migration test marks its target version as carrying a known issue, which removes that version from those considered ready to roll out, and records the server and the failing migration so whoever picks it up knows which deployment's data provoked it.
+This is the gate an operator-filed known issue uses, so a failure found automatically and one found by hand have the same effect on a rollout.
+Clearing the issue is an operator action, and a later passing test does not clear it, because whether the resolution is a change to the migration, a change to the data, or an accepted limitation is a judgement.
+
 ## Alerting
 
 A failed or overdue restore-health report raises a restore-verification check on the affected server, subject to the same monitoring and incident gates as any other of that server's checks.
@@ -213,9 +271,18 @@ For an intent carrying `once`, the expectation is measured against the latest sn
 For an intent without `once`, it is measured against wall-clock time since the last healthy report.
 Overdue applies only to intents carrying `check`.
 
+A failed migration test against a published candidate version raises a migration-test check on the affected server, under the same gates, because that server is on the upgrade path to the version that failed.
+The check names the target version as well as the type and intent, so a failure against one candidate version does not mask a pass against another.
+
+A failed test against a nominated version that is not yet published raises no check on the server.
+The server lent its data; nothing running on it is at risk from a version that has not shipped.
+That failure lands on the version's readiness instead, for whoever owns the release.
+
 ## Out of scope
 
-- How a consumer provisions, runs, names, or tears down a replica.
+- How a consumer provisions, runs, names, or tears down a replica, or how it applies migrations to one.
 - A consumer's runtime placement, storage sizing, or scheduling.
+- Producing reporting schemas, or any other artefact, from a migrated replica.
+- Deciding or scheduling when a deployment upgrades: verdicts inform that decision without making it.
 - Scoping object-storage credentials below the granularity of a group's repo: one repo holds all of a group's servers' snapshots, so credentials are necessarily group-wide while targeting and reporting are per-server.
 - Longer-lived or non-chained credentials: a consumer refreshes within a restore, so the per-issuance lifetime is not a constraint.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -221,7 +221,8 @@ Where that path passes through several versions of one minor series, only the ne
 Only a published version is a candidate, because a version's migrations reach a consumer as its published artefacts, and an unpublished version has none to fetch.
 Publication is what makes a version testable and what makes it reachable by a server, so the two arrive together.
 
-A server with no successful backup of a restorable type has no candidates, because there is nothing to restore and migrate.
+Only a server running Tamanu has candidates, because the migrations under test are Tamanu's and no other product's server has an upgrade path through them.
+A server with no successful backup of a restorable type has no candidates either, because there is nothing to restore and migrate.
 
 Testing therefore sits between a version being available and a deployment being told to take it.
 That window is where the answer is still cheap: the fleet is not moving yet, and a version found to break a deployment's data can be held back before anyone schedules its upgrade.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -215,8 +215,15 @@ Canopy knows the version each server reports running and the upgrade path it wou
 
 Canopy decides which versions are tested against which servers, rather than an operator naming each pair.
 
-A published version is a candidate for a server when that server could upgrade to it: the version is newer than the one the server reports running, and it lies on the upgrade path Canopy would serve that server.
-Where that path passes through several versions of one minor series, only the newest of the series is a candidate, because that is the version an upgrade applies.
+A server's candidate is the newest published version it could upgrade to: newer than the version it reports running, and on the upgrade path Canopy would serve it.
+
+One candidate, not one per version along the path.
+Migrations are applied to the restored snapshot in sequence, so a run targeting the newest version applies every migration between the snapshot's version and that one, and exercises the whole chain an upgrade would.
+
+Which minor a deployment moves to is a decision Canopy has no part in, and testing every minor ahead of a server would cost a full restore each to cover the ones it does not choose.
+It does not need to: coverage accumulates on its own.
+Snapshots arrive daily and releases far less often, so every version is tested against a deployment's data while it is the newest, and a deployment that later settles on an older minor already has a result from when that version was current.
+Where a chain does break, the failing migration named in the report identifies the step without a second run.
 
 Only a published version is a candidate, because a version's migrations reach a consumer as its published artefacts, and an unpublished version has none to fetch.
 Publication is what makes a version testable and what makes it reachable by a server, so the two arrive together.
@@ -280,6 +287,11 @@ Overdue applies only to intents carrying `check`.
 
 A failed migration test raises a migration-test check on the affected server, under the same gates, because that server is on the upgrade path to the version that failed.
 The check names the target version as well as the type and intent, so a failure against one candidate version does not mask a pass against another.
+
+The check is a warning rather than a failure, and does not escalate.
+Nothing is wrong with the live server: it is running the version it always was, serving patients, and the finding is about a version it has not taken yet.
+Treating it as a failure would open an incident against a healthy deployment and put a migration problem in front of whoever is on call for outages, when the people who need it are the ones deciding whether that version ships.
+The version's readiness is where the finding does its work.
 
 ## Out of scope
 

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -259,6 +259,10 @@ Beyond the fields every report carries, a migration-testing report carries:
 - the **elapsed time of each migration** that ran;
 - the **size of the data**, both before the migrations ran and after.
 
+The report's outcome and replica health describe the restore, and the named failing migration describes the migrations.
+A restore that succeeded into a healthy replica whose migrations then failed reports a healthy restore and names the migration that failed.
+Keeping the two apart is what lets restore health and version readiness stay separate signals: the backup restored, so the backup is fine, and the finding belongs to the version.
+
 Per-migration timings are a primary result rather than diagnostic detail.
 A version whose migrations all apply but whose slowest migration takes hours against a large deployment is a finding, and a report carries enough detail to name the migration to attend to.
 
@@ -293,7 +297,8 @@ For an intent without `once`, it is measured against wall-clock time since the l
 Overdue applies only to intents carrying `check`.
 
 A failed migration test raises a migration-test check on the affected server, under the same gates, because that server is on the upgrade path to the version that failed.
-The check names the target version as well as the type and intent, so a failure against one candidate version does not mask a pass against another.
+The check is named for the type and intent, as restore-verification is, and carries the target version in its detail rather than its name.
+A server has one candidate at a time, so there is no second version whose result the first could mask, and a name per version would spawn a catalog policy per release.
 
 The check is a warning rather than a failure, and does not escalate.
 Nothing is wrong with the live server: it is running the version it always was, serving patients, and the finding is about a version it has not taken yet.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -239,6 +239,13 @@ That window is where the answer is still cheap: the fleet is not moving yet, and
 
 ### Dispatching a migration test
 
+`migrate` rides on an intent rather than being one, and that is the point.
+An intent that already restores a snapshot to prove it restorable can apply the migrations to that same replica, so one restore answers both questions: the backup is good, and the next version's migrations survive this deployment's data.
+A consumer that advertises `check`, `once` and `migrate` together reports the replica's health and the migrations' outcome from a single run, and the two land as separate signals from the one report.
+
+Declaring a migrate-only intent alongside a verifying one is possible and costs a second full restore of the same snapshot.
+That is worth paying only when the two need different cadences or overdue bounds, because a restore is the expensive part and the migrations are cheap next to it.
+
 An entry for a `migrate` intent names the target version alongside the snapshot.
 A consumer obtains that version's migrations from its published artefacts, the same way a server being upgraded does, so naming the version is the whole reference it needs.
 

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -95,6 +95,9 @@ The recognised semantics are:
   Without `once`, the intent is always pointed at the latest snapshot and manages its own refresh.
   An intent whose result depends on more than the snapshot keys `once` to that wider input as well, and may treat a failure as settled rather than retryable (see [Pre-upgrade migration testing](#pre-upgrade-migration-testing)).
 - **url** — the intent's health report carries a link to the running replica within its attached health data, which Canopy surfaces to operators.
+- **migrate** — the intent applies a Tamanu version's schema migrations to the replica it restores.
+  Canopy names a target version on each of the intent's worklist entries and withholds an entry from a server that has no candidate version.
+  `once` for such an intent is keyed to the snapshot and the target version together (see [Pre-upgrade migration testing](#pre-upgrade-migration-testing)).
 
 ### Parameters
 
@@ -205,7 +208,7 @@ A restore for which credentials were issued but no report has arrived is shown a
 
 ## Pre-upgrade migration testing
 
-An intent may apply a Tamanu version's schema migrations to the replica it restores, so a version's effect on a deployment's real data is known ahead of an upgrade window rather than discovered inside one.
+An intent carrying the `migrate` semantic applies a Tamanu version's schema migrations to the replica it restores, so a version's effect on a deployment's real data is known ahead of an upgrade window rather than discovered inside one.
 
 An upgrade applies schema migrations to the live database with the deployment down for the duration.
 A migration that fails against real data, and one that succeeds but runs far longer than the window allowed for, are both properties of that deployment's data rather than of the migration alone, so neither shows against a small or synthetic database.
@@ -236,7 +239,11 @@ That window is where the answer is still cheap: the fleet is not moving yet, and
 
 ### Dispatching a migration test
 
-A migration-testing entry carries the target version alongside the snapshot, and a reference to that version's migrations in the same form Canopy publishes a version's artefacts to devices, so a consumer obtains them the way a server being upgraded does.
+An entry for a `migrate` intent names the target version alongside the snapshot.
+A consumer obtains that version's migrations from its published artefacts, the same way a server being upgraded does, so naming the version is the whole reference it needs.
+
+A server with no candidate version contributes no entry, whatever its declaration says.
+There is nothing to migrate to, and an entry naming no version would ask a consumer to restore a database for no reason.
 
 `once` is keyed to the pair of snapshot and target version: an entry is omitted once that pair has a verdict, and reinstated when either a newer snapshot or a new candidate version appears.
 A failed verdict settles that pair rather than leaving it retryable.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -239,11 +239,14 @@ Beyond the fields every report carries, a migration-testing report carries:
 - whether **every migration applied**, or which one failed and the error it produced;
 - the **total elapsed time** of the migration run;
 - the **elapsed time of each migration** that ran;
-- the **size of the data** the migrations ran against.
+- the **size of the data**, both before the migrations ran and after.
 
 Per-migration timings are a primary result rather than diagnostic detail.
 A version whose migrations all apply but whose slowest migration takes hours against a large deployment is a finding, and a report carries enough detail to name the migration to attend to.
-Recording the data size alongside the timings is what lets a duration be read against the volume that produced it, and compared across deployments of different sizes.
+
+The size before the run is what lets a duration be read against the volume that produced it, and compared across deployments of different sizes.
+The growth between the two figures is its own finding: a migration that backfills a large table leaves the deployment needing disk it was not provisioned for, and every deployment that has yet to run it will grow the same way in proportion to its own data.
+Growth is also a second reason a window overruns, since the write volume that produces it is time the deployment spends down.
 
 ### Verdicts
 

--- a/crates/commons-types/src/backup.rs
+++ b/crates/commons-types/src/backup.rs
@@ -387,6 +387,11 @@ pub mod semantics {
 	/// The intent's health report carries a link to the running replica within
 	/// its health data, which Canopy surfaces to operators.
 	pub const URL: &str = "url";
+	/// The intent applies a Tamanu version's schema migrations to the replica it
+	/// restores: Canopy names a target version on the worklist entry, withholds
+	/// an entry from a server with no candidate version, and keys `once` to the
+	/// snapshot and target version together.
+	pub const MIGRATE: &str = "migrate";
 }
 
 /// The data type of a restore-replica configuration parameter, which

--- a/crates/database/src/backup/refs.rs
+++ b/crates/database/src/backup/refs.rs
@@ -71,6 +71,7 @@ pub const PREFLIGHT_OBJECT_LOCK: &str = "preflight-object-lock";
 /// restorability check. Group-scoped, `Error`. Routed through the same
 /// group-level helper.
 pub const RESTORE_VERIFICATION: &str = "restore-verification";
+pub const MIGRATION_TEST: &str = "migration-test";
 
 // --- shipped documentation (seeded into the catalog on first filing) ---
 
@@ -217,3 +218,15 @@ The managed restore replica for this (server, type, intent) reported a failed or
 ## Solve
 
 Check the restore consumer's report detail: restore errors point at the snapshot or credentials, staleness at the consumer itself.";
+
+pub const MIGRATION_TEST_DOC: &str = "## Description
+
+A candidate version's schema migrations were applied to a restore replica of this server's data, and one of them failed. The server itself is unaffected: it is still running the version it was, and the finding is about a version it has not taken.
+
+## Results
+
+- **warn**: the migrations did not complete against this deployment's data. The version carries a known issue and is held back from rollout.
+
+## Solve
+
+Read the failing migration named in the report detail. The fix belongs to the migration or to the deployment's data, and the version stays unready until someone resolves the known issue against it.";

--- a/crates/database/src/bin/seed.rs
+++ b/crates/database/src/bin/seed.rs
@@ -290,6 +290,7 @@ async fn seed_known_issues(conn: &mut AsyncPgConnection) -> Result<()> {
 		(2, 11, 0),
 		"carol.releases@example.com",
 		"Report exports time out on large datasets; avoid 2.11.x in production.",
+		None,
 	)
 	.await?;
 
@@ -298,6 +299,7 @@ async fn seed_known_issues(conn: &mut AsyncPgConnection) -> Result<()> {
 		(2, 9, 0),
 		"carol.releases@example.com",
 		"Sync stalls when a facility reconnects after a long outage.",
+		None,
 	)
 	.await?;
 	VersionKnownIssue::resolve(

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -15,6 +15,7 @@ pub mod chrome_releases;
 pub mod devices;
 pub mod issues;
 pub mod mcp_tokens;
+pub mod migration_tests;
 pub mod notes;
 pub mod pg_duration;
 pub mod recovery_vault;

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -213,7 +213,16 @@ impl MigrationTest {
 		let target_version_id = test.target_version_id;
 		let failed_migration = test.failed_migration.clone();
 
+		let restore_failed = report.outcome != RunOutcome::Success;
+
 		let check_id = BackupRestoreCheck::record_report(db, report).await?;
+
+		// A failed restore with no named migration says nothing about the
+		// version: the migrations never ran. Restore-health already raises on
+		// the failure, and leaving no result keeps the pair retryable.
+		if restore_failed && failed_migration.is_none() {
+			return Ok(check_id);
+		}
 
 		diesel::insert_into(crate::schema::migration_tests::table)
 			.values((

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -6,8 +6,9 @@
 
 use commons_errors::Result;
 use commons_types::{
-	backup::RunOutcome,
+	backup::{BackupType, RestoreIntent, RunOutcome},
 	server::product::Product,
+	status::CheckResult,
 	version::{VersionStatus, VersionStr},
 };
 use diesel::prelude::*;
@@ -16,8 +17,15 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-	pg_duration::PgDuration, reported_detail::ReportedDetail, restore::BackupRestoreCheck,
-	restore::NewBackupRestoreCheck, servers::Server, versions::Version,
+	backup::refs,
+	issues::{CheckFiling, Scope, file_check},
+	pg_duration::PgDuration,
+	reported_detail::ReportedDetail,
+	restore::BackupRestoreCheck,
+	restore::NewBackupRestoreCheck,
+	servers::Server,
+	version_known_issues::VersionKnownIssue,
+	versions::Version,
 };
 
 /// A version a server could upgrade to, so one to test against that server's
@@ -134,6 +142,12 @@ impl MigrationTest {
 		report: NewBackupRestoreCheck,
 		test: NewMigrationTest,
 	) -> Result<i64> {
+		let server_id = report.server_id;
+		let r#type = report.r#type.clone();
+		let intent = report.intent.clone();
+		let target_version_id = test.target_version_id;
+		let failed_migration = test.failed_migration.clone();
+
 		let check_id = BackupRestoreCheck::record_report(db, report).await?;
 
 		diesel::insert_into(crate::schema::migration_tests::table)
@@ -166,6 +180,20 @@ impl MigrationTest {
 				.values(timings)
 				.execute(db)
 				.await?;
+		}
+
+		// A report with no server is recorded but has nobody to hold the finding
+		// against, matching how restore-health treats one.
+		if let Some(server_id) = server_id {
+			file_outcome(
+				db,
+				server_id,
+				&r#type,
+				&intent,
+				target_version_id,
+				failed_migration.as_deref(),
+			)
+			.await?;
 		}
 
 		Ok(check_id)
@@ -245,4 +273,87 @@ pub async fn has_verdict(
 		.optional()?;
 
 	Ok(existing.is_some())
+}
+
+/// Raise or recover the server's migration-test check, and hold the target
+/// version back when its migrations failed.
+///
+/// A warning that does not escalate. The server is running the version it
+/// always was and is serving patients; the finding is about a version it has
+/// not taken, so it belongs to whoever decides whether that version ships
+/// rather than to whoever is on call for outages.
+// spec: RST#alerting
+async fn file_outcome(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	r#type: &BackupType,
+	intent: &RestoreIntent,
+	target_version_id: Uuid,
+	failed_migration: Option<&str>,
+) -> Result<()> {
+	let version = Version::get_by_id(db, target_version_id).await?;
+	let semver = version.as_semver();
+	// Named per (type, intent) like restore-verification, so the catalog holds
+	// one policy rather than one per release. The version rides in the detail.
+	let r#ref = format!("{}:{}:{}", refs::MIGRATION_TEST, r#type, intent);
+
+	let Some(migration) = failed_migration else {
+		file_check(
+			db,
+			CheckFiling {
+				source: crate::statuses::CANOPY_SOURCE,
+				scope: Scope::Server(server_id),
+				device_id: None,
+				check: &r#ref,
+				observed: CheckResult::Passed,
+				title: None,
+				message: &format!("Migrations for {semver} applied against server {server_id}"),
+				detail: Some(serde_json::json!({ "target_version": semver.to_string() })),
+				default_ceiling: CheckResult::Warning,
+				default_escalates: false,
+				documentation: Some(refs::MIGRATION_TEST_DOC),
+			},
+		)
+		.await?;
+		return Ok(());
+	};
+
+	file_check(
+		db,
+		CheckFiling {
+			source: crate::statuses::CANOPY_SOURCE,
+			scope: Scope::Server(server_id),
+			device_id: None,
+			check: &r#ref,
+			observed: CheckResult::Warning,
+			title: Some("migration test failed"),
+			message: &format!(
+				"Migration {migration} failed applying {semver} to a replica of server {server_id}"
+			),
+			detail: Some(serde_json::json!({
+				"target_version": semver.to_string(),
+				"failed_migration": migration,
+				"type": r#type.to_string(),
+				"intent": intent.to_string(),
+			})),
+			default_ceiling: CheckResult::Warning,
+			default_escalates: false,
+			documentation: Some(refs::MIGRATION_TEST_DOC),
+		},
+	)
+	.await?;
+
+	let affected = (version.major, version.minor, version.patch);
+	if !VersionKnownIssue::unresolved_for_server(db, affected, server_id).await? {
+		VersionKnownIssue::add(
+			db,
+			affected,
+			refs::MIGRATION_TEST,
+			&format!("Migration {migration} failed against server {server_id}'s data."),
+			Some(server_id),
+		)
+		.await?;
+	}
+
+	Ok(())
 }

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -59,28 +59,42 @@ pub fn upgrade_target(reported: &VersionStr, versions: &[Version]) -> Option<Uui
 		.map(|version| version.id)
 }
 
-/// Every candidate across the fleet, at most one per server.
+/// The version `server` should be tested against, if any.
 ///
 /// Tamanu servers only: the migrations under test are Tamanu's, so no other
-/// product's server has an upgrade path through them.
+/// product's server has an upgrade path through them. `None` also when the
+/// server has never reported a version, or is already on the newest published
+/// one.
+// spec: RST#candidate-versions
+pub async fn candidate_for(db: &mut AsyncPgConnection, server: &Server) -> Result<Option<Version>> {
+	if server.product != Product::Tamanu {
+		return Ok(None);
+	}
+
+	let Some(reported) = ReportedDetail::last_version(db, server.id).await? else {
+		return Ok(None);
+	};
+
+	let versions = Version::get_all(db).await?;
+	let Some(version_id) = upgrade_target(&reported, &versions) else {
+		return Ok(None);
+	};
+
+	Ok(versions
+		.into_iter()
+		.find(|version| version.id == version_id))
+}
+
+/// Every candidate across the fleet, at most one per server.
 // spec: RST#candidate-versions
 pub async fn candidates(db: &mut AsyncPgConnection) -> Result<Vec<Candidate>> {
-	let versions = Version::get_all(db).await?;
 	let mut candidates = Vec::new();
 
 	for server in Server::get_all(db, 0, None).await? {
-		if server.product != Product::Tamanu {
-			continue;
-		}
-
-		let Some(reported) = ReportedDetail::last_version(db, server.id).await? else {
-			continue;
-		};
-
-		if let Some(version_id) = upgrade_target(&reported, &versions) {
+		if let Some(version) = candidate_for(db, &server).await? {
 			candidates.push(Candidate {
 				server_id: server.id,
-				version_id,
+				version_id: version.id,
 			});
 		}
 	}

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -13,6 +13,7 @@ use commons_types::{
 };
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -138,6 +139,43 @@ pub struct NewMigrationTest {
 	pub timings: Vec<(String, PgDuration)>,
 }
 
+/// One joined row behind [`latest_test`].
+#[derive(Queryable)]
+struct LatestRow {
+	outcome: RunOutcome,
+	failed_migration: Option<String>,
+	snapshot_id: Option<String>,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp)]
+	reported_at: Timestamp,
+	total_elapsed: PgDuration,
+	data_bytes_before: i64,
+	data_bytes_after: i64,
+}
+
+/// The most recent test of one (server, version) pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LatestTest {
+	pub verdict: Verdict,
+	pub failed_migration: Option<String>,
+	pub snapshot_id: Option<String>,
+	pub reported_at: Timestamp,
+	pub total_elapsed: PgDuration,
+	pub data_bytes_before: i64,
+	pub data_bytes_after: i64,
+}
+
+/// Where one of a group's servers stands against the version it would take
+/// next.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupVerdict {
+	pub server_id: Uuid,
+	pub target_version_id: Uuid,
+	pub target_version: String,
+	pub verdict: Verdict,
+	/// The test the verdict came from, absent when there has not been one.
+	pub latest: Option<LatestTest>,
+}
+
 /// Where a (server, version) pair stands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -230,6 +268,48 @@ impl MigrationTest {
 	}
 }
 
+/// The most recent test of `server` against `version`, with the report context
+/// that says when it was and what it ran against.
+// spec: RST#verdicts
+pub async fn latest_test(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	target_version_id: Uuid,
+) -> Result<Option<LatestTest>> {
+	use crate::schema::{backup_restore_checks, migration_tests};
+
+	let row: Option<LatestRow> = migration_tests::table
+		.inner_join(backup_restore_checks::table)
+		.select((
+			backup_restore_checks::outcome,
+			migration_tests::failed_migration,
+			backup_restore_checks::snapshot_id,
+			backup_restore_checks::reported_at,
+			migration_tests::total_elapsed,
+			migration_tests::data_bytes_before,
+			migration_tests::data_bytes_after,
+		))
+		.filter(migration_tests::target_version_id.eq(target_version_id))
+		.filter(backup_restore_checks::server_id.eq(server_id))
+		.order(backup_restore_checks::reported_at.desc())
+		.first(db)
+		.await
+		.optional()?;
+
+	Ok(row.map(|row| LatestTest {
+		verdict: match (row.outcome, &row.failed_migration) {
+			(RunOutcome::Success, None) => Verdict::Passed,
+			_ => Verdict::Failed,
+		},
+		failed_migration: row.failed_migration,
+		snapshot_id: row.snapshot_id,
+		reported_at: row.reported_at,
+		total_elapsed: row.total_elapsed,
+		data_bytes_before: row.data_bytes_before,
+		data_bytes_after: row.data_bytes_after,
+	}))
+}
+
 /// Where `server` stands against `version`, from its most recent test.
 ///
 /// A pass means every migration applied. Anything else is a failure, including
@@ -240,26 +320,9 @@ pub async fn verdict(
 	server_id: Uuid,
 	target_version_id: Uuid,
 ) -> Result<Verdict> {
-	use crate::schema::{backup_restore_checks, migration_tests};
-
-	let latest: Option<(RunOutcome, Option<String>)> = migration_tests::table
-		.inner_join(backup_restore_checks::table)
-		.select((
-			backup_restore_checks::outcome,
-			migration_tests::failed_migration,
-		))
-		.filter(migration_tests::target_version_id.eq(target_version_id))
-		.filter(backup_restore_checks::server_id.eq(server_id))
-		.order(backup_restore_checks::reported_at.desc())
-		.first(db)
-		.await
-		.optional()?;
-
-	Ok(match latest {
-		None => Verdict::NotTested,
-		Some((RunOutcome::Success, None)) => Verdict::Passed,
-		Some(_) => Verdict::Failed,
-	})
+	Ok(latest_test(db, server_id, target_version_id)
+		.await?
+		.map_or(Verdict::NotTested, |test| test.verdict))
 }
 
 /// Whether `server` already has a verdict for this snapshot and target version.
@@ -370,4 +433,36 @@ async fn file_outcome(
 	}
 
 	Ok(())
+}
+
+/// Where every server in `group` stands against the version it would take next.
+///
+/// One row per server that has a candidate at all: a server on the newest
+/// version, running another product, or yet to report one has nothing to be
+/// tested against and so nothing to show.
+// spec: RST#verdicts
+pub async fn verdicts_for_group(
+	db: &mut AsyncPgConnection,
+	group_id: Uuid,
+) -> Result<Vec<GroupVerdict>> {
+	let mut out = Vec::new();
+
+	for server in Server::list_live_in_group(db, group_id).await? {
+		let Some(version) = candidate_for(db, &server).await? else {
+			continue;
+		};
+		let latest = latest_test(db, server.id, version.id).await?;
+
+		out.push(GroupVerdict {
+			server_id: server.id,
+			target_version_id: version.id,
+			target_version: version.as_semver().to_string(),
+			verdict: latest
+				.as_ref()
+				.map_or(Verdict::NotTested, |test| test.verdict),
+			latest,
+		});
+	}
+
+	Ok(out)
 }

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -4,8 +4,6 @@
 //! Candidacy here is the version axis only. Whether a server has a snapshot to
 //! restore and migrate is settled when a consumer's worklist is built.
 
-use std::collections::BTreeMap;
-
 use commons_errors::Result;
 use commons_types::{
 	backup::RunOutcome,
@@ -30,45 +28,30 @@ pub struct Candidate {
 	pub version_id: Uuid,
 }
 
-/// The published versions `reported` could upgrade to, one per minor series.
+/// The newest published version `reported` could upgrade to, if any.
 ///
 /// Stays within the reported major, matching the update path Canopy serves a
-/// server. Only the newest patch of each minor is returned: an upgrade applies
-/// that patch, so an earlier one is never what the server ends up running, and
-/// testing it would answer a question nobody asks.
+/// server. One version rather than every step along the path: migrations run
+/// against the restored snapshot in sequence, so targeting the newest applies
+/// every migration in between and exercises the whole chain.
 // spec: RST#candidate-versions
-pub fn upgrade_path(reported: &VersionStr, versions: &[Version]) -> Vec<Uuid> {
+pub fn upgrade_target(reported: &VersionStr, versions: &[Version]) -> Option<Uuid> {
 	let current = &reported.0;
-	let mut newest_per_minor: BTreeMap<i32, &Version> = BTreeMap::new();
 
-	for version in versions {
-		if version.status != VersionStatus::Published || version.major != current.major as i32 {
-			continue;
-		}
-
-		let is_newer = version.minor > current.minor as i32
-			|| (version.minor == current.minor as i32 && version.patch > current.patch as i32);
-		if !is_newer {
-			continue;
-		}
-
-		newest_per_minor
-			.entry(version.minor)
-			.and_modify(|held| {
-				if version.patch > held.patch {
-					*held = version;
-				}
-			})
-			.or_insert(version);
-	}
-
-	newest_per_minor
-		.into_values()
+	versions
+		.iter()
+		.filter(|version| {
+			version.status == VersionStatus::Published && version.major == current.major as i32
+		})
+		.filter(|version| {
+			version.minor > current.minor as i32
+				|| (version.minor == current.minor as i32 && version.patch > current.patch as i32)
+		})
+		.max_by_key(|version| (version.minor, version.patch))
 		.map(|version| version.id)
-		.collect()
 }
 
-/// Every candidate across the fleet.
+/// Every candidate across the fleet, at most one per server.
 ///
 /// Tamanu servers only: the migrations under test are Tamanu's, so no other
 /// product's server has an upgrade path through them.
@@ -86,14 +69,12 @@ pub async fn candidates(db: &mut AsyncPgConnection) -> Result<Vec<Candidate>> {
 			continue;
 		};
 
-		candidates.extend(
-			upgrade_path(&reported, &versions)
-				.into_iter()
-				.map(|version_id| Candidate {
-					server_id: server.id,
-					version_id,
-				}),
-		);
+		if let Some(version_id) = upgrade_target(&reported, &versions) {
+			candidates.push(Candidate {
+				server_id: server.id,
+				version_id,
+			});
+		}
 	}
 
 	Ok(candidates)

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -1,19 +1,26 @@
-//! Which versions Canopy asks to be migration-tested against which servers.
+//! Which versions Canopy asks to be migration-tested against which servers,
+//! and what came back.
 //!
-//! The version axis only. Whether a server has a snapshot to restore and
-//! migrate is settled when a consumer's worklist is built.
+//! Candidacy here is the version axis only. Whether a server has a snapshot to
+//! restore and migrate is settled when a consumer's worklist is built.
 
 use std::collections::BTreeMap;
 
 use commons_errors::Result;
 use commons_types::{
+	backup::RunOutcome,
 	server::product::Product,
 	version::{VersionStatus, VersionStr},
 };
-use diesel_async::AsyncPgConnection;
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{reported_detail::ReportedDetail, servers::Server, versions::Version};
+use crate::{
+	pg_duration::PgDuration, reported_detail::ReportedDetail, restore::BackupRestoreCheck,
+	restore::NewBackupRestoreCheck, servers::Server, versions::Version,
+};
 
 /// A version a server could upgrade to, so one to test against that server's
 /// data before it gets there.
@@ -90,4 +97,144 @@ pub async fn candidates(db: &mut AsyncPgConnection) -> Result<Vec<Candidate>> {
 	}
 
 	Ok(candidates)
+}
+
+/// How long one migration took, in the order it ran.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::migration_timings)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct MigrationTiming {
+	pub ordinal: i32,
+	pub name: String,
+	pub elapsed: PgDuration,
+}
+
+/// A recorded migration test, alongside the report carrying its common fields.
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::migration_tests)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct MigrationTest {
+	pub check_id: i64,
+	pub target_version_id: Uuid,
+	pub total_elapsed: PgDuration,
+	pub failed_migration: Option<String>,
+	pub data_bytes_before: i64,
+	pub data_bytes_after: i64,
+}
+
+/// What a consumer reports for one migration test, beyond the report's own
+/// fields.
+#[derive(Debug, Clone)]
+pub struct NewMigrationTest {
+	pub target_version_id: Uuid,
+	pub total_elapsed: PgDuration,
+	pub failed_migration: Option<String>,
+	pub data_bytes_before: i64,
+	pub data_bytes_after: i64,
+	/// One entry per migration that ran, in the order they ran.
+	pub timings: Vec<(String, PgDuration)>,
+}
+
+/// Where a (server, version) pair stands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Verdict {
+	NotTested,
+	Passed,
+	Failed,
+}
+
+impl MigrationTest {
+	/// Record a migration test: the report that carries the common fields,
+	/// then the result and its per-migration timings.
+	// spec: RST#what-a-migration-test-reports
+	pub async fn record(
+		db: &mut AsyncPgConnection,
+		report: NewBackupRestoreCheck,
+		test: NewMigrationTest,
+	) -> Result<i64> {
+		let check_id = BackupRestoreCheck::record_report(db, report).await?;
+
+		diesel::insert_into(crate::schema::migration_tests::table)
+			.values((
+				crate::schema::migration_tests::check_id.eq(check_id),
+				crate::schema::migration_tests::target_version_id.eq(test.target_version_id),
+				crate::schema::migration_tests::total_elapsed.eq(test.total_elapsed),
+				crate::schema::migration_tests::failed_migration.eq(test.failed_migration),
+				crate::schema::migration_tests::data_bytes_before.eq(test.data_bytes_before),
+				crate::schema::migration_tests::data_bytes_after.eq(test.data_bytes_after),
+			))
+			.execute(db)
+			.await?;
+
+		let timings: Vec<_> = test
+			.timings
+			.into_iter()
+			.enumerate()
+			.map(|(index, (name, elapsed))| {
+				(
+					crate::schema::migration_timings::check_id.eq(check_id),
+					crate::schema::migration_timings::ordinal.eq(index as i32),
+					crate::schema::migration_timings::name.eq(name),
+					crate::schema::migration_timings::elapsed.eq(elapsed),
+				)
+			})
+			.collect();
+		if !timings.is_empty() {
+			diesel::insert_into(crate::schema::migration_timings::table)
+				.values(timings)
+				.execute(db)
+				.await?;
+		}
+
+		Ok(check_id)
+	}
+
+	/// The per-migration timings of one test, in the order they ran.
+	pub async fn timings(
+		db: &mut AsyncPgConnection,
+		check_id: i64,
+	) -> Result<Vec<MigrationTiming>> {
+		use crate::schema::migration_timings::dsl;
+
+		dsl::migration_timings
+			.select(MigrationTiming::as_select())
+			.filter(dsl::check_id.eq(check_id))
+			.order(dsl::ordinal.asc())
+			.load(db)
+			.await
+			.map_err(Into::into)
+	}
+}
+
+/// Where `server` stands against `version`, from its most recent test.
+///
+/// A pass means every migration applied. Anything else is a failure, including
+/// a report whose restore never got as far as migrating.
+// spec: RST#verdicts
+pub async fn verdict(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	target_version_id: Uuid,
+) -> Result<Verdict> {
+	use crate::schema::{backup_restore_checks, migration_tests};
+
+	let latest: Option<(RunOutcome, Option<String>)> = migration_tests::table
+		.inner_join(backup_restore_checks::table)
+		.select((
+			backup_restore_checks::outcome,
+			migration_tests::failed_migration,
+		))
+		.filter(migration_tests::target_version_id.eq(target_version_id))
+		.filter(backup_restore_checks::server_id.eq(server_id))
+		.order(backup_restore_checks::reported_at.desc())
+		.first(db)
+		.await
+		.optional()?;
+
+	Ok(match latest {
+		None => Verdict::NotTested,
+		Some((RunOutcome::Success, None)) => Verdict::Passed,
+		Some(_) => Verdict::Failed,
+	})
 }

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -153,31 +153,44 @@ struct LatestRow {
 }
 
 /// The most recent test of one (server, version) pair.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct LatestTest {
+	/// Whether the migrations applied.
 	pub verdict: Verdict,
+	/// The migration that failed, when one did.
 	pub failed_migration: Option<String>,
+	/// The snapshot the verdict was reached against.
 	pub snapshot_id: Option<String>,
+	/// When the consumer reported it.
+	#[schema(value_type = String)]
 	pub reported_at: Timestamp,
+	/// Whole seconds the migration run took.
+	#[schema(value_type = i64)]
 	pub total_elapsed: PgDuration,
+	/// Size of the data the migrations ran against.
 	pub data_bytes_before: i64,
+	/// Size of it afterwards; the growth is what a heavy backfill shows up as.
 	pub data_bytes_after: i64,
 }
 
 /// Where one of a group's servers stands against the version it would take
 /// next.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct GroupVerdict {
+	/// The server the verdict is about.
 	pub server_id: Uuid,
+	/// The version it would take next.
 	pub target_version_id: Uuid,
+	/// That version, as semver.
 	pub target_version: String,
+	/// Where it stands against that version.
 	pub verdict: Verdict,
 	/// The test the verdict came from, absent when there has not been one.
 	pub latest: Option<LatestTest>,
 }
 
 /// Where a (server, version) pair stands.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Verdict {
 	NotTested,

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -219,3 +219,30 @@ pub async fn verdict(
 		Some(_) => Verdict::Failed,
 	})
 }
+
+/// Whether `server` already has a verdict for this snapshot and target version.
+///
+/// A failure counts. A migration failing against a fixed snapshot fails the
+/// same way every time, so re-dispatching it would spend a full restore on an
+/// answer already held.
+// spec: RST#dispatching-a-migration-test
+pub async fn has_verdict(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	snapshot_id: &str,
+	target_version_id: Uuid,
+) -> Result<bool> {
+	use crate::schema::{backup_restore_checks, migration_tests};
+
+	let existing: Option<i64> = migration_tests::table
+		.inner_join(backup_restore_checks::table)
+		.select(migration_tests::check_id)
+		.filter(migration_tests::target_version_id.eq(target_version_id))
+		.filter(backup_restore_checks::server_id.eq(server_id))
+		.filter(backup_restore_checks::snapshot_id.eq(snapshot_id))
+		.first(db)
+		.await
+		.optional()?;
+
+	Ok(existing.is_some())
+}

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -1,0 +1,93 @@
+//! Which versions Canopy asks to be migration-tested against which servers.
+//!
+//! The version axis only. Whether a server has a snapshot to restore and
+//! migrate is settled when a consumer's worklist is built.
+
+use std::collections::BTreeMap;
+
+use commons_errors::Result;
+use commons_types::{
+	server::product::Product,
+	version::{VersionStatus, VersionStr},
+};
+use diesel_async::AsyncPgConnection;
+use uuid::Uuid;
+
+use crate::{reported_detail::ReportedDetail, servers::Server, versions::Version};
+
+/// A version a server could upgrade to, so one to test against that server's
+/// data before it gets there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+	pub server_id: Uuid,
+	pub version_id: Uuid,
+}
+
+/// The published versions `reported` could upgrade to, one per minor series.
+///
+/// Stays within the reported major, matching the update path Canopy serves a
+/// server. Only the newest patch of each minor is returned: an upgrade applies
+/// that patch, so an earlier one is never what the server ends up running, and
+/// testing it would answer a question nobody asks.
+// spec: RST#candidate-versions
+pub fn upgrade_path(reported: &VersionStr, versions: &[Version]) -> Vec<Uuid> {
+	let current = &reported.0;
+	let mut newest_per_minor: BTreeMap<i32, &Version> = BTreeMap::new();
+
+	for version in versions {
+		if version.status != VersionStatus::Published || version.major != current.major as i32 {
+			continue;
+		}
+
+		let is_newer = version.minor > current.minor as i32
+			|| (version.minor == current.minor as i32 && version.patch > current.patch as i32);
+		if !is_newer {
+			continue;
+		}
+
+		newest_per_minor
+			.entry(version.minor)
+			.and_modify(|held| {
+				if version.patch > held.patch {
+					*held = version;
+				}
+			})
+			.or_insert(version);
+	}
+
+	newest_per_minor
+		.into_values()
+		.map(|version| version.id)
+		.collect()
+}
+
+/// Every candidate across the fleet.
+///
+/// Tamanu servers only: the migrations under test are Tamanu's, so no other
+/// product's server has an upgrade path through them.
+// spec: RST#candidate-versions
+pub async fn candidates(db: &mut AsyncPgConnection) -> Result<Vec<Candidate>> {
+	let versions = Version::get_all(db).await?;
+	let mut candidates = Vec::new();
+
+	for server in Server::get_all(db, 0, None).await? {
+		if server.product != Product::Tamanu {
+			continue;
+		}
+
+		let Some(reported) = ReportedDetail::last_version(db, server.id).await? else {
+			continue;
+		};
+
+		candidates.extend(
+			upgrade_path(&reported, &versions)
+				.into_iter()
+				.map(|version_id| Candidate {
+					server_id: server.id,
+					version_id,
+				}),
+		);
+	}
+
+	Ok(candidates)
+}

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -868,8 +868,15 @@ pub async fn sweep_overdue(db: &mut AsyncPgConnection) -> Result<usize> {
 			// whether the candidate version has been tried against the latest
 			// snapshot, not whether the replica restored.
 			if migrates {
-				if let Some(filed_one) =
-					sweep_migration_overdue(db, &d, &server, now, overdue_after).await?
+				if let Some(filed_one) = sweep_migration_overdue(
+					db,
+					&d,
+					&server,
+					&latest_snapshot_cache[&d.group_id],
+					now,
+					overdue_after,
+				)
+				.await?
 				{
 					filed += filed_one;
 				}
@@ -954,14 +961,13 @@ async fn sweep_migration_overdue(
 	db: &mut AsyncPgConnection,
 	declaration: &RestoreReplica,
 	server: &crate::servers::Server,
+	latest: &HashMap<(Uuid, BackupType), BackupRun>,
 	now: Timestamp,
 	overdue_after: PgDuration,
 ) -> Result<Option<usize>> {
 	let Some(version) = crate::migration_tests::candidate_for(db, server).await? else {
 		return Ok(None);
 	};
-	let latest =
-		BackupRun::latest_success_by_server_type_for_group(db, declaration.group_id).await?;
 	let Some(run) = latest.get(&(server.id, declaration.r#type.clone())) else {
 		return Ok(None);
 	};

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -605,7 +605,7 @@ impl BackupRestoreCheck {
 	pub async fn record_report(
 		db: &mut AsyncPgConnection,
 		new: NewBackupRestoreCheck,
-	) -> Result<()> {
+	) -> Result<i64> {
 		use crate::schema::backup_restore_checks::dsl;
 
 		let healthy = new.outcome == RunOutcome::Success && new.replica_healthy;
@@ -615,9 +615,10 @@ impl BackupRestoreCheck {
 		let error = new.error.clone();
 		let snapshot_id = new.snapshot_id.clone();
 
-		diesel::insert_into(dsl::backup_restore_checks)
+		let check_id: i64 = diesel::insert_into(dsl::backup_restore_checks)
 			.values(new)
-			.execute(db)
+			.returning(dsl::id)
+			.get_result(db)
 			.await?;
 
 		// Restore-health is attributed per server; a report without one is
@@ -676,7 +677,7 @@ impl BackupRestoreCheck {
 				.await?;
 			}
 		}
-		Ok(())
+		Ok(check_id)
 	}
 
 	/// Recent reports for a group, newest first — the operator restore-health

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -833,22 +833,19 @@ pub async fn sweep_overdue(db: &mut AsyncPgConnection) -> Result<usize> {
 			continue;
 		}
 		let once = descriptor.has_semantic(semantics::ONCE);
+		let migrates = descriptor.has_semantic(semantics::MIGRATE);
 
-		let servers = match d.server_id {
+		let servers: Vec<crate::servers::Server> = match d.server_id {
 			Some(sid) => {
 				let s = crate::servers::Server::get_by_id(db, sid).await.ok();
 				match s {
 					Some(s) if s.group_id == Some(d.group_id) && s.deleted_at.is_none() => {
-						vec![sid]
+						vec![s]
 					}
 					_ => vec![],
 				}
 			}
-			None => crate::servers::Server::list_live_in_group(db, d.group_id)
-				.await?
-				.into_iter()
-				.map(|s| s.id)
-				.collect(),
+			None => crate::servers::Server::list_live_in_group(db, d.group_id).await?,
 		};
 
 		if let Entry::Vacant(e) = healthy_cache.entry(d.group_id) {
@@ -864,7 +861,21 @@ pub async fn sweep_overdue(db: &mut AsyncPgConnection) -> Result<usize> {
 			);
 		}
 
-		for sid in servers {
+		for server in servers {
+			let sid = server.id;
+
+			// A `migrate` intent is overdue on its own terms: the question is
+			// whether the candidate version has been tried against the latest
+			// snapshot, not whether the replica restored.
+			if migrates {
+				if let Some(filed_one) =
+					sweep_migration_overdue(db, &d, &server, now, overdue_after).await?
+				{
+					filed += filed_one;
+				}
+				continue;
+			}
+
 			let key = (sid, d.r#type.clone(), d.intent.clone());
 			let overdue = if once {
 				// A `once` intent is overdue only when a snapshot exists to verify,
@@ -931,4 +942,71 @@ pub async fn sweep_overdue(db: &mut AsyncPgConnection) -> Result<usize> {
 	}
 
 	Ok(filed)
+}
+
+/// Whether a `migrate` declaration's server has left its candidate version
+/// untested past the bound, filing the migration-test check when it has.
+///
+/// Returns the number of checks filed, or `None` when the server has nothing to
+/// be overdue about: no candidate version, or no snapshot to migrate.
+// spec: RST#alerting
+async fn sweep_migration_overdue(
+	db: &mut AsyncPgConnection,
+	declaration: &RestoreReplica,
+	server: &crate::servers::Server,
+	now: Timestamp,
+	overdue_after: PgDuration,
+) -> Result<Option<usize>> {
+	let Some(version) = crate::migration_tests::candidate_for(db, server).await? else {
+		return Ok(None);
+	};
+	let latest =
+		BackupRun::latest_success_by_server_type_for_group(db, declaration.group_id).await?;
+	let Some(run) = latest.get(&(server.id, declaration.r#type.clone())) else {
+		return Ok(None);
+	};
+	let Some(snapshot_id) = run.snapshot_id.as_ref() else {
+		return Ok(None);
+	};
+
+	if crate::migration_tests::has_verdict(db, server.id, snapshot_id, version.id).await? {
+		return Ok(None);
+	}
+	// Measured from when the snapshot landed, which is when it became available
+	// to migrate, not how old the data inside it is.
+	if now.duration_since(run.reported_at) <= overdue_after.0 {
+		return Ok(None);
+	}
+
+	let semver = version.as_semver();
+	file_check(
+		db,
+		CheckFiling {
+			source: crate::statuses::CANOPY_SOURCE,
+			scope: Scope::Server(server.id),
+			device_id: None,
+			check: &format!(
+				"{}:{}:{}",
+				refs::MIGRATION_TEST, declaration.r#type, declaration.intent
+			),
+			observed: CheckResult::Warning,
+			title: Some("migration test overdue"),
+			message: &format!(
+				"Migrations for {semver} have not been tried against server {}'s latest snapshot within its overdue bound",
+				server.id
+			),
+			detail: Some(serde_json::json!({
+				"target_version": semver.to_string(),
+				"snapshot_id": snapshot_id,
+				"type": declaration.r#type.to_string(),
+				"intent": declaration.intent.to_string(),
+			})),
+			default_ceiling: CheckResult::Warning,
+			default_escalates: false,
+			documentation: Some(refs::MIGRATION_TEST_DOC),
+		},
+	)
+	.await?;
+
+	Ok(Some(1))
 }

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -649,6 +649,7 @@ diesel::table! {
 		max_major -> Nullable<Int4>,
 		max_minor -> Nullable<Int4>,
 		max_patch -> Nullable<Int4>,
+		server_id -> Nullable<Uuid>,
 	}
 }
 
@@ -718,6 +719,7 @@ diesel::joinable!(slack_outbox -> incidents (incident_id));
 diesel::joinable!(slack_outbox -> issues (issue_id));
 diesel::joinable!(statuses -> devices (device_id));
 diesel::joinable!(statuses -> servers (server_id));
+diesel::joinable!(version_known_issues -> servers (server_id));
 diesel::joinable!(versions -> devices (device_id));
 
 diesel::allow_tables_to_appear_in_same_query!(

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -389,6 +389,26 @@ diesel::table! {
 }
 
 diesel::table! {
+	migration_tests (check_id) {
+		check_id -> Int8,
+		target_version_id -> Uuid,
+		total_elapsed -> Interval,
+		failed_migration -> Nullable<Text>,
+		data_bytes_before -> Int8,
+		data_bytes_after -> Int8,
+	}
+}
+
+diesel::table! {
+	migration_timings (check_id, ordinal) {
+		check_id -> Int8,
+		ordinal -> Int4,
+		name -> Text,
+		elapsed -> Interval,
+	}
+}
+
+diesel::table! {
 	recovery_vault_writes (id) {
 		id -> Uuid,
 		written_at -> Timestamptz,
@@ -699,6 +719,9 @@ diesel::joinable!(incidents -> server_groups (server_group_id));
 diesel::joinable!(issue_notes -> issues (issue_id));
 diesel::joinable!(issues -> devices (device_id));
 diesel::joinable!(issues -> server_groups (server_group_id));
+diesel::joinable!(migration_tests -> backup_restore_checks (check_id));
+diesel::joinable!(migration_tests -> versions (target_version_id));
+diesel::joinable!(migration_timings -> migration_tests (check_id));
 diesel::joinable!(issues -> servers (server_id));
 diesel::joinable!(restore_consumer_capabilities -> devices (consumer_device_id));
 diesel::joinable!(restore_replicas -> devices (consumer_device_id));
@@ -731,6 +754,7 @@ diesel::allow_tables_to_appear_in_same_query!(
 	backup_repo_snapshots,
 	backup_repo_stats,
 	backup_requests,
+	backup_restore_checks,
 	backup_run_progress,
 	backup_runs,
 	backup_type_defaults,
@@ -750,6 +774,8 @@ diesel::allow_tables_to_appear_in_same_query!(
 	issue_notes,
 	issues,
 	mcp_tokens,
+	migration_tests,
+	migration_timings,
 	recovery_vault_writes,
 	restore_consumer_capabilities,
 	restore_replicas,

--- a/crates/database/src/version_known_issues.rs
+++ b/crates/database/src/version_known_issues.rs
@@ -63,6 +63,34 @@ impl VersionKnownIssue {
 			.map_err(AppError::from)
 	}
 
+	/// Whether an unresolved issue already blames `server_id` for this exact
+	/// version.
+	///
+	/// Snapshots arrive daily, so a version that fails against a deployment
+	/// fails again on tomorrow's data. One issue per version and server is the
+	/// finding; a second is noise.
+	pub async fn unresolved_for_server(
+		db: &mut AsyncPgConnection,
+		version: (i32, i32, i32),
+		server_id: Uuid,
+	) -> Result<bool> {
+		use crate::schema::version_known_issues::dsl;
+
+		let existing: Option<Uuid> = dsl::version_known_issues
+			.select(dsl::id)
+			.filter(dsl::min_major.eq(version.0))
+			.filter(dsl::min_minor.eq(version.1))
+			.filter(dsl::min_patch.eq(version.2))
+			.filter(dsl::server_id.eq(server_id))
+			.filter(dsl::resolved_at.is_null())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)?;
+
+		Ok(existing.is_some())
+	}
+
 	/// All known issues whose minor branch matches the given (major, minor)
 	/// — ordered newest first. Used by the version-detail UI to show
 	/// every issue ever raised against this minor, including ones already

--- a/crates/database/src/version_known_issues.rs
+++ b/crates/database/src/version_known_issues.rs
@@ -34,6 +34,9 @@ pub struct VersionKnownIssue {
 	pub max_major: Option<i32>,
 	pub max_minor: Option<i32>,
 	pub max_patch: Option<i32>,
+	/// Provenance, not scope: the server whose data provoked the issue, where
+	/// one did. The issue itself covers the version range regardless.
+	pub server_id: Option<Uuid>,
 }
 
 impl VersionKnownIssue {
@@ -42,6 +45,7 @@ impl VersionKnownIssue {
 		min: (i32, i32, i32),
 		author: &str,
 		description: &str,
+		server_id: Option<Uuid>,
 	) -> Result<Self> {
 		use crate::schema::version_known_issues;
 		diesel::insert_into(version_known_issues::table)
@@ -51,6 +55,7 @@ impl VersionKnownIssue {
 				version_known_issues::min_patch.eq(min.2),
 				version_known_issues::author.eq(author),
 				version_known_issues::description.eq(description),
+				version_known_issues::server_id.eq(server_id),
 			))
 			.returning(Self::as_select())
 			.get_result(db)

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -40,3 +40,4 @@ mod slack_outbox_enqueue;
 mod status_figures;
 mod statuses_device_fk;
 mod tag_reserved_prefix;
+mod version_known_issue_provenance;

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -23,6 +23,7 @@ mod incident_result_semantics;
 mod incident_stats;
 mod mcp_tokens;
 mod migration_test_candidates;
+mod migration_test_reports;
 mod reachability_sweep;
 mod recovery_vault;
 mod reported_detail;

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -22,6 +22,7 @@ mod incident_reeval_queue;
 mod incident_result_semantics;
 mod incident_stats;
 mod mcp_tokens;
+mod migration_test_candidates;
 mod reachability_sweep;
 mod recovery_vault;
 mod reported_detail;

--- a/crates/database/tests/it/migration_test_candidates.rs
+++ b/crates/database/tests/it/migration_test_candidates.rs
@@ -1,0 +1,179 @@
+//! Candidate derivation: which versions a server is asked to be tested
+//! against. One per minor series, newest patch, within the server's major,
+//! and only for Tamanu servers that have reported a version.
+
+use commons_types::{
+	server::product::Product,
+	version::{VersionStatus, VersionStr},
+};
+use database::{
+	migration_tests::{Candidate, candidates, upgrade_path},
+	reported_detail::ReportedDetail,
+	versions::{NewVersion, Version},
+};
+use diesel::{QueryableByName, SelectableHelper, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+fn reported(text: &str) -> VersionStr {
+	text.parse().expect("parse reported version")
+}
+
+async fn add_version(
+	conn: &mut diesel_async::AsyncPgConnection,
+	major: i32,
+	minor: i32,
+	patch: i32,
+	status: VersionStatus,
+) -> Version {
+	diesel::insert_into(database::schema::versions::table)
+		.values(NewVersion {
+			major,
+			minor,
+			patch,
+			status,
+			changelog: String::new(),
+			device_id: None,
+		})
+		.returning(Version::as_returning())
+		.get_result(conn)
+		.await
+		.expect("insert version")
+}
+
+async fn publish(
+	conn: &mut diesel_async::AsyncPgConnection,
+	major: i32,
+	minor: i32,
+	patch: i32,
+) -> Version {
+	add_version(conn, major, minor, patch, VersionStatus::Published).await
+}
+
+async fn insert_server(
+	conn: &mut diesel_async::AsyncPgConnection,
+	host: &str,
+	product: Product,
+) -> Uuid {
+	let group: RowId = sql_query("INSERT INTO server_groups (name) VALUES ('kamaka') RETURNING id")
+		.get_result(conn)
+		.await
+		.expect("group");
+	let server: RowId =
+		sql_query("INSERT INTO servers (host, group_id, product) VALUES ($1, $2, $3) RETURNING id")
+			.bind::<sql_types::Text, _>(host)
+			.bind::<sql_types::Uuid, _>(group.id)
+			.bind::<sql_types::Text, _>(product.to_string())
+			.get_result(conn)
+			.await
+			.expect("server");
+	server.id
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn newest_patch_of_each_minor_ahead_of_the_server() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let behind = publish(&mut conn, 2, 61, 0).await;
+		let same_minor_older = publish(&mut conn, 2, 62, 1).await;
+		let same_minor_newest = publish(&mut conn, 2, 62, 4).await;
+		let next_minor_older = publish(&mut conn, 2, 63, 0).await;
+		let next_minor_newest = publish(&mut conn, 2, 63, 2).await;
+		let other_major = publish(&mut conn, 3, 0, 0).await;
+
+		let versions = Version::get_all(&mut conn).await.expect("versions");
+		let path = upgrade_path(&reported("2.62.0"), &versions);
+
+		assert_eq!(
+			path,
+			vec![same_minor_newest.id, next_minor_newest.id],
+			"one entry per minor, each the newest patch"
+		);
+		assert!(!path.contains(&behind.id), "already past it");
+		assert!(!path.contains(&same_minor_older.id), "superseded patch");
+		assert!(!path.contains(&next_minor_older.id), "superseded patch");
+		assert!(
+			!path.contains(&other_major.id),
+			"the path stays within the major"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_server_on_the_newest_version_has_no_candidates() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		publish(&mut conn, 2, 62, 0).await;
+		let versions = Version::get_all(&mut conn).await.expect("versions");
+
+		assert!(upgrade_path(&reported("2.62.0"), &versions).is_empty());
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drafts_are_not_candidates_on_their_own() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let draft = add_version(&mut conn, 2, 63, 0, VersionStatus::Draft).await;
+
+		let all = Version::get_all_including_drafts(&mut conn)
+			.await
+			.expect("versions");
+		assert!(
+			!upgrade_path(&reported("2.62.0"), &all).contains(&draft.id),
+			"an unpublished version reaches a server only by nomination"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn only_tamanu_servers_that_reported_a_version() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let target = publish(&mut conn, 2, 63, 0).await;
+
+		let tamanu =
+			insert_server(&mut conn, "https://central.kamaka.example", Product::Tamanu).await;
+		let senaite =
+			insert_server(&mut conn, "https://lims.kamaka.example", Product::Senaite).await;
+		let silent =
+			insert_server(&mut conn, "https://quiet.kamaka.example", Product::Tamanu).await;
+
+		let running = reported("2.62.0");
+		for server in [tamanu, senaite] {
+			ReportedDetail::record(
+				&mut conn,
+				server,
+				"test",
+				&serde_json::json!({}),
+				Some(&running),
+			)
+			.await
+			.expect("record detail");
+		}
+
+		let found = candidates(&mut conn).await.expect("candidates");
+
+		assert_eq!(
+			found,
+			vec![Candidate {
+				server_id: tamanu,
+				version_id: target.id,
+			}],
+		);
+		assert!(
+			!found.iter().any(|c| c.server_id == senaite),
+			"another product has no path through Tamanu's migrations"
+		);
+		assert!(
+			!found.iter().any(|c| c.server_id == silent),
+			"nothing to compare against without a reported version"
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/migration_test_candidates.rs
+++ b/crates/database/tests/it/migration_test_candidates.rs
@@ -1,13 +1,13 @@
-//! Candidate derivation: which versions a server is asked to be tested
-//! against. One per minor series, newest patch, within the server's major,
-//! and only for Tamanu servers that have reported a version.
+//! Candidate derivation: which version a server is asked to be tested against.
+//! The newest published one it could upgrade to, within its major, and only for
+//! Tamanu servers that have reported a version.
 
 use commons_types::{
 	server::product::Product,
 	version::{VersionStatus, VersionStr},
 };
 use database::{
-	migration_tests::{Candidate, candidates, upgrade_path},
+	migration_tests::{Candidate, candidates, upgrade_target},
 	reported_detail::ReportedDetail,
 	versions::{NewVersion, Version},
 };
@@ -77,29 +77,36 @@ async fn insert_server(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn newest_patch_of_each_minor_ahead_of_the_server() {
+async fn the_newest_published_version_ahead_of_the_server() {
 	commons_tests::db::TestDb::run(async |mut conn, _url| {
-		let behind = publish(&mut conn, 2, 61, 0).await;
-		let same_minor_older = publish(&mut conn, 2, 62, 1).await;
-		let same_minor_newest = publish(&mut conn, 2, 62, 4).await;
-		let next_minor_older = publish(&mut conn, 2, 63, 0).await;
-		let next_minor_newest = publish(&mut conn, 2, 63, 2).await;
-		let other_major = publish(&mut conn, 3, 0, 0).await;
+		publish(&mut conn, 2, 61, 0).await;
+		publish(&mut conn, 2, 62, 1).await;
+		publish(&mut conn, 2, 62, 4).await;
+		publish(&mut conn, 2, 63, 0).await;
+		let newest = publish(&mut conn, 2, 63, 2).await;
+		publish(&mut conn, 3, 0, 0).await;
 
 		let versions = Version::get_all(&mut conn).await.expect("versions");
-		let path = upgrade_path(&reported("2.62.0"), &versions);
 
 		assert_eq!(
-			path,
-			vec![same_minor_newest.id, next_minor_newest.id],
-			"one entry per minor, each the newest patch"
+			upgrade_target(&reported("2.62.0"), &versions),
+			Some(newest.id),
+			"the newest patch of the newest minor, and nothing outside the major"
 		);
-		assert!(!path.contains(&behind.id), "already past it");
-		assert!(!path.contains(&same_minor_older.id), "superseded patch");
-		assert!(!path.contains(&next_minor_older.id), "superseded patch");
-		assert!(
-			!path.contains(&other_major.id),
-			"the path stays within the major"
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_newer_patch_of_the_current_minor_counts() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let patch = publish(&mut conn, 2, 62, 4).await;
+		let versions = Version::get_all(&mut conn).await.expect("versions");
+
+		assert_eq!(
+			upgrade_target(&reported("2.62.0"), &versions),
+			Some(patch.id),
+			"a patch upgrade is still an upgrade worth testing"
 		);
 	})
 	.await
@@ -111,7 +118,7 @@ async fn a_server_on_the_newest_version_has_no_candidates() {
 		publish(&mut conn, 2, 62, 0).await;
 		let versions = Version::get_all(&mut conn).await.expect("versions");
 
-		assert!(upgrade_path(&reported("2.62.0"), &versions).is_empty());
+		assert!(upgrade_target(&reported("2.62.0"), &versions).is_none());
 	})
 	.await
 }
@@ -124,8 +131,9 @@ async fn drafts_are_not_candidates_on_their_own() {
 		let all = Version::get_all_including_drafts(&mut conn)
 			.await
 			.expect("versions");
-		assert!(
-			!upgrade_path(&reported("2.62.0"), &all).contains(&draft.id),
+		assert_ne!(
+			upgrade_target(&reported("2.62.0"), &all),
+			Some(draft.id),
 			"an unpublished version has no artefacts to fetch, so nothing to test"
 		);
 	})

--- a/crates/database/tests/it/migration_test_candidates.rs
+++ b/crates/database/tests/it/migration_test_candidates.rs
@@ -126,7 +126,7 @@ async fn drafts_are_not_candidates_on_their_own() {
 			.expect("versions");
 		assert!(
 			!upgrade_path(&reported("2.62.0"), &all).contains(&draft.id),
-			"an unpublished version reaches a server only by nomination"
+			"an unpublished version has no artefacts to fetch, so nothing to test"
 		);
 	})
 	.await

--- a/crates/database/tests/it/migration_test_reports.rs
+++ b/crates/database/tests/it/migration_test_reports.rs
@@ -391,3 +391,117 @@ async fn a_later_pass_recovers_the_check() {
 	})
 	.await
 }
+
+/// A `migrate` declaration plus the capability that advertises it, so the
+/// overdue sweep has something to walk.
+async fn declare_migrate(
+	conn: &mut AsyncPgConnection,
+	consumer: Uuid,
+	group: Uuid,
+	overdue_seconds: i64,
+) {
+	sql_query(
+		"INSERT INTO restore_consumer_capabilities (consumer_device_id, intent, description, semantics, params)
+		 VALUES ($1, 'migrate', '', '[\"check\",\"once\",\"migrate\"]'::jsonb, '[]'::jsonb)",
+	)
+	.bind::<sql_types::Uuid, _>(consumer)
+	.execute(conn)
+	.await
+	.expect("register capability");
+
+	sql_query(
+		"INSERT INTO restore_replicas
+		 (consumer_device_id, group_id, type, intent, name, overdue_after, params)
+		 VALUES ($1, $2, 'tamanu-postgres', 'migrate', 'kamaka-migrate', make_interval(secs => $3), '{}'::jsonb)",
+	)
+	.bind::<sql_types::Uuid, _>(consumer)
+	.bind::<sql_types::Uuid, _>(group)
+	.bind::<sql_types::Double, _>(overdue_seconds as f64)
+	.execute(conn)
+	.await
+	.expect("declare replica");
+}
+
+/// A successful backup run, which is the snapshot a migration test would use.
+async fn record_snapshot(
+	conn: &mut AsyncPgConnection,
+	consumer: Uuid,
+	group: Uuid,
+	server: Uuid,
+	snapshot: &str,
+	age_seconds: i64,
+) {
+	sql_query(
+		"INSERT INTO backup_runs
+		 (id, device_id, group_id, server_id, type, purpose, outcome, snapshot_id, reported_at)
+		 VALUES (gen_random_uuid(), $1, $2, $3, 'tamanu-postgres', 'backup', 'success', $4,
+		         NOW() - make_interval(secs => $5))",
+	)
+	.bind::<sql_types::Uuid, _>(consumer)
+	.bind::<sql_types::Uuid, _>(group)
+	.bind::<sql_types::Uuid, _>(server)
+	.bind::<sql_types::Text, _>(snapshot)
+	.bind::<sql_types::Double, _>(age_seconds as f64)
+	.execute(conn)
+	.await
+	.expect("record backup run");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn an_untried_candidate_goes_overdue_and_a_tested_one_does_not() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+		let running: commons_types::version::VersionStr = "2.62.0".parse().expect("parse");
+		database::reported_detail::ReportedDetail::record(
+			&mut conn,
+			server,
+			"test",
+			&serde_json::json!({}),
+			Some(&running),
+		)
+		.await
+		.expect("report version");
+		declare_migrate(&mut conn, consumer, group, 3600).await;
+		record_snapshot(&mut conn, consumer, group, server, "snap-old", 7200).await;
+
+		let filed = database::restore::sweep_overdue(&mut conn)
+			.await
+			.expect("sweep");
+		assert_eq!(filed, 1, "the candidate has gone untried past the bound");
+		let check = migration_check(&mut conn, server)
+			.await
+			.expect("a check was filed");
+		assert_eq!(check.observed.as_deref(), Some("warning"));
+		assert!(!check.escalates);
+
+		// Once it has a verdict for that snapshot, it is no longer overdue.
+		let mut passing = report(consumer, group, server, RunOutcome::Success);
+		passing.snapshot_id = Some("snap-old".into());
+		MigrationTest::record(
+			&mut conn,
+			passing,
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(10),
+				failed_migration: None,
+				data_bytes_before: 1,
+				data_bytes_after: 1,
+				timings: vec![],
+			},
+		)
+		.await
+		.expect("record pass");
+
+		assert_eq!(
+			database::restore::sweep_overdue(&mut conn)
+				.await
+				.expect("sweep"),
+			0,
+			"a tried pair is not overdue"
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/migration_test_reports.rs
+++ b/crates/database/tests/it/migration_test_reports.rs
@@ -584,3 +584,64 @@ async fn a_group_shows_where_each_server_stands() {
 	})
 	.await
 }
+
+async fn restore_check(conn: &mut AsyncPgConnection, server: Uuid) -> Option<FiledCheck> {
+	sql_query(
+		"SELECT i.observed_result AS observed, i.effective_result AS effective, i.escalates
+		 FROM issues i
+		 WHERE i.server_id = $1 AND i.ref LIKE 'restore-verification:%' AND i.active = true",
+	)
+	.bind::<sql_types::Uuid, _>(server)
+	.get_result(conn)
+	.await
+	.optional()
+	.expect("read restore check")
+}
+
+/// One restore, two answers. A `migrate` semantic riding on a verifying intent
+/// means a single report says both "the backup restores" and "this version's
+/// migrations do not survive the data", and those must not contaminate each
+/// other: the backup is fine, the version is not.
+#[tokio::test(flavor = "multi_thread")]
+async fn one_report_keeps_backup_health_and_version_readiness_apart() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+
+		// The restore succeeded into a healthy replica; the migrations then failed.
+		MigrationTest::record(
+			&mut conn,
+			report(consumer, group, server, RunOutcome::Success),
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(45),
+				failed_migration: Some("backfillNoteTypeIds".into()),
+				data_bytes_before: 10,
+				data_bytes_after: 10,
+				timings: vec![],
+			},
+		)
+		.await
+		.expect("record");
+
+		assert!(
+			restore_check(&mut conn, server).await.is_none(),
+			"the backup restored, so restore-health raises nothing"
+		);
+
+		let migration = migration_check(&mut conn, server)
+			.await
+			.expect("the migration finding stands on its own");
+		assert_eq!(migration.observed.as_deref(), Some("warning"));
+
+		assert!(
+			!VersionKnownIssue::version_is_ready(&mut conn, 2, 63, 0)
+				.await
+				.expect("readiness"),
+			"and it is the version that is held back, not the server"
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/migration_test_reports.rs
+++ b/crates/database/tests/it/migration_test_reports.rs
@@ -1,0 +1,216 @@
+//! Recording a migration test and reading the verdict it produces.
+
+use commons_tests::db::TestDb;
+use commons_types::backup::{BackupType, RestoreIntent, RunOutcome};
+use database::{
+	migration_tests::{MigrationTest, NewMigrationTest, Verdict, verdict},
+	pg_duration::PgDuration,
+	restore::NewBackupRestoreCheck,
+	versions::{NewVersion, Version},
+};
+use diesel::{QueryableByName, SelectableHelper, sql_query, sql_types};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::{SignedDuration, Timestamp};
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_group(conn: &mut AsyncPgConnection) -> Uuid {
+	let row: RowId = sql_query("INSERT INTO server_groups (name) VALUES ('kamaka') RETURNING id")
+		.get_result(conn)
+		.await
+		.expect("group");
+	row.id
+}
+
+async fn insert_server(conn: &mut AsyncPgConnection, group_id: Uuid) -> Uuid {
+	let row: RowId = sql_query("INSERT INTO servers (host, group_id) VALUES ($1, $2) RETURNING id")
+		.bind::<sql_types::Text, _>("https://central.kamaka.example")
+		.bind::<sql_types::Uuid, _>(group_id)
+		.get_result(conn)
+		.await
+		.expect("server");
+	row.id
+}
+
+async fn insert_consumer(conn: &mut AsyncPgConnection) -> Uuid {
+	let row: RowId = sql_query("INSERT INTO devices (role) VALUES ('backup-restore') RETURNING id")
+		.get_result(conn)
+		.await
+		.expect("consumer");
+	row.id
+}
+
+async fn insert_version(conn: &mut AsyncPgConnection, minor: i32) -> Version {
+	diesel::insert_into(database::schema::versions::table)
+		.values(NewVersion {
+			major: 2,
+			minor,
+			patch: 0,
+			status: commons_types::version::VersionStatus::Published,
+			changelog: String::new(),
+			device_id: None,
+		})
+		.returning(Version::as_returning())
+		.get_result(conn)
+		.await
+		.expect("version")
+}
+
+fn report(consumer: Uuid, group: Uuid, server: Uuid, outcome: RunOutcome) -> NewBackupRestoreCheck {
+	NewBackupRestoreCheck {
+		replica_id: None,
+		consumer_device_id: consumer,
+		group_id: group,
+		server_id: Some(server),
+		r#type: BackupType::TamanuPostgres,
+		intent: RestoreIntent::from("migration-test"),
+		snapshot_id: Some("snap-x".into()),
+		outcome,
+		error: None,
+		replica_healthy: true,
+		postgres_version: Some("18".into()),
+		observed_at: Timestamp::now(),
+		s3_sent_raw_bytes: None,
+		s3_sent_payload_bytes: None,
+		s3_received_raw_bytes: None,
+		s3_received_payload_bytes: None,
+		health_details: None,
+		run_id: None,
+	}
+}
+
+fn secs(n: i64) -> PgDuration {
+	PgDuration(SignedDuration::from_secs(n))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_passing_test_records_timings_in_order() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+
+		let check_id = MigrationTest::record(
+			&mut conn,
+			report(consumer, group, server, RunOutcome::Success),
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(900),
+				failed_migration: None,
+				data_bytes_before: 200_000_000_000,
+				data_bytes_after: 260_000_000_000,
+				timings: vec![
+					("addIndexToFhirJobs".into(), secs(12)),
+					("backfillNoteTypeIds".into(), secs(880)),
+				],
+			},
+		)
+		.await
+		.expect("record");
+
+		assert_eq!(
+			verdict(&mut conn, server, target.id)
+				.await
+				.expect("verdict"),
+			Verdict::Passed
+		);
+
+		let timings = MigrationTest::timings(&mut conn, check_id)
+			.await
+			.expect("timings");
+		let names: Vec<&str> = timings.iter().map(|t| t.name.as_str()).collect();
+		assert_eq!(
+			names,
+			vec!["addIndexToFhirJobs", "backfillNoteTypeIds"],
+			"kept in the order they ran"
+		);
+		assert_eq!(
+			timings[1].elapsed,
+			secs(880),
+			"the slow one is attributable"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_named_failing_migration_is_a_failed_verdict() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+
+		MigrationTest::record(
+			&mut conn,
+			report(consumer, group, server, RunOutcome::Failure),
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(45),
+				failed_migration: Some("backfillNoteTypeIds".into()),
+				data_bytes_before: 200_000_000_000,
+				data_bytes_after: 200_000_000_000,
+				timings: vec![("backfillNoteTypeIds".into(), secs(45))],
+			},
+		)
+		.await
+		.expect("record");
+
+		assert_eq!(
+			verdict(&mut conn, server, target.id)
+				.await
+				.expect("verdict"),
+			Verdict::Failed
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn an_untested_pair_and_an_untested_version() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let tested = insert_version(&mut conn, 63).await;
+		let untested = insert_version(&mut conn, 64).await;
+
+		assert_eq!(
+			verdict(&mut conn, server, tested.id)
+				.await
+				.expect("verdict"),
+			Verdict::NotTested,
+			"nothing reported yet"
+		);
+
+		MigrationTest::record(
+			&mut conn,
+			report(consumer, group, server, RunOutcome::Success),
+			NewMigrationTest {
+				target_version_id: tested.id,
+				total_elapsed: secs(10),
+				failed_migration: None,
+				data_bytes_before: 1,
+				data_bytes_after: 1,
+				timings: vec![],
+			},
+		)
+		.await
+		.expect("record");
+
+		assert_eq!(
+			verdict(&mut conn, server, untested.id)
+				.await
+				.expect("verdict"),
+			Verdict::NotTested,
+			"one version's pass says nothing about another's"
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/migration_test_reports.rs
+++ b/crates/database/tests/it/migration_test_reports.rs
@@ -505,3 +505,82 @@ async fn an_untried_candidate_goes_overdue_and_a_tested_one_does_not() {
 	})
 	.await
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_group_shows_where_each_server_stands() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let tested = insert_server(&mut conn, group).await;
+		let untested = insert_server(&mut conn, group).await;
+		let current = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+
+		let behind: commons_types::version::VersionStr = "2.62.0".parse().expect("parse");
+		let newest: commons_types::version::VersionStr = "2.63.0".parse().expect("parse");
+		for (server, running) in [
+			(tested, &behind),
+			(untested, &behind),
+			// Already on the newest published version, so nothing to test.
+			(current, &newest),
+		] {
+			database::reported_detail::ReportedDetail::record(
+				&mut conn,
+				server,
+				"test",
+				&serde_json::json!({}),
+				Some(running),
+			)
+			.await
+			.expect("report version");
+		}
+
+		let mut failing = report(consumer, group, tested, RunOutcome::Success);
+		failing.snapshot_id = Some("snap-1".into());
+		MigrationTest::record(
+			&mut conn,
+			failing,
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(3600),
+				failed_migration: Some("backfillNoteTypeIds".into()),
+				data_bytes_before: 200,
+				data_bytes_after: 260,
+				timings: vec![],
+			},
+		)
+		.await
+		.expect("record failure");
+
+		let verdicts = database::migration_tests::verdicts_for_group(&mut conn, group)
+			.await
+			.expect("verdicts");
+
+		assert_eq!(verdicts.len(), 2, "the up-to-date server has no row");
+		let by_server: std::collections::HashMap<Uuid, _> =
+			verdicts.into_iter().map(|v| (v.server_id, v)).collect();
+
+		let failed = &by_server[&tested];
+		assert_eq!(failed.verdict, database::migration_tests::Verdict::Failed);
+		assert_eq!(failed.target_version, "2.63.0");
+		let latest = failed.latest.as_ref().expect("a test was reported");
+		assert_eq!(latest.snapshot_id.as_deref(), Some("snap-1"));
+		assert_eq!(
+			latest.failed_migration.as_deref(),
+			Some("backfillNoteTypeIds")
+		);
+		assert_eq!(
+			latest.data_bytes_after - latest.data_bytes_before,
+			60,
+			"growth is readable from the verdict"
+		);
+
+		let pending = &by_server[&untested];
+		assert_eq!(
+			pending.verdict,
+			database::migration_tests::Verdict::NotTested
+		);
+		assert!(pending.latest.is_none());
+	})
+	.await
+}

--- a/crates/database/tests/it/migration_test_reports.rs
+++ b/crates/database/tests/it/migration_test_reports.rs
@@ -6,9 +6,10 @@ use database::{
 	migration_tests::{MigrationTest, NewMigrationTest, Verdict, verdict},
 	pg_duration::PgDuration,
 	restore::NewBackupRestoreCheck,
+	version_known_issues::VersionKnownIssue,
 	versions::{NewVersion, Version},
 };
-use diesel::{QueryableByName, SelectableHelper, sql_query, sql_types};
+use diesel::{OptionalExtension, QueryableByName, SelectableHelper, sql_query, sql_types};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use jiff::{SignedDuration, Timestamp};
 use uuid::Uuid;
@@ -210,6 +211,182 @@ async fn an_untested_pair_and_an_untested_version() {
 				.expect("verdict"),
 			Verdict::NotTested,
 			"one version's pass says nothing about another's"
+		);
+	})
+	.await
+}
+
+#[derive(QueryableByName)]
+struct FiledCheck {
+	#[diesel(sql_type = sql_types::Nullable<sql_types::Text>)]
+	observed: Option<String>,
+	#[diesel(sql_type = sql_types::Nullable<sql_types::Text>)]
+	effective: Option<String>,
+	#[diesel(sql_type = sql_types::Bool)]
+	escalates: bool,
+}
+
+async fn migration_check(conn: &mut AsyncPgConnection, server: Uuid) -> Option<FiledCheck> {
+	sql_query(
+		"SELECT i.observed_result AS observed, i.effective_result AS effective, i.escalates
+		 FROM issues i
+		 WHERE i.server_id = $1 AND i.ref LIKE 'migration-test:%' AND i.active = true",
+	)
+	.bind::<sql_types::Uuid, _>(server)
+	.get_result(conn)
+	.await
+	.optional()
+	.expect("read filed check")
+}
+
+async fn unresolved_issues_for(conn: &mut AsyncPgConnection, server: Uuid) -> i64 {
+	#[derive(QueryableByName)]
+	struct Count {
+		#[diesel(sql_type = sql_types::BigInt)]
+		count: i64,
+	}
+	sql_query(
+		"SELECT count(*) AS count FROM version_known_issues
+		 WHERE server_id = $1 AND resolved_at IS NULL",
+	)
+	.bind::<sql_types::Uuid, _>(server)
+	.get_result::<Count>(conn)
+	.await
+	.expect("count known issues")
+	.count
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failure_warns_on_the_server_and_holds_the_version_back() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+
+		MigrationTest::record(
+			&mut conn,
+			report(consumer, group, server, RunOutcome::Success),
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(45),
+				failed_migration: Some("backfillNoteTypeIds".into()),
+				data_bytes_before: 10,
+				data_bytes_after: 10,
+				timings: vec![],
+			},
+		)
+		.await
+		.expect("record failure");
+
+		let filed = migration_check(&mut conn, server)
+			.await
+			.expect("a check was filed");
+		assert_eq!(
+			filed.observed.as_deref(),
+			Some("warning"),
+			"a warning, not a failure"
+		);
+		assert_eq!(
+			filed.effective.as_deref(),
+			Some("warning"),
+			"and the policy ceiling keeps it there"
+		);
+		assert!(!filed.escalates, "does not page against a healthy server");
+
+		assert!(
+			!VersionKnownIssue::version_is_ready(&mut conn, 2, 63, 0)
+				.await
+				.expect("readiness"),
+			"the version is held back from rollout"
+		);
+		assert_eq!(unresolved_issues_for(&mut conn, server).await, 1);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tomorrows_snapshot_does_not_file_the_issue_twice() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+
+		for snapshot in ["snap-1", "snap-2"] {
+			let mut failing = report(consumer, group, server, RunOutcome::Success);
+			failing.snapshot_id = Some(snapshot.into());
+			MigrationTest::record(
+				&mut conn,
+				failing,
+				NewMigrationTest {
+					target_version_id: target.id,
+					total_elapsed: secs(45),
+					failed_migration: Some("backfillNoteTypeIds".into()),
+					data_bytes_before: 10,
+					data_bytes_after: 10,
+					timings: vec![],
+				},
+			)
+			.await
+			.expect("record failure");
+		}
+
+		assert_eq!(
+			unresolved_issues_for(&mut conn, server).await,
+			1,
+			"the same version failing again is the same finding"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_later_pass_recovers_the_check() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+
+		let mut failing = report(consumer, group, server, RunOutcome::Success);
+		failing.snapshot_id = Some("snap-1".into());
+		MigrationTest::record(
+			&mut conn,
+			failing,
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(45),
+				failed_migration: Some("backfillNoteTypeIds".into()),
+				data_bytes_before: 10,
+				data_bytes_after: 10,
+				timings: vec![],
+			},
+		)
+		.await
+		.expect("record failure");
+		assert!(migration_check(&mut conn, server).await.is_some());
+
+		let mut passing = report(consumer, group, server, RunOutcome::Success);
+		passing.snapshot_id = Some("snap-2".into());
+		MigrationTest::record(
+			&mut conn,
+			passing,
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(50),
+				failed_migration: None,
+				data_bytes_before: 10,
+				data_bytes_after: 12,
+				timings: vec![],
+			},
+		)
+		.await
+		.expect("record pass");
+
+		assert!(
+			migration_check(&mut conn, server).await.is_none(),
+			"the check recovers once the migrations apply"
 		);
 	})
 	.await

--- a/crates/database/tests/it/migration_test_reports.rs
+++ b/crates/database/tests/it/migration_test_reports.rs
@@ -645,3 +645,43 @@ async fn one_report_keeps_backup_health_and_version_readiness_apart() {
 	})
 	.await
 }
+
+/// A restore that failed before migrating says nothing about the version: no
+/// verdict lands, the pair stays retryable, and no check files either way.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failed_restore_leaves_the_version_unjudged() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn).await;
+		let server = insert_server(&mut conn, group).await;
+		let target = insert_version(&mut conn, 63).await;
+
+		MigrationTest::record(
+			&mut conn,
+			report(consumer, group, server, RunOutcome::Failure),
+			NewMigrationTest {
+				target_version_id: target.id,
+				total_elapsed: secs(0),
+				failed_migration: None,
+				data_bytes_before: 0,
+				data_bytes_after: 0,
+				timings: vec![],
+			},
+		)
+		.await
+		.expect("record");
+
+		assert_eq!(
+			database::migration_tests::verdict(&mut conn, server, target.id)
+				.await
+				.expect("verdict"),
+			database::migration_tests::Verdict::NotTested,
+			"retryable: the migrations never ran"
+		);
+		assert!(
+			migration_check(&mut conn, server).await.is_none(),
+			"neither a pass nor a warning is filed"
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/version_known_issue_provenance.rs
+++ b/crates/database/tests/it/version_known_issue_provenance.rs
@@ -1,0 +1,86 @@
+//! A known issue can name the server whose data provoked it. The reference is
+//! provenance, so removing the server clears the reference and leaves the issue
+//! standing against its version range.
+
+use database::version_known_issues::VersionKnownIssue;
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn server_reference_survives_as_provenance() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let group: RowId =
+			sql_query("INSERT INTO server_groups (name) VALUES ('kamaka') RETURNING id")
+				.get_result(&mut conn)
+				.await
+				.expect("group");
+		let server: RowId =
+			sql_query("INSERT INTO servers (host, group_id) VALUES ($1, $2) RETURNING id")
+				.bind::<sql_types::Text, _>("kamaka-central")
+				.bind::<sql_types::Uuid, _>(group.id)
+				.get_result(&mut conn)
+				.await
+				.expect("server");
+
+		let filed = VersionKnownIssue::add(
+			&mut conn,
+			(2, 63, 0),
+			"migration-test",
+			"backfillNoteTypeIds did not complete.",
+			Some(server.id),
+		)
+		.await
+		.expect("add with provenance");
+		assert_eq!(filed.server_id, Some(server.id));
+
+		assert!(
+			!VersionKnownIssue::version_is_ready(&mut conn, 2, 63, 0)
+				.await
+				.expect("readiness"),
+			"a filed issue holds the version back"
+		);
+
+		sql_query("DELETE FROM servers WHERE id = $1")
+			.bind::<sql_types::Uuid, _>(server.id)
+			.execute(&mut conn)
+			.await
+			.expect("delete server");
+
+		let issues = VersionKnownIssue::list_for_minor(&mut conn, 2, 63)
+			.await
+			.expect("list");
+		let still_there = issues
+			.iter()
+			.find(|issue| issue.id == filed.id)
+			.expect("the issue outlives the server");
+		assert_eq!(
+			still_there.server_id, None,
+			"provenance clears rather than cascading the issue away"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn operator_filed_issue_names_no_server() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let filed = VersionKnownIssue::add(
+			&mut conn,
+			(2, 62, 0),
+			"someone@example.com",
+			"Reported by hand.",
+			None,
+		)
+		.await
+		.expect("add without provenance");
+		assert_eq!(filed.server_id, None);
+	})
+	.await
+}

--- a/crates/private-server/src/fns.rs
+++ b/crates/private-server/src/fns.rs
@@ -11,6 +11,7 @@ pub mod healthchecks;
 pub mod incidents;
 pub mod issues;
 pub mod mcp_tokens;
+pub mod migration_tests;
 pub mod restore_replicas;
 pub mod self_alerts;
 pub mod server_groups;
@@ -61,6 +62,7 @@ pub fn routes() -> OpenApiRouter<crate::state::AppState> {
 			.nest("/incidents", incidents::routes())
 			.nest("/issues", issues::routes())
 			.nest("/mcp_tokens", mcp_tokens::routes())
+			.nest("/migration_tests", migration_tests::routes())
 			.nest("/restore_replicas", restore_replicas::routes())
 			.nest("/self_alerts", self_alerts::routes())
 			.nest("/server_groups", server_groups::routes())

--- a/crates/private-server/src/fns/migration_tests.rs
+++ b/crates/private-server/src/fns/migration_tests.rs
@@ -1,0 +1,52 @@
+use axum::Json;
+use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
+use commons_errors::{ProblemDetailsSchema, Result};
+use commons_servers::tailscale_auth::TailscaleAdmin;
+use database::migration_tests::GroupVerdict;
+use serde::Deserialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::state::AppState;
+
+pub fn routes() -> OpenApiRouter<AppState> {
+	OpenApiRouter::new().routes(routes!(for_group))
+}
+
+/// Request body for reading a group's migration-test verdicts.
+#[derive(Deserialize, ToSchema)]
+pub struct ForGroupArgs {
+	/// The group to report on.
+	pub group_id: Uuid,
+}
+
+/// Where each of a group's servers stands against the version it would take
+/// next.
+///
+/// One entry per server that has a candidate version. A server already on the
+/// newest published version, running another product, or yet to report a
+/// version has nothing to be tested against and is absent.
+// spec: RST#verdicts
+#[utoipa::path(
+	post,
+	path = "/for_group",
+	operation_id = "migration_tests_for_group",
+	tag = "migration_tests",
+	security(("tailscale-admin" = [])),
+	request_body = ForGroupArgs,
+	responses(
+		(status = 200, description = "Verdicts, one per server with a candidate.", body = Vec<GroupVerdict>),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn for_group(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<ForGroupArgs>,
+) -> Result<Json<Vec<GroupVerdict>>> {
+	let mut conn = state.db.get().await?;
+	let verdicts = database::migration_tests::verdicts_for_group(&mut conn, args.group_id).await?;
+	Ok(Json(verdicts))
+}

--- a/crates/private-server/src/fns/versions.rs
+++ b/crates/private-server/src/fns/versions.rs
@@ -738,6 +738,7 @@ pub async fn add_known_issue(
 		(v.major, v.minor, v.patch),
 		&admin.0.login,
 		description,
+		None,
 	)
 	.await?;
 	Ok(Json(KnownIssueData::from(row)))

--- a/crates/private-server/src/openapi.rs
+++ b/crates/private-server/src/openapi.rs
@@ -26,6 +26,7 @@ use utoipa::{
 		(name = "incidents", description = "Operational incidents (groups of issues against a server)."),
 		(name = "issues", description = "Per-server issues raised from device events."),
 		(name = "mcp_tokens", description = "Bearer tokens for the public MCP mount."),
+		(name = "migration_tests", description = "Where each server stands against the version it would take next."),
 		(name = "restore_replicas", description = "Managed restore replicas: capabilities, worklist, and health."),
 		(name = "self_alerts", description = "Canopy's alerts about its own operation."),
 		(name = "server_groups", description = "Server group management and group-level configuration."),

--- a/crates/private-server/tests/it/main.rs
+++ b/crates/private-server/tests/it/main.rs
@@ -17,6 +17,7 @@ mod health;
 mod healthchecks;
 mod issues;
 mod mcp;
+mod migration_tests;
 mod notes;
 mod openapi_spec;
 mod operator_presence;

--- a/crates/private-server/tests/it/migration_tests.rs
+++ b/crates/private-server/tests/it/migration_tests.rs
@@ -1,0 +1,57 @@
+//! The operator's view of where a group stands: one entry per server with a
+//! candidate version, carrying its verdict and the test behind it.
+
+use commons_tests::diesel_async::SimpleAsyncConnection;
+use serde_json::{Value, json};
+
+const GROUP: &str = "bbbbbbbb-0000-0000-0000-000000000001";
+const BEHIND: &str = "bbbbbbbb-0000-0000-0000-0000000000a0";
+const CURRENT: &str = "bbbbbbbb-0000-0000-0000-0000000000b0";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn for_group_reports_a_verdict_per_candidate() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (major, minor, patch, changelog, status)
+				VALUES (2, 62, 0, 'x', 'published'), (2, 63, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name)
+				VALUES ('bbbbbbbb-0000-0000-0000-000000000001', 'Kamaka');
+			INSERT INTO servers (id, name, host, kind, group_id) VALUES
+				('bbbbbbbb-0000-0000-0000-0000000000a0', 'behind',
+				 'https://behind.example.com', 'central',
+				 'bbbbbbbb-0000-0000-0000-000000000001'),
+				('bbbbbbbb-0000-0000-0000-0000000000b0', 'current',
+				 'https://current.example.com', 'facility',
+				 'bbbbbbbb-0000-0000-0000-000000000001');
+			INSERT INTO server_reported_detail (server_id, source, extra, version) VALUES
+				('bbbbbbbb-0000-0000-0000-0000000000a0', 'test', '{}'::jsonb, '2.62.0'),
+				('bbbbbbbb-0000-0000-0000-0000000000b0', 'test', '{}'::jsonb, '2.63.0');",
+		)
+		.await
+		.unwrap();
+
+		let resp = private
+			.post("/api/migration_tests/for_group")
+			.json(&json!({ "group_id": GROUP }))
+			.await;
+		resp.assert_status_ok();
+		let verdicts: Vec<Value> = resp.json();
+
+		assert_eq!(
+			verdicts.len(),
+			1,
+			"only the server with somewhere to upgrade to: got {verdicts:?}"
+		);
+		assert_eq!(verdicts[0]["server_id"], BEHIND);
+		assert_eq!(verdicts[0]["target_version"], "2.63.0");
+		assert_eq!(verdicts[0]["verdict"], "nottested");
+		assert!(verdicts[0]["latest"].is_null());
+
+		let current_absent = verdicts.iter().all(|v| v["server_id"] != CURRENT);
+		assert!(
+			current_absent,
+			"a server already on the newest version has nothing to test"
+		);
+	})
+	.await;
+}

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -2450,6 +2450,21 @@
             "type": "string",
             "description": "Kind of storage backend. Always `\"s3\"`."
           },
+          "target_version": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "For a `migrate` intent, the version whose schema migrations to apply\nafter restoring. Obtain them from that version's published artefacts, the\nsame way a server being upgraded does. `null` for every other intent."
+          },
+          "target_version_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Identifier of that version. Echo it back in the migration-test report."
+          },
           "type": {
             "type": "string",
             "description": "The backup type to restore (e.g. `tamanu-postgres`)."

--- a/crates/public-server/openapi.json
+++ b/crates/public-server/openapi.json
@@ -1624,6 +1624,72 @@
           }
         }
       },
+      "MigrationArgs": {
+        "type": "object",
+        "description": "How the target version's migrations went against the restored replica.",
+        "required": [
+          "target_version_id",
+          "total_elapsed_seconds",
+          "data_bytes_before",
+          "data_bytes_after",
+          "timings"
+        ],
+        "properties": {
+          "data_bytes_after": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Size of the data after they ran. The growth between the two is what shows\na migration that backfills heavily."
+          },
+          "data_bytes_before": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Size of the data before the migrations ran."
+          },
+          "failed_migration": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The migration that failed, when one did."
+          },
+          "target_version_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The version whose migrations were applied, taken from the worklist\nentry's `target_version_id`."
+          },
+          "timings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MigrationTimingArgs"
+            },
+            "description": "One entry per migration that ran, in the order they ran."
+          },
+          "total_elapsed_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Whole seconds the whole migration run took."
+          }
+        }
+      },
+      "MigrationTimingArgs": {
+        "type": "object",
+        "description": "How long one migration took.",
+        "required": [
+          "name",
+          "elapsed_seconds"
+        ],
+        "properties": {
+          "elapsed_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Whole seconds it took."
+          },
+          "name": {
+            "type": "string",
+            "description": "The migration's name, as the migration runner reports it."
+          }
+        }
+      },
       "ParamType": {
         "type": "string",
         "description": "The data type of a restore-replica configuration parameter, which\ndetermines how its value is validated. `duration` and `bytes` values must\nbe non-negative integers (a count of seconds and of bytes, respectively);\n`integer` accepts any whole number, positive or negative; `boolean` is a\nJSON boolean; `text` is a JSON string.",
@@ -2169,6 +2235,17 @@
           "intent": {
             "type": "string",
             "description": "The restore intent this attempt was performed under."
+          },
+          "migration": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MigrationArgs",
+                "description": "What the migrations did, for a report under a `migrate` intent. Omit for\nevery other intent."
+              }
+            ]
           },
           "observed_at": {
             "type": "string",

--- a/crates/public-server/src/restore.rs
+++ b/crates/public-server/src/restore.rs
@@ -25,7 +25,8 @@ use commons_types::backup::{
 use database::{
 	Db,
 	backups::{BackupRun, NewBackupCredentialIssuance, ServerGroupBackupConfig},
-	migration_tests,
+	migration_tests::{self, MigrationTest, NewMigrationTest},
+	pg_duration::PgDuration,
 	reported_detail::ReportedDetail,
 	restore::{
 		BackupRestoreCheck, NewBackupRestoreCheck, RestoreConsumerCapability, RestoreReplica,
@@ -33,7 +34,7 @@ use database::{
 	servers::Server,
 	versions::Version,
 };
-use jiff::Timestamp;
+use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use utoipa::ToSchema;
@@ -594,6 +595,37 @@ pub struct VerificationArgs {
 	/// The field is optional only so older clients don't break; it WILL be made
 	/// mandatory in future.
 	pub run_id: Option<Uuid>,
+	/// What the migrations did, for a report under a `migrate` intent. Omit for
+	/// every other intent.
+	pub migration: Option<MigrationArgs>,
+}
+
+/// How the target version's migrations went against the restored replica.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct MigrationArgs {
+	/// The version whose migrations were applied, taken from the worklist
+	/// entry's `target_version_id`.
+	pub target_version_id: Uuid,
+	/// Whole seconds the whole migration run took.
+	pub total_elapsed_seconds: i64,
+	/// The migration that failed, when one did.
+	pub failed_migration: Option<String>,
+	/// Size of the data before the migrations ran.
+	pub data_bytes_before: i64,
+	/// Size of the data after they ran. The growth between the two is what shows
+	/// a migration that backfills heavily.
+	pub data_bytes_after: i64,
+	/// One entry per migration that ran, in the order they ran.
+	pub timings: Vec<MigrationTimingArgs>,
+}
+
+/// How long one migration took.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct MigrationTimingArgs {
+	/// The migration's name, as the migration runner reports it.
+	pub name: String,
+	/// Whole seconds it took.
+	pub elapsed_seconds: i64,
 }
 
 /// Report the outcome of a restore attempt and the replica's health.
@@ -634,30 +666,57 @@ async fn verification(
 		});
 	}
 
-	BackupRestoreCheck::record_report(
-		&mut conn,
-		NewBackupRestoreCheck {
-			replica_id: args.replica_id,
-			consumer_device_id,
-			group_id: args.group,
-			server_id: Some(args.server_id),
-			r#type: args.r#type,
-			intent: args.intent,
-			snapshot_id: args.snapshot_id,
-			outcome: args.outcome,
-			error: args.error,
-			replica_healthy: args.replica_healthy,
-			postgres_version: args.postgres_version,
-			observed_at: args.observed_at,
-			s3_sent_raw_bytes: args.s3_sent_raw_bytes,
-			s3_sent_payload_bytes: args.s3_sent_payload_bytes,
-			s3_received_raw_bytes: args.s3_received_raw_bytes,
-			s3_received_payload_bytes: args.s3_received_payload_bytes,
-			health_details: args.health_details,
-			run_id: args.run_id,
-		},
-	)
-	.await?;
+	let report = NewBackupRestoreCheck {
+		replica_id: args.replica_id,
+		consumer_device_id,
+		group_id: args.group,
+		server_id: Some(args.server_id),
+		r#type: args.r#type,
+		intent: args.intent,
+		snapshot_id: args.snapshot_id,
+		outcome: args.outcome,
+		error: args.error,
+		replica_healthy: args.replica_healthy,
+		postgres_version: args.postgres_version,
+		observed_at: args.observed_at,
+		s3_sent_raw_bytes: args.s3_sent_raw_bytes,
+		s3_sent_payload_bytes: args.s3_sent_payload_bytes,
+		s3_received_raw_bytes: args.s3_received_raw_bytes,
+		s3_received_payload_bytes: args.s3_received_payload_bytes,
+		health_details: args.health_details,
+		run_id: args.run_id,
+	};
+
+	match args.migration {
+		Some(migration) => {
+			MigrationTest::record(&mut conn, report, migration.into()).await?;
+		}
+		None => {
+			BackupRestoreCheck::record_report(&mut conn, report).await?;
+		}
+	}
 
 	Ok(StatusCode::NO_CONTENT)
+}
+
+impl From<MigrationArgs> for NewMigrationTest {
+	fn from(args: MigrationArgs) -> Self {
+		Self {
+			target_version_id: args.target_version_id,
+			total_elapsed: PgDuration(SignedDuration::from_secs(args.total_elapsed_seconds)),
+			failed_migration: args.failed_migration,
+			data_bytes_before: args.data_bytes_before,
+			data_bytes_after: args.data_bytes_after,
+			timings: args
+				.timings
+				.into_iter()
+				.map(|timing| {
+					(
+						timing.name,
+						PgDuration(SignedDuration::from_secs(timing.elapsed_seconds)),
+					)
+				})
+				.collect(),
+		}
+	}
 }

--- a/crates/public-server/src/restore.rs
+++ b/crates/public-server/src/restore.rs
@@ -27,12 +27,10 @@ use database::{
 	backups::{BackupRun, NewBackupCredentialIssuance, ServerGroupBackupConfig},
 	migration_tests::{self, MigrationTest, NewMigrationTest},
 	pg_duration::PgDuration,
-	reported_detail::ReportedDetail,
 	restore::{
 		BackupRestoreCheck, NewBackupRestoreCheck, RestoreConsumerCapability, RestoreReplica,
 	},
 	servers::Server,
-	versions::Version,
 };
 use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
@@ -159,40 +157,6 @@ pub struct WorklistEntry {
 	pub target_version_id: Option<Uuid>,
 }
 
-/// The version a `migrate` entry for `server` should target, with its semver
-/// for the consumer to resolve artefacts by.
-///
-/// `None` when the server runs another product, has never reported a version,
-/// or is already on the newest published one.
-// spec: RST#candidate-versions
-async fn migration_target(
-	conn: &mut diesel_async::AsyncPgConnection,
-	server: &Server,
-) -> Result<Option<(Uuid, commons_types::version::VersionStr)>> {
-	if server.product != commons_types::server::product::Product::Tamanu {
-		return Ok(None);
-	}
-
-	let Some(reported) = ReportedDetail::last_version(conn, server.id).await? else {
-		return Ok(None);
-	};
-
-	let versions = Version::get_all(conn).await?;
-	let Some(version_id) = migration_tests::upgrade_target(&reported, &versions) else {
-		return Ok(None);
-	};
-
-	let target = versions
-		.iter()
-		.find(|version| version.id == version_id)
-		.expect("upgrade_target returns one of the versions it was given");
-
-	Ok(Some((
-		version_id,
-		commons_types::version::VersionStr(target.as_semver()),
-	)))
-}
-
 /// Fetch the full set of replicas this device should maintain.
 ///
 /// Returns the device's complete desired state, computed fresh on every call:
@@ -308,8 +272,8 @@ async fn worklist(
 			// A `migrate` intent needs a version to migrate to, so a server with
 			// no candidate contributes nothing rather than an entry naming none.
 			let target = if migrates {
-				match migration_target(&mut conn, &server).await? {
-					Some(target) => Some(target),
+				match migration_tests::candidate_for(&mut conn, &server).await? {
+					Some(version) => Some((version.id, version.as_semver())),
 					None => continue,
 				}
 			} else {

--- a/crates/public-server/src/restore.rs
+++ b/crates/public-server/src/restore.rs
@@ -25,10 +25,13 @@ use commons_types::backup::{
 use database::{
 	Db,
 	backups::{BackupRun, NewBackupCredentialIssuance, ServerGroupBackupConfig},
+	migration_tests,
+	reported_detail::ReportedDetail,
 	restore::{
 		BackupRestoreCheck, NewBackupRestoreCheck, RestoreConsumerCapability, RestoreReplica,
 	},
 	servers::Server,
+	versions::Version,
 };
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -147,6 +150,46 @@ pub struct WorklistEntry {
 	pub prefix: String,
 	/// AWS region of the bucket.
 	pub region: String,
+	/// For a `migrate` intent, the version whose schema migrations to apply
+	/// after restoring. Obtain them from that version's published artefacts, the
+	/// same way a server being upgraded does. `null` for every other intent.
+	pub target_version: Option<String>,
+	/// Identifier of that version. Echo it back in the migration-test report.
+	pub target_version_id: Option<Uuid>,
+}
+
+/// The version a `migrate` entry for `server` should target, with its semver
+/// for the consumer to resolve artefacts by.
+///
+/// `None` when the server runs another product, has never reported a version,
+/// or is already on the newest published one.
+// spec: RST#candidate-versions
+async fn migration_target(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server: &Server,
+) -> Result<Option<(Uuid, commons_types::version::VersionStr)>> {
+	if server.product != commons_types::server::product::Product::Tamanu {
+		return Ok(None);
+	}
+
+	let Some(reported) = ReportedDetail::last_version(conn, server.id).await? else {
+		return Ok(None);
+	};
+
+	let versions = Version::get_all(conn).await?;
+	let Some(version_id) = migration_tests::upgrade_target(&reported, &versions) else {
+		return Ok(None);
+	};
+
+	let target = versions
+		.iter()
+		.find(|version| version.id == version_id)
+		.expect("upgrade_target returns one of the versions it was given");
+
+	Ok(Some((
+		version_id,
+		commons_types::version::VersionStr(target.as_semver()),
+	)))
 }
 
 /// Fetch the full set of replicas this device should maintain.
@@ -248,6 +291,7 @@ async fn worklist(
 		// The descriptor governs the intent's semantics and parameter resolution.
 		let descriptor = &descriptors[&d.intent];
 		let once = descriptor.has_semantic(semantics::ONCE);
+		let migrates = descriptor.has_semantic(semantics::MIGRATE);
 		let replica_values: ParamValues =
 			serde_json::from_value(d.params.clone()).unwrap_or_default();
 		let params = resolve_params(&descriptor.params, &replica_values);
@@ -259,15 +303,35 @@ async fn worklist(
 				continue;
 			}
 			let latest = snapshots.get(&(server.id, d.r#type.clone()));
-			// A `once` intent drops off the worklist once the latest snapshot has
-			// a healthy report; it reappears only when a newer snapshot exists.
+
+			// A `migrate` intent needs a version to migrate to, so a server with
+			// no candidate contributes nothing rather than an entry naming none.
+			let target = if migrates {
+				match migration_target(&mut conn, &server).await? {
+					Some(target) => Some(target),
+					None => continue,
+				}
+			} else {
+				None
+			};
+
+			// A `once` intent drops off the worklist once its work is settled for
+			// the latest snapshot, and reappears only when a newer one exists. For
+			// a `migrate` intent that settling is keyed to the target version too,
+			// and a failure settles it as firmly as a pass.
 			if once {
-				let key = (server.id, d.r#type.clone(), d.intent.clone());
-				let already = matches!(
-					(verified.get(&key), latest.and_then(|r| r.snapshot_id.as_ref())),
-					(Some(v), Some(s)) if v == s
-				);
-				if already {
+				let settled = match (&target, latest.and_then(|r| r.snapshot_id.as_ref())) {
+					(Some((version_id, _)), Some(snapshot)) => {
+						migration_tests::has_verdict(&mut conn, server.id, snapshot, *version_id)
+							.await?
+					}
+					(Some(_), None) => false,
+					(None, snapshot) => {
+						let key = (server.id, d.r#type.clone(), d.intent.clone());
+						matches!((verified.get(&key), snapshot), (Some(v), Some(s)) if v == s)
+					}
+				};
+				if settled {
 					continue;
 				}
 			}
@@ -286,6 +350,8 @@ async fn worklist(
 				bucket: cfg.bucket.clone(),
 				prefix: cfg.prefix.clone(),
 				region: region.clone(),
+				target_version: target.as_ref().map(|(_, version)| version.to_string()),
+				target_version_id: target.as_ref().map(|(version_id, _)| *version_id),
 			});
 		}
 	}

--- a/crates/public-server/tests/it/restore.rs
+++ b/crates/public-server/tests/it/restore.rs
@@ -545,12 +545,15 @@ async fn report_version(conn: &mut AsyncPgConnection, server_id: Uuid, version: 
 	.expect("report version");
 }
 
+/// One intent that both verifies the restore and applies the migrations: the
+/// `migrate` semantic rides on the verifying intent so a single restore answers
+/// both questions.
 async fn register_migrate_intent(public: &axum_test::TestServer, cert: &str) {
 	public
 		.post("/restore-capabilities")
 		.add_header("mtls-certificate", cert)
 		.json(&serde_json::json!({
-			"intents": [{"intent": "migrate", "semantics": ["check", "once", "migrate"]}]
+			"intents": [{"intent": "verify", "semantics": ["check", "once", "migrate"]}]
 		}))
 		.await
 		.assert_status(http::StatusCode::NO_CONTENT);
@@ -568,7 +571,7 @@ async fn a_migrate_entry_names_the_newest_version_the_server_could_take() {
 			report_version(&mut conn, server, "2.62.0").await;
 			publish_version(&mut conn, 62, 0).await;
 			let newest = publish_version(&mut conn, 63, 2).await;
-			declare_replica(&mut conn, device_id, group, "migrate").await;
+			declare_replica(&mut conn, device_id, group, "verify").await;
 			register_migrate_intent(&public, &cert).await;
 
 			let resp = public
@@ -598,7 +601,7 @@ async fn a_server_already_on_the_newest_version_gets_no_migrate_entry() {
 			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
 			report_version(&mut conn, server, "2.63.2").await;
 			publish_version(&mut conn, 63, 2).await;
-			declare_replica(&mut conn, device_id, group, "migrate").await;
+			declare_replica(&mut conn, device_id, group, "verify").await;
 			register_migrate_intent(&public, &cert).await;
 
 			let resp = public
@@ -628,7 +631,7 @@ async fn a_failed_verdict_settles_the_snapshot_and_version_pair() {
 			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
 			report_version(&mut conn, server, "2.62.0").await;
 			let newest = publish_version(&mut conn, 63, 2).await;
-			declare_replica(&mut conn, device_id, group, "migrate").await;
+			declare_replica(&mut conn, device_id, group, "verify").await;
 			register_migrate_intent(&public, &cert).await;
 
 			let before: Vec<serde_json::Value> = public
@@ -648,7 +651,7 @@ async fn a_failed_verdict_settles_the_snapshot_and_version_pair() {
 					group_id: group,
 					server_id: Some(server),
 					r#type: commons_types::backup::BackupType::TamanuPostgres,
-					intent: commons_types::backup::RestoreIntent::from("migrate"),
+					intent: commons_types::backup::RestoreIntent::from("verify"),
 					snapshot_id: Some("snap-1".into()),
 					// The restore itself was fine; only the migration failed.
 					outcome: commons_types::backup::RunOutcome::Success,
@@ -702,7 +705,7 @@ async fn a_reported_migration_test_lands_and_settles_the_entry() {
 			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
 			report_version(&mut conn, server, "2.62.0").await;
 			let newest = publish_version(&mut conn, 63, 2).await;
-			declare_replica(&mut conn, device_id, group, "migrate").await;
+			declare_replica(&mut conn, device_id, group, "verify").await;
 			register_migrate_intent(&public, &cert).await;
 
 			let dispatched: Vec<serde_json::Value> = public
@@ -722,7 +725,7 @@ async fn a_reported_migration_test_lands_and_settles_the_entry() {
 					"group": group,
 					"server_id": server,
 					"type": "tamanu-postgres",
-					"intent": "migrate",
+					"intent": "verify",
 					"snapshot_id": entry["snapshot_id"],
 					"outcome": "success",
 					"replica_healthy": true,

--- a/crates/public-server/tests/it/restore.rs
+++ b/crates/public-server/tests/it/restore.rs
@@ -689,3 +689,74 @@ async fn a_failed_verdict_settles_the_snapshot_and_version_pair() {
 	)
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_reported_migration_test_lands_and_settles_the_entry() {
+	commons_tests::server::run_with_device_auth(
+		"backup-restore",
+		async |mut conn, cert, device_id, public, _| {
+			let group = make_group(&mut conn).await;
+			make_config(&mut conn, group, "ready").await;
+			let server = make_server(&mut conn, group).await;
+			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
+			report_version(&mut conn, server, "2.62.0").await;
+			let newest = publish_version(&mut conn, 63, 2).await;
+			declare_replica(&mut conn, device_id, group, "migrate").await;
+			register_migrate_intent(&public, &cert).await;
+
+			let dispatched: Vec<serde_json::Value> = public
+				.get("/restore-worklist")
+				.add_header("mtls-certificate", &cert)
+				.await
+				.json();
+			assert_eq!(dispatched.len(), 1, "got {dispatched:?}");
+			let entry = &dispatched[0];
+
+			// Report it back the way a consumer would, echoing the entry.
+			public
+				.post("/restore-verification")
+				.add_header("mtls-certificate", &cert)
+				.json(&serde_json::json!({
+					"replica_id": entry["replica_id"],
+					"group": group,
+					"server_id": server,
+					"type": "tamanu-postgres",
+					"intent": "migrate",
+					"snapshot_id": entry["snapshot_id"],
+					"outcome": "success",
+					"replica_healthy": true,
+					"postgres_version": "18",
+					"observed_at": "2026-07-30T00:00:00Z",
+					"migration": {
+						"target_version_id": entry["target_version_id"],
+						"total_elapsed_seconds": 900,
+						"data_bytes_before": 200_000_000_000i64,
+						"data_bytes_after": 260_000_000_000i64,
+						"timings": [
+							{"name": "addIndexToFhirJobs", "elapsed_seconds": 12},
+							{"name": "backfillNoteTypeIds", "elapsed_seconds": 880},
+						],
+					},
+				}))
+				.await
+				.assert_status(http::StatusCode::NO_CONTENT);
+
+			// The verdict is readable, and the timings survived the round trip.
+			assert_eq!(
+				database::migration_tests::verdict(&mut conn, server, newest)
+					.await
+					.expect("verdict"),
+				database::migration_tests::Verdict::Passed
+			);
+
+			// And the pair is settled, so it is not dispatched again.
+			let after: Vec<serde_json::Value> = public
+				.get("/restore-worklist")
+				.add_header("mtls-certificate", &cert)
+				.await
+				.json();
+			assert!(after.is_empty(), "got {after:?}");
+		},
+	)
+	.await;
+}

--- a/crates/public-server/tests/it/restore.rs
+++ b/crates/public-server/tests/it/restore.rs
@@ -650,8 +650,9 @@ async fn a_failed_verdict_settles_the_snapshot_and_version_pair() {
 					r#type: commons_types::backup::BackupType::TamanuPostgres,
 					intent: commons_types::backup::RestoreIntent::from("migrate"),
 					snapshot_id: Some("snap-1".into()),
-					outcome: commons_types::backup::RunOutcome::Failure,
-					error: Some("migration failed".into()),
+					// The restore itself was fine; only the migration failed.
+					outcome: commons_types::backup::RunOutcome::Success,
+					error: None,
 					replica_healthy: true,
 					postgres_version: Some("18".into()),
 					observed_at: jiff::Timestamp::now(),

--- a/crates/public-server/tests/it/restore.rs
+++ b/crates/public-server/tests/it/restore.rs
@@ -513,3 +513,179 @@ async fn restore_verification_records_and_raises_alert() {
 	)
 	.await;
 }
+
+/// A published version, so a server has something to be migration-tested
+/// against.
+async fn publish_version(conn: &mut AsyncPgConnection, minor: i32, patch: i32) -> Uuid {
+	let version_id = Uuid::new_v4();
+	sql_query(
+		"INSERT INTO versions (id, major, minor, patch, status, changelog)
+		 VALUES ($1, 2, $2, $3, 'published', '')",
+	)
+	.bind::<sql_types::Uuid, _>(version_id)
+	.bind::<sql_types::Integer, _>(minor)
+	.bind::<sql_types::Integer, _>(patch)
+	.execute(conn)
+	.await
+	.expect("publish version");
+	version_id
+}
+
+/// What the server reports itself as running, which is what a candidate is
+/// measured against.
+async fn report_version(conn: &mut AsyncPgConnection, server_id: Uuid, version: &str) {
+	sql_query(
+		"INSERT INTO server_reported_detail (server_id, source, extra, version)
+		 VALUES ($1, 'test', '{}'::jsonb, $2)",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(version)
+	.execute(conn)
+	.await
+	.expect("report version");
+}
+
+async fn register_migrate_intent(public: &axum_test::TestServer, cert: &str) {
+	public
+		.post("/restore-capabilities")
+		.add_header("mtls-certificate", cert)
+		.json(&serde_json::json!({
+			"intents": [{"intent": "migrate", "semantics": ["check", "once", "migrate"]}]
+		}))
+		.await
+		.assert_status(http::StatusCode::NO_CONTENT);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_migrate_entry_names_the_newest_version_the_server_could_take() {
+	commons_tests::server::run_with_device_auth(
+		"backup-restore",
+		async |mut conn, cert, device_id, public, _| {
+			let group = make_group(&mut conn).await;
+			make_config(&mut conn, group, "ready").await;
+			let server = make_server(&mut conn, group).await;
+			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
+			report_version(&mut conn, server, "2.62.0").await;
+			publish_version(&mut conn, 62, 0).await;
+			let newest = publish_version(&mut conn, 63, 2).await;
+			declare_replica(&mut conn, device_id, group, "migrate").await;
+			register_migrate_intent(&public, &cert).await;
+
+			let resp = public
+				.get("/restore-worklist")
+				.add_header("mtls-certificate", &cert)
+				.await;
+			resp.assert_status_ok();
+			let entries: Vec<serde_json::Value> = resp.json();
+
+			assert_eq!(entries.len(), 1, "got {entries:?}");
+			assert_eq!(entries[0]["target_version"], "2.63.2");
+			assert_eq!(entries[0]["target_version_id"], newest.to_string());
+			assert_eq!(entries[0]["snapshot_id"], "snap-1");
+		},
+	)
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_server_already_on_the_newest_version_gets_no_migrate_entry() {
+	commons_tests::server::run_with_device_auth(
+		"backup-restore",
+		async |mut conn, cert, device_id, public, _| {
+			let group = make_group(&mut conn).await;
+			make_config(&mut conn, group, "ready").await;
+			let server = make_server(&mut conn, group).await;
+			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
+			report_version(&mut conn, server, "2.63.2").await;
+			publish_version(&mut conn, 63, 2).await;
+			declare_replica(&mut conn, device_id, group, "migrate").await;
+			register_migrate_intent(&public, &cert).await;
+
+			let resp = public
+				.get("/restore-worklist")
+				.add_header("mtls-certificate", &cert)
+				.await;
+			resp.assert_status_ok();
+			let entries: Vec<serde_json::Value> = resp.json();
+
+			assert!(
+				entries.is_empty(),
+				"nothing to migrate to, so no entry: got {entries:?}"
+			);
+		},
+	)
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failed_verdict_settles_the_snapshot_and_version_pair() {
+	commons_tests::server::run_with_device_auth(
+		"backup-restore",
+		async |mut conn, cert, device_id, public, _| {
+			let group = make_group(&mut conn).await;
+			make_config(&mut conn, group, "ready").await;
+			let server = make_server(&mut conn, group).await;
+			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
+			report_version(&mut conn, server, "2.62.0").await;
+			let newest = publish_version(&mut conn, 63, 2).await;
+			declare_replica(&mut conn, device_id, group, "migrate").await;
+			register_migrate_intent(&public, &cert).await;
+
+			let before: Vec<serde_json::Value> = public
+				.get("/restore-worklist")
+				.add_header("mtls-certificate", &cert)
+				.await
+				.json();
+			assert_eq!(before.len(), 1, "dispatched once: got {before:?}");
+
+			// A failing migration is a settled answer for this snapshot: the
+			// same run against the same data would fail the same way.
+			database::migration_tests::MigrationTest::record(
+				&mut conn,
+				database::restore::NewBackupRestoreCheck {
+					replica_id: None,
+					consumer_device_id: device_id,
+					group_id: group,
+					server_id: Some(server),
+					r#type: commons_types::backup::BackupType::TamanuPostgres,
+					intent: commons_types::backup::RestoreIntent::from("migrate"),
+					snapshot_id: Some("snap-1".into()),
+					outcome: commons_types::backup::RunOutcome::Failure,
+					error: Some("migration failed".into()),
+					replica_healthy: true,
+					postgres_version: Some("18".into()),
+					observed_at: jiff::Timestamp::now(),
+					s3_sent_raw_bytes: None,
+					s3_sent_payload_bytes: None,
+					s3_received_raw_bytes: None,
+					s3_received_payload_bytes: None,
+					health_details: None,
+					run_id: None,
+				},
+				database::migration_tests::NewMigrationTest {
+					target_version_id: newest,
+					total_elapsed: database::pg_duration::PgDuration(
+						jiff::SignedDuration::from_secs(30),
+					),
+					failed_migration: Some("backfillNoteTypeIds".into()),
+					data_bytes_before: 10,
+					data_bytes_after: 10,
+					timings: vec![],
+				},
+			)
+			.await
+			.expect("record failing test");
+
+			let after: Vec<serde_json::Value> = public
+				.get("/restore-worklist")
+				.add_header("mtls-certificate", &cert)
+				.await
+				.json();
+			assert!(
+				after.is_empty(),
+				"a failure settles the pair rather than retrying: got {after:?}"
+			);
+		},
+	)
+	.await;
+}

--- a/migrations/2026-07-29-221016-0000_add_server_to_version_known_issues/down.sql
+++ b/migrations/2026-07-29-221016-0000_add_server_to_version_known_issues/down.sql
@@ -1,0 +1,2 @@
+-- DESTRUCTIVE: the provenance of automatically-filed issues is not recoverable.
+ALTER TABLE version_known_issues DROP COLUMN server_id;

--- a/migrations/2026-07-29-221016-0000_add_server_to_version_known_issues/up.sql
+++ b/migrations/2026-07-29-221016-0000_add_server_to_version_known_issues/up.sql
@@ -1,0 +1,4 @@
+-- Which deployment's data provoked the issue; null when an operator filed it by
+-- hand. SET NULL rather than CASCADE: the issue is about the version, and
+-- outlives the server it was found on.
+ALTER TABLE version_known_issues ADD COLUMN server_id UUID REFERENCES servers (id) ON DELETE SET NULL;

--- a/migrations/2026-07-29-225557-0000_add_migration_test_results/down.sql
+++ b/migrations/2026-07-29-225557-0000_add_migration_test_results/down.sql
@@ -1,0 +1,4 @@
+-- DESTRUCTIVE: every recorded migration-test result and timing goes with them.
+DROP TABLE migration_timings;
+
+DROP TABLE migration_tests;

--- a/migrations/2026-07-29-225557-0000_add_migration_test_results/up.sql
+++ b/migrations/2026-07-29-225557-0000_add_migration_test_results/up.sql
@@ -1,0 +1,30 @@
+-- A migration test's result, hanging off the restore-health report that carries
+-- its common fields. Its own table rather than nullable columns on the report,
+-- because the timings and sizes are the whole point of the test and a plain
+-- restore report has nothing to put in them.
+--
+-- Neither table has `test_` in its name: `except_tables` in diesel.toml matches
+-- unanchored, so a name containing it is silently left out of the generated
+-- schema.
+CREATE TABLE migration_tests (
+	check_id BIGINT PRIMARY KEY REFERENCES backup_restore_checks (id) ON DELETE CASCADE,
+	target_version_id UUID NOT NULL REFERENCES versions (id) ON DELETE CASCADE,
+	total_elapsed INTERVAL NOT NULL,
+	failed_migration TEXT,
+	data_bytes_before BIGINT NOT NULL,
+	data_bytes_after BIGINT NOT NULL
+);
+
+CREATE INDEX migration_tests_target_version ON migration_tests (target_version_id);
+
+CREATE TABLE migration_timings (
+	check_id BIGINT NOT NULL REFERENCES migration_tests (check_id) ON DELETE CASCADE,
+	ordinal INTEGER NOT NULL,
+	name TEXT NOT NULL,
+	elapsed INTERVAL NOT NULL,
+	PRIMARY KEY (check_id, ordinal)
+);
+
+-- Reading one migration's duration across every deployment that ran it is the
+-- cross-row question these timings exist to answer.
+CREATE INDEX migration_timings_name ON migration_timings (name);

--- a/private-web/e2e/migration-tests.spec.ts
+++ b/private-web/e2e/migration-tests.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "./test-fixtures";
+import {
+	resetSeededTables,
+	seedDevice,
+	seedMigrationTest,
+	seedServer,
+	seedServerGroup,
+	seedStatus,
+	seedVersion,
+} from "./seed";
+
+test.describe("pre-upgrade migration tests on the group page", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("shows each server's verdict against the version it would take next", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "kamaka" });
+		const consumer = await seedDevice(sql, { role: "backup-restore" });
+		await seedVersion(sql, { major: 2, minor: 62, patch: 0 });
+		const target = await seedVersion(sql, { major: 2, minor: 63, patch: 0 });
+
+		const failed = await seedServer(sql, {
+			name: "kamaka-central",
+			groupId: group.id,
+		});
+		const untested = await seedServer(sql, {
+			name: "kamaka-facility",
+			groupId: group.id,
+		});
+		for (const server of [failed, untested]) {
+			await seedStatus(sql, { serverId: server.id, version: "2.62.0" });
+		}
+
+		// One server has been tried and its migrations failed; the other has not
+		// been tried yet.
+		await seedMigrationTest(sql, {
+			consumerDeviceId: consumer.id,
+			groupId: group.id,
+			serverId: failed.id,
+			targetVersionId: target.id,
+			failedMigration: "backfillNoteTypeIds",
+			totalElapsedSecs: 5400,
+			dataBytesBefore: 200_000_000_000,
+			dataBytesAfter: 260_000_000_000,
+		});
+
+		await page.goto(`/groups/${group.id}`);
+
+		const section = page.getByTestId("migration-tests");
+		await expect(section).toBeVisible();
+		await expect(
+			section.getByRole("heading", { name: "Pre-upgrade migration tests" }),
+		).toBeVisible();
+
+		const failedRow = section
+			.getByTestId("migration-test-row")
+			.filter({ hasText: "kamaka-central" });
+		await expect(failedRow).toContainText("2.63.0");
+		await expect(failedRow).toContainText("failed");
+		// The window estimate and the growth a heavy backfill leaves behind are
+		// the numbers an operator schedules against.
+		await expect(failedRow).toContainText("1.5h");
+		await expect(failedRow).toContainText("30%");
+
+		const untestedRow = section
+			.getByTestId("migration-test-row")
+			.filter({ hasText: "kamaka-facility" });
+		await expect(untestedRow).toContainText("not yet tested");
+	});
+
+	test("says so when every server is already on the newest version", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "current" });
+		await seedVersion(sql, { major: 2, minor: 63, patch: 0 });
+		const server = await seedServer(sql, {
+			name: "up-to-date",
+			groupId: group.id,
+		});
+		await seedStatus(sql, { serverId: server.id, version: "2.63.0" });
+
+		await page.goto(`/groups/${group.id}`);
+
+		await expect(page.getByTestId("migration-tests")).toContainText(
+			"nothing to test against",
+		);
+	});
+});

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,7 +47,7 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, recovery_vault_writes RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, migration_tests, migration_timings, recovery_vault_writes RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
 	// self-alerts attach to that row, so put it back. `kind = 'canopy'` is the
@@ -1141,6 +1141,58 @@ export async function seedRestoreCheck(
 			opts.runId ?? null,
 		],
 	);
+}
+
+/** Seed a migration-test result: the restore-health report that carries the
+ * common fields, plus the migration outcome hung off it. A named
+ * `failedMigration` is what makes the verdict a failure. */
+export async function seedMigrationTest(
+	sql: Sql,
+	opts: {
+		consumerDeviceId: string;
+		groupId: string;
+		serverId: string;
+		targetVersionId: string;
+		snapshotId?: string;
+		failedMigration?: string | null;
+		totalElapsedSecs?: number;
+		dataBytesBefore?: number;
+		dataBytesAfter?: number;
+		timings?: Array<{ name: string; elapsedSecs: number }>;
+	},
+): Promise<void> {
+	const rows = await sql.query<{ id: string }>(
+		`INSERT INTO backup_restore_checks
+		 (consumer_device_id, group_id, server_id, type, intent, snapshot_id, outcome,
+		  replica_healthy, observed_at)
+		 VALUES ($1, $2, $3, 'tamanu-postgres', 'migrate', $4, 'success', true, NOW())
+		 RETURNING id`,
+		[opts.consumerDeviceId, opts.groupId, opts.serverId, opts.snapshotId ?? "snap-1"],
+	);
+	const checkId = rows[0]!.id;
+
+	await sql.query(
+		`INSERT INTO migration_tests
+		 (check_id, target_version_id, total_elapsed, failed_migration,
+		  data_bytes_before, data_bytes_after)
+		 VALUES ($1, $2, make_interval(secs => $3), $4, $5, $6)`,
+		[
+			checkId,
+			opts.targetVersionId,
+			opts.totalElapsedSecs ?? 60,
+			opts.failedMigration ?? null,
+			opts.dataBytesBefore ?? 0,
+			opts.dataBytesAfter ?? 0,
+		],
+	);
+
+	for (const [ordinal, timing] of (opts.timings ?? []).entries()) {
+		await sql.query(
+			`INSERT INTO migration_timings (check_id, ordinal, name, elapsed)
+			 VALUES ($1, $2, $3, make_interval(secs => $4))`,
+			[checkId, ordinal, timing.name, timing.elapsedSecs],
+		);
+	}
 }
 
 /** Seed a `recovery_vault_writes` row. `writtenAgoSecs` backdates the write;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4284,6 +4284,66 @@
         ]
       }
     },
+    "/api/migration_tests/for_group": {
+      "post": {
+        "tags": [
+          "migration_tests"
+        ],
+        "summary": "Where each of a group's servers stands against the version it would take\nnext.",
+        "description": "One entry per server that has a candidate version. A server already on the\nnewest published version, running another product, or yet to report a\nversion has nothing to be tested against and is absent.",
+        "operationId": "migration_tests_for_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ForGroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Verdicts, one per server with a candidate.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GroupVerdict"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/restore_replicas/checks": {
       "post": {
         "tags": [
@@ -8684,6 +8744,20 @@
           }
         }
       },
+      "ForGroupArgs": {
+        "type": "object",
+        "description": "Request body for reading a group's migration-test verdicts.",
+        "required": [
+          "group_id"
+        ],
+        "properties": {
+          "group_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group to report on."
+          }
+        }
+      },
       "GeoPoint": {
         "type": "object",
         "description": "A geographic coordinate, used to place a server on a map.",
@@ -8908,6 +8982,47 @@
           "type": {
             "type": "string",
             "description": "Backup type this schedule and retention apply to."
+          }
+        }
+      },
+      "GroupVerdict": {
+        "type": "object",
+        "description": "Where one of a group's servers stands against the version it would take\nnext.",
+        "required": [
+          "server_id",
+          "target_version_id",
+          "target_version",
+          "verdict"
+        ],
+        "properties": {
+          "latest": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LatestTest",
+                "description": "The test the verdict came from, absent when there has not been one."
+              }
+            ]
+          },
+          "server_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The server the verdict is about."
+          },
+          "target_version": {
+            "type": "string",
+            "description": "That version, as semver."
+          },
+          "target_version_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The version it would take next."
+          },
+          "verdict": {
+            "$ref": "#/components/schemas/Verdict",
+            "description": "Where it stands against that version."
           }
         }
       },
@@ -9948,6 +10063,56 @@
               "null"
             ],
             "description": "Login of the operator who resolved this issue, if any."
+          }
+        }
+      },
+      "LatestTest": {
+        "type": "object",
+        "description": "The most recent test of one (server, version) pair.",
+        "required": [
+          "verdict",
+          "reported_at",
+          "total_elapsed",
+          "data_bytes_before",
+          "data_bytes_after"
+        ],
+        "properties": {
+          "data_bytes_after": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Size of it afterwards; the growth is what a heavy backfill shows up as."
+          },
+          "data_bytes_before": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Size of the data the migrations ran against."
+          },
+          "failed_migration": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The migration that failed, when one did."
+          },
+          "reported_at": {
+            "type": "string",
+            "description": "When the consumer reported it."
+          },
+          "snapshot_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The snapshot the verdict was reached against."
+          },
+          "total_elapsed": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Whole seconds the migration run took."
+          },
+          "verdict": {
+            "$ref": "#/components/schemas/Verdict",
+            "description": "Whether the migrations applied."
           }
         }
       },
@@ -14292,6 +14457,15 @@
         }
       },
       "Value": {},
+      "Verdict": {
+        "type": "string",
+        "description": "Where a (server, version) pair stands.",
+        "enum": [
+          "nottested",
+          "passed",
+          "failed"
+        ]
+      },
       "VersionData": {
         "type": "object",
         "description": "A single released (or draft) software version.",
@@ -14529,6 +14703,10 @@
     {
       "name": "mcp_tokens",
       "description": "Bearer tokens for the public MCP mount."
+    },
+    {
+      "name": "migration_tests",
+      "description": "Where each server stands against the version it would take next."
     },
     {
       "name": "restore_replicas",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2131,6 +2131,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/migration_tests/for_group": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Where each of a group's servers stands against the version it would take
+         *     next.
+         * @description One entry per server that has a candidate version. A server already on the
+         *     newest published version, running another product, or yet to report a
+         *     version has nothing to be tested against and is absent.
+         */
+        post: operations["migration_tests_for_group"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/restore_replicas/checks": {
         parameters: {
             query?: never;
@@ -4708,6 +4731,14 @@ export interface components {
             timezone?: string | null;
             version?: null | components["schemas"]["VersionStr"];
         };
+        /** @description Request body for reading a group's migration-test verdicts. */
+        ForGroupArgs: {
+            /**
+             * Format: uuid
+             * @description The group to report on.
+             */
+            group_id: string;
+        };
         /** @description A geographic coordinate, used to place a server on a map. */
         GeoPoint: {
             /**
@@ -4849,6 +4880,27 @@ export interface components {
             next_run_at?: string | null;
             /** @description Backup type this schedule and retention apply to. */
             type: string;
+        };
+        /**
+         * @description Where one of a group's servers stands against the version it would take
+         *     next.
+         */
+        GroupVerdict: {
+            latest?: null | components["schemas"]["LatestTest"];
+            /**
+             * Format: uuid
+             * @description The server the verdict is about.
+             */
+            server_id: string;
+            /** @description That version, as semver. */
+            target_version: string;
+            /**
+             * Format: uuid
+             * @description The version it would take next.
+             */
+            target_version_id: string;
+            /** @description Where it stands against that version. */
+            verdict: components["schemas"]["Verdict"];
         };
         /**
          * @description A server's self-reported health, derived from the outcomes of its own
@@ -5554,6 +5606,32 @@ export interface components {
             resolved_at?: string | null;
             /** @description Login of the operator who resolved this issue, if any. */
             resolved_by?: string | null;
+        };
+        /** @description The most recent test of one (server, version) pair. */
+        LatestTest: {
+            /**
+             * Format: int64
+             * @description Size of it afterwards; the growth is what a heavy backfill shows up as.
+             */
+            data_bytes_after: number;
+            /**
+             * Format: int64
+             * @description Size of the data the migrations ran against.
+             */
+            data_bytes_before: number;
+            /** @description The migration that failed, when one did. */
+            failed_migration?: string | null;
+            /** @description When the consumer reported it. */
+            reported_at: string;
+            /** @description The snapshot the verdict was reached against. */
+            snapshot_id?: string | null;
+            /**
+             * Format: int64
+             * @description Whole seconds the migration run took.
+             */
+            total_elapsed: number;
+            /** @description Whether the migrations applied. */
+            verdict: components["schemas"]["Verdict"];
         };
         /** @description Filters for listing open incidents. */
         ListActiveArgs: {
@@ -8279,6 +8357,11 @@ export interface components {
             target_role_arn: string;
         };
         Value: unknown;
+        /**
+         * @description Where a (server, version) pair stands.
+         * @enum {string}
+         */
+        Verdict: "nottested" | "passed" | "failed";
         /** @description A single released (or draft) software version. */
         VersionData: {
             /**
@@ -11297,6 +11380,46 @@ export interface operations {
                 };
             };
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    migration_tests_for_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ForGroupArgs"];
+            };
+        };
+        responses: {
+            /** @description Verdicts, one per server with a candidate. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GroupVerdict"][];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/private-web/src/components/MigrationTestsSection.tsx
+++ b/private-web/src/components/MigrationTestsSection.tsx
@@ -1,0 +1,191 @@
+import {
+	Alert,
+	Box,
+	Chip,
+	LinearProgress,
+	Paper,
+	Stack,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableRow,
+	Tooltip,
+	Typography,
+} from "@mui/material";
+import { useApi } from "../api";
+import type { ServerInfo } from "../types";
+import ServerShorty from "./ServerShorty";
+import TimeAgo from "./TimeAgo";
+
+/// Where each of the group's servers stands against the version it would take
+/// next: the migrations were run against a restore replica of its real data, so
+/// a pass means that data survives the upgrade and the timings say how long the
+/// window needs to be.
+// spec: RST#verdicts
+export default function MigrationTestsSection({
+	groupId,
+	servers,
+}: {
+	groupId: string;
+	servers: ServerInfo[];
+}) {
+	const byId = new Map(servers.map((server) => [server.id, server]));
+	const verdicts = useApi(
+		"migration_tests",
+		"for_group",
+		{ group_id: groupId },
+		[groupId],
+	);
+
+	if (verdicts.status === "loading" || verdicts.status === "idle") {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<SectionHeading />
+				<LinearProgress />
+			</Paper>
+		);
+	}
+	if (verdicts.status === "error") {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<SectionHeading />
+				<Alert severity="error">{verdicts.error.message}</Alert>
+			</Paper>
+		);
+	}
+
+	if (verdicts.data.length === 0) {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }} data-testid="migration-tests">
+				<SectionHeading />
+				<Typography variant="body2" color="text.secondary">
+					Every server here is on the newest version it can take, so there is
+					nothing to test against.
+				</Typography>
+			</Paper>
+		);
+	}
+
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }} data-testid="migration-tests">
+			<SectionHeading />
+			<Table size="small">
+				<TableHead>
+					<TableRow>
+						<TableCell>Server</TableCell>
+						<TableCell>Upgrading to</TableCell>
+						<TableCell>Verdict</TableCell>
+						<TableCell>Migrations took</TableCell>
+						<TableCell>Growth</TableCell>
+						<TableCell>Tested</TableCell>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{verdicts.data.map((row) => (
+						<TableRow key={row.server_id} data-testid="migration-test-row">
+							<TableCell>
+								{byId.has(row.server_id) ? (
+									<ServerShorty server={byId.get(row.server_id)!} />
+								) : (
+									row.server_id
+								)}
+							</TableCell>
+							<TableCell>{row.target_version}</TableCell>
+							<TableCell>
+								<VerdictChip
+									verdict={row.verdict}
+									failedMigration={row.latest?.failed_migration ?? null}
+								/>
+							</TableCell>
+							<TableCell>
+								{row.latest ? formatDuration(row.latest.total_elapsed) : "—"}
+							</TableCell>
+							<TableCell>
+								{row.latest
+									? formatGrowth(
+											row.latest.data_bytes_before,
+											row.latest.data_bytes_after,
+										)
+									: "—"}
+							</TableCell>
+							<TableCell>
+								{row.latest ? (
+									<Tooltip
+										title={`snapshot ${row.latest.snapshot_id ?? "unknown"}`}
+									>
+										<Box component="span">
+											<TimeAgo timestamp={row.latest.reported_at} />
+										</Box>
+									</Tooltip>
+								) : (
+									"—"
+								)}
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</Paper>
+	);
+}
+
+function SectionHeading() {
+	return (
+		<Stack direction="row" spacing={1} sx={{ mb: 1, alignItems: "baseline" }}>
+			<Typography variant="h6" component="h2">
+				Pre-upgrade migration tests
+			</Typography>
+			<Typography variant="body2" color="text.secondary">
+				run against a restore of each server's own data
+			</Typography>
+		</Stack>
+	);
+}
+
+function VerdictChip({
+	verdict,
+	failedMigration,
+}: {
+	verdict: "passed" | "failed" | "nottested";
+	failedMigration: string | null;
+}) {
+	if (verdict === "passed") {
+		return <Chip size="small" color="success" label="passed" />;
+	}
+	if (verdict === "nottested") {
+		return <Chip size="small" variant="outlined" label="not yet tested" />;
+	}
+	return (
+		<Tooltip title={failedMigration ?? "no migration named"}>
+			<Chip size="small" color="warning" label="failed" />
+		</Tooltip>
+	);
+}
+
+function formatDuration(seconds: number) {
+	if (seconds < 60) return `${seconds}s`;
+	if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+	const hours = seconds / 3600;
+	return `${hours.toFixed(hours < 10 ? 1 : 0)}h`;
+}
+
+/// How much the migrations added. Sizes are what makes a duration comparable
+/// across deployments, and growth is what catches a heavy backfill.
+function formatGrowth(before: number, after: number) {
+	const added = after - before;
+	if (added <= 0) return "none";
+	const percent = before > 0 ? Math.round((added / before) * 100) : null;
+	return percent === null ? formatBytes(added) : `+${formatBytes(added)} (${percent}%)`;
+}
+
+function formatBytes(bytes: number) {
+	const units = ["B", "kB", "MB", "GB", "TB"];
+	let value = bytes;
+	let unit = 0;
+	while (value >= 1000 && unit < units.length - 1) {
+		value /= 1000;
+		unit += 1;
+	}
+	return `${value.toFixed(value < 10 && unit > 0 ? 1 : 0)}${units[unit]}`;
+}

--- a/private-web/src/components/MigrationTestsSection.tsx
+++ b/private-web/src/components/MigrationTestsSection.tsx
@@ -13,9 +13,10 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
+import { Link as MuiLink } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
 import { useApi } from "../api";
 import type { ServerInfo } from "../types";
-import ServerShorty from "./ServerShorty";
 import TimeAgo from "./TimeAgo";
 
 /// Where each of the group's servers stands against the version it would take
@@ -31,6 +32,7 @@ export default function MigrationTestsSection({
 	servers: ServerInfo[];
 }) {
 	const byId = new Map(servers.map((server) => [server.id, server]));
+	const nameOf = (id: string) => byId.get(id)?.name ?? id;
 	const verdicts = useApi(
 		"migration_tests",
 		"for_group",
@@ -82,14 +84,23 @@ export default function MigrationTestsSection({
 					</TableRow>
 				</TableHead>
 				<TableBody>
-					{verdicts.data.map((row) => (
+					{[...verdicts.data]
+						.sort(
+							(a, b) =>
+								VERDICT_ORDER[a.verdict] - VERDICT_ORDER[b.verdict] ||
+								nameOf(a.server_id).localeCompare(nameOf(b.server_id)),
+						)
+						.map((row) => (
 						<TableRow key={row.server_id} data-testid="migration-test-row">
 							<TableCell>
-								{byId.has(row.server_id) ? (
-									<ServerShorty server={byId.get(row.server_id)!} />
-								) : (
-									row.server_id
-								)}
+								<MuiLink
+									component={RouterLink}
+									to={`/servers/${row.server_id}`}
+									underline="hover"
+									color="text.primary"
+								>
+									{byId.get(row.server_id)?.name ?? row.server_id}
+								</MuiLink>
 							</TableCell>
 							<TableCell>{row.target_version}</TableCell>
 							<TableCell>
@@ -123,12 +134,19 @@ export default function MigrationTestsSection({
 								)}
 							</TableCell>
 						</TableRow>
-					))}
+						))}
 				</TableBody>
 			</Table>
 		</Paper>
 	);
 }
+
+/// Problems first: a passing server is the row an operator scrolls past.
+const VERDICT_ORDER: Record<string, number> = {
+	failed: 0,
+	nottested: 1,
+	passed: 2,
+};
 
 function SectionHeading() {
 	return (

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -16,6 +16,7 @@ import RestoreIcon from "@mui/icons-material/RestoreFromTrash";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Link as RouterLink, useNavigate, useParams } from "react-router-dom";
 import GroupDomainsSection from "../components/GroupDomainsSection";
+import MigrationTestsSection from "../components/MigrationTestsSection";
 import { OperatorAvatar, connectedFor } from "../components/OperatorAvatars";
 import ServerShorty from "../components/ServerShorty";
 import SilencedRefsSection from "../components/SilencedRefsSection";
@@ -237,6 +238,8 @@ export default function GroupDetail() {
 			</Box>
 
 			<BackupsCard groupId={group.id} isAdmin={admin} />
+
+			<MigrationTestsSection groupId={group.id} servers={servers} />
 
 			<GroupDomainsSection groupId={group.id} />
 


### PR DESCRIPTION
Runs a candidate version's schema migrations against a restore replica of a deployment's real data, before that version reaches it. Spec folded into RST; implementation closes the loop from candidate through verdict to the operator's screen.

A migration that fails on real data, or one that succeeds but runs for hours, is a property of *that deployment's data*. Today both are discovered inside the maintenance window, with the deployment down. This answers it beforehand, and the per-migration timings say how long the window needs to be.

Four decisions a reviewer would otherwise flag:

**`migrate` is a semantic, not an intent.** An intent that already restores a snapshot to prove it restorable applies the migrations to that same replica, so one restore answers both questions. A migrate-only intent is possible and costs a second full restore, which is only worth different cadences.

**The report's two signals stay apart.** Outcome and replica health describe the restore; a named failing migration describes the migrations. A healthy restore whose migrations failed says the backup is fine and the *version* is not, so restore health and version readiness never contaminate each other.

**One candidate per server, the newest.** Which minor a deployment picks isn't Canopy's call, and testing every minor ahead would pay a restore for versions it won't choose. Coverage accumulates instead: snapshots are daily and releases far rarer, so each version gets tested while it is newest.

**A failed verdict settles the (snapshot, version) pair**, diverging from RST's `once` where failures retry. The same migration against the same snapshot fails identically, and a retry costs a full restore for a known answer.

Per Felix's review, the check is a **warning that does not escalate**: nothing is wrong with the live server, and the finding belongs to whoever decides if the version ships. Failures also file a known issue against the version, deduped per version and server so daily snapshots don't file it daily.

Recording which version a deployment *intends* to take is deliberately not here; it gets its own card and would change candidate derivation.

1067 tests green including Felix's certificate work, which is merged in. `schema.rs` needed one drift fix (`backup_restore_checks` was missing from the join allowlist); the rest of that drift is untouched.
