### PR TITLE
Planned upgrades (UPG)

### DIFF
--- a/.workhorse/specs/private-server/upgrade-plans.md
+++ b/.workhorse/specs/private-server/upgrade-plans.md
@@ -35,6 +35,11 @@ An operator records, per group:
 A group has at most one open plan.
 A group moves to one place next, so a second plan replaces the first rather than queueing behind it, and the replaced plan is retained as history.
 
+An open plan's date and note can be amended, and an amendment records who made it and when.
+A corrected date or a reworded note is the same plan better described, so it stays one plan rather than entering the history as a second.
+Changing the target is not an amendment: where a deployment is going is what the history exists to record, so a new target replaces the plan as any other second plan would.
+A plan that has been met or replaced is history and is no longer amendable.
+
 Plans are managed through the operator interface and are audited.
 Deleting a plan says the deployment is no longer going there; it does not say the upgrade happened.
 

--- a/.workhorse/specs/private-server/upgrade-plans.md
+++ b/.workhorse/specs/private-server/upgrade-plans.md
@@ -63,6 +63,7 @@ A plan changes what is tested, so changing one invalidates nothing already recor
 Canopy presents planned upgrades across the fleet in one view, so the question "what is moving, and when" is answered without reading each group.
 
 For each group with an open plan it shows the target version, the version the group is on now, the planned date where there is one, and the pre-upgrade verdict for that target, so an operator sees both the intent and whether the deployment's data survives it.
+Where an attempt is under way it shows that too, since a restore takes hours and a verdict of not-yet-tested otherwise looks the same whether the pipeline is working or has stopped.
 Groups with no plan are shown too: an unplanned deployment several minors behind is the thing this view exists to surface.
 
 A plan whose date has passed without being met is presented as late.

--- a/.workhorse/specs/private-server/upgrade-plans.md
+++ b/.workhorse/specs/private-server/upgrade-plans.md
@@ -1,0 +1,75 @@
+---
+id: UPG
+---
+
+# Planned upgrades
+
+Canopy records where each deployment is going: the version a group intends to move to, and optionally when.
+A plan makes the fleet's intended upgrades visible in one place, and it tells the rest of Canopy which version to hold a deployment's data against, so pre-upgrade testing exercises the version that will actually be applied rather than guessing.
+
+## Scope
+
+This spec covers what a plan records, who sets it, when Canopy considers it met, and what reads it.
+
+It does not cover performing an upgrade.
+Canopy serves versions to servers and records what they report running; the act of upgrading is the deployment's own, and a plan is a statement of intent rather than an instruction to anything.
+
+## Why it exists
+
+Canopy already knows what every server runs and every version that exists.
+What it cannot derive is where a deployment is going: which minor a deployment moves to next is a decision made by people, weighing what the release contains against what the site can absorb.
+
+Left unrecorded, that decision costs twice.
+Pre-upgrade migration testing has to guess, and guesses the newest published version, which is the right default and the wrong answer for a deployment deliberately moving to something older (see [RST](../public-server/restore-replicas.md)).
+And nobody can see at a glance which deployments are mid-plan, which are overdue to move, and which have no plan at all.
+
+## A plan
+
+An operator records, per group:
+
+- the **target version**, which must be a published version newer than the group is running;
+- an optional **planned date**, the day the upgrade is expected to happen;
+- an optional **note**, for whatever an operator needs the next reader to know;
+- who recorded it and when.
+
+A group has at most one open plan.
+A group moves to one place next, so a second plan replaces the first rather than queueing behind it, and the replaced plan is retained as history.
+
+Plans are managed through the operator interface and are audited.
+Deleting a plan says the deployment is no longer going there; it does not say the upgrade happened.
+
+A planned date is a plan, not a deadline.
+Canopy neither schedules nor blocks anything on it, and a date that passes changes only how the plan is presented.
+
+## When a plan is met
+
+Canopy decides a plan is met, rather than asking anyone to mark it done.
+A plan is met once the group's reported version has reached its target, at which point the plan closes and records when.
+
+Reaching a version *past* the target also meets the plan: a deployment that jumped further than planned has done the upgrade and then some, and holding the plan open would misreport it as outstanding.
+
+A met plan is retained.
+The record of what a deployment planned, when it planned it for, and when it actually landed is the fleet's upgrade history, and it is what makes "how long do our upgrades really take to happen" answerable.
+
+## What reads a plan
+
+Pre-upgrade migration testing takes its target from the open plan when a group has one, and falls back to the newest published version when it does not.
+A deployment planning to move to an older minor is then tested against that minor, and no restore is spent on a version nobody intends to apply.
+
+A plan changes what is tested, so changing one invalidates nothing already recorded: earlier verdicts stand against the versions they named, and the new target simply becomes the one that has not been tested yet.
+
+## The dashboard
+
+Canopy presents planned upgrades across the fleet in one view, so the question "what is moving, and when" is answered without reading each group.
+
+For each group with an open plan it shows the target version, the version the group is on now, the planned date where there is one, and the pre-upgrade verdict for that target, so an operator sees both the intent and whether the deployment's data survives it.
+Groups with no plan are shown too: an unplanned deployment several minors behind is the thing this view exists to surface.
+
+A plan whose date has passed without being met is presented as late.
+Late is a presentational state and not an incident: an upgrade slipping is normal operational reality, and Canopy has no basis for treating a date someone typed as a failure of anything.
+
+## Out of scope
+
+- Performing, scheduling, or triggering an upgrade.
+- Approving a plan, or gating who may record one beyond the existing operator permissions.
+- Planning anything other than a version move, such as an infrastructure migration.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -218,7 +218,8 @@ Canopy knows the version each server reports running and the upgrade path it wou
 
 Canopy decides which versions are tested against which servers, rather than an operator naming each pair.
 
-A server's candidate is the newest published version it could upgrade to: newer than the version it reports running, and on the upgrade path Canopy would serve it.
+A server's candidate is the version its group plans to move to, when a plan is open (see [UPG](../private-server/upgrade-plans.md)).
+Without a plan it is the newest published version the server could upgrade to: newer than the version it reports running, and on the upgrade path Canopy would serve it.
 
 One candidate, not one per version along the path.
 Migrations are applied to the restored snapshot in sequence, so a run targeting the newest version applies every migration between the snapshot's version and that one, and exercises the whole chain an upgrade would.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -286,6 +286,13 @@ Verdicts are presented per group, as the set of versions tested against that gro
 A verdict names the snapshot it was reached against and when that was, because a pass against a month-old snapshot is a weaker statement than one against last night's.
 A newer test of the same pair supersedes the previous verdict, and the superseded reports remain.
 
+Whether an attempt is under way is carried beside the verdict rather than folded into it.
+A restore takes hours, so a group with a test running would otherwise read as untested for the whole window, and a consumer that has quietly stopped would look the same as one that has not started.
+An attempt is in flight while credentials have been issued and not yet expired with no report, and is a run that ended without reporting once they have, exactly as [Restore-health reporting](#restore-health-reporting) already derives for restores.
+
+Keeping the two apart is what lets a pair read as failed with a fresh attempt already running.
+Folding the attempt into the verdict would overwrite the answer with the activity and lose the finding.
+
 ### Version readiness
 
 A failed migration test marks its target version as carrying a known issue, which removes that version from those considered ready to roll out, and records the server and the failing migration so whoever picks it up knows which deployment's data provoked it.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -224,7 +224,7 @@ Without a plan it is the newest published version the server could upgrade to: n
 One candidate, not one per version along the path.
 Migrations are applied to the restored snapshot in sequence, so a run targeting the newest version applies every migration between the snapshot's version and that one, and exercises the whole chain an upgrade would.
 
-Which minor a deployment moves to is a decision Canopy has no part in, and testing every minor ahead of a server would cost a full restore each to cover the ones it does not choose.
+Which minor a deployment moves to is not something Canopy can derive, and testing every minor ahead of a server would cost a full restore each to cover the ones it does not choose.
 It does not need to: coverage accumulates on its own.
 Snapshots arrive daily and releases far less often, so every version is tested against a deployment's data while it is the newest, and a deployment that later settles on an older minor already has a result from when that version was current.
 Where a chain does break, the failing migration named in the report identifies the step without a second run.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -240,15 +240,15 @@ That window is where the answer is still cheap: the fleet is not moving yet, and
 
 ### Dispatching a migration test
 
-`migrate` is a semantic an intent opts into, and it belongs on an intent of its own rather than on one that verifies backups.
-Such an intent still answers both questions from the one restore, since it carries `check` too: the replica's health and the migrations' outcome land as separate signals from a single report.
+`migrate` is a semantic an intent opts into, and an intent carrying it carries no other purpose.
+It carries `check` alongside, so a single restore reports the replica's health and the migrations' outcome as two signals from one report.
 
-Two things make `migrate` wrong to add to an intent that already does something else.
-The withholding rule below stops an intent carrying `migrate` from being dispatched at all for a server with no candidate, so on a verifying intent it would silently stop verifying the backups of every such server: any non-Tamanu product, and any deployment already on the newest version it could move to.
-And a replica whose data has been migrated sits at a version its deployment is not running, so an intent that keeps a replica queryable must never migrate, or promoting a declaration to it would hand an operator a replica whose schema does not match production.
+An intent carrying `migrate` is withheld from a server with no candidate version.
+An intent that verifies backups therefore does not also migrate: it would go undispatched for every server without a candidate, leaving the backups of any non-Tamanu product, and of any deployment already on the newest version available to it, unverified.
+An intent that keeps a replica queryable does not migrate either: a migrated replica sits at a version its deployment is not running, so a declaration promoted to it would give an operator a schema that does not match production.
 
-The second restore this implies is cheaper than it sounds.
-A verifying intent restores once per snapshot, while a migrating intent's `once` is keyed to the snapshot and target version together, so it restores when a new candidate appears rather than on every snapshot.
+A verifying intent and a migrating intent restore the same snapshot separately.
+A verifying intent restores once per snapshot, and a migrating intent's `once` is keyed to the snapshot and target version together, so it restores when a new candidate version appears rather than on every snapshot.
 
 An entry for a `migrate` intent names the target version alongside the snapshot.
 A consumer obtains that version's migrations from its published artefacts, the same way a server being upgraded does, so naming the version is the whole reference it needs.

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -240,12 +240,15 @@ That window is where the answer is still cheap: the fleet is not moving yet, and
 
 ### Dispatching a migration test
 
-`migrate` rides on an intent rather than being one, and that is the point.
-An intent that already restores a snapshot to prove it restorable can apply the migrations to that same replica, so one restore answers both questions: the backup is good, and the next version's migrations survive this deployment's data.
-A consumer that advertises `check`, `once` and `migrate` together reports the replica's health and the migrations' outcome from a single run, and the two land as separate signals from the one report.
+`migrate` is a semantic an intent opts into, and it belongs on an intent of its own rather than on one that verifies backups.
+Such an intent still answers both questions from the one restore, since it carries `check` too: the replica's health and the migrations' outcome land as separate signals from a single report.
 
-Declaring a migrate-only intent alongside a verifying one is possible and costs a second full restore of the same snapshot.
-That is worth paying only when the two need different cadences or overdue bounds, because a restore is the expensive part and the migrations are cheap next to it.
+Two things make `migrate` wrong to add to an intent that already does something else.
+The withholding rule below stops an intent carrying `migrate` from being dispatched at all for a server with no candidate, so on a verifying intent it would silently stop verifying the backups of every such server: any non-Tamanu product, and any deployment already on the newest version it could move to.
+And a replica whose data has been migrated sits at a version its deployment is not running, so an intent that keeps a replica queryable must never migrate, or promoting a declaration to it would hand an operator a replica whose schema does not match production.
+
+The second restore this implies is cheaper than it sounds.
+A verifying intent restores once per snapshot, while a migrating intent's `once` is keyed to the snapshot and target version together, so it restores when a new candidate appears rather than on every snapshot.
 
 An entry for a `migrate` intent names the target version alongside the snapshot.
 A consumer obtains that version's migrations from its published artefacts, the same way a server being upgraded does, so naming the version is the whole reference it needs.

--- a/crates/database/src/backup.rs
+++ b/crates/database/src/backup.rs
@@ -29,5 +29,8 @@ pub async fn sweep(db: &mut AsyncPgConnection) -> Result<usize> {
 	let mut filed = staleness::sweep(db, &rows).await?;
 	filed += reconcile::sweep(db, &rows).await?;
 	filed += crate::restore::sweep_overdue(db).await?;
+	// Not an event, but the same cadence: a plan closes once its group reports
+	// the target, and this sweep is what notices.
+	crate::upgrade_plans::close_met_plans(db).await?;
 	Ok(filed)
 }

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -39,6 +39,7 @@ pub mod stability;
 pub mod statuses;
 pub mod tags;
 pub mod tailscale_users;
+pub mod upgrade_plans;
 pub mod url_field;
 pub mod version_known_issues;
 pub mod versions;

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -62,6 +62,9 @@ pub fn upgrade_target(reported: &VersionStr, versions: &[Version]) -> Option<Uui
 
 /// The version `server` should be tested against, if any.
 ///
+/// Its group's planned target where there is one (see [`crate::upgrade_plans`]),
+/// otherwise the newest published version it could upgrade to.
+///
 /// Tamanu servers only: the migrations under test are Tamanu's, so no other
 /// product's server has an upgrade path through them. `None` also when the
 /// server has never reported a version, or is already on the newest published
@@ -70,6 +73,15 @@ pub fn upgrade_target(reported: &VersionStr, versions: &[Version]) -> Option<Uui
 pub async fn candidate_for(db: &mut AsyncPgConnection, server: &Server) -> Result<Option<Version>> {
 	if server.product != Product::Tamanu {
 		return Ok(None);
+	}
+
+	// Where the deployment says it is going beats where Canopy would guess: a
+	// group deliberately moving to an older minor is held against that minor,
+	// and no restore is spent on a version nobody intends to apply.
+	if let Some(group_id) = server.group_id
+		&& let Some(planned) = crate::upgrade_plans::planned_target(db, group_id).await?
+	{
+		return Ok(Some(planned));
 	}
 
 	let Some(reported) = ReportedDetail::last_version(db, server.id).await? else {

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -707,6 +707,20 @@ diesel::table! {
 }
 
 diesel::table! {
+	upgrade_plans (id) {
+		id -> Uuid,
+		group_id -> Uuid,
+		target_version_id -> Uuid,
+		planned_for -> Nullable<Date>,
+		note -> Nullable<Text>,
+		created_by -> Nullable<Text>,
+		created_at -> Timestamptz,
+		met_at -> Nullable<Timestamptz>,
+		superseded_at -> Nullable<Timestamptz>,
+	}
+}
+
+diesel::table! {
 	version_known_issues (id) {
 		id -> Uuid,
 		created_at -> Timestamptz,
@@ -797,6 +811,8 @@ diesel::joinable!(slack_outbox -> incidents (incident_id));
 diesel::joinable!(slack_outbox -> issues (issue_id));
 diesel::joinable!(statuses -> devices (device_id));
 diesel::joinable!(statuses -> servers (server_id));
+diesel::joinable!(upgrade_plans -> server_groups (group_id));
+diesel::joinable!(upgrade_plans -> versions (target_version_id));
 diesel::joinable!(version_known_issues -> servers (server_id));
 diesel::joinable!(versions -> devices (device_id));
 
@@ -851,6 +867,7 @@ diesel::allow_tables_to_appear_in_same_query!(
 	sql_playground_history,
 	statuses,
 	tailscale_users,
+	upgrade_plans,
 	version_known_issues,
 	versions,
 );

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -717,6 +717,8 @@ diesel::table! {
 		created_at -> Timestamptz,
 		met_at -> Nullable<Timestamptz>,
 		superseded_at -> Nullable<Timestamptz>,
+		amended_by -> Nullable<Text>,
+		amended_at -> Nullable<Timestamptz>,
 	}
 }
 

--- a/crates/database/src/upgrade_plans.rs
+++ b/crates/database/src/upgrade_plans.rs
@@ -46,6 +46,12 @@ pub struct UpgradePlan {
 	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
 	#[schema(value_type = Option<String>)]
 	pub superseded_at: Option<Timestamp>,
+	/// The operator who last amended the date or note, where one has.
+	pub amended_by: Option<String>,
+	/// When it was last amended.
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	#[schema(value_type = Option<String>)]
+	pub amended_at: Option<Timestamp>,
 }
 
 impl UpgradePlan {
@@ -160,6 +166,38 @@ impl UpgradePlan {
 			.load(db)
 			.await
 			.map_err(AppError::from)
+	}
+
+	/// Amend an open plan's date and note.
+	///
+	/// The same plan better described, so it is not superseded and does not
+	/// enter the history as a second plan. Changing where a deployment is going
+	/// is a replacement instead, so the target is not amendable here.
+	// spec: UPG#a-plan
+	pub async fn amend(
+		db: &mut AsyncPgConnection,
+		id: Uuid,
+		planned_for: Option<Date>,
+		note: Option<&str>,
+		amended_by: &str,
+	) -> Result<Self> {
+		use crate::schema::upgrade_plans::dsl;
+
+		diesel::update(dsl::upgrade_plans)
+			.filter(dsl::id.eq(id))
+			.filter(dsl::met_at.is_null())
+			.filter(dsl::superseded_at.is_null())
+			.set((
+				dsl::planned_for.eq(planned_for.map(jiff_diesel::Date::from)),
+				dsl::note.eq(note),
+				dsl::amended_by.eq(amended_by),
+				dsl::amended_at.eq(diesel::dsl::now),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.optional()?
+			.ok_or_else(|| AppError::BadRequest("only an open plan can be amended".into()))
 	}
 
 	/// Withdraw a plan: the deployment is no longer going there.

--- a/crates/database/src/upgrade_plans.rs
+++ b/crates/database/src/upgrade_plans.rs
@@ -20,6 +20,7 @@ use crate::{server_groups::ServerGroup, versions::Version};
 #[diesel(table_name = crate::schema::upgrade_plans)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct UpgradePlan {
+	/// Unique identifier for this plan.
 	pub id: Uuid,
 	/// The group that intends to move.
 	pub group_id: Uuid,
@@ -33,6 +34,7 @@ pub struct UpgradePlan {
 	pub note: Option<String>,
 	/// The operator who recorded it.
 	pub created_by: Option<String>,
+	/// When it was recorded.
 	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
 	#[schema(value_type = String)]
 	pub created_at: Timestamp,

--- a/crates/database/src/upgrade_plans.rs
+++ b/crates/database/src/upgrade_plans.rs
@@ -1,0 +1,235 @@
+//! Where each deployment is going: the version a group intends to move to, and
+//! optionally when.
+//!
+//! A plan is a statement of intent. Nothing here performs or schedules an
+//! upgrade; the date is presentational and Canopy decides a plan is met by
+//! watching what the group reports running.
+
+use commons_errors::{AppError, Result};
+use commons_types::version::VersionStr;
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::{Timestamp, civil::Date};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{server_groups::ServerGroup, versions::Version};
+
+/// A group's recorded intention to move to a version.
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::upgrade_plans)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct UpgradePlan {
+	pub id: Uuid,
+	/// The group that intends to move.
+	pub group_id: Uuid,
+	/// The version it intends to move to.
+	pub target_version_id: Uuid,
+	/// The day the upgrade is expected, where one is known.
+	#[diesel(deserialize_as = jiff_diesel::NullableDate, serialize_as = jiff_diesel::NullableDate)]
+	#[schema(value_type = Option<String>)]
+	pub planned_for: Option<Date>,
+	/// Whatever the operator needs the next reader to know.
+	pub note: Option<String>,
+	/// The operator who recorded it.
+	pub created_by: Option<String>,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	#[schema(value_type = String)]
+	pub created_at: Timestamp,
+	/// When the group's reported version reached the target.
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	#[schema(value_type = Option<String>)]
+	pub met_at: Option<Timestamp>,
+	/// When a newer plan replaced this one.
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	#[schema(value_type = Option<String>)]
+	pub superseded_at: Option<Timestamp>,
+}
+
+impl UpgradePlan {
+	/// Record where a group is going, retiring any plan it already had.
+	///
+	/// The target must be published and ahead of what the group runs: a plan to
+	/// move somewhere the deployment has already been is not a plan.
+	// spec: UPG#a-plan
+	pub async fn record(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		target_version_id: Uuid,
+		planned_for: Option<Date>,
+		note: Option<&str>,
+		created_by: &str,
+	) -> Result<Self> {
+		use crate::schema::upgrade_plans::dsl;
+
+		let target = Version::get_by_id(db, target_version_id).await?;
+		if target.status != commons_types::version::VersionStatus::Published {
+			return Err(AppError::BadRequest(
+				"an unpublished version cannot be planned for".into(),
+			));
+		}
+		if let Some(running) = ServerGroup::get_by_id(db, group_id)
+			.await?
+			.effective_version
+			.clone() && target.as_semver() <= running.0
+		{
+			return Err(AppError::BadRequest(format!(
+				"this group already runs {running}, which is not behind {}",
+				target.as_semver()
+			)));
+		}
+
+		diesel::update(dsl::upgrade_plans)
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::met_at.is_null())
+			.filter(dsl::superseded_at.is_null())
+			.set(dsl::superseded_at.eq(diesel::dsl::now))
+			.execute(db)
+			.await?;
+
+		diesel::insert_into(dsl::upgrade_plans)
+			.values((
+				dsl::group_id.eq(group_id),
+				dsl::target_version_id.eq(target_version_id),
+				dsl::planned_for.eq(planned_for.map(jiff_diesel::Date::from)),
+				dsl::note.eq(note),
+				dsl::created_by.eq(created_by),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// The group's open plan, if it has one.
+	// spec: UPG#a-plan
+	pub async fn open_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<Option<Self>> {
+		use crate::schema::upgrade_plans::dsl;
+
+		dsl::upgrade_plans
+			.select(Self::as_select())
+			.filter(dsl::group_id.eq(group_id))
+			.filter(dsl::met_at.is_null())
+			.filter(dsl::superseded_at.is_null())
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
+	/// Every plan a group has had, newest first.
+	// spec: UPG#when-a-plan-is-met
+	pub async fn history_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<Vec<Self>> {
+		use crate::schema::upgrade_plans::dsl;
+
+		dsl::upgrade_plans
+			.select(Self::as_select())
+			.filter(dsl::group_id.eq(group_id))
+			.order(dsl::created_at.desc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Every open plan across the fleet, newest first.
+	// spec: UPG#the-dashboard
+	pub async fn all_open(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::upgrade_plans::dsl;
+
+		dsl::upgrade_plans
+			.select(Self::as_select())
+			.filter(dsl::met_at.is_null())
+			.filter(dsl::superseded_at.is_null())
+			.order(dsl::created_at.desc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Withdraw a plan: the deployment is no longer going there.
+	pub async fn delete(db: &mut AsyncPgConnection, id: Uuid) -> Result<()> {
+		use crate::schema::upgrade_plans::dsl;
+
+		diesel::delete(dsl::upgrade_plans.filter(dsl::id.eq(id)))
+			.execute(db)
+			.await?;
+		Ok(())
+	}
+}
+
+/// Close every open plan whose group has reached its target, returning how many
+/// were closed.
+///
+/// Reaching a version past the target closes the plan too: a deployment that
+/// jumped further has done the upgrade and then some, and holding the plan open
+/// would report it as outstanding.
+// spec: UPG#when-a-plan-is-met
+pub async fn close_met_plans(db: &mut AsyncPgConnection) -> Result<usize> {
+	use crate::schema::upgrade_plans::dsl;
+
+	let mut closed = 0;
+	for plan in UpgradePlan::all_open(db).await? {
+		let Some(running) = ServerGroup::get_by_id(db, plan.group_id)
+			.await?
+			.effective_version
+			.clone()
+		else {
+			continue;
+		};
+		let target = Version::get_by_id(db, plan.target_version_id).await?;
+		if running.0 < target.as_semver() {
+			continue;
+		}
+
+		diesel::update(dsl::upgrade_plans)
+			.filter(dsl::id.eq(plan.id))
+			.set(dsl::met_at.eq(diesel::dsl::now))
+			.execute(db)
+			.await?;
+		closed += 1;
+	}
+
+	Ok(closed)
+}
+
+/// The version `group` plans to move to, if it has an open plan.
+///
+/// This is what pre-upgrade testing targets in preference to the newest
+/// published version, so a deployment deliberately moving to an older minor is
+/// held against that minor instead.
+// spec: UPG#what-reads-a-plan
+pub async fn planned_target(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<Option<Version>> {
+	let Some(plan) = UpgradePlan::open_for_group(db, group_id).await? else {
+		return Ok(None);
+	};
+	Version::get_by_id(db, plan.target_version_id)
+		.await
+		.map(Some)
+}
+
+/// Whether an open plan's date has passed without it being met.
+///
+/// Presentational only: an upgrade slipping is normal, and a date someone typed
+/// is no basis for treating anything as failed.
+// spec: UPG#the-dashboard
+pub fn is_late(plan: &UpgradePlan, today: Date) -> bool {
+	plan.met_at.is_none()
+		&& plan.superseded_at.is_none()
+		&& plan.planned_for.is_some_and(|date| date < today)
+}
+
+/// A plan's target rendered as semver, for display beside what the group runs.
+pub async fn target_version_str(
+	db: &mut AsyncPgConnection,
+	plan: &UpgradePlan,
+) -> Result<VersionStr> {
+	Version::get_by_id(db, plan.target_version_id)
+		.await
+		.map(|version| VersionStr(version.as_semver()))
+}

--- a/crates/database/src/upgrade_plans.rs
+++ b/crates/database/src/upgrade_plans.rs
@@ -100,7 +100,15 @@ impl UpgradePlan {
 			.returning(Self::as_select())
 			.get_result(db)
 			.await
-			.map_err(AppError::from)
+			.map_err(|e| match e {
+				diesel::result::Error::DatabaseError(
+					diesel::result::DatabaseErrorKind::UniqueViolation,
+					_,
+				) => AppError::Conflict(
+					"another plan was recorded for this group at the same time".into(),
+				),
+				e => AppError::from(e),
+			})
 	}
 
 	/// The group's open plan, if it has one.
@@ -210,9 +218,13 @@ pub async fn planned_target(db: &mut AsyncPgConnection, group_id: Uuid) -> Resul
 	let Some(plan) = UpgradePlan::open_for_group(db, group_id).await? else {
 		return Ok(None);
 	};
-	Version::get_by_id(db, plan.target_version_id)
-		.await
-		.map(Some)
+	let target = Version::get_by_id(db, plan.target_version_id).await?;
+	// A target yanked after the plan was recorded has no artefacts to fetch, so
+	// it cannot steer testing; the plan stays open for the operator to revisit.
+	if target.status != commons_types::version::VersionStatus::Published {
+		return Ok(None);
+	}
+	Ok(Some(target))
 }
 
 /// Whether an open plan's date has passed without it being met.

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -44,4 +44,5 @@ mod slack_outbox_enqueue;
 mod status_figures;
 mod statuses_device_fk;
 mod tag_reserved_prefix;
+mod upgrade_plans;
 mod version_known_issue_provenance;

--- a/crates/database/tests/it/upgrade_plans.rs
+++ b/crates/database/tests/it/upgrade_plans.rs
@@ -243,3 +243,149 @@ async fn a_date_that_has_passed_reads_as_late() {
 	})
 	.await
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn amending_a_plan_keeps_it_the_same_plan() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let target = publish(&mut conn, 61, 0).await;
+
+		let plan = UpgradePlan::record(
+			&mut conn,
+			group,
+			target.id,
+			Some(date(2026, 7, 1)),
+			Some("waiting on the site"),
+			"a@example.com",
+		)
+		.await
+		.expect("plan");
+
+		let amended = UpgradePlan::amend(
+			&mut conn,
+			plan.id,
+			Some(date(2026, 8, 14)),
+			Some("site confirmed the window"),
+			"b@example.com",
+		)
+		.await
+		.expect("amend");
+
+		assert_eq!(amended.id, plan.id, "the same plan, better described");
+		assert_eq!(
+			amended.target_version_id, target.id,
+			"the target is untouched"
+		);
+		assert_eq!(amended.planned_for, Some(date(2026, 8, 14)));
+		assert_eq!(amended.note.as_deref(), Some("site confirmed the window"));
+		assert_eq!(amended.amended_by.as_deref(), Some("b@example.com"));
+		assert!(amended.amended_at.is_some());
+		assert_eq!(
+			amended.created_by.as_deref(),
+			Some("a@example.com"),
+			"who recorded it is not overwritten by who amended it"
+		);
+		assert!(
+			amended.superseded_at.is_none(),
+			"an amendment is not a replacement"
+		);
+
+		let history = UpgradePlan::history_for_group(&mut conn, group)
+			.await
+			.expect("history");
+		assert_eq!(history.len(), 1, "amending does not add to the history");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn amending_can_clear_the_date_and_note() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let target = publish(&mut conn, 61, 0).await;
+
+		let plan = UpgradePlan::record(
+			&mut conn,
+			group,
+			target.id,
+			Some(date(2026, 7, 1)),
+			Some("waiting on the site"),
+			"a@example.com",
+		)
+		.await
+		.expect("plan");
+
+		let amended = UpgradePlan::amend(&mut conn, plan.id, None, None, "b@example.com")
+			.await
+			.expect("amend");
+
+		assert!(
+			amended.planned_for.is_none(),
+			"a date that is no longer expected can be taken off"
+		);
+		assert!(amended.note.is_none());
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_replaced_plan_is_not_amendable() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let first = publish(&mut conn, 61, 0).await;
+		let second = publish(&mut conn, 62, 0).await;
+
+		let replaced = UpgradePlan::record(&mut conn, group, first.id, None, None, "a@example.com")
+			.await
+			.expect("first plan");
+		UpgradePlan::record(&mut conn, group, second.id, None, None, "a@example.com")
+			.await
+			.expect("second plan");
+
+		let refused = UpgradePlan::amend(
+			&mut conn,
+			replaced.id,
+			Some(date(2026, 8, 1)),
+			None,
+			"b@example.com",
+		)
+		.await;
+		assert!(
+			refused.is_err(),
+			"a replaced plan is history and stands as it was"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_met_plan_is_not_amendable() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let target = publish(&mut conn, 61, 0).await;
+		let plan = UpgradePlan::record(&mut conn, group, target.id, None, None, "a@example.com")
+			.await
+			.expect("plan");
+
+		sql_query("UPDATE server_groups SET effective_version = '2.61.0' WHERE id = $1")
+			.bind::<sql_types::Uuid, _>(group)
+			.execute(&mut conn)
+			.await
+			.expect("arrive");
+		close_met_plans(&mut conn).await.expect("sweep");
+
+		let refused = UpgradePlan::amend(
+			&mut conn,
+			plan.id,
+			Some(date(2026, 8, 1)),
+			None,
+			"b@example.com",
+		)
+		.await;
+		assert!(
+			refused.is_err(),
+			"the upgrade happened; the record of it stands as it was"
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/upgrade_plans.rs
+++ b/crates/database/tests/it/upgrade_plans.rs
@@ -1,0 +1,244 @@
+//! Recording where a deployment is going, and what that changes: the planned
+//! version becomes what pre-upgrade testing holds the data against.
+
+use commons_tests::db::TestDb;
+use commons_types::version::{VersionStatus, VersionStr};
+use database::{
+	migration_tests::candidate_for,
+	reported_detail::ReportedDetail,
+	server_groups::ServerGroup,
+	servers::Server,
+	upgrade_plans::{UpgradePlan, close_met_plans, is_late, planned_target},
+	versions::{NewVersion, Version},
+};
+use diesel::{QueryableByName, SelectableHelper, sql_query, sql_types};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::civil::date;
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn publish(conn: &mut AsyncPgConnection, minor: i32, patch: i32) -> Version {
+	diesel::insert_into(database::schema::versions::table)
+		.values(NewVersion {
+			major: 2,
+			minor,
+			patch,
+			status: VersionStatus::Published,
+			changelog: String::new(),
+			device_id: None,
+		})
+		.returning(Version::as_returning())
+		.get_result(conn)
+		.await
+		.expect("publish")
+}
+
+/// A group with one server reporting `running`, and the group's cached
+/// effective version recomputed through the real path.
+async fn group_running(conn: &mut AsyncPgConnection, running: &str) -> (Uuid, Server) {
+	let group: RowId = sql_query("INSERT INTO server_groups (name) VALUES ('kamaka') RETURNING id")
+		.get_result(conn)
+		.await
+		.expect("group");
+	let server: RowId = sql_query(
+		"INSERT INTO servers (host, kind, group_id) VALUES ($1, 'central', $2) RETURNING id",
+	)
+	.bind::<sql_types::Text, _>("https://central.kamaka.example")
+	.bind::<sql_types::Uuid, _>(group.id)
+	.get_result(conn)
+	.await
+	.expect("server");
+
+	let version: VersionStr = running.parse().expect("parse");
+	ReportedDetail::record(
+		conn,
+		server.id,
+		"test",
+		&serde_json::json!({}),
+		Some(&version),
+	)
+	.await
+	.expect("report");
+	sql_query(
+		"INSERT INTO statuses (server_id, version, healthy, health) VALUES ($1, $2, true, '[]'::jsonb)",
+	)
+	.bind::<sql_types::Uuid, _>(server.id)
+	.bind::<sql_types::Text, _>(running)
+	.execute(conn)
+	.await
+	.expect("status");
+	ServerGroup::recompute_version(conn, group.id)
+		.await
+		.expect("recompute");
+
+	let server = Server::get_by_id(conn, server.id)
+		.await
+		.expect("get server");
+	(group.id, server)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_plan_overrides_the_newest_version_as_the_test_target() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, server) = group_running(&mut conn, "2.60.0").await;
+		let intended = publish(&mut conn, 61, 2).await;
+		let newest = publish(&mut conn, 63, 0).await;
+
+		// With no plan, testing aims at the newest published version.
+		assert_eq!(
+			candidate_for(&mut conn, &server)
+				.await
+				.expect("candidate")
+				.map(|v| v.id),
+			Some(newest.id),
+		);
+
+		UpgradePlan::record(
+			&mut conn,
+			group,
+			intended.id,
+			Some(date(2026, 8, 14)),
+			Some("site can absorb 2.61 only"),
+			"someone@example.com",
+		)
+		.await
+		.expect("record plan");
+
+		// With one, it aims where the deployment says it is going.
+		assert_eq!(
+			candidate_for(&mut conn, &server)
+				.await
+				.expect("candidate")
+				.map(|v| v.id),
+			Some(intended.id),
+			"no restore is spent on a version nobody intends to apply"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recording_a_plan_retires_the_one_before_it() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let first = publish(&mut conn, 61, 0).await;
+		let second = publish(&mut conn, 62, 0).await;
+
+		UpgradePlan::record(&mut conn, group, first.id, None, None, "a@example.com")
+			.await
+			.expect("first plan");
+		UpgradePlan::record(&mut conn, group, second.id, None, None, "a@example.com")
+			.await
+			.expect("second plan");
+
+		let open = UpgradePlan::open_for_group(&mut conn, group)
+			.await
+			.expect("open")
+			.expect("there is one");
+		assert_eq!(
+			open.target_version_id, second.id,
+			"a group goes one place next"
+		);
+
+		let history = UpgradePlan::history_for_group(&mut conn, group)
+			.await
+			.expect("history");
+		assert_eq!(history.len(), 2, "the retired plan is kept");
+		let retired = history
+			.iter()
+			.find(|plan| plan.target_version_id == first.id)
+			.expect("the first plan");
+		assert!(retired.superseded_at.is_some());
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_plan_cannot_aim_at_where_the_group_already_is() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.62.0").await;
+		let behind = publish(&mut conn, 61, 0).await;
+
+		let refused =
+			UpgradePlan::record(&mut conn, group, behind.id, None, None, "a@example.com").await;
+		assert!(refused.is_err(), "a plan to go backwards is not a plan");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn canopy_closes_a_plan_once_the_group_arrives() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let target = publish(&mut conn, 61, 0).await;
+		UpgradePlan::record(&mut conn, group, target.id, None, None, "a@example.com")
+			.await
+			.expect("plan");
+
+		assert_eq!(
+			close_met_plans(&mut conn).await.expect("sweep"),
+			0,
+			"still on its way"
+		);
+
+		// The deployment lands past the target: further than planned still means
+		// the upgrade happened.
+		sql_query("UPDATE server_groups SET effective_version = '2.62.0' WHERE id = $1")
+			.bind::<sql_types::Uuid, _>(group)
+			.execute(&mut conn)
+			.await
+			.expect("arrive");
+
+		assert_eq!(close_met_plans(&mut conn).await.expect("sweep"), 1);
+		assert!(
+			UpgradePlan::open_for_group(&mut conn, group)
+				.await
+				.expect("open")
+				.is_none(),
+			"a met plan is closed, not left outstanding"
+		);
+		assert!(
+			planned_target(&mut conn, group)
+				.await
+				.expect("target")
+				.is_none(),
+			"and stops steering the test target"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_date_that_has_passed_reads_as_late() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let target = publish(&mut conn, 61, 0).await;
+		let plan = UpgradePlan::record(
+			&mut conn,
+			group,
+			target.id,
+			Some(date(2026, 7, 1)),
+			None,
+			"a@example.com",
+		)
+		.await
+		.expect("plan");
+
+		assert!(is_late(&plan, date(2026, 7, 30)));
+		assert!(!is_late(&plan, date(2026, 6, 30)));
+
+		let undated = UpgradePlan::record(&mut conn, group, target.id, None, None, "a@example.com")
+			.await
+			.expect("undated plan");
+		assert!(
+			!is_late(&undated, date(2026, 7, 30)),
+			"no date means nothing to be late against"
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/upgrade_plans.rs
+++ b/crates/database/tests/it/upgrade_plans.rs
@@ -194,7 +194,8 @@ async fn canopy_closes_a_plan_once_the_group_arrives() {
 			.await
 			.expect("arrive");
 
-		assert_eq!(close_met_plans(&mut conn).await.expect("sweep"), 1);
+		// Through the periodic sweep, which is what runs in production.
+		database::backup::sweep(&mut conn).await.expect("sweep");
 		assert!(
 			UpgradePlan::open_for_group(&mut conn, group)
 				.await

--- a/crates/private-server/src/fns.rs
+++ b/crates/private-server/src/fns.rs
@@ -20,6 +20,7 @@ pub mod servers;
 pub mod silenced_refs;
 pub mod sql;
 pub mod statuses;
+pub mod upgrade_plans;
 pub mod versions;
 
 /// A single page of a paginated list response.
@@ -72,6 +73,7 @@ pub fn routes() -> OpenApiRouter<crate::state::AppState> {
 			.nest("/silenced_refs", silenced_refs::routes())
 			.nest("/sql", sql::routes())
 			.nest("/statuses", statuses::routes())
+			.nest("/upgrade_plans", upgrade_plans::routes())
 			.nest("/versions", versions::routes()),
 	)
 }

--- a/crates/private-server/src/fns/migration_tests.rs
+++ b/crates/private-server/src/fns/migration_tests.rs
@@ -106,6 +106,15 @@ pub async fn attempt_state(
 
 	let (_starts, attempts) = crate::run_pairing::pair_issuances(issuances, &report_refs);
 
+	// A chain abandoned before the newest report is history, not the pipeline's
+	// current state: something has reported since, so showing it would nag about
+	// a run already superseded.
+	let newest_report = report_refs.iter().map(|r| r.reported_at).max();
+	let attempts: Vec<_> = attempts
+		.into_iter()
+		.filter(|a| newest_report.is_none_or(|newest| a.latest_expires > newest))
+		.collect();
+
 	// An in-flight attempt is the more useful of the two to report, since it
 	// says the pipeline is working right now.
 	let newest_in_flight = attempts

--- a/crates/private-server/src/fns/migration_tests.rs
+++ b/crates/private-server/src/fns/migration_tests.rs
@@ -4,7 +4,7 @@ use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
 use database::migration_tests::GroupVerdict;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -49,4 +49,73 @@ pub async fn for_group(
 	let mut conn = state.db.get().await?;
 	let verdicts = database::migration_tests::verdicts_for_group(&mut conn, args.group_id).await?;
 	Ok(Json(verdicts))
+}
+
+/// Whether a restore attempt is under way for a group, for showing beside a
+/// verdict.
+///
+/// Group-level, because credentials are issued per `(group, type)`: RST scopes
+/// them that way since one repo holds all of a group's snapshots, so this is the
+/// finest granularity the signal honestly has.
+// spec: RST#verdicts
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AttemptState {
+	/// Credentials were issued and have not expired with no report yet.
+	InFlight,
+	/// Credentials expired with no report: it ran and never said how it went.
+	EndedWithoutReport,
+}
+
+/// The state of the newest unreported restore attempt for `group_id`, if any.
+///
+/// A restore takes hours, so without this a group mid-test reads as untested for
+/// the whole window and a consumer that has stopped looks the same as one that
+/// never started.
+// spec: RST#verdicts
+pub async fn attempt_state(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	group_id: Uuid,
+	now: jiff::Timestamp,
+) -> Result<Option<AttemptState>> {
+	use database::backups::BackupCredentialIssuance;
+
+	let reports =
+		database::restore::BackupRestoreCheck::list_recent_for_group(conn, group_id, 50).await?;
+	let since =
+		crate::run_pairing::issuance_since(now, reports.iter().map(|c| c.reported_at).min());
+	let issuances: Vec<_> =
+		BackupCredentialIssuance::list_for_group_since(conn, group_id, since, 200)
+			.await?
+			.into_iter()
+			.filter(|i| i.purpose == commons_types::backup::BackupPurpose::Restore)
+			.collect();
+
+	let report_refs: Vec<crate::run_pairing::ReportRef> = reports
+		.iter()
+		.map(|c| crate::run_pairing::ReportRef {
+			run_id: c.run_id,
+			key: crate::run_pairing::run_key(
+				c.consumer_device_id,
+				&c.r#type,
+				commons_types::backup::BackupPurpose::Restore,
+			),
+			reported_at: c.reported_at,
+		})
+		.collect();
+
+	let (_starts, attempts) = crate::run_pairing::pair_issuances(issuances, &report_refs);
+
+	// An in-flight attempt is the more useful of the two to report, since it
+	// says the pipeline is working right now.
+	let newest_in_flight = attempts
+		.iter()
+		.any(|a| matches!(a.status(now), crate::run_pairing::RunStatus::InProgress));
+	if newest_in_flight {
+		return Ok(Some(AttemptState::InFlight));
+	}
+	if attempts.is_empty() {
+		return Ok(None);
+	}
+	Ok(Some(AttemptState::EndedWithoutReport))
 }

--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -17,6 +17,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 		.routes(routes!(targets))
 		.routes(routes!(for_group))
 		.routes(routes!(record))
+		.routes(routes!(amend))
 		.routes(routes!(withdraw))
 }
 
@@ -288,6 +289,54 @@ pub async fn record(
 		&admin.0.login,
 	)
 	.await?;
+	Ok(Json(plan))
+}
+
+/// Request body for amending an open plan.
+#[derive(Deserialize, ToSchema)]
+pub struct AmendArgs {
+	/// The plan to amend.
+	pub id: Uuid,
+	/// The day it is expected to happen, as `YYYY-MM-DD`. Cleared when absent.
+	#[schema(value_type = Option<String>)]
+	pub planned_for: Option<Date>,
+	/// Anything the next reader needs to know. Cleared when absent.
+	pub note: Option<String>,
+}
+
+/// Amend an open plan's date and note.
+///
+/// The same plan better described, so it keeps its place in the history rather
+/// than being replaced. Moving a group to a different version is a new plan:
+/// record that instead.
+// spec: UPG#a-plan
+#[utoipa::path(
+	post,
+	path = "/amend",
+	operation_id = "upgrade_plans_amend",
+	tag = "upgrade_plans",
+	security(("tailscale-admin" = [])),
+	request_body = AmendArgs,
+	responses(
+		(status = 200, description = "The amended plan.", body = UpgradePlan),
+		(status = 400, description = "The plan has been met or replaced, so it is history.", body = ProblemDetailsSchema),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn amend(
+	State(state): State<AppState>,
+	admin: TailscaleAdmin,
+	Json(args): Json<AmendArgs>,
+) -> Result<Json<UpgradePlan>> {
+	let mut conn = state.db.get().await?;
+	let note = args
+		.note
+		.as_deref()
+		.map(str::trim)
+		.filter(|n| !n.is_empty());
+	let plan =
+		UpgradePlan::amend(&mut conn, args.id, args.planned_for, note, &admin.0.login).await?;
 	Ok(Json(plan))
 }
 

--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -40,6 +40,10 @@ pub struct PlannedUpgrade {
 	/// its servers: any failure makes the group a failure, since one server
 	/// whose data breaks is enough to stop the upgrade. `null` without a plan.
 	pub verdict: Option<String>,
+	/// Whether a restore attempt is under way, carried beside the verdict rather
+	/// than folded into it: a restore takes hours, so a group mid-test would
+	/// otherwise read as untested for the whole window.
+	pub attempt: Option<crate::fns::migration_tests::AttemptState>,
 }
 
 /// Planned upgrades across the fleet.
@@ -68,6 +72,7 @@ pub async fn fleet(
 	// Late is judged against the server's own day; nothing depends on it beyond
 	// presentation.
 	let today = Zoned::now().date();
+	let now_ts = jiff::Timestamp::now();
 
 	let mut out = Vec::new();
 	for group in database::server_groups::ServerGroup::list_all(&mut conn).await? {
@@ -96,6 +101,13 @@ pub async fn fleet(
 			}
 		};
 
+		let attempt = match &plan {
+			None => None,
+			Some(_) => {
+				crate::fns::migration_tests::attempt_state(&mut conn, group.id, now_ts).await?
+			}
+		};
+
 		out.push(PlannedUpgrade {
 			group_id: group.id,
 			group_name: group.name,
@@ -104,6 +116,7 @@ pub async fn fleet(
 			target_version: target,
 			late,
 			verdict,
+			attempt,
 		});
 	}
 

--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -14,6 +14,7 @@ use crate::state::AppState;
 pub fn routes() -> OpenApiRouter<AppState> {
 	OpenApiRouter::new()
 		.routes(routes!(fleet))
+		.routes(routes!(targets))
 		.routes(routes!(for_group))
 		.routes(routes!(record))
 		.routes(routes!(withdraw))
@@ -35,6 +36,10 @@ pub struct PlannedUpgrade {
 	/// Whether the planned date has passed without the upgrade happening.
 	/// Presentational: a slipping upgrade is normal operational reality.
 	pub late: bool,
+	/// Where the group's data stands against the planned version, rolled up from
+	/// its servers: any failure makes the group a failure, since one server
+	/// whose data breaks is enough to stop the upgrade. `null` without a plan.
+	pub verdict: Option<String>,
 }
 
 /// Planned upgrades across the fleet.
@@ -79,6 +84,18 @@ pub async fn fleet(
 			.as_ref()
 			.is_some_and(|plan| database::upgrade_plans::is_late(plan, today));
 
+		// The plan says where the group is going; the verdict says whether its
+		// data survives getting there. Pairing them is what makes this view
+		// worth reading.
+		let verdict = match &plan {
+			None => None,
+			Some(_) => {
+				let per_server =
+					database::migration_tests::verdicts_for_group(&mut conn, group.id).await?;
+				Some(roll_up(&per_server).to_owned())
+			}
+		};
+
 		out.push(PlannedUpgrade {
 			group_id: group.id,
 			group_name: group.name,
@@ -86,10 +103,30 @@ pub async fn fleet(
 			plan,
 			target_version: target,
 			late,
+			verdict,
 		});
 	}
 
 	Ok(Json(out))
+}
+
+/// The group's standing against its planned version: the worst of its servers'.
+///
+/// One server whose data breaks the migrations is enough to stop the upgrade, so
+/// a failure anywhere is the group's answer.
+fn roll_up(per_server: &[database::migration_tests::GroupVerdict]) -> &'static str {
+	use database::migration_tests::Verdict;
+
+	if per_server.is_empty() {
+		return "nottested";
+	}
+	if per_server.iter().any(|v| v.verdict == Verdict::Failed) {
+		return "failed";
+	}
+	if per_server.iter().any(|v| v.verdict == Verdict::NotTested) {
+		return "nottested";
+	}
+	"passed"
 }
 
 /// Request body for reading one group's plans. Named apart from the
@@ -127,6 +164,62 @@ pub async fn for_group(
 	Ok(Json(
 		UpgradePlan::history_for_group(&mut conn, args.group_id).await?,
 	))
+}
+
+/// A version a group could be planned onto.
+#[derive(Serialize, ToSchema)]
+pub struct PlannableVersion {
+	/// The version's identifier, for `record`.
+	pub id: Uuid,
+	/// Its semver.
+	pub version: String,
+}
+
+/// The versions a group could be planned onto: published, and ahead of what it
+/// runs.
+///
+/// Offering only valid targets is what keeps the operator from picking one
+/// `record` would refuse.
+// spec: UPG#a-plan
+#[utoipa::path(
+	post,
+	path = "/targets",
+	operation_id = "upgrade_plans_targets",
+	tag = "upgrade_plans",
+	security(("tailscale-admin" = [])),
+	request_body = PlansForGroupArgs,
+	responses(
+		(status = 200, description = "Plannable versions, newest first.", body = Vec<PlannableVersion>),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn targets(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<PlansForGroupArgs>,
+) -> Result<Json<Vec<PlannableVersion>>> {
+	let mut conn = state.db.get().await?;
+	let running = database::server_groups::ServerGroup::get_by_id(&mut conn, args.group_id)
+		.await?
+		.effective_version;
+
+	let mut out: Vec<PlannableVersion> = database::versions::Version::get_all(&mut conn)
+		.await?
+		.into_iter()
+		.filter(|version| {
+			running
+				.as_ref()
+				.is_none_or(|running| version.as_semver() > running.0)
+		})
+		.map(|version| PlannableVersion {
+			id: version.id,
+			version: version.as_semver().to_string(),
+		})
+		.collect();
+	// get_all is already newest-first; keep that for the picker.
+	out.truncate(50);
+	Ok(Json(out))
 }
 
 /// Request body for recording where a group is going.

--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -1,0 +1,221 @@
+use axum::Json;
+use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
+use commons_errors::{ProblemDetailsSchema, Result};
+use commons_servers::tailscale_auth::TailscaleAdmin;
+use database::upgrade_plans::UpgradePlan;
+use jiff::{Zoned, civil::Date};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::state::AppState;
+
+pub fn routes() -> OpenApiRouter<AppState> {
+	OpenApiRouter::new()
+		.routes(routes!(fleet))
+		.routes(routes!(for_group))
+		.routes(routes!(record))
+		.routes(routes!(withdraw))
+}
+
+/// One row of the planned-upgrades view.
+#[derive(Serialize, ToSchema)]
+pub struct PlannedUpgrade {
+	/// The group this concerns.
+	pub group_id: Uuid,
+	/// Its name, so the view reads without a second lookup.
+	pub group_name: String,
+	/// The version the group runs now, where it has reported one.
+	pub current_version: Option<String>,
+	/// The plan, absent for a group with none.
+	pub plan: Option<UpgradePlan>,
+	/// The plan's target as semver.
+	pub target_version: Option<String>,
+	/// Whether the planned date has passed without the upgrade happening.
+	/// Presentational: a slipping upgrade is normal operational reality.
+	pub late: bool,
+}
+
+/// Planned upgrades across the fleet.
+///
+/// Every live group, whether or not it has a plan. A group several minors
+/// behind with no plan is the thing this view exists to surface, so it is listed
+/// rather than omitted.
+// spec: UPG#the-dashboard
+#[utoipa::path(
+	post,
+	path = "/fleet",
+	operation_id = "upgrade_plans_fleet",
+	tag = "upgrade_plans",
+	security(("tailscale-admin" = [])),
+	responses(
+		(status = 200, description = "One row per live group.", body = Vec<PlannedUpgrade>),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn fleet(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+) -> Result<Json<Vec<PlannedUpgrade>>> {
+	let mut conn = state.db.get().await?;
+	// Late is judged against the server's own day; nothing depends on it beyond
+	// presentation.
+	let today = Zoned::now().date();
+
+	let mut out = Vec::new();
+	for group in database::server_groups::ServerGroup::list_all(&mut conn).await? {
+		let plan = UpgradePlan::open_for_group(&mut conn, group.id).await?;
+		let target = match &plan {
+			Some(plan) => Some(
+				database::upgrade_plans::target_version_str(&mut conn, plan)
+					.await?
+					.to_string(),
+			),
+			None => None,
+		};
+		let late = plan
+			.as_ref()
+			.is_some_and(|plan| database::upgrade_plans::is_late(plan, today));
+
+		out.push(PlannedUpgrade {
+			group_id: group.id,
+			group_name: group.name,
+			current_version: group.effective_version.map(|v| v.to_string()),
+			plan,
+			target_version: target,
+			late,
+		});
+	}
+
+	Ok(Json(out))
+}
+
+/// Request body for reading one group's plans. Named apart from the
+/// migration-test one because utoipa keys component schemas by short name.
+#[derive(Deserialize, ToSchema)]
+pub struct PlansForGroupArgs {
+	/// The group to read.
+	pub group_id: Uuid,
+}
+
+/// A group's plan and the plans it has had before.
+///
+/// The history is the record of what a deployment planned, when for, and when
+/// it landed.
+// spec: UPG#when-a-plan-is-met
+#[utoipa::path(
+	post,
+	path = "/for_group",
+	operation_id = "upgrade_plans_for_group",
+	tag = "upgrade_plans",
+	security(("tailscale-admin" = [])),
+	request_body = PlansForGroupArgs,
+	responses(
+		(status = 200, description = "Every plan the group has had, newest first.", body = Vec<UpgradePlan>),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn for_group(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<PlansForGroupArgs>,
+) -> Result<Json<Vec<UpgradePlan>>> {
+	let mut conn = state.db.get().await?;
+	Ok(Json(
+		UpgradePlan::history_for_group(&mut conn, args.group_id).await?,
+	))
+}
+
+/// Request body for recording where a group is going.
+#[derive(Deserialize, ToSchema)]
+pub struct RecordArgs {
+	/// The group that intends to move.
+	pub group_id: Uuid,
+	/// The published version it intends to move to.
+	pub target_version_id: Uuid,
+	/// The day it is expected to happen, as `YYYY-MM-DD`. Optional.
+	#[schema(value_type = Option<String>)]
+	pub planned_for: Option<Date>,
+	/// Anything the next reader needs to know. Optional.
+	pub note: Option<String>,
+}
+
+/// Record where a group is going, retiring any plan it already had.
+///
+/// A group goes one place next, so this replaces rather than queues. The target
+/// must be published and ahead of what the group runs.
+// spec: UPG#a-plan
+#[utoipa::path(
+	post,
+	path = "/record",
+	operation_id = "upgrade_plans_record",
+	tag = "upgrade_plans",
+	security(("tailscale-admin" = [])),
+	request_body = RecordArgs,
+	responses(
+		(status = 200, description = "The recorded plan.", body = UpgradePlan),
+		(status = 400, description = "The target is unpublished, or not ahead of the group.", body = ProblemDetailsSchema),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn record(
+	State(state): State<AppState>,
+	admin: TailscaleAdmin,
+	Json(args): Json<RecordArgs>,
+) -> Result<Json<UpgradePlan>> {
+	let mut conn = state.db.get().await?;
+	let note = args
+		.note
+		.as_deref()
+		.map(str::trim)
+		.filter(|n| !n.is_empty());
+	let plan = UpgradePlan::record(
+		&mut conn,
+		args.group_id,
+		args.target_version_id,
+		args.planned_for,
+		note,
+		&admin.0.login,
+	)
+	.await?;
+	Ok(Json(plan))
+}
+
+/// Request body for withdrawing a plan.
+#[derive(Deserialize, ToSchema)]
+pub struct WithdrawArgs {
+	/// The plan to withdraw.
+	pub id: Uuid,
+}
+
+/// Withdraw a plan: the deployment is no longer going there.
+///
+/// This does not say the upgrade happened. Canopy closes a met plan on its own
+/// once the group reports the target.
+// spec: UPG#a-plan
+#[utoipa::path(
+	post,
+	path = "/withdraw",
+	operation_id = "upgrade_plans_withdraw",
+	tag = "upgrade_plans",
+	security(("tailscale-admin" = [])),
+	request_body = WithdrawArgs,
+	responses(
+		(status = 200, description = "Withdrawn (idempotent)."),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn withdraw(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+	Json(args): Json<WithdrawArgs>,
+) -> Result<Json<()>> {
+	let mut conn = state.db.get().await?;
+	UpgradePlan::delete(&mut conn, args.id).await?;
+	Ok(Json(()))
+}

--- a/crates/private-server/src/openapi.rs
+++ b/crates/private-server/src/openapi.rs
@@ -27,6 +27,7 @@ use utoipa::{
 		(name = "incidents", description = "Operational incidents (groups of issues against a server)."),
 		(name = "issues", description = "Per-server issues raised from device events."),
 		(name = "mcp_tokens", description = "Bearer tokens for the public MCP mount."),
+		(name = "upgrade_plans", description = "Where each deployment is going: the version a group intends to move to, and when."),
 		(name = "migration_tests", description = "Where each server stands against the version it would take next."),
 		(name = "restore_replicas", description = "Managed restore replicas: capabilities, worklist, and health."),
 		(name = "self_alerts", description = "Canopy's alerts about its own operation."),

--- a/crates/private-server/tests/it/main.rs
+++ b/crates/private-server/tests/it/main.rs
@@ -31,5 +31,6 @@ mod tailnet_device_auth;
 mod tailnet_key_expiry_sweep;
 mod tailscale_header;
 mod update_server;
+mod upgrade_plans;
 mod version_known_issues;
 mod versions;

--- a/crates/private-server/tests/it/upgrade_plans.rs
+++ b/crates/private-server/tests/it/upgrade_plans.rs
@@ -87,3 +87,61 @@ async fn a_target_behind_the_group_is_refused() {
 	})
 	.await;
 }
+
+/// A restore takes hours, so a group mid-test must not read as untested: an
+/// issuance with no report yet is an attempt in flight.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_attempt_in_flight_shows_beside_the_verdict() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+				('cccccccc-0000-0000-0000-0000000000f1', 2, 61, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');
+			INSERT INTO devices (id, role) VALUES
+				('cccccccc-0000-0000-0000-0000000000d0', 'backup-restore');
+			INSERT INTO upgrade_plans (group_id, target_version_id) VALUES
+				('cccccccc-0000-0000-0000-000000000001',
+				 'cccccccc-0000-0000-0000-0000000000f1');",
+		)
+		.await
+		.unwrap();
+
+		let before: Vec<Value> = private
+			.post("/api/upgrade_plans/fleet")
+			.json(&json!({}))
+			.await
+			.json();
+		let row = before.iter().find(|r| r["group_id"] == GROUP).unwrap();
+		assert!(row["attempt"].is_null(), "nothing has started");
+
+		// Credentials issued, still valid, nothing reported: a restore is running.
+		conn.batch_execute(
+			"INSERT INTO backup_credential_issuances
+				(device_id, group_id, type, purpose, issued_at, expires_at,
+				 sts_assumed_role, bucket, prefix)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'restore',
+				NOW() - INTERVAL '20 minutes', NOW() + INTERVAL '40 minutes',
+				'arn:aws:iam::1:role/r', 'b', '')",
+		)
+		.await
+		.unwrap();
+
+		let during: Vec<Value> = private
+			.post("/api/upgrade_plans/fleet")
+			.json(&json!({}))
+			.await
+			.json();
+		let row = during.iter().find(|r| r["group_id"] == GROUP).unwrap();
+		assert_eq!(
+			row["attempt"], "in_flight",
+			"a group mid-test does not read as merely untested"
+		);
+		assert_eq!(
+			row["verdict"], "nottested",
+			"and the verdict is untouched by the activity"
+		);
+	})
+	.await;
+}

--- a/crates/private-server/tests/it/upgrade_plans.rs
+++ b/crates/private-server/tests/it/upgrade_plans.rs
@@ -1,0 +1,89 @@
+//! Recording where a deployment is going, through the operator API, and reading
+//! the fleet view that surfaces it.
+
+use commons_tests::diesel_async::SimpleAsyncConnection;
+use serde_json::{Value, json};
+
+const GROUP: &str = "cccccccc-0000-0000-0000-000000000001";
+const UNPLANNED: &str = "cccccccc-0000-0000-0000-000000000002";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn record_then_the_fleet_view_shows_it() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+				('cccccccc-0000-0000-0000-0000000000f1', 2, 61, 0, 'x', 'published'),
+				('cccccccc-0000-0000-0000-0000000000f2', 2, 63, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0'),
+				('cccccccc-0000-0000-0000-000000000002', 'no-plan', '2.60.0');",
+		)
+		.await
+		.unwrap();
+
+		// Planning the older minor deliberately: the site can only absorb 2.61.
+		let resp = private
+			.post("/api/upgrade_plans/record")
+			.json(&json!({
+				"group_id": GROUP,
+				"target_version_id": "cccccccc-0000-0000-0000-0000000000f1",
+				// Long past, so `late` is stable however far in the future this
+				// test runs. Date arithmetic itself is unit-tested with injected days.
+				"planned_for": "2020-01-01",
+				"note": "site can absorb 2.61 only",
+			}))
+			.await;
+		resp.assert_status_ok();
+		let plan: Value = resp.json();
+		assert_eq!(plan["planned_for"], "2020-01-01");
+		assert_eq!(plan["note"], "site can absorb 2.61 only");
+
+		let fleet: Vec<Value> = private
+			.post("/api/upgrade_plans/fleet")
+			.json(&json!({}))
+			.await
+			.json();
+
+		let planned = fleet
+			.iter()
+			.find(|row| row["group_id"] == GROUP)
+			.expect("the planned group");
+		assert_eq!(planned["target_version"], "2.61.0");
+		assert_eq!(planned["current_version"], "2.60.0");
+		assert_eq!(planned["late"], true, "the planned day has passed unmet");
+
+		// A group with no plan is still listed: an unplanned deployment several
+		// minors behind is what the view exists to surface.
+		let unplanned = fleet
+			.iter()
+			.find(|row| row["group_id"] == UNPLANNED)
+			.expect("the unplanned group");
+		assert!(unplanned["plan"].is_null());
+		assert_eq!(unplanned["late"], false);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_target_behind_the_group_is_refused() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+				('cccccccc-0000-0000-0000-0000000000f1', 2, 61, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'ahead', '2.62.0');",
+		)
+		.await
+		.unwrap();
+
+		private
+			.post("/api/upgrade_plans/record")
+			.json(&json!({
+				"group_id": GROUP,
+				"target_version_id": "cccccccc-0000-0000-0000-0000000000f1",
+			}))
+			.await
+			.assert_status_bad_request();
+	})
+	.await;
+}

--- a/crates/private-server/tests/it/upgrade_plans.rs
+++ b/crates/private-server/tests/it/upgrade_plans.rs
@@ -145,3 +145,105 @@ async fn an_attempt_in_flight_shows_beside_the_verdict() {
 	})
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn amend_changes_the_date_and_note_without_replacing_the_plan() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+				('cccccccc-0000-0000-0000-0000000000f1', 2, 61, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');",
+		)
+		.await
+		.unwrap();
+
+		let recorded: Value = private
+			.post("/api/upgrade_plans/record")
+			.json(&json!({
+				"group_id": GROUP,
+				"target_version_id": "cccccccc-0000-0000-0000-0000000000f1",
+				"planned_for": "2020-01-01",
+				"note": "waiting on the site",
+			}))
+			.await
+			.json();
+
+		let resp = private
+			.post("/api/upgrade_plans/amend")
+			.json(&json!({
+				"id": recorded["id"],
+				"planned_for": "2020-02-02",
+				"note": "site confirmed the window",
+			}))
+			.await;
+		resp.assert_status_ok();
+		let amended: Value = resp.json();
+		assert_eq!(amended["id"], recorded["id"], "the same plan");
+		assert_eq!(amended["planned_for"], "2020-02-02");
+		assert_eq!(amended["note"], "site confirmed the window");
+		assert_eq!(
+			amended["target_version_id"], recorded["target_version_id"],
+			"amending does not move the deployment somewhere else"
+		);
+		assert!(amended["superseded_at"].is_null());
+		assert!(!amended["amended_at"].is_null());
+
+		let fleet: Vec<Value> = private
+			.post("/api/upgrade_plans/fleet")
+			.json(&json!({}))
+			.await
+			.json();
+		let row = fleet
+			.iter()
+			.find(|row| row["group_id"] == GROUP)
+			.expect("the planned group");
+		assert_eq!(row["plan"]["note"], "site confirmed the window");
+		assert_eq!(
+			row["target_version"], "2.61.0",
+			"still going to the same place"
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn amending_a_withdrawn_plan_is_refused() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+				('cccccccc-0000-0000-0000-0000000000f1', 2, 61, 0, 'x', 'published'),
+				('cccccccc-0000-0000-0000-0000000000f2', 2, 63, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');",
+		)
+		.await
+		.unwrap();
+
+		let first: Value = private
+			.post("/api/upgrade_plans/record")
+			.json(&json!({
+				"group_id": GROUP,
+				"target_version_id": "cccccccc-0000-0000-0000-0000000000f1",
+			}))
+			.await
+			.json();
+
+		// Recording a second plan replaces the first, which is then history.
+		private
+			.post("/api/upgrade_plans/record")
+			.json(&json!({
+				"group_id": GROUP,
+				"target_version_id": "cccccccc-0000-0000-0000-0000000000f2",
+			}))
+			.await
+			.assert_status_ok();
+
+		private
+			.post("/api/upgrade_plans/amend")
+			.json(&json!({ "id": first["id"], "note": "too late" }))
+			.await
+			.assert_status_bad_request();
+	})
+	.await;
+}

--- a/migrations/2026-07-30-011056-0000_add_upgrade_plans/down.sql
+++ b/migrations/2026-07-30-011056-0000_add_upgrade_plans/down.sql
@@ -1,0 +1,2 @@
+-- DESTRUCTIVE: every recorded plan, and the upgrade history they form, goes.
+DROP TABLE upgrade_plans;

--- a/migrations/2026-07-30-011056-0000_add_upgrade_plans/up.sql
+++ b/migrations/2026-07-30-011056-0000_add_upgrade_plans/up.sql
@@ -1,0 +1,26 @@
+-- Where a deployment is going: the version a group intends to move to, and
+-- optionally when. A statement of intent, not an instruction; nothing acts on
+-- the date.
+CREATE TABLE upgrade_plans (
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	group_id UUID NOT NULL REFERENCES server_groups (id) ON DELETE CASCADE,
+	target_version_id UUID NOT NULL REFERENCES versions (id) ON DELETE CASCADE,
+	planned_for DATE,
+	note TEXT,
+	created_by TEXT,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	-- Canopy decides a plan is met once the group's reported version reaches
+	-- the target; nobody ticks it off.
+	met_at TIMESTAMPTZ,
+	-- A group goes one place next, so recording a new plan retires the old one
+	-- rather than queueing behind it.
+	superseded_at TIMESTAMPTZ
+);
+
+-- At most one open plan per group. Met and superseded plans are history and
+-- accumulate freely, which is why this is partial rather than a plain unique.
+CREATE UNIQUE INDEX upgrade_plans_one_open_per_group
+	ON upgrade_plans (group_id)
+	WHERE met_at IS NULL AND superseded_at IS NULL;
+
+CREATE INDEX upgrade_plans_group ON upgrade_plans (group_id, created_at DESC);

--- a/migrations/2026-07-30-205604-0000_add_upgrade_plan_amendments/down.sql
+++ b/migrations/2026-07-30-205604-0000_add_upgrade_plan_amendments/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE upgrade_plans
+	DROP COLUMN amended_by,
+	DROP COLUMN amended_at;

--- a/migrations/2026-07-30-205604-0000_add_upgrade_plan_amendments/up.sql
+++ b/migrations/2026-07-30-205604-0000_add_upgrade_plan_amendments/up.sql
@@ -1,0 +1,6 @@
+-- A corrected date or a reworded note is the same plan better described, so it
+-- is amended in place rather than superseded. Changing the target stays a
+-- replacement, since where a deployment is going is what the history records.
+ALTER TABLE upgrade_plans
+	ADD COLUMN amended_by TEXT,
+	ADD COLUMN amended_at TIMESTAMPTZ;

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,7 +47,7 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, migration_tests, migration_timings, recovery_vault_writes, server_names, server_certificates, compromised_keys RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, migration_tests, migration_timings, upgrade_plans, recovery_vault_writes, server_names, server_certificates, compromised_keys RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
 	// self-alerts attach to that row, so put it back. `kind = 'canopy'` is the
@@ -1193,6 +1193,31 @@ export async function seedMigrationTest(
 			[checkId, ordinal, timing.name, timing.elapsedSecs],
 		);
 	}
+}
+
+/** Record where a group is going. `plannedFor` is `YYYY-MM-DD`; omit for a plan
+ * with no date. */
+export async function seedUpgradePlan(
+	sql: Sql,
+	opts: {
+		groupId: string;
+		targetVersionId: string;
+		plannedFor?: string | null;
+		note?: string | null;
+		createdBy?: string;
+	},
+): Promise<void> {
+	await sql.query(
+		`INSERT INTO upgrade_plans (group_id, target_version_id, planned_for, note, created_by)
+		 VALUES ($1, $2, $3::date, $4, $5)`,
+		[
+			opts.groupId,
+			opts.targetVersionId,
+			opts.plannedFor ?? null,
+			opts.note ?? null,
+			opts.createdBy ?? "e2e@example.com",
+		],
+	);
 }
 
 /** Seed a `recovery_vault_writes` row. `writtenAgoSecs` backdates the write;

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -40,6 +40,9 @@ test.describe("upgrades dashboard", () => {
 		await expect(plannedRow).toContainText("2.61.0");
 		await expect(plannedRow).toContainText("site can absorb 2.61 only");
 		await expect(plannedRow).toContainText("late");
+		// The plan says where it is going; the verdict says whether the data
+		// survives getting there. Untested until a consumer reports.
+		await expect(plannedRow).toContainText("not yet tested");
 
 		// The deployment with nothing recorded is the one this view exists to
 		// surface, so it is listed rather than omitted.

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -21,7 +21,11 @@ test.describe("upgrades dashboard", () => {
 			"UPDATE server_groups SET effective_version = '2.60.0' WHERE id = ANY($1)",
 			[[planned.id, unplanned.id]],
 		);
-		const target = await seedVersion(sql, { major: 2, minor: 61, patch: 0 });
+		const target = await seedVersion(sql, {
+			major: 2,
+			minor: 61,
+			patch: 0,
+		});
 
 		// Long past, so `late` holds however far in the future this runs.
 		await seedUpgradePlan(sql, {
@@ -47,7 +51,9 @@ test.describe("upgrades dashboard", () => {
 		// The deployment with nothing recorded is the one this view exists to
 		// surface, so it is listed rather than omitted.
 		await expect(
-			page.getByTestId("unplanned-upgrade-row").filter({ hasText: "drifting" }),
+			page
+				.getByTestId("unplanned-upgrade-row")
+				.filter({ hasText: "drifting" }),
 		).toBeVisible();
 		await expect(page.getByTestId("unplanned-upgrades")).not.toContainText(
 			"kamaka",
@@ -73,7 +79,11 @@ test.describe("upgrades dashboard", () => {
 			"UPDATE server_groups SET effective_version = '2.60.0' WHERE id = $1",
 			[group.id],
 		);
-		const target = await seedVersion(sql, { major: 2, minor: 61, patch: 0 });
+		const target = await seedVersion(sql, {
+			major: 2,
+			minor: 61,
+			patch: 0,
+		});
 		await seedUpgradePlan(sql, {
 			groupId: group.id,
 			targetVersionId: target.id,
@@ -81,19 +91,105 @@ test.describe("upgrades dashboard", () => {
 
 		await page.goto("/upgrades");
 		await expect(
-			page.getByTestId("planned-upgrade-row").filter({ hasText: "kamaka" }),
+			page
+				.getByTestId("planned-upgrade-row")
+				.filter({ hasText: "kamaka" }),
 		).toBeVisible();
 
 		page.once("dialog", (dialog) => dialog.accept());
-		await page.getByRole("button", { name: "Withdraw kamaka's plan" }).click();
+		await page
+			.getByRole("button", { name: "Withdraw kamaka's plan" })
+			.click();
 
 		// Withdrawn, so it moves to the unplanned list and testing goes back to
 		// aiming at the newest version.
 		await expect(
-			page.getByTestId("unplanned-upgrade-row").filter({ hasText: "kamaka" }),
+			page
+				.getByTestId("unplanned-upgrade-row")
+				.filter({ hasText: "kamaka" }),
 		).toBeVisible();
 		await expect(page.getByTestId("planned-upgrades")).toContainText(
 			"No deployment has a recorded plan",
 		);
+	});
+
+	test("amending a plan changes its date and note but not where it is going", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "kamaka" });
+		await sql.query(
+			"UPDATE server_groups SET effective_version = '2.60.0' WHERE id = $1",
+			[group.id],
+		);
+		const target = await seedVersion(sql, {
+			major: 2,
+			minor: 61,
+			patch: 0,
+		});
+		await seedUpgradePlan(sql, {
+			groupId: group.id,
+			targetVersionId: target.id,
+			plannedFor: "2020-01-01",
+			note: "waiting on the site",
+		});
+
+		await page.goto("/upgrades");
+		const row = page
+			.getByTestId("planned-upgrade-row")
+			.filter({ hasText: "kamaka" });
+		await expect(row).toContainText("waiting on the site");
+
+		await page.getByRole("button", { name: "Edit kamaka's plan" }).click();
+		const dialog = page.getByTestId("edit-plan");
+		// Prefilled from the plan, so an operator amends rather than retypes.
+		await expect(dialog.getByLabel("Planned for")).toHaveValue(
+			"2020-01-01",
+		);
+		await expect(dialog.getByLabel("Note")).toHaveValue(
+			"waiting on the site",
+		);
+
+		await dialog.getByLabel("Planned for").fill("2020-03-03");
+		await dialog.getByLabel("Note").fill("site confirmed the window");
+		await dialog.getByRole("button", { name: "Save" }).click();
+
+		await expect(row).toContainText("site confirmed the window");
+		await expect(row).toContainText("2020-03-03");
+		// Same plan, same destination: amending is not a replacement.
+		await expect(row).toContainText("2.61.0");
+		await expect(page.getByTestId("planned-upgrade-row")).toHaveCount(1);
+	});
+
+	test("a date no longer expected can be cleared", async ({ page, sql }) => {
+		const group = await seedServerGroup(sql, { name: "kamaka" });
+		await sql.query(
+			"UPDATE server_groups SET effective_version = '2.60.0' WHERE id = $1",
+			[group.id],
+		);
+		const target = await seedVersion(sql, {
+			major: 2,
+			minor: 61,
+			patch: 0,
+		});
+		await seedUpgradePlan(sql, {
+			groupId: group.id,
+			targetVersionId: target.id,
+			plannedFor: "2020-01-01",
+		});
+
+		await page.goto("/upgrades");
+		const row = page
+			.getByTestId("planned-upgrade-row")
+			.filter({ hasText: "kamaka" });
+		await expect(row).toContainText("late");
+
+		await page.getByRole("button", { name: "Edit kamaka's plan" }).click();
+		const dialog = page.getByTestId("edit-plan");
+		await dialog.getByLabel("Planned for").fill("");
+		await dialog.getByRole("button", { name: "Save" }).click();
+
+		// No date means nothing to be late against.
+		await expect(row).not.toContainText("late");
 	});
 });

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "./test-fixtures";
+import {
+	resetSeededTables,
+	seedServerGroup,
+	seedUpgradePlan,
+	seedVersion,
+} from "./seed";
+
+test.describe("upgrades dashboard", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("separates planned deployments from ones with nothing recorded", async ({
+		page,
+		sql,
+	}) => {
+		const planned = await seedServerGroup(sql, { name: "kamaka" });
+		const unplanned = await seedServerGroup(sql, { name: "drifting" });
+		await sql.query(
+			"UPDATE server_groups SET effective_version = '2.60.0' WHERE id = ANY($1)",
+			[[planned.id, unplanned.id]],
+		);
+		const target = await seedVersion(sql, { major: 2, minor: 61, patch: 0 });
+
+		// Long past, so `late` holds however far in the future this runs.
+		await seedUpgradePlan(sql, {
+			groupId: planned.id,
+			targetVersionId: target.id,
+			plannedFor: "2020-01-01",
+			note: "site can absorb 2.61 only",
+		});
+
+		await page.goto("/upgrades");
+
+		const plannedRow = page
+			.getByTestId("planned-upgrade-row")
+			.filter({ hasText: "kamaka" });
+		await expect(plannedRow).toContainText("2.60.0");
+		await expect(plannedRow).toContainText("2.61.0");
+		await expect(plannedRow).toContainText("site can absorb 2.61 only");
+		await expect(plannedRow).toContainText("late");
+
+		// The deployment with nothing recorded is the one this view exists to
+		// surface, so it is listed rather than omitted.
+		await expect(
+			page.getByTestId("unplanned-upgrade-row").filter({ hasText: "drifting" }),
+		).toBeVisible();
+		await expect(page.getByTestId("unplanned-upgrades")).not.toContainText(
+			"kamaka",
+		);
+	});
+
+	test("says so when nothing is planned", async ({ page, sql }) => {
+		await seedServerGroup(sql, { name: "quiet" });
+
+		await page.goto("/upgrades");
+
+		await expect(page.getByTestId("planned-upgrades")).toContainText(
+			"No deployment has a recorded plan",
+		);
+	});
+});

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -63,4 +63,37 @@ test.describe("upgrades dashboard", () => {
 			"No deployment has a recorded plan",
 		);
 	});
+
+	test("withdrawing a plan puts the deployment back to unplanned", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "kamaka" });
+		await sql.query(
+			"UPDATE server_groups SET effective_version = '2.60.0' WHERE id = $1",
+			[group.id],
+		);
+		const target = await seedVersion(sql, { major: 2, minor: 61, patch: 0 });
+		await seedUpgradePlan(sql, {
+			groupId: group.id,
+			targetVersionId: target.id,
+		});
+
+		await page.goto("/upgrades");
+		await expect(
+			page.getByTestId("planned-upgrade-row").filter({ hasText: "kamaka" }),
+		).toBeVisible();
+
+		page.once("dialog", (dialog) => dialog.accept());
+		await page.getByRole("button", { name: "Withdraw kamaka's plan" }).click();
+
+		// Withdrawn, so it moves to the unplanned list and testing goes back to
+		// aiming at the newest version.
+		await expect(
+			page.getByTestId("unplanned-upgrade-row").filter({ hasText: "kamaka" }),
+		).toBeVisible();
+		await expect(page.getByTestId("planned-upgrades")).toContainText(
+			"No deployment has a recorded plan",
+		);
+	});
 });

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6730,6 +6730,233 @@
         }
       }
     },
+    "/api/upgrade_plans/fleet": {
+      "post": {
+        "tags": [
+          "upgrade_plans"
+        ],
+        "summary": "Planned upgrades across the fleet.",
+        "description": "Every live group, whether or not it has a plan. A group several minors\nbehind with no plan is the thing this view exists to surface, so it is listed\nrather than omitted.",
+        "operationId": "upgrade_plans_fleet",
+        "responses": {
+          "200": {
+            "description": "One row per live group.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PlannedUpgrade"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/upgrade_plans/for_group": {
+      "post": {
+        "tags": [
+          "upgrade_plans"
+        ],
+        "summary": "A group's plan and the plans it has had before.",
+        "description": "The history is the record of what a deployment planned, when for, and when\nit landed.",
+        "operationId": "upgrade_plans_for_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlansForGroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Every plan the group has had, newest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UpgradePlan"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/upgrade_plans/record": {
+      "post": {
+        "tags": [
+          "upgrade_plans"
+        ],
+        "summary": "Record where a group is going, retiring any plan it already had.",
+        "description": "A group goes one place next, so this replaces rather than queues. The target\nmust be published and ahead of what the group runs.",
+        "operationId": "upgrade_plans_record",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecordArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The recorded plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpgradePlan"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The target is unpublished, or not ahead of the group.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/upgrade_plans/withdraw": {
+      "post": {
+        "tags": [
+          "upgrade_plans"
+        ],
+        "summary": "Withdraw a plan: the deployment is no longer going there.",
+        "description": "This does not say the upgrade happened. Canopy closes a met plan on its own\nonce the group reports the target.",
+        "operationId": "upgrade_plans_withdraw",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WithdrawArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Withdrawn (idempotent)."
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/versions/add_known_issue": {
       "post": {
         "tags": [
@@ -11727,6 +11954,69 @@
           }
         }
       },
+      "PlannedUpgrade": {
+        "type": "object",
+        "description": "One row of the planned-upgrades view.",
+        "required": [
+          "group_id",
+          "group_name",
+          "late"
+        ],
+        "properties": {
+          "current_version": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The version the group runs now, where it has reported one."
+          },
+          "group_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group this concerns."
+          },
+          "group_name": {
+            "type": "string",
+            "description": "Its name, so the view reads without a second lookup."
+          },
+          "late": {
+            "type": "boolean",
+            "description": "Whether the planned date has passed without the upgrade happening.\nPresentational: a slipping upgrade is normal operational reality."
+          },
+          "plan": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/UpgradePlan",
+                "description": "The plan, absent for a group with none."
+              }
+            ]
+          },
+          "target_version": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The plan's target as semver."
+          }
+        }
+      },
+      "PlansForGroupArgs": {
+        "type": "object",
+        "description": "Request body for reading one group's plans. Named apart from the\nmigration-test one because utoipa keys component schemas by short name.",
+        "required": [
+          "group_id"
+        ],
+        "properties": {
+          "group_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group to read."
+          }
+        }
+      },
       "ProbeArgs": {
         "type": "object",
         "description": "Request to inspect a bucket/prefix before configuring backups on it.",
@@ -12114,6 +12404,40 @@
           "type": {
             "type": "string",
             "description": "The backup type that ran."
+          }
+        }
+      },
+      "RecordArgs": {
+        "type": "object",
+        "description": "Request body for recording where a group is going.",
+        "required": [
+          "group_id",
+          "target_version_id"
+        ],
+        "properties": {
+          "group_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group that intends to move."
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Anything the next reader needs to know. Optional."
+          },
+          "planned_for": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The day it is expected to happen, as `YYYY-MM-DD`. Optional."
+          },
+          "target_version_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The published version it intends to move to."
           }
         }
       },
@@ -15212,6 +15536,72 @@
           }
         }
       },
+      "UpgradePlan": {
+        "type": "object",
+        "description": "A group's recorded intention to move to a version.",
+        "required": [
+          "id",
+          "group_id",
+          "target_version_id",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "When it was recorded."
+          },
+          "created_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The operator who recorded it."
+          },
+          "group_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group that intends to move."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for this plan."
+          },
+          "met_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "When the group's reported version reached the target."
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Whatever the operator needs the next reader to know."
+          },
+          "planned_for": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The day the upgrade is expected, where one is known."
+          },
+          "superseded_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "When a newer plan replaced this one."
+          },
+          "target_version_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The version it intends to move to."
+          }
+        }
+      },
       "UpsertBackupConfigArgs": {
         "type": "object",
         "description": "Request to declaratively create or update a group's backup configuration,\nfor automated/infrastructure-as-code callers. Always creates the\nrepository with an automatically generated passphrase; importing an\nexisting repository is only supported through the interactive setup\nwizard. `bucket`/`prefix` identify the configuration and are immutable\nafter creation; the role ARNs and region are reconciled to the request on\nevery call. Schedule and retention are not configurable here — see the\n`/backups/set_schedule` endpoint.",
@@ -15442,6 +15832,20 @@
           "reported",
           "absent"
         ]
+      },
+      "WithdrawArgs": {
+        "type": "object",
+        "description": "Request body for withdrawing a plan.",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The plan to withdraw."
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -15503,6 +15907,10 @@
     {
       "name": "mcp_tokens",
       "description": "Bearer tokens for the public MCP mount."
+    },
+    {
+      "name": "upgrade_plans",
+      "description": "Where each deployment is going: the version a group intends to move to, and when."
     },
     {
       "name": "migration_tests",

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -7624,6 +7624,14 @@
           }
         }
       },
+      "AttemptState": {
+        "type": "string",
+        "description": "Whether a restore attempt is under way for a group, for showing beside a\nverdict.\n\nGroup-level, because credentials are issued per `(group, type)`: RST scopes\nthem that way since one repo holds all of a group's snapshots, so this is the\nfinest granularity the signal honestly has.",
+        "enum": [
+          "in_flight",
+          "ended_without_report"
+        ]
+      },
       "AuthorityView": {
         "type": "object",
         "description": "The certificate authority Canopy is configured to use, and whether it works.",
@@ -12042,6 +12050,17 @@
           "late"
         ],
         "properties": {
+          "attempt": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AttemptState",
+                "description": "Whether a restore attempt is under way, carried beside the verdict rather\nthan folded into it: a restore takes hours, so a group mid-test would\notherwise read as untested for the whole window."
+              }
+            ]
+          },
           "current_version": {
             "type": [
               "string",

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6907,6 +6907,66 @@
         ]
       }
     },
+    "/api/upgrade_plans/targets": {
+      "post": {
+        "tags": [
+          "upgrade_plans"
+        ],
+        "summary": "The versions a group could be planned onto: published, and ahead of what it\nruns.",
+        "description": "Offering only valid targets is what keeps the operator from picking one\n`record` would refuse.",
+        "operationId": "upgrade_plans_targets",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlansForGroupArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Plannable versions, newest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PlannableVersion"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/upgrade_plans/withdraw": {
       "post": {
         "tags": [
@@ -11954,6 +12014,25 @@
           }
         }
       },
+      "PlannableVersion": {
+        "type": "object",
+        "description": "A version a group could be planned onto.",
+        "required": [
+          "id",
+          "version"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The version's identifier, for `record`."
+          },
+          "version": {
+            "type": "string",
+            "description": "Its semver."
+          }
+        }
+      },
       "PlannedUpgrade": {
         "type": "object",
         "description": "One row of the planned-upgrades view.",
@@ -12000,6 +12079,13 @@
               "null"
             ],
             "description": "The plan's target as semver."
+          },
+          "verdict": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Where the group's data stands against the planned version, rolled up from\nits servers: any failure makes the group a failure, since one server\nwhose data breaks is enough to stop the upgrade. `null` without a plan."
           }
         }
       },

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6730,6 +6730,73 @@
         }
       }
     },
+    "/api/upgrade_plans/amend": {
+      "post": {
+        "tags": [
+          "upgrade_plans"
+        ],
+        "summary": "Amend an open plan's date and note.",
+        "description": "The same plan better described, so it keeps its place in the history rather\nthan being replaced. Moving a group to a different version is a new plan:\nrecord that instead.",
+        "operationId": "upgrade_plans_amend",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AmendArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The amended plan.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpgradePlan"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The plan has been met or replaced, so it is history.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/upgrade_plans/fleet": {
       "post": {
         "tags": [
@@ -7518,6 +7585,34 @@
             "type": "string",
             "format": "uuid",
             "description": "Id of a version in the release line the issue affects. The issue is\nrecorded as affecting that version's exact patch onward, within its\nrelease line."
+          }
+        }
+      },
+      "AmendArgs": {
+        "type": "object",
+        "description": "Request body for amending an open plan.",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The plan to amend."
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Anything the next reader needs to know. Cleared when absent."
+          },
+          "planned_for": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The day it is expected to happen, as `YYYY-MM-DD`. Cleared when absent."
           }
         }
       },
@@ -15651,6 +15746,20 @@
           "created_at"
         ],
         "properties": {
+          "amended_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "When it was last amended."
+          },
+          "amended_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The operator who last amended the date or note, where one has."
+          },
           "created_at": {
             "type": "string",
             "description": "When it was recorded."

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -51,6 +51,7 @@ import Settings from "./routes/Settings";
 import Sql from "./routes/Sql";
 import UngroupedServersList from "./routes/UngroupedServersList";
 import VersionDetail from "./routes/VersionDetail";
+import Upgrades from "./routes/Upgrades";
 import Versions from "./routes/Versions";
 
 interface NavItem {
@@ -63,6 +64,7 @@ const BASE_NAV: NavItem[] = [
 	{ label: "Incidents", to: "/incidents" },
 	{ label: "Fleet", to: "/servers" },
 	{ label: "Versions", to: "/versions" },
+	{ label: "Upgrades", to: "/upgrades" },
 	{ label: "Devices", to: "/devices" },
 	{ label: "Bestool", to: "/bestool" },
 	{ label: "Settings", to: "/settings" },
@@ -193,6 +195,7 @@ export default function App() {
 					<Route path="/incidents" element={<Incidents />} />
 					<Route path="/incidents/:id" element={<IncidentDetail />} />
 					<Route path="/healthchecks/:source/:check" element={<CheckDetail />} />
+					<Route path="/upgrades" element={<Upgrades />} />
 					<Route path="/versions" element={<Versions />} />
 					<Route path="/versions/:version" element={<VersionDetail />} />
 					<Route path="/servers" element={<Servers />}>

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3469,6 +3469,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/upgrade_plans/amend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Amend an open plan's date and note.
+         * @description The same plan better described, so it keeps its place in the history rather
+         *     than being replaced. Moving a group to a different version is a new plan:
+         *     record that instead.
+         */
+        post: operations["upgrade_plans_amend"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/upgrade_plans/fleet": {
         parameters: {
             query?: never;
@@ -3852,6 +3874,18 @@ export interface components {
              *     release line.
              */
             version_id: string;
+        };
+        /** @description Request body for amending an open plan. */
+        AmendArgs: {
+            /**
+             * Format: uuid
+             * @description The plan to amend.
+             */
+            id: string;
+            /** @description Anything the next reader needs to know. Cleared when absent. */
+            note?: string | null;
+            /** @description The day it is expected to happen, as `YYYY-MM-DD`. Cleared when absent. */
+            planned_for?: string | null;
         };
         /**
          * @description A downloadable artifact (for example an installer) associated with a
@@ -8948,6 +8982,10 @@ export interface components {
         };
         /** @description A group's recorded intention to move to a version. */
         UpgradePlan: {
+            /** @description When it was last amended. */
+            amended_at?: string | null;
+            /** @description The operator who last amended the date or note, where one has. */
+            amended_by?: string | null;
             /** @description When it was recorded. */
             created_at: string;
             /** @description The operator who recorded it. */
@@ -13725,6 +13763,55 @@ export interface operations {
                 };
             };
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    upgrade_plans_amend: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AmendArgs"];
+            };
+        };
+        responses: {
+            /** @description The amended plan. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpgradePlan"];
+                };
+            };
+            /** @description The plan has been met or replaced, so it is history. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3928,6 +3928,16 @@ export interface components {
              */
             server_id: string;
         };
+        /**
+         * @description Whether a restore attempt is under way for a group, for showing beside a
+         *     verdict.
+         *
+         *     Group-level, because credentials are issued per `(group, type)`: RST scopes
+         *     them that way since one repo holds all of a group's snapshots, so this is the
+         *     finest granularity the signal honestly has.
+         * @enum {string}
+         */
+        AttemptState: "in_flight" | "ended_without_report";
         /** @description The certificate authority Canopy is configured to use, and whether it works. */
         AuthorityView: {
             /**
@@ -6694,6 +6704,7 @@ export interface components {
         };
         /** @description One row of the planned-upgrades view. */
         PlannedUpgrade: {
+            attempt?: null | components["schemas"]["AttemptState"];
             /** @description The version the group runs now, where it has reported one. */
             current_version?: string | null;
             /**

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3469,6 +3469,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/upgrade_plans/fleet": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Planned upgrades across the fleet.
+         * @description Every live group, whether or not it has a plan. A group several minors
+         *     behind with no plan is the thing this view exists to surface, so it is listed
+         *     rather than omitted.
+         */
+        post: operations["upgrade_plans_fleet"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/upgrade_plans/for_group": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * A group's plan and the plans it has had before.
+         * @description The history is the record of what a deployment planned, when for, and when
+         *     it landed.
+         */
+        post: operations["upgrade_plans_for_group"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/upgrade_plans/record": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record where a group is going, retiring any plan it already had.
+         * @description A group goes one place next, so this replaces rather than queues. The target
+         *     must be published and ahead of what the group runs.
+         */
+        post: operations["upgrade_plans_record"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/upgrade_plans/withdraw": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Withdraw a plan: the deployment is no longer going there.
+         * @description This does not say the upgrade happened. Canopy closes a met plan on its own
+         *     once the group reports the target.
+         */
+        post: operations["upgrade_plans_withdraw"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/versions/add_known_issue": {
         parameters: {
             query?: never;
@@ -6575,6 +6660,37 @@ export interface components {
             /** @description Backup type requested. */
             type: string;
         };
+        /** @description One row of the planned-upgrades view. */
+        PlannedUpgrade: {
+            /** @description The version the group runs now, where it has reported one. */
+            current_version?: string | null;
+            /**
+             * Format: uuid
+             * @description The group this concerns.
+             */
+            group_id: string;
+            /** @description Its name, so the view reads without a second lookup. */
+            group_name: string;
+            /**
+             * @description Whether the planned date has passed without the upgrade happening.
+             *     Presentational: a slipping upgrade is normal operational reality.
+             */
+            late: boolean;
+            plan?: null | components["schemas"]["UpgradePlan"];
+            /** @description The plan's target as semver. */
+            target_version?: string | null;
+        };
+        /**
+         * @description Request body for reading one group's plans. Named apart from the
+         *     migration-test one because utoipa keys component schemas by short name.
+         */
+        PlansForGroupArgs: {
+            /**
+             * Format: uuid
+             * @description The group to read.
+             */
+            group_id: string;
+        };
         /** @description Request to inspect a bucket/prefix before configuring backups on it. */
         ProbeArgs: {
             /** @description Name of the S3 bucket to inspect. */
@@ -6841,6 +6957,23 @@ export interface components {
             status: components["schemas"]["RunStatus"];
             /** @description The backup type that ran. */
             type: string;
+        };
+        /** @description Request body for recording where a group is going. */
+        RecordArgs: {
+            /**
+             * Format: uuid
+             * @description The group that intends to move.
+             */
+            group_id: string;
+            /** @description Anything the next reader needs to know. Optional. */
+            note?: string | null;
+            /** @description The day it is expected to happen, as `YYYY-MM-DD`. Optional. */
+            planned_for?: string | null;
+            /**
+             * Format: uuid
+             * @description The published version it intends to move to.
+             */
+            target_version_id: string;
         };
         /** @description A freshly issued recovery-verification challenge. */
         RecoveryChallengeResponse: {
@@ -8764,6 +8897,36 @@ export interface components {
             /** @description Exact version string to update (e.g. `"1.2.3"`). */
             version: string;
         };
+        /** @description A group's recorded intention to move to a version. */
+        UpgradePlan: {
+            /** @description When it was recorded. */
+            created_at: string;
+            /** @description The operator who recorded it. */
+            created_by?: string | null;
+            /**
+             * Format: uuid
+             * @description The group that intends to move.
+             */
+            group_id: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier for this plan.
+             */
+            id: string;
+            /** @description When the group's reported version reached the target. */
+            met_at?: string | null;
+            /** @description Whatever the operator needs the next reader to know. */
+            note?: string | null;
+            /** @description The day the upgrade is expected, where one is known. */
+            planned_for?: string | null;
+            /** @description When a newer plan replaced this one. */
+            superseded_at?: string | null;
+            /**
+             * Format: uuid
+             * @description The version it intends to move to.
+             */
+            target_version_id: string;
+        };
         /**
          * @description Request to declaratively create or update a group's backup configuration,
          *     for automated/infrastructure-as-code callers. Always creates the
@@ -8929,6 +9092,14 @@ export interface components {
          * @enum {string}
          */
         VersionTracking: "tracked" | "reported" | "absent";
+        /** @description Request body for withdrawing a plan. */
+        WithdrawArgs: {
+            /**
+             * Format: uuid
+             * @description The plan to withdraw.
+             */
+            id: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -13505,6 +13676,169 @@ export interface operations {
                 };
             };
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    upgrade_plans_fleet: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description One row per live group. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlannedUpgrade"][];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    upgrade_plans_for_group: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlansForGroupArgs"];
+            };
+        };
+        responses: {
+            /** @description Every plan the group has had, newest first. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpgradePlan"][];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    upgrade_plans_record: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecordArgs"];
+            };
+        };
+        responses: {
+            /** @description The recorded plan. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpgradePlan"];
+                };
+            };
+            /** @description The target is unpublished, or not ahead of the group. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    upgrade_plans_withdraw: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WithdrawArgs"];
+            };
+        };
+        responses: {
+            /** @description Withdrawn (idempotent). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3533,6 +3533,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/upgrade_plans/targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * The versions a group could be planned onto: published, and ahead of what it
+         *     runs.
+         * @description Offering only valid targets is what keeps the operator from picking one
+         *     `record` would refuse.
+         */
+        post: operations["upgrade_plans_targets"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/upgrade_plans/withdraw": {
         parameters: {
             query?: never;
@@ -6660,6 +6682,16 @@ export interface components {
             /** @description Backup type requested. */
             type: string;
         };
+        /** @description A version a group could be planned onto. */
+        PlannableVersion: {
+            /**
+             * Format: uuid
+             * @description The version's identifier, for `record`.
+             */
+            id: string;
+            /** @description Its semver. */
+            version: string;
+        };
         /** @description One row of the planned-upgrades view. */
         PlannedUpgrade: {
             /** @description The version the group runs now, where it has reported one. */
@@ -6679,6 +6711,12 @@ export interface components {
             plan?: null | components["schemas"]["UpgradePlan"];
             /** @description The plan's target as semver. */
             target_version?: string | null;
+            /**
+             * @description Where the group's data stands against the planned version, rolled up from
+             *     its servers: any failure makes the group a failure, since one server
+             *     whose data breaks is enough to stop the upgrade. `null` without a plan.
+             */
+            verdict?: string | null;
         };
         /**
          * @description Request body for reading one group's plans. Named apart from the
@@ -13790,6 +13828,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    upgrade_plans_targets: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlansForGroupArgs"];
+            };
+        };
+        responses: {
+            /** @description Plannable versions, newest first. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlannableVersion"][];
                 };
             };
             401: {

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -1,8 +1,13 @@
 import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from "@mui/icons-material/Edit";
 import {
 	Alert,
 	Button,
 	Chip,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
 	IconButton,
 	LinearProgress,
 	MenuItem,
@@ -109,6 +114,14 @@ export default function Upgrades() {
 									<TableCell>{row.plan?.note ?? ""}</TableCell>
 									{isAdmin && (
 										<TableCell align="right">
+											<EditPlan
+												planId={row.plan?.id ?? ""}
+												groupName={row.group_name}
+												targetVersion={row.target_version ?? ""}
+												plannedFor={row.plan?.planned_for ?? null}
+												note={row.plan?.note ?? null}
+												onAmended={() => setTick((t) => t + 1)}
+											/>
 											<WithdrawPlan
 												planId={row.plan?.id ?? ""}
 												groupName={row.group_name}
@@ -338,6 +351,106 @@ function RecordPlan({
 				</Alert>
 			)}
 		</Paper>
+	);
+}
+
+/// Amend an open plan's date and note. The target is deliberately absent:
+/// moving a deployment somewhere else is a new plan, not a correction to this
+/// one, so it goes through the record form.
+// spec: UPG#a-plan
+function EditPlan({
+	planId,
+	groupName,
+	targetVersion,
+	plannedFor,
+	note,
+	onAmended,
+}: {
+	planId: string;
+	groupName: string;
+	targetVersion: string;
+	plannedFor: string | null;
+	note: string | null;
+	onAmended: () => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const [date, setDate] = useState("");
+	const [text, setText] = useState("");
+	const amend = useApiAction("upgrade_plans", "amend");
+
+	// Re-read the plan on each open so a row refreshed underneath doesn't leave
+	// the form showing what it held last time.
+	const start = () => {
+		setDate(plannedFor ?? "");
+		setText(note ?? "");
+		setOpen(true);
+	};
+
+	const save = async () => {
+		await amend.call({
+			id: planId,
+			planned_for: date || null,
+			note: text || null,
+		});
+		setOpen(false);
+		onAmended();
+	};
+
+	return (
+		<>
+			<IconButton
+				size="small"
+				aria-label={`Edit ${groupName}'s plan`}
+				onClick={start}
+				disabled={!planId}
+			>
+				<EditIcon fontSize="small" />
+			</IconButton>
+			<Dialog
+				open={open}
+				onClose={() => setOpen(false)}
+				fullWidth
+				maxWidth="sm"
+				data-testid="edit-plan"
+			>
+				<DialogTitle>
+					{groupName} &rarr; {targetVersion}
+				</DialogTitle>
+				<DialogContent>
+					<Stack spacing={2} sx={{ mt: 1 }}>
+						<TextField
+							size="small"
+							type="date"
+							label="Planned for"
+							value={date}
+							onChange={(e) => setDate(e.target.value)}
+							slotProps={{ inputLabel: { shrink: true } }}
+						/>
+						<TextField
+							size="small"
+							label="Note"
+							value={text}
+							onChange={(e) => setText(e.target.value)}
+							multiline
+							minRows={2}
+						/>
+						<Typography variant="body2" color="text.secondary">
+							To move {groupName} to a different version, record a new plan
+							instead. This one is kept as history.
+						</Typography>
+						{amend.error && (
+							<Alert severity="error">{amend.error.message}</Alert>
+						)}
+					</Stack>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setOpen(false)}>Cancel</Button>
+					<Button variant="contained" onClick={save} disabled={amend.pending}>
+						Save
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</>
 	);
 }
 

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -1,7 +1,9 @@
+import DeleteIcon from "@mui/icons-material/Delete";
 import {
 	Alert,
 	Button,
 	Chip,
+	IconButton,
 	LinearProgress,
 	MenuItem,
 	Paper,
@@ -75,6 +77,7 @@ export default function Upgrades() {
 								<TableCell>Data survives it</TableCell>
 								<TableCell>Planned for</TableCell>
 								<TableCell>Note</TableCell>
+								{isAdmin && <TableCell />}
 							</TableRow>
 						</TableHead>
 						<TableBody>
@@ -97,6 +100,16 @@ export default function Upgrades() {
 										/>
 									</TableCell>
 									<TableCell>{row.plan?.note ?? ""}</TableCell>
+									{isAdmin && (
+										<TableCell align="right">
+											<WithdrawPlan
+												planId={row.plan?.id ?? ""}
+												groupName={row.group_name}
+												targetVersion={row.target_version ?? ""}
+												onWithdrawn={() => setTick((t) => t + 1)}
+											/>
+										</TableCell>
+									)}
 								</TableRow>
 							))}
 						</TableBody>
@@ -289,5 +302,47 @@ function RecordPlan({
 				</Alert>
 			)}
 		</Paper>
+	);
+}
+
+/// Withdraw a plan: the deployment is no longer going there. This does not say
+/// the upgrade happened; Canopy closes a met plan on its own.
+// spec: UPG#a-plan
+function WithdrawPlan({
+	planId,
+	groupName,
+	targetVersion,
+	onWithdrawn,
+}: {
+	planId: string;
+	groupName: string;
+	targetVersion: string;
+	onWithdrawn: () => void;
+}) {
+	const withdraw = useApiAction("upgrade_plans", "withdraw");
+	const onClick = async () => {
+		if (
+			!window.confirm(
+				`Withdraw ${groupName}'s plan to move to ${targetVersion}? Pre-upgrade testing goes back to aiming at the newest version.`,
+			)
+		)
+			return;
+		try {
+			await withdraw.call({ id: planId });
+			onWithdrawn();
+		} catch {
+			/* surfaced by the reload showing the plan still there */
+		}
+	};
+
+	return (
+		<IconButton
+			size="small"
+			aria-label={`Withdraw ${groupName}'s plan`}
+			onClick={onClick}
+			disabled={withdraw.pending || !planId}
+		>
+			<DeleteIcon fontSize="small" />
+		</IconButton>
 	);
 }

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -1,0 +1,142 @@
+import {
+	Alert,
+	Chip,
+	LinearProgress,
+	Paper,
+	Stack,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableRow,
+	Tooltip,
+	Typography,
+} from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { useApi } from "../api";
+import { usePageTitle } from "../hooks/usePageTitle";
+
+/// Where every deployment is going. A group with no plan is listed too: one
+/// several minors behind with nothing recorded is what this view exists to
+/// surface.
+// spec: UPG#the-dashboard
+export default function Upgrades() {
+	usePageTitle("Upgrades");
+	const fleet = useApi("upgrade_plans", "fleet", {}, []);
+
+	if (fleet.status === "loading" || fleet.status === "idle") {
+		return <LinearProgress />;
+	}
+	if (fleet.status === "error") {
+		return <Alert severity="error">{fleet.error.message}</Alert>;
+	}
+
+	const planned = fleet.data.filter((row) => row.plan);
+	const unplanned = fleet.data.filter((row) => !row.plan);
+
+	return (
+		<Stack spacing={2}>
+			<Typography variant="h4" component="h1">
+				Upgrades
+			</Typography>
+
+			<Paper variant="outlined" sx={{ p: 2 }} data-testid="planned-upgrades">
+				<Typography variant="h6" component="h2" gutterBottom>
+					Planned
+				</Typography>
+				{planned.length === 0 ? (
+					<Typography variant="body2" color="text.secondary">
+						No deployment has a recorded plan.
+					</Typography>
+				) : (
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell>Deployment</TableCell>
+								<TableCell>Running</TableCell>
+								<TableCell>Going to</TableCell>
+								<TableCell>Planned for</TableCell>
+								<TableCell>Note</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{planned.map((row) => (
+								<TableRow key={row.group_id} data-testid="planned-upgrade-row">
+									<TableCell>
+										<RouterLink to={`/servers/groups/${row.group_id}`}>
+											{row.group_name}
+										</RouterLink>
+									</TableCell>
+									<TableCell>{row.current_version ?? "unknown"}</TableCell>
+									<TableCell>{row.target_version}</TableCell>
+									<TableCell>
+										<PlannedFor
+											date={row.plan?.planned_for ?? null}
+											late={row.late}
+										/>
+									</TableCell>
+									<TableCell>{row.plan?.note ?? ""}</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				)}
+			</Paper>
+
+			<Paper variant="outlined" sx={{ p: 2 }} data-testid="unplanned-upgrades">
+				<Stack direction="row" spacing={1} sx={{ mb: 1, alignItems: "baseline" }}>
+					<Typography variant="h6" component="h2">
+						No plan recorded
+					</Typography>
+					<Typography variant="body2" color="text.secondary">
+						pre-upgrade testing aims at the newest version for these
+					</Typography>
+				</Stack>
+				{unplanned.length === 0 ? (
+					<Typography variant="body2" color="text.secondary">
+						Every deployment has a plan.
+					</Typography>
+				) : (
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell>Deployment</TableCell>
+								<TableCell>Running</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{unplanned.map((row) => (
+								<TableRow key={row.group_id} data-testid="unplanned-upgrade-row">
+									<TableCell>
+										<RouterLink to={`/servers/groups/${row.group_id}`}>
+											{row.group_name}
+										</RouterLink>
+									</TableCell>
+									<TableCell>{row.current_version ?? "unknown"}</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				)}
+			</Paper>
+		</Stack>
+	);
+}
+
+function PlannedFor({ date, late }: { date: string | null; late: boolean }) {
+	if (!date) {
+		return (
+			<Typography variant="body2" color="text.secondary">
+				no date
+			</Typography>
+		);
+	}
+	if (!late) {
+		return <>{date}</>;
+	}
+	return (
+		<Tooltip title="the planned day has passed and the deployment has not moved">
+			<Chip size="small" color="warning" variant="outlined" label={`${date} (late)`} />
+		</Tooltip>
+	);
+}

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -91,7 +91,14 @@ export default function Upgrades() {
 									<TableCell>{row.current_version ?? "unknown"}</TableCell>
 									<TableCell>{row.target_version}</TableCell>
 									<TableCell>
-										<VerdictChip verdict={row.verdict} />
+										<Stack
+											direction="row"
+											spacing={0.5}
+											sx={{ alignItems: "center" }}
+										>
+											<VerdictChip verdict={row.verdict} />
+											<AttemptChip attempt={row.attempt} />
+										</Stack>
 									</TableCell>
 									<TableCell>
 										<PlannedFor
@@ -171,6 +178,35 @@ function VerdictChip({ verdict }: { verdict: string | null | undefined }) {
 		);
 	}
 	return <Chip size="small" variant="outlined" label="not yet tested" />;
+}
+
+/// An attempt under way, beside the verdict rather than replacing it: a row can
+/// read as failed with a fresh attempt already running.
+function AttemptChip({
+	attempt,
+}: {
+	attempt: "in_flight" | "ended_without_report" | null | undefined;
+}) {
+	if (attempt === "in_flight") {
+		return (
+			<Tooltip title="a restore is under way; a verdict lands when it reports">
+				<Chip size="small" color="info" variant="outlined" label="testing" />
+			</Tooltip>
+		);
+	}
+	if (attempt === "ended_without_report") {
+		return (
+			<Tooltip title="a restore ran and never reported how it went, so the pipeline may be stuck">
+				<Chip
+					size="small"
+					color="warning"
+					variant="outlined"
+					label="no report"
+				/>
+			</Tooltip>
+		);
+	}
+	return null;
 }
 
 function PlannedFor({ date, late }: { date: string | null; late: boolean }) {

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -1,7 +1,9 @@
 import {
 	Alert,
+	Button,
 	Chip,
 	LinearProgress,
+	MenuItem,
 	Paper,
 	Stack,
 	Table,
@@ -9,11 +11,14 @@ import {
 	TableCell,
 	TableHead,
 	TableRow,
+	TextField,
 	Tooltip,
 	Typography,
 } from "@mui/material";
+import { useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
-import { useApi } from "../api";
+import { useApi, useApiAction } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
 
 /// Where every deployment is going. A group with no plan is listed too: one
@@ -22,7 +27,9 @@ import { usePageTitle } from "../hooks/usePageTitle";
 // spec: UPG#the-dashboard
 export default function Upgrades() {
 	usePageTitle("Upgrades");
-	const fleet = useApi("upgrade_plans", "fleet", {}, []);
+	const isAdmin = useIsAdmin() === true;
+	const [tick, setTick] = useState(0);
+	const fleet = useApi("upgrade_plans", "fleet", {}, [tick]);
 
 	if (fleet.status === "loading" || fleet.status === "idle") {
 		return <LinearProgress />;
@@ -40,6 +47,16 @@ export default function Upgrades() {
 				Upgrades
 			</Typography>
 
+			{isAdmin && (
+				<RecordPlan
+					groups={fleet.data.map((row) => ({
+						id: row.group_id,
+						name: row.group_name,
+					}))}
+					onRecorded={() => setTick((t) => t + 1)}
+				/>
+			)}
+
 			<Paper variant="outlined" sx={{ p: 2 }} data-testid="planned-upgrades">
 				<Typography variant="h6" component="h2" gutterBottom>
 					Planned
@@ -55,6 +72,7 @@ export default function Upgrades() {
 								<TableCell>Deployment</TableCell>
 								<TableCell>Running</TableCell>
 								<TableCell>Going to</TableCell>
+								<TableCell>Data survives it</TableCell>
 								<TableCell>Planned for</TableCell>
 								<TableCell>Note</TableCell>
 							</TableRow>
@@ -69,6 +87,9 @@ export default function Upgrades() {
 									</TableCell>
 									<TableCell>{row.current_version ?? "unknown"}</TableCell>
 									<TableCell>{row.target_version}</TableCell>
+									<TableCell>
+										<VerdictChip verdict={row.verdict} />
+									</TableCell>
 									<TableCell>
 										<PlannedFor
 											date={row.plan?.planned_for ?? null}
@@ -123,6 +144,22 @@ export default function Upgrades() {
 	);
 }
 
+/// Whether the deployment's own data survives the planned version, rolled up
+/// from its servers. Pairing it with the plan is the point of this view.
+function VerdictChip({ verdict }: { verdict: string | null | undefined }) {
+	if (verdict === "passed") {
+		return <Chip size="small" color="success" label="passed" />;
+	}
+	if (verdict === "failed") {
+		return (
+			<Tooltip title="a server's data broke the migrations; the version is held back">
+				<Chip size="small" color="warning" label="failed" />
+			</Tooltip>
+		);
+	}
+	return <Chip size="small" variant="outlined" label="not yet tested" />;
+}
+
 function PlannedFor({ date, late }: { date: string | null; late: boolean }) {
 	if (!date) {
 		return (
@@ -138,5 +175,119 @@ function PlannedFor({ date, late }: { date: string | null; late: boolean }) {
 		<Tooltip title="the planned day has passed and the deployment has not moved">
 			<Chip size="small" color="warning" variant="outlined" label={`${date} (late)`} />
 		</Tooltip>
+	);
+}
+
+/// Record where a deployment is going. The version picker offers only valid
+/// targets, so the operator cannot pick one the API would refuse.
+// spec: UPG#a-plan
+function RecordPlan({
+	groups,
+	onRecorded,
+}: {
+	groups: Array<{ id: string; name: string }>;
+	onRecorded: () => void;
+}) {
+	const [groupId, setGroupId] = useState("");
+	const [versionId, setVersionId] = useState("");
+	const [plannedFor, setPlannedFor] = useState("");
+	const [note, setNote] = useState("");
+	const record = useApiAction("upgrade_plans", "record");
+	const targets = useApi(
+		"upgrade_plans",
+		"targets",
+		groupId ? { group_id: groupId } : undefined,
+		[groupId],
+	);
+
+	const options = targets.status === "ok" ? targets.data : [];
+
+	const submit = async () => {
+		if (!groupId || !versionId) return;
+		await record.call({
+			group_id: groupId,
+			target_version_id: versionId,
+			planned_for: plannedFor || null,
+			note: note || null,
+		});
+		setVersionId("");
+		setPlannedFor("");
+		setNote("");
+		onRecorded();
+	};
+
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }} data-testid="record-plan">
+			<Typography variant="h6" component="h2" gutterBottom>
+				Record a plan
+			</Typography>
+			<Stack direction="row" spacing={1} sx={{ alignItems: "flex-start" }}>
+				<TextField
+					select
+					size="small"
+					label="Deployment"
+					value={groupId}
+					onChange={(e) => {
+						setGroupId(e.target.value);
+						setVersionId("");
+					}}
+					sx={{ minWidth: 180 }}
+				>
+					{groups.map((group) => (
+						<MenuItem key={group.id} value={group.id}>
+							{group.name}
+						</MenuItem>
+					))}
+				</TextField>
+				<TextField
+					select
+					size="small"
+					label="Going to"
+					value={versionId}
+					disabled={!groupId || options.length === 0}
+					onChange={(e) => setVersionId(e.target.value)}
+					sx={{ minWidth: 140 }}
+					helperText={
+						groupId && options.length === 0
+							? "already on the newest"
+							: undefined
+					}
+				>
+					{options.map((option) => (
+						<MenuItem key={option.id} value={option.id}>
+							{option.version}
+						</MenuItem>
+					))}
+				</TextField>
+				<TextField
+					size="small"
+					type="date"
+					label="Planned for"
+					value={plannedFor}
+					onChange={(e) => setPlannedFor(e.target.value)}
+					slotProps={{ inputLabel: { shrink: true } }}
+				/>
+				<TextField
+					size="small"
+					label="Note"
+					value={note}
+					onChange={(e) => setNote(e.target.value)}
+					sx={{ flex: 1 }}
+				/>
+				<Button
+					variant="contained"
+					disabled={!groupId || !versionId || record.pending}
+					onClick={submit}
+					sx={{ mt: 0.25 }}
+				>
+					Record
+				</Button>
+			</Stack>
+			{record.error && (
+				<Alert severity="error" sx={{ mt: 1 }}>
+					{record.error.message}
+				</Alert>
+			)}
+		</Paper>
 	);
 }


### PR DESCRIPTION

<img width="1152" height="223" alt="screen2-group-migration-tests" src="https://github.com/user-attachments/assets/c12ce63f-41e5-4e3f-b5b7-75f57966a084" />
<img width="1280" height="720" alt="upgrades-dashboard" src="https://github.com/user-attachments/assets/deec4a2d-ea23-4927-82b4-6b618a2f05d7" />
<img width="1280" height="720" alt="upgrades-edit-plan" src="https://github.com/user-attachments/assets/cea64b7c-4b30-4282-935f-fed7fc4359dd" />

Records where each deployment is going, so pre-upgrade testing aims at the version that will actually be applied instead of guessing.

**Based on `feature/tam-6884-pre-upgrade-migration-testing`, not main.** Review that first; this diff is the four commits on top.

Canopy knows what every server runs and every version that exists, but not which minor a site takes next, because that is a human call. So migration testing guessed newest, which is wrong for a deployment deliberately moving to an older minor and spends a full restore proving it. And nothing showed which deployments were mid-plan, late, or unplanned.

An operator records per group: target version, optional date, optional note. `candidate_for` then prefers the plan over newest, which is the whole point. Dashboard at `/upgrades` splits planned from nothing-recorded.

Four decisions worth arguing with:

**"Plan", not "intent".** `intent` already means restore-consumer intent here, and two meanings in one crate would confuse. Mechanical to rename if you disagree.

**A date is not a deadline.** Nothing schedules or blocks on it, and `late` is presentational. An upgrade slipping is normal operational reality, and a date someone typed is no basis for an incident.

**Overshooting meets the plan.** A deployment that jumped further than planned has done the upgrade and then some; holding the plan open would report it as outstanding.

**One open plan per group, enforced by a partial unique index.** A group goes one place next, so recording replaces rather than queues, and the retired plan is kept as history. That history is what makes "how long do our upgrades actually take to happen" answerable.

Canopy closes a met plan itself by watching what the group reports, so nobody ticks anything off. A target that is unpublished, or not ahead of the group, is refused.

Spec is UPG (`.workhorse/specs/private-server/upgrade-plans.md`); RST's candidate rule now points at it.

1074 Rust tests green plus 2 Playwright. `server-reachability-silence.spec.ts:121` flaked once under full-suite load and passes in isolation; my branch touches nothing reachability-related, but I did not bisect it against main.
