### PR TITLE
History partition runway: provision ahead, alert before it bites

### DIFF
--- a/.workhorse/specs/platform/history-storage.md
+++ b/.workhorse/specs/platform/history-storage.md
@@ -1,0 +1,26 @@
+---
+id: HST
+---
+
+# History storage
+
+Canopy keeps two high-volume histories: every ingested status push (see [STA](../public-server/statuses.md)), and every authenticated device connection.
+Both are stored in weekly ranges, so a read bounded to a recent window touches only the weeks that window covers.
+
+## Provisioning ahead
+
+A history write succeeds only while a range covering its timestamp exists, so Canopy provisions ranges ahead of time rather than at the moment first data needs one.
+Canopy keeps at least four weeks of future ranges provisioned for each history, and maintains them for as long as it is running rather than on an external schedule.
+
+Provisioning is idempotent: applied over ranges that already exist it changes nothing, so it can be run at any time and by more than one component at once.
+Provisioning a range does not block reads or writes of the history it extends — a status push or a connection record is never delayed by it, and a long-running reader never delays it.
+
+## Running short
+
+Canopy reports how much future range each history has left, and raises a self-alert (see [SELF](../private-server/self-alerts.md)) as it runs short: a warning below two weeks remaining, and a failure below one week, because a history with no range left cannot be written at all.
+The alert names each history that is short and the date its ranges run out, and clears once every history is provisioned ahead again.
+
+## Recording a connection
+
+Recording an authenticated device connection is part of accepting the request, not a condition of it.
+When the record cannot be written the request proceeds regardless, and authentication does not fail on account of the history being unwritable.

--- a/.workhorse/specs/private-server/self-alerts.md
+++ b/.workhorse/specs/private-server/self-alerts.md
@@ -18,6 +18,7 @@ The current conditions are:
 - An operator-notification delivery has permanently failed (stays until operator-resolved).
 - An MCP access token is within fifteen days of its expiry (see [MCP](mcp.md), "Access tokens").
 - One or more catalogued checks have gone unreported across the whole fleet for thirty days (see [CHK](../monitoring/checks.md), "Liveness and decommissioning"); it clears when no such check remains, each having been decommissioned or reported again.
+- A history has less than two weeks of future range left to write into, failing below one week (see [HST](../platform/history-storage.md), "Running short"); it clears once every history is provisioned ahead again.
 - One or more group domains fall outside the DNS zones Canopy is configured with, failing when Canopy can read no zones at all and warning when only some claims are uncovered (see [DOM](../servers/domains.md), "When the zone configuration changes"); it clears when every live group's domains sit within a configured zone again.
 
 ## Notification

--- a/.workhorse/specs/public-server/statuses.md
+++ b/.workhorse/specs/public-server/statuses.md
@@ -28,7 +28,7 @@ Per the check-state model, the push is the source's whole truth: checks omitted 
 
 The source's ingest mode (see [CHK](../monitoring/checks.md), "Source policy") gates the push: an `allow` source is ingested as above; an `ignore` source's push is accepted but recorded nowhere, its checks and detail discarded; a `deny` source's push is rejected. Gating is per source, so other sources on the same server are unaffected.
 
-Every ingested push is recorded in full as the server's status history.
+Every ingested push is recorded in full as the server's status history, held as described by the history-storage rules (see [HST](../platform/history-storage.md)).
 
 ## Legacy pushes
 

--- a/crates/commons-servers/src/device_auth/mod.rs
+++ b/crates/commons-servers/src/device_auth/mod.rs
@@ -31,6 +31,8 @@ use database::{
 	devices::{Device, NewDeviceConnection},
 };
 
+use tracing::warn;
+
 use crate::tailnet_directory::TailnetDirectory;
 
 pub mod keygen;
@@ -129,13 +131,23 @@ where
 		let client_ip: Option<ClientIp> = parts.extract().await.ok();
 		let ip = client_ip.map_or(IpAddr::V6(Ipv6Addr::UNSPECIFIED), |c| c.0);
 
-		NewDeviceConnection {
+		// Recording the connection is part of accepting the request, not a
+		// condition of it: the caller authenticated, and history it can't
+		// influence must not decide that for it. Connection history is stored
+		// in weekly ranges, so an unprovisioned week would otherwise fail this
+		// insert and with it every authenticated request on both mounts — a
+		// full device-API outage caused by an audit-trail write.
+		// spec: HST#recording-a-connection
+		if let Err(err) = (NewDeviceConnection {
 			device_id: device.id,
 			ip: ip.into(),
 			user_agent,
-		}
+		})
 		.create(&mut db)
-		.await?;
+		.await
+		{
+			warn!(device_id = %device.id, "failed to record device connection: {err}");
+		}
 
 		Ok(Self(device, method))
 	}

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -17,6 +17,7 @@ pub mod devices;
 pub mod issues;
 pub mod mcp_tokens;
 pub mod notes;
+pub mod partitions;
 pub mod pg_duration;
 pub mod recovery_vault;
 pub mod reported_detail;

--- a/crates/database/src/partitions.rs
+++ b/crates/database/src/partitions.rs
@@ -1,0 +1,145 @@
+//! Provisioning the weekly ranges the high-volume histories are written into.
+//!
+//! Spec: `.workhorse/specs/platform/history-storage.md` (id `HST`).
+//!
+//! `statuses` and `device_connections` are range-partitioned by week, and a
+//! write only lands if a partition covering its timestamp exists — there is no
+//! catch-all, so a week with no partition is a week the history cannot be
+//! written at all. Canopy keeps the ranges provisioned ahead of itself from the
+//! monitor loop rather than relying on an external schedule, and reports the
+//! runway so the shortfall is alerted on long before it bites (see
+//! [`crate::self_alerts::sweep_partition_runway`]).
+//!
+//! The DDL lives in SQL (`ensure_weekly_partitions`) because it has to: it
+//! builds each partition detached and attaches it, which is what keeps it from
+//! taking an exclusive lock on the history it is extending.
+
+use commons_errors::Result;
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+
+/// The histories whose ranges Canopy provisions. `partition_runway` discovers
+/// partitioned tables on its own; provisioning has to be told, because creating
+/// a partition is not something to do to a table by inference.
+pub const HISTORIES: [&str; 2] = ["statuses", "device_connections"];
+
+/// Weeks of future range kept provisioned beyond the current week. Four weeks
+/// leaves the runway alert (below) a fortnight of warning before anything is at
+/// risk, which is ample for a condition that only needs one successful pass to
+/// clear.
+pub const WEEKS_AHEAD: i32 = 4;
+
+/// Runway below which the self-alert warns.
+pub const WARN_DAYS: i32 = 14;
+
+/// Runway below which the self-alert fails: a week's notice before the history
+/// stops accepting writes.
+pub const FAIL_DAYS: i32 = 7;
+
+/// One week's outcome from a provisioning pass.
+#[derive(Debug, Clone)]
+pub struct Provisioned {
+	pub partition: String,
+	/// `created`, `attached`, `already_exists`, or `failed: <error>` — the SQL
+	/// function isolates each week, so one failure doesn't stop the rest.
+	pub action: String,
+}
+
+impl Provisioned {
+	/// Whether this week failed to provision. The pass as a whole still
+	/// succeeds: it runs again shortly, and the runway alert is what catches a
+	/// failure that persists.
+	pub fn failed(&self) -> bool {
+		self.action.starts_with("failed")
+	}
+}
+
+/// How much future range a history has left.
+#[derive(Debug, Clone)]
+pub struct Runway {
+	pub parent: String,
+	pub partitions: i64,
+	/// Exclusive upper bound of the last partition, as an ISO date. `None` when
+	/// the history has no ranges at all.
+	pub covered_to: Option<String>,
+	/// Days from today to that bound. Zero or negative means the history is
+	/// already unwritable.
+	pub days_remaining: i32,
+}
+
+impl Runway {
+	pub fn short(&self) -> bool {
+		self.days_remaining < WARN_DAYS
+	}
+
+	pub fn critical(&self) -> bool {
+		self.days_remaining < FAIL_DAYS
+	}
+}
+
+/// Provision the current week plus `weeks` future weeks for every history.
+///
+/// Idempotent and safe to run concurrently with itself, with the external
+/// schedule, and with ingestion. Returns only the weeks that were acted on or
+/// failed — a steady state returns nothing.
+pub async fn ensure_runway(db: &mut AsyncPgConnection, weeks: i32) -> Result<Vec<Provisioned>> {
+	#[derive(QueryableByName)]
+	struct Row {
+		#[diesel(sql_type = sql_types::Text)]
+		partition_name: String,
+		#[diesel(sql_type = sql_types::Text)]
+		action: String,
+	}
+
+	let mut acted = Vec::new();
+	for history in HISTORIES {
+		let rows: Vec<Row> =
+			sql_query("SELECT partition_name, action FROM ensure_weekly_partitions($1, $2)")
+				.bind::<sql_types::Text, _>(history)
+				.bind::<sql_types::Integer, _>(weeks)
+				.load(db)
+				.await?;
+		acted.extend(
+			rows.into_iter()
+				.filter(|r| r.action != "already_exists")
+				.map(|r| Provisioned {
+					partition: r.partition_name,
+					action: r.action,
+				}),
+		);
+	}
+	Ok(acted)
+}
+
+/// Future range remaining per partitioned history, worst first.
+pub async fn runway(db: &mut AsyncPgConnection) -> Result<Vec<Runway>> {
+	#[derive(QueryableByName)]
+	struct Row {
+		#[diesel(sql_type = sql_types::Text)]
+		parent: String,
+		#[diesel(sql_type = sql_types::BigInt)]
+		partitions: i64,
+		#[diesel(sql_type = sql_types::Nullable<sql_types::Text>)]
+		covered_to: Option<String>,
+		#[diesel(sql_type = sql_types::Integer)]
+		days_remaining: i32,
+	}
+
+	let rows: Vec<Row> = sql_query(
+		"SELECT parent, partitions, covered_to::text AS covered_to, days_remaining \
+		 FROM partition_runway() \
+		 ORDER BY days_remaining, parent",
+	)
+	.load(db)
+	.await?;
+
+	Ok(rows
+		.into_iter()
+		.map(|r| Runway {
+			parent: r.parent,
+			partitions: r.partitions,
+			covered_to: r.covered_to,
+			days_remaining: r.days_remaining,
+		})
+		.collect())
+}

--- a/crates/database/src/self_alerts.rs
+++ b/crates/database/src/self_alerts.rs
@@ -51,6 +51,29 @@ One or more catalogued healthchecks have not been reported by any server in the 
 
 Review the checks listed in the operator UI's healthcheck settings and decommission the ones that are gone for good; a decommissioned check's stale issues are cleared fleet-wide.";
 
+/// A history has nearly run out of the weekly range it is written into.
+/// Coalescing: one alert covers every short history. Recovers once all of
+/// them are provisioned ahead again.
+// spec: HST#running-short
+pub const PARTITION_RUNWAY_REF: &str = "history-partition-runway";
+
+pub const PARTITION_RUNWAY_DOC: &str = "## Description
+
+Status and connection history are stored in weekly ranges, and a write only lands if a range covering its timestamp exists. Canopy provisions ranges ahead of itself while it runs, so this alert means that provisioning has stopped happening — and there is a deadline attached, because a history with no range left cannot be written at all.
+
+What breaks at the deadline is writing, not reading: status pushes and connection records start failing while queries over existing history keep working.
+
+## Results
+
+- **warn** — less than two weeks of range remain.
+- **fail** — less than one week remains.
+
+Both recover on the next successful provisioning pass, which needs nothing but a working monitor pod and a database that accepts DDL.
+
+## Solve
+
+The monitor pod provisions ranges every minute, so a runway that keeps shrinking means those passes are failing: check its logs for the week it could not provision and why. A permissions change on the database role, or a lock it cannot get, are the usual causes. Provisioning by hand is `SELECT ensure_weekly_partitions('statuses', 4)` (and the same for `device_connections`), which is idempotent and safe to run at any time.";
+
 /// Canopy's configured DNS zones don't cover the domains groups have been
 /// given — either the configuration is unreadable, or a zone has left it while
 /// claims inside it stand. Coalescing: one alert lists every affected group.
@@ -337,6 +360,65 @@ pub async fn sweep_stale_healthchecks(conn: &mut AsyncPgConnection) -> Result<Op
 		false,
 		Some(STALE_CHECKS_DOC),
 		"Healthchecks gone quiet",
+		&message,
+	)
+	.await
+	.map(Some)
+}
+
+/// Evaluate the history-runway condition and raise or recover the coalescing
+/// [`PARTITION_RUNWAY_REF`] self-alert.
+///
+/// Reads the runway rather than the outcome of provisioning: a pass that fails
+/// is only a problem while it keeps failing, and the runway is what says whether
+/// it has been failing long enough to matter. That also covers the case where no
+/// pass is running at all.
+// spec: HST#running-short
+pub async fn sweep_partition_runway(conn: &mut AsyncPgConnection) -> Result<Option<Issue>> {
+	use crate::partitions;
+
+	let histories = partitions::runway(conn).await?;
+	let short: Vec<&partitions::Runway> = histories.iter().filter(|r| r.short()).collect();
+
+	if short.is_empty() {
+		return recover(
+			conn,
+			PARTITION_RUNWAY_REF,
+			"every history has weekly range provisioned ahead",
+		)
+		.await;
+	}
+
+	let listed = short
+		.iter()
+		.map(|r| match &r.covered_to {
+			Some(covered_to) => format!(
+				"{} covered to {covered_to} ({} day(s) left)",
+				r.parent, r.days_remaining
+			),
+			None => format!("{} has no range at all", r.parent),
+		})
+		.collect::<Vec<_>>()
+		.join(", ");
+	let message = format!(
+		"{} history(ies) short of weekly range: {listed}",
+		short.len()
+	);
+
+	let observed = if short.iter().any(|r| r.critical()) {
+		CheckResult::Failed
+	} else {
+		CheckResult::Warning
+	};
+
+	raise(
+		conn,
+		PARTITION_RUNWAY_REF,
+		observed,
+		CheckResult::Failed,
+		true,
+		Some(PARTITION_RUNWAY_DOC),
+		"History storage running out of range",
 		&message,
 	)
 	.await

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -23,6 +23,7 @@ mod incident_reeval_queue;
 mod incident_result_semantics;
 mod incident_stats;
 mod mcp_tokens;
+mod partitions;
 mod reachability_sweep;
 mod recovery_vault;
 mod reported_detail;

--- a/crates/database/tests/it/partitions.rs
+++ b/crates/database/tests/it/partitions.rs
@@ -1,0 +1,292 @@
+//! History-storage runway (spec `HST`): provisioning weekly ranges is
+//! idempotent and doesn't lock the history it extends, a week with no range
+//! cannot be written at all, and the runway self-alert warns, fails, and
+//! recovers.
+
+use commons_types::status::CheckResult;
+use database::{
+	partitions::{self, FAIL_DAYS, HISTORIES, WARN_DAYS},
+	self_alerts::{self, PARTITION_RUNWAY_REF},
+};
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+#[derive(QueryableByName)]
+struct RowName {
+	#[diesel(sql_type = sql_types::Text)]
+	relname: String,
+}
+
+async fn insert_server(conn: &mut AsyncPgConnection, host: &str) -> Uuid {
+	let row: RowId = sql_query("INSERT INTO servers (host) VALUES ($1) RETURNING id")
+		.bind::<sql_types::Text, _>(host)
+		.get_result(conn)
+		.await
+		.expect("insert server");
+	row.id
+}
+
+/// Drop every partition of `parent` whose range starts on or after
+/// `CURRENT_DATE + from_days`, shrinking the runway to a known band. A large
+/// negative `from_days` strips the history of ranges entirely.
+async fn drop_partitions_from(conn: &mut AsyncPgConnection, parent: &str, from_days: i32) -> usize {
+	let names: Vec<RowName> = sql_query(
+		r#"
+			SELECT c.relname::text AS relname
+			FROM pg_inherits i
+			JOIN pg_class c ON c.oid = i.inhrelid
+			JOIN pg_class p ON p.oid = i.inhparent
+			WHERE p.relname = $1
+			  AND SUBSTRING(pg_get_expr(c.relpartbound, c.oid) FROM 'FROM \(''(\d{4}-\d{2}-\d{2})')::date
+			      >= CURRENT_DATE + $2
+		"#,
+	)
+	.bind::<sql_types::Text, _>(parent)
+	.bind::<sql_types::Integer, _>(from_days)
+	.load(conn)
+	.await
+	.expect("list partitions");
+
+	let dropped = names.len();
+	for name in names {
+		// The name comes from pg_class, and only ever matches the weekly
+		// partition shape.
+		sql_query(format!("DROP TABLE {}", name.relname))
+			.execute(conn)
+			.await
+			.expect("drop partition");
+	}
+	dropped
+}
+
+async fn days_remaining(conn: &mut AsyncPgConnection, parent: &str) -> i32 {
+	partitions::runway(conn)
+		.await
+		.expect("runway")
+		.into_iter()
+		.find(|r| r.parent == parent)
+		.unwrap_or_else(|| panic!("{parent} missing from runway"))
+		.days_remaining
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn provisioning_is_idempotent_and_reports_runway() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let acted = partitions::ensure_runway(&mut conn, 6)
+			.await
+			.expect("provision");
+		assert!(
+			acted.iter().all(|week| !week.failed()),
+			"provisioning reported failures: {acted:?}"
+		);
+
+		// Second pass over the same weeks does nothing at all.
+		let again = partitions::ensure_runway(&mut conn, 6)
+			.await
+			.expect("provision again");
+		assert!(again.is_empty(), "second pass acted on: {again:?}");
+
+		for history in HISTORIES {
+			let runway = partitions::runway(&mut conn)
+				.await
+				.expect("runway")
+				.into_iter()
+				.find(|r| r.parent == history)
+				.unwrap_or_else(|| panic!("{history} missing from runway"));
+			assert!(
+				runway.days_remaining >= 6 * 7,
+				"{history} covered only {} day(s) after asking for 6 weeks",
+				runway.days_remaining
+			);
+			assert!(runway.covered_to.is_some(), "{history} has no bound");
+			assert!(
+				!runway.short(),
+				"{history} reads as short right after a pass"
+			);
+		}
+	})
+	.await;
+}
+
+/// A history stripped of every range is the worst case, not an absent one: it
+/// must still be reported, or the alert would read the emptiest possible state
+/// as healthy.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_history_with_no_ranges_reports_as_out_of_runway() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		assert!(
+			drop_partitions_from(&mut conn, "device_connections", -100_000).await > 0,
+			"nothing to drop"
+		);
+
+		let runway = partitions::runway(&mut conn)
+			.await
+			.expect("runway")
+			.into_iter()
+			.find(|r| r.parent == "device_connections")
+			.expect("history still reported with no partitions");
+		assert_eq!(runway.partitions, 0);
+		assert_eq!(runway.covered_to, None);
+		assert!(
+			runway.critical(),
+			"{} day(s) reads as fine",
+			runway.days_remaining
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unprovisioned_week_cannot_be_written() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		let server = insert_server(&mut conn, "https://unprovisioned.example.com").await;
+		drop_partitions_from(&mut conn, "statuses", 14).await;
+
+		let write = sql_query(
+			"INSERT INTO statuses (server_id, created_at, extra) \
+			 VALUES ($1, NOW() + INTERVAL '21 days', '{}'::jsonb)",
+		)
+		.bind::<sql_types::Uuid, _>(server)
+		.execute(&mut conn)
+		.await;
+		assert!(
+			write.is_err(),
+			"a week with no range accepted a write — the whole point of provisioning ahead"
+		);
+
+		partitions::ensure_runway(&mut conn, 4)
+			.await
+			.expect("provision");
+
+		sql_query(
+			"INSERT INTO statuses (server_id, created_at, extra) \
+			 VALUES ($1, NOW() + INTERVAL '21 days', '{}'::jsonb)",
+		)
+		.bind::<sql_types::Uuid, _>(server)
+		.execute(&mut conn)
+		.await
+		.expect("write into a provisioned week");
+	})
+	.await;
+}
+
+/// The reason partitions are attached rather than created in place: `CREATE
+/// TABLE ... PARTITION OF` takes ACCESS EXCLUSIVE on the parent, so it waits
+/// behind any in-flight write and queues every new reader and writer behind
+/// itself. `ATTACH PARTITION` takes SHARE UPDATE EXCLUSIVE, which an INSERT
+/// does not conflict with.
+///
+/// The SQL function caps its own lock wait, so a regression here surfaces as a
+/// `failed: canceling statement due to lock timeout` week rather than a hang.
+#[tokio::test(flavor = "multi_thread")]
+async fn provisioning_does_not_block_ingestion() {
+	commons_tests::db::TestDb::run(async |mut conn, url| {
+		let server = insert_server(&mut conn, "https://concurrent.example.com").await;
+		// Leave real work for the provisioning pass to do.
+		assert!(drop_partitions_from(&mut conn, "statuses", 7).await > 0);
+
+		// Hold an uncommitted write on the history being extended.
+		sql_query("BEGIN").execute(&mut conn).await.expect("begin");
+		sql_query("INSERT INTO statuses (server_id, extra) VALUES ($1, '{}'::jsonb)")
+			.bind::<sql_types::Uuid, _>(server)
+			.execute(&mut conn)
+			.await
+			.expect("ingest");
+
+		let pool = database::init_to(&url);
+		let mut other = pool.get().await.expect("second connection");
+		let acted = partitions::ensure_runway(&mut other, 4)
+			.await
+			.expect("provision alongside an open write");
+
+		assert!(
+			acted.iter().any(|week| week.action == "created"),
+			"nothing was provisioned, so the test proved nothing: {acted:?}"
+		);
+		assert!(
+			acted.iter().all(|week| !week.failed()),
+			"provisioning blocked behind an open write: {acted:?}"
+		);
+
+		sql_query("COMMIT")
+			.execute(&mut conn)
+			.await
+			.expect("commit");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn runway_alert_warns_fails_and_recovers() {
+	commons_tests::db::TestDb::run(async |mut conn, _url| {
+		partitions::ensure_runway(&mut conn, 4)
+			.await
+			.expect("provision");
+
+		// Nothing short, so nothing is ever raised.
+		assert!(
+			self_alerts::sweep_partition_runway(&mut conn)
+				.await
+				.expect("sweep")
+				.is_none()
+		);
+		assert!(
+			self_alerts::current(&mut conn, PARTITION_RUNWAY_REF)
+				.await
+				.expect("current")
+				.is_none(),
+			"a healthy runway raised an alert"
+		);
+
+		// Trim both histories into the warning band. Weeks start on Mondays, so
+		// dropping from a week out leaves between one and two weeks of range
+		// whatever day the test runs on.
+		for history in HISTORIES {
+			drop_partitions_from(&mut conn, history, 7).await;
+			let days = days_remaining(&mut conn, history).await;
+			assert!(
+				(FAIL_DAYS..WARN_DAYS).contains(&days),
+				"{history} left with {days} day(s), outside the warning band"
+			);
+		}
+
+		let warned = self_alerts::sweep_partition_runway(&mut conn)
+			.await
+			.expect("sweep")
+			.expect("alert raised");
+		assert!(warned.active);
+		assert_eq!(warned.observed_result, Some(CheckResult::Warning));
+		assert!(
+			warned.message.contains("statuses"),
+			"alert doesn't name the short history: {}",
+			warned.message
+		);
+
+		// Strip one history entirely: past warning, into failure.
+		drop_partitions_from(&mut conn, "device_connections", -100_000).await;
+		let failed = self_alerts::sweep_partition_runway(&mut conn)
+			.await
+			.expect("sweep")
+			.expect("alert still raised");
+		assert!(failed.active);
+		assert_eq!(failed.observed_result, Some(CheckResult::Failed));
+
+		// One successful pass is all it takes to clear.
+		partitions::ensure_runway(&mut conn, 4)
+			.await
+			.expect("provision");
+		let recovered = self_alerts::sweep_partition_runway(&mut conn)
+			.await
+			.expect("sweep")
+			.expect("recovery filed");
+		assert!(!recovered.active, "alert stayed active after provisioning");
+	})
+	.await;
+}

--- a/crates/jobs/src/bin/monitor.rs
+++ b/crates/jobs/src/bin/monitor.rs
@@ -25,6 +25,7 @@ use commons_servers::{
 };
 use commons_types::dns::ManagedZone;
 use database::{issues::reconcile_open_incidents, statuses::Status};
+use diesel_async::AsyncPgConnection;
 use lloggs::{LoggingArgs, PreArgs};
 use miette::IntoDiagnostic;
 use tokio::{
@@ -94,6 +95,28 @@ async fn backfill_stability_on_startup(pool: &database::Db) {
 	}
 }
 
+/// Provision the histories' weekly ranges ahead of now.
+///
+/// Never fatal, and deliberately quiet in the steady state: once the runway is
+/// full a pass reports nothing and this logs nothing. A pass that fails is
+/// retried on the next tick, and one that keeps failing is what the runway
+/// self-alert exists to surface — so failures are logged, not propagated.
+// spec: HST#provisioning-ahead
+async fn ensure_partition_runway(db: &mut AsyncPgConnection) {
+	match database::partitions::ensure_runway(db, database::partitions::WEEKS_AHEAD).await {
+		Ok(acted) => {
+			for week in acted {
+				if week.failed() {
+					warn!("partition provisioning: {} {}", week.partition, week.action);
+				} else {
+					info!("partition provisioning: {} {}", week.partition, week.action);
+				}
+			}
+		}
+		Err(err) => error!("partition provisioning failed: {err}"),
+	}
+}
+
 /// How often the deferred incident-reeval worker drains its queue. Short so
 /// incidents open/close promptly after a status push; work is coalesced per
 /// server, so a tight cadence is cheap.
@@ -107,6 +130,16 @@ pub fn spawn() -> JoinHandle<()> {
 	let pool = database::init();
 	task::spawn(async move {
 		reconcile_on_startup(&pool).await;
+
+		// Ahead of the loop, which doesn't reach its first sweep for a minute:
+		// a pod starting up into a week with no range provisioned shouldn't
+		// spend that minute rejecting writes.
+		// spec: HST#provisioning-ahead
+		match pool.get().await {
+			Ok(mut db) => ensure_partition_runway(&mut db).await,
+			Err(err) => warn!("partition provisioning: no database connection at startup: {err}"),
+		}
+
 		let backfill_pool = pool.clone();
 		task::spawn(async move { backfill_stability_on_startup(&backfill_pool).await });
 
@@ -178,6 +211,20 @@ pub fn spawn() -> JoinHandle<()> {
 				Ok(0) => {}
 				Ok(n) => debug!("re-animated {n} decommissioned check(s)"),
 				Err(err) => error!("check liveness reconcile failed: {err}"),
+			}
+
+			// Keep the histories' weekly ranges provisioned ahead of us, and
+			// alert on the runway. Canopy's own job rather than an external
+			// schedule's: this pod is already long-running and retries, and a
+			// failure here surfaces as a self-alert instead of a job status
+			// nothing watches. Idempotent, so it costs a handful of catalog
+			// lookups per pass once the runway is full.
+			// spec: HST
+			ensure_partition_runway(&mut db).await;
+
+			match database::self_alerts::sweep_partition_runway(&mut db).await {
+				Ok(_) => {}
+				Err(err) => error!("history runway self-alert sweep failed: {err}"),
 			}
 
 			// Canopy-wide warning for checks gone quiet across the whole

--- a/crates/public-server/tests/it/device_key_auth.rs
+++ b/crates/public-server/tests/it/device_key_auth.rs
@@ -46,6 +46,59 @@ async fn device_key_authentication_works() {
 	.await;
 }
 
+/// Recording the connection is part of accepting an authenticated request, not
+/// a condition of it. Connection history is stored in weekly ranges, so a week
+/// with no range provisioned makes that insert fail — and it must not take
+/// every authenticated request on the device API with it.
+// spec: HST#recording-a-connection
+#[tokio::test(flavor = "multi_thread")]
+async fn authentication_survives_unwritable_connection_history() {
+	commons_tests::server::run_with_device_auth(
+		"releaser",
+		async |mut conn, cert, _device_id, public, _| {
+			conn.batch_execute(
+				"INSERT INTO versions (major, minor, patch, changelog, status) VALUES (1, 0, 0, 'Test version', 'published')",
+			)
+			.await
+			.unwrap();
+
+			// Drop the range today falls in, so there is nowhere for the
+			// connection record to go.
+			conn.batch_execute(
+				r#"
+					DO $$
+					DECLARE v_name TEXT;
+					BEGIN
+						SELECT c.relname INTO v_name
+						FROM pg_inherits i
+						JOIN pg_class c ON c.oid = i.inhrelid
+						JOIN pg_class p ON p.oid = i.inhparent
+						WHERE p.relname = 'device_connections'
+						  AND CURRENT_DATE >= SUBSTRING(pg_get_expr(c.relpartbound, c.oid) FROM 'FROM \(''(\d{4}-\d{2}-\d{2})')::date
+						  AND CURRENT_DATE <  SUBSTRING(pg_get_expr(c.relpartbound, c.oid) FROM 'TO \(''(\d{4}-\d{2}-\d{2})')::date;
+						IF v_name IS NULL THEN
+							RAISE EXCEPTION 'no current device_connections range to drop';
+						END IF;
+						EXECUTE FORMAT('DROP TABLE %I', v_name);
+					END;
+					$$;
+				"#,
+			)
+			.await
+			.unwrap();
+
+			let response = public
+				.post("/versions/1.0.1")
+				.add_header("mtls-certificate", &cert)
+				.text("changelog for 1.0.1")
+				.await;
+
+			response.assert_status_ok();
+		},
+	)
+	.await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_keys_per_device() {
 	commons_tests::server::run_with_device_auth(

--- a/migrations/2026-07-30-111221-0000_partition_runway/down.sql
+++ b/migrations/2026-07-30-111221-0000_partition_runway/down.sql
@@ -1,0 +1,128 @@
+-- Back to the per-table functions, each creating partitions with CREATE TABLE
+-- ... PARTITION OF (ACCESS EXCLUSIVE on the parent) and analysing the whole
+-- table afterwards.
+
+DROP FUNCTION IF EXISTS partition_runway();
+DROP FUNCTION IF EXISTS create_statuses_partitions(INTEGER);
+DROP FUNCTION IF EXISTS create_device_connections_partitions(INTEGER);
+DROP FUNCTION IF EXISTS ensure_weekly_partitions(TEXT, INTEGER);
+
+CREATE OR REPLACE FUNCTION create_statuses_partitions(weeks_ahead INTEGER DEFAULT 8)
+RETURNS TABLE(partition_name TEXT, week_start DATE, week_end DATE, action TEXT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_week_start DATE;
+    v_week_end DATE;
+    v_partition_name TEXT;
+    v_year INT;
+    v_week_num INT;
+    v_i INT;
+BEGIN
+    -- Generate partitions for the next N weeks
+    FOR v_i IN 0..weeks_ahead-1 LOOP
+        -- Calculate the start of the week (Monday)
+        v_week_start := DATE_TRUNC('week', CURRENT_DATE + (v_i * INTERVAL '1 week'))::DATE;
+        v_week_end := v_week_start + INTERVAL '7 days';
+
+        -- Extract year and ISO week number
+        v_year := EXTRACT(ISOYEAR FROM v_week_start);
+        v_week_num := EXTRACT(WEEK FROM v_week_start);
+
+        -- Format partition name (e.g., statuses_2025w47)
+        v_partition_name := FORMAT('statuses_%sw%s', v_year, LPAD(v_week_num::TEXT, 2, '0'));
+
+        -- Check if partition already exists
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = v_partition_name
+            AND n.nspname = 'public'
+        ) THEN
+            -- Create the partition
+            EXECUTE FORMAT(
+                'CREATE TABLE %I PARTITION OF statuses FOR VALUES FROM (%L) TO (%L)',
+                v_partition_name,
+                v_week_start,
+                v_week_end
+            );
+
+            partition_name := v_partition_name;
+            week_start := v_week_start;
+            week_end := v_week_end;
+            action := 'created';
+            RETURN NEXT;
+        ELSE
+            partition_name := v_partition_name;
+            week_start := v_week_start;
+            week_end := v_week_end;
+            action := 'already_exists';
+            RETURN NEXT;
+        END IF;
+    END LOOP;
+
+    -- Analyze the table to update statistics
+    EXECUTE 'ANALYZE statuses';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_device_connections_partitions(weeks_ahead INTEGER DEFAULT 8)
+RETURNS TABLE(partition_name TEXT, week_start DATE, week_end DATE, action TEXT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_week_start DATE;
+    v_week_end DATE;
+    v_partition_name TEXT;
+    v_year INT;
+    v_week_num INT;
+    v_i INT;
+BEGIN
+    -- Generate partitions for the next N weeks
+    FOR v_i IN 0..weeks_ahead-1 LOOP
+        -- Calculate the start of the week (Monday)
+        v_week_start := DATE_TRUNC('week', CURRENT_DATE + (v_i * INTERVAL '1 week'))::DATE;
+        v_week_end := v_week_start + INTERVAL '7 days';
+
+        -- Extract year and ISO week number
+        v_year := EXTRACT(ISOYEAR FROM v_week_start);
+        v_week_num := EXTRACT(WEEK FROM v_week_start);
+
+        -- Format partition name (e.g., device_connections_2025w47)
+        v_partition_name := FORMAT('device_connections_%sw%s', v_year, LPAD(v_week_num::TEXT, 2, '0'));
+
+        -- Check if partition already exists
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = v_partition_name
+            AND n.nspname = 'public'
+        ) THEN
+            -- Create the partition
+            EXECUTE FORMAT(
+                'CREATE TABLE %I PARTITION OF device_connections FOR VALUES FROM (%L) TO (%L)',
+                v_partition_name,
+                v_week_start,
+                v_week_end
+            );
+
+            partition_name := v_partition_name;
+            week_start := v_week_start;
+            week_end := v_week_end;
+            action := 'created';
+            RETURN NEXT;
+        ELSE
+            partition_name := v_partition_name;
+            week_start := v_week_start;
+            week_end := v_week_end;
+            action := 'already_exists';
+            RETURN NEXT;
+        END IF;
+    END LOOP;
+
+    -- Analyze the table to update statistics
+    EXECUTE 'ANALYZE device_connections';
+END;
+$$;

--- a/migrations/2026-07-30-111221-0000_partition_runway/up.sql
+++ b/migrations/2026-07-30-111221-0000_partition_runway/up.sql
@@ -125,6 +125,11 @@ $$;
 -- is the exclusive upper bound of its last partition, so a table covered to
 -- tomorrow has one day of runway. DEFAULT partitions carry no bound and are
 -- ignored here.
+--
+-- Partitions are joined outer, so a partitioned table that has none at all is
+-- still a row — the worst case there is, and it would read as healthy if it
+-- were simply absent. With no bound to measure from, its runway is reported as
+-- a day already gone.
 CREATE OR REPLACE FUNCTION partition_runway()
 RETURNS TABLE(parent TEXT, partitions BIGINT, covered_to DATE, days_remaining INTEGER)
 LANGUAGE sql
@@ -132,14 +137,17 @@ STABLE
 AS $$
     SELECT
         p.relname::TEXT,
-        COUNT(*)::BIGINT,
+        COUNT(c.oid)::BIGINT,
         MAX(SUBSTRING(pg_get_expr(c.relpartbound, c.oid) FROM 'TO \(''(\d{4}-\d{2}-\d{2})'))::DATE,
-        (MAX(SUBSTRING(pg_get_expr(c.relpartbound, c.oid) FROM 'TO \(''(\d{4}-\d{2}-\d{2})'))::DATE
-            - CURRENT_DATE)::INTEGER
+        COALESCE(
+            MAX(SUBSTRING(pg_get_expr(c.relpartbound, c.oid) FROM 'TO \(''(\d{4}-\d{2}-\d{2})'))::DATE
+                - CURRENT_DATE,
+            -1
+        )::INTEGER
     FROM pg_class p
     JOIN pg_namespace n ON n.oid = p.relnamespace
-    JOIN pg_inherits i ON i.inhparent = p.oid
-    JOIN pg_class c ON c.oid = i.inhrelid
+    LEFT JOIN pg_inherits i ON i.inhparent = p.oid
+    LEFT JOIN pg_class c ON c.oid = i.inhrelid
     WHERE p.relkind = 'p' AND n.nspname = 'public'
     GROUP BY p.relname;
 $$;

--- a/migrations/2026-07-30-111221-0000_partition_runway/up.sql
+++ b/migrations/2026-07-30-111221-0000_partition_runway/up.sql
@@ -1,0 +1,177 @@
+-- Weekly-partition provisioning that doesn't lock out the history it extends,
+-- plus the runway reading the self-alert is filed from.
+--
+-- spec: HST
+--
+-- Three changes of substance over the per-table functions this replaces:
+--
+--  * Partitions are built detached and then ATTACHed. `CREATE TABLE ...
+--    PARTITION OF` takes ACCESS EXCLUSIVE on the parent, so it waits behind
+--    every in-flight query on the history and queues all new readers and
+--    writers behind itself while it waits — a convoy risk on a table with
+--    known multi-minute queries. `ALTER TABLE ... ATTACH PARTITION` takes
+--    SHARE UPDATE EXCLUSIVE, which conflicts with neither SELECT nor INSERT.
+--  * An advisory lock single-flights callers, so the in-process maintenance
+--    loop and any external caller can't both pass the existence check and
+--    then collide on CREATE.
+--  * The trailing fleet-wide `ANALYZE` is gone. It re-analysed the entire
+--    history (tens of gigabytes across a hundred-odd partitions) on every
+--    run, to no purpose: the partition it had just created is empty.
+--    Autovacuum analyses partitions as they fill.
+
+-- Provision `weeks_ahead` weeks of future partitions for a range-partitioned
+-- table, plus the current week. Idempotent, and safe to call concurrently.
+CREATE OR REPLACE FUNCTION ensure_weekly_partitions(
+    parent TEXT,
+    weeks_ahead INTEGER DEFAULT 4
+)
+RETURNS TABLE(partition_name TEXT, week_start DATE, week_end DATE, action TEXT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    -- Arbitrary, but canopy-specific: this database is shared with other
+    -- services, and advisory locks are per-database.
+    c_lock_key CONSTANT BIGINT := 6819230114770001;
+    v_week_start DATE;
+    v_week_end DATE;
+    v_name TEXT;
+    v_i INT;
+    v_attached BOOLEAN;
+    v_exists BOOLEAN;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = parent AND n.nspname = 'public' AND c.relkind = 'p'
+    ) THEN
+        RAISE EXCEPTION 'ensure_weekly_partitions: % is not a partitioned table', parent;
+    END IF;
+
+    -- Whoever holds this is doing the same idempotent work, so a caller that
+    -- can't take it has nothing to do. Held to end of transaction.
+    IF NOT pg_try_advisory_xact_lock(c_lock_key) THEN
+        RETURN;
+    END IF;
+
+    -- Never queue: every statement below is idempotent and runs again shortly,
+    -- so failing fast beats waiting behind a long reader.
+    SET LOCAL lock_timeout = '5s';
+
+    FOR v_i IN 0..weeks_ahead LOOP
+        v_week_start := DATE_TRUNC('week', CURRENT_DATE + (v_i * INTERVAL '1 week'))::DATE;
+        v_week_end := v_week_start + INTERVAL '7 days';
+        v_name := FORMAT(
+            '%s_%sw%s',
+            parent,
+            EXTRACT(ISOYEAR FROM v_week_start),
+            LPAD(EXTRACT(WEEK FROM v_week_start)::TEXT, 2, '0')
+        );
+
+        -- Attachment, not mere existence: a run that created the table and
+        -- then failed to attach it leaves a table of the right name that
+        -- nothing routes to. Checking the name alone would call that done and
+        -- leave the week permanently unwritable.
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            JOIN pg_class p ON p.oid = i.inhparent
+            WHERE p.relname = parent AND c.relname = v_name
+        ) INTO v_attached;
+
+        partition_name := v_name;
+        week_start := v_week_start;
+        week_end := v_week_end;
+
+        IF v_attached THEN
+            action := 'already_exists';
+            RETURN NEXT;
+            CONTINUE;
+        END IF;
+
+        SELECT EXISTS (
+            SELECT 1 FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = v_name AND n.nspname = 'public'
+        ) INTO v_exists;
+
+        -- Each week in its own subtransaction: one week failing (a lock
+        -- timeout, most likely) must not undo the weeks already provisioned
+        -- in this call, nor stop the ones after it.
+        BEGIN
+            IF NOT v_exists THEN
+                EXECUTE FORMAT(
+                    'CREATE TABLE %I (LIKE %I INCLUDING DEFAULTS INCLUDING CONSTRAINTS INCLUDING STORAGE)',
+                    v_name, parent
+                );
+            END IF;
+
+            EXECUTE FORMAT(
+                'ALTER TABLE %I ATTACH PARTITION %I FOR VALUES FROM (%L) TO (%L)',
+                parent, v_name, v_week_start, v_week_end
+            );
+
+            action := CASE WHEN v_exists THEN 'attached' ELSE 'created' END;
+        EXCEPTION WHEN OTHERS THEN
+            action := FORMAT('failed: %s', SQLERRM);
+        END;
+
+        RETURN NEXT;
+    END LOOP;
+END;
+$$;
+
+-- How much future range each range-partitioned table has left. `covered_to`
+-- is the exclusive upper bound of its last partition, so a table covered to
+-- tomorrow has one day of runway. DEFAULT partitions carry no bound and are
+-- ignored here.
+CREATE OR REPLACE FUNCTION partition_runway()
+RETURNS TABLE(parent TEXT, partitions BIGINT, covered_to DATE, days_remaining INTEGER)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT
+        p.relname::TEXT,
+        COUNT(*)::BIGINT,
+        MAX(SUBSTRING(pg_get_expr(c.relpartbound, c.oid) FROM 'TO \(''(\d{4}-\d{2}-\d{2})'))::DATE,
+        (MAX(SUBSTRING(pg_get_expr(c.relpartbound, c.oid) FROM 'TO \(''(\d{4}-\d{2}-\d{2})'))::DATE
+            - CURRENT_DATE)::INTEGER
+    FROM pg_class p
+    JOIN pg_namespace n ON n.oid = p.relnamespace
+    JOIN pg_inherits i ON i.inhparent = p.oid
+    JOIN pg_class c ON c.oid = i.inhrelid
+    WHERE p.relkind = 'p' AND n.nspname = 'public'
+    GROUP BY p.relname;
+$$;
+
+-- The named entry points stay: an external schedule still calls them, and
+-- their shape is a contract with it. They forward to the generic one.
+CREATE OR REPLACE FUNCTION create_statuses_partitions(weeks_ahead INTEGER DEFAULT 8)
+RETURNS TABLE(partition_name TEXT, week_start DATE, week_end DATE, action TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY SELECT * FROM ensure_weekly_partitions('statuses', weeks_ahead);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION create_device_connections_partitions(weeks_ahead INTEGER DEFAULT 8)
+RETURNS TABLE(partition_name TEXT, week_start DATE, week_end DATE, action TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY SELECT * FROM ensure_weekly_partitions('device_connections', weeks_ahead);
+END;
+$$;
+
+COMMENT ON FUNCTION ensure_weekly_partitions(TEXT, INTEGER) IS
+    'Provisions the current week plus N future weekly partitions of a range-partitioned table. Idempotent, concurrency-safe, and does not block reads or writes of the table.';
+
+COMMENT ON FUNCTION partition_runway() IS
+    'Future range remaining per range-partitioned table: partition count, exclusive upper bound of the last partition, and days from today to that bound.';
+
+COMMENT ON FUNCTION create_statuses_partitions(INTEGER) IS
+    'Provisions weekly partitions for the statuses table. Canopy maintains these itself while running; this entry point exists for external callers.';
+
+COMMENT ON FUNCTION create_device_connections_partitions(INTEGER) IS
+    'Provisions weekly partitions for the device_connections table. Canopy maintains these itself while running; this entry point exists for external callers.';


### PR DESCRIPTION
🤖 Weekly partitions for `statuses` and `device_connections` are provisioned by two k8s CronJobs that nothing watches. Alertmanager is disabled, so a failing job is invisible; the runway is 7–14 days, and when it runs out the failure is not "telemetry stops" but a device-API outage, because the auth extractor writes a `device_connections` row with `?`.

Prod is currently fine (covered to 2026-08-10, both jobs succeeded this morning, no gaps in 101/73 partitions since Sept 2024). This makes the mechanism self-sufficient and the failure visible.

## Provisioning moves into the monitor loop

Canopy keeps four weeks of range provisioned ahead of itself, at startup and on every tick. Idempotent, so a steady state costs a handful of catalog lookups and logs nothing; off the request path, with its own `lock_timeout`, so a failed pass is retried rather than escalated. A failure here now surfaces as a self-alert instead of a `Job` status nothing reads. The CronJobs keep working alongside it — both mechanisms are idempotent and fail for uncorrelated reasons.

## Partitions are attached, not created in place

`CREATE TABLE ... PARTITION OF` takes `AccessExclusive` on the parent, so it waits behind every in-flight query and queues all new readers and writers behind itself while it waits — on a table with known multi-minute queries. `ALTER TABLE ... ATTACH PARTITION` takes `ShareUpdateExclusive`, which conflicts with neither `SELECT` nor `INSERT`. Measured on PG 18.4, holding an uncommitted INSERT on the parent:

| DDL form | Lock on parent | Under concurrent INSERT |
|---|---|---|
| `CREATE TABLE ... PARTITION OF` | `AccessExclusiveLock` | blocked, `lock timeout` at 2.01s |
| `CREATE` + `ATTACH PARTITION` | `ShareUpdateExclusiveLock` | succeeded in 0.01s |

So the nightly job has been taking a full exclusive lock on `statuses` all along; it gets away with it because 00:00 UTC is quiet. The two per-table functions collapse into one generic `ensure_weekly_partitions`, single-flighted by advisory lock, with per-week error isolation and existence tested by *attachment* — checking the name alone would let a run that created a table but failed to attach it leave that week permanently unwritable. The named entry points stay as forwarding wrappers for the external caller.

Also drops the trailing fleet-wide `ANALYZE`, which re-analysed 38 GB across ~100 partitions on every run to populate statistics for an empty partition, and is most of the job's 2m42s runtime.

## Recording a connection no longer gates authentication

An audit-trail write the caller can't influence shouldn't be able to reject an authenticated request. Verified both ways: with the write fatal the new test returns 500, without it 200.

## The alert

A canopy-wide self-alert (`HST`/`SELF`) warning under two weeks of runway and failing under one, carrying which history is short and the date it runs out. It reads the runway rather than the outcome of a pass, so it covers "no pass is running at all" and not just "a pass failed". A history stripped of every partition reports as out of runway rather than dropping out of the reading — the worst case would otherwise have read as healthy.

Presentation and notification come free from the existing self-alert surface, so there's no UI change and no new e2e coverage.

## Not in scope

`drop_old_*_partitions` is left alone. It's unscheduled, and with a 520-week default it would drop nothing today, so the retention question is a policy decision rather than part of this fix — and rewriting destructive DDL for tidiness isn't worth it here. The JIT-on-insert backstop discussed alongside this is also left out: with provisioning in-process and the runway alerted, it's a third layer for a hole the first two close.