### PR TITLE
fix(backup): resolve the effective interval identically everywhere (audit C1, H3)

### DIFF
--- a/crates/commons-servers/src/backup_jobs.rs
+++ b/crates/commons-servers/src/backup_jobs.rs
@@ -136,23 +136,15 @@ pub async fn effective_retention_for_group(
 	Ok(out)
 }
 
-/// Resolve the effective backup interval for one `(group, type)`: the schedule
-/// `expected_interval` override, else the type's `default_interval`. `None` ⇒
-/// manual-only (no scheduled cadence).
+/// Resolve the effective backup interval for one `(group, type)`: an override
+/// row's `expected_interval` (NULL there means manual-only), else the type's
+/// `default_interval`. `None` ⇒ manual-only (no scheduled cadence).
 async fn effective_interval_for_type(
 	db: &mut AsyncPgConnection,
 	group_id: Uuid,
 	ty: &BackupType,
 ) -> Result<Option<Duration>> {
-	let interval = match ServerGroupBackupSchedule::get(db, group_id, ty)
-		.await?
-		.and_then(|s| s.expected_interval)
-	{
-		Some(i) => Some(i),
-		None => BackupTypeDefault::get(db, ty)
-			.await?
-			.and_then(|d| d.default_interval),
-	};
+	let interval = database::backups::effective_interval(db, group_id, ty).await?;
 	// PgDuration wraps a jiff SignedDuration; whole seconds → Duration.
 	Ok(interval.map(|pg| Duration::from_secs(pg.0.as_secs().max(0) as u64)))
 }

--- a/crates/database/src/backup/staleness.rs
+++ b/crates/database/src/backup/staleness.rs
@@ -5,8 +5,12 @@
 //!
 //! The scanned set is every enabled `(server, type)` capability whose
 //! effective schedule has a non-NULL `expected_interval` and whose group's
-//! `server_group_backup_config.status = 'ready'`. Disabled / manual-only
-//! (NULL interval) / non-ready configs are simply not in the set, so
+//! `server_group_backup_config.status = 'ready'`. The effective schedule is
+//! the group's override row if it has one, else the type's canopy-wide
+//! `default_interval` — the same precedence the schedulers resolve with
+//! ([`crate::backups::effective_interval`]), so every pair that is commanded
+//! to back up is also monitored. Disabled / manual-only (an override row with
+//! a NULL interval) / non-ready configs are simply not in the set, so
 //! unauthorized or un-set-up devices never alert.
 
 use std::collections::HashMap;
@@ -109,16 +113,31 @@ impl ScanRow {
 }
 
 /// Raw scan-set row: `(server_id, group_id, is_monitored, device_id, type,
-/// expected_interval, config_created_at)`.
+/// has_schedule_override, override_interval, default_interval,
+/// config_created_at)`.
 type ScanBaseRow = (
 	Uuid,
 	Uuid,
 	bool,
 	Option<Uuid>,
 	String,
-	crate::pg_duration::PgDuration,
+	bool,
+	Option<crate::pg_duration::PgDuration>,
+	Option<crate::pg_duration::PgDuration>,
 	jiff_diesel::Timestamp,
 );
+
+/// A scan-set row with its effective interval resolved, before the success and
+/// anchor lookups are attached.
+struct ScanRowBase {
+	server_id: Uuid,
+	group_id: Uuid,
+	is_monitored: bool,
+	device_id: Option<Uuid>,
+	r#type: BackupType,
+	expected_interval: SignedDuration,
+	config_created_at: Timestamp,
+}
 
 /// Build the scan set: every enabled `(server, type)` capability in a
 /// `status='ready'` group whose effective schedule has a non-NULL
@@ -126,35 +145,76 @@ type ScanBaseRow = (
 /// and the `MIN(first_seen)` anchor.
 pub async fn scan_rows(db: &mut AsyncPgConnection) -> Result<Vec<ScanRow>> {
 	use crate::schema::{
-		device_server_associations as dsa, server_backup_capabilities as cap,
-		server_group_backup_config as cfg, server_group_backup_schedule as sched, servers,
+		backup_type_defaults as defaults, device_server_associations as dsa,
+		server_backup_capabilities as cap, server_group_backup_config as cfg,
+		server_group_backup_schedule as sched, servers,
 	};
 
-	// Join: servers -> their group's ready config -> enabled capability ->
-	// per-(group,type) schedule with a non-NULL interval.
+	// Join: servers -> their group's ready config -> enabled capability, with
+	// both interval sources left-joined. The effective interval is resolved in
+	// Rust below rather than in SQL, because "override row present but NULL"
+	// (manual-only) and "no override row" (inherit the default) have to stay
+	// distinguishable — a COALESCE would flatten them together.
 	let base: Vec<ScanBaseRow> = servers::table
 		.inner_join(cfg::table.on(cfg::group_id.nullable().eq(servers::group_id)))
 		.inner_join(cap::table.on(cap::server_id.eq(servers::id)))
-		.inner_join(
+		.left_join(
 			sched::table.on(sched::group_id
 				.eq(cfg::group_id)
 				.and(sched::type_.eq(cap::type_))),
 		)
+		.left_join(defaults::table.on(defaults::type_.eq(cap::type_)))
 		.filter(servers::deleted_at.is_null())
 		.filter(cfg::status.eq("ready"))
 		.filter(cap::enabled.eq(true))
-		.filter(sched::expected_interval.is_not_null())
 		.select((
 			servers::id,
 			cfg::group_id,
 			servers::is_monitored,
 			servers::device_id,
 			cap::type_,
-			sched::expected_interval.assume_not_null(),
+			sched::group_id.nullable().is_not_null(),
+			sched::expected_interval.nullable(),
+			defaults::default_interval.nullable(),
 			cfg::created_at,
 		))
 		.load(db)
 		.await?;
+
+	// Resolve each pair's effective interval, dropping the ones with none: an
+	// override row answers on its own (NULL = manual-only), otherwise the type
+	// default applies. Mirrors [`crate::backups::effective_interval`].
+	let base: Vec<ScanRowBase> = base
+		.into_iter()
+		.filter_map(
+			|(
+				server_id,
+				group_id,
+				is_monitored,
+				device_id,
+				ty,
+				has_override,
+				override_interval,
+				default_interval,
+				created_at,
+			)| {
+				let interval = if has_override {
+					override_interval
+				} else {
+					default_interval
+				}?;
+				Some(ScanRowBase {
+					server_id,
+					group_id,
+					is_monitored,
+					device_id,
+					r#type: BackupType::from(ty),
+					expected_interval: interval.0,
+					config_created_at: Timestamp::from(created_at),
+				})
+			},
+		)
+		.collect();
 
 	if base.is_empty() {
 		return Ok(Vec::new());
@@ -162,7 +222,7 @@ pub async fn scan_rows(db: &mut AsyncPgConnection) -> Result<Vec<ScanRow>> {
 
 	// Anchors: MIN(first_seen) per server over all its association rows.
 	let server_ids: Vec<Uuid> = {
-		let mut s: std::collections::HashSet<Uuid> = base.iter().map(|r| r.0).collect();
+		let mut s: std::collections::HashSet<Uuid> = base.iter().map(|r| r.server_id).collect();
 		s.drain().collect()
 	};
 	let assoc: Vec<(Uuid, Option<jiff_diesel::Timestamp>)> = dsa::table
@@ -178,7 +238,7 @@ pub async fn scan_rows(db: &mut AsyncPgConnection) -> Result<Vec<ScanRow>> {
 
 	// Latest success per (server, type), fetched per distinct group.
 	let group_ids: Vec<Uuid> = {
-		let mut s: std::collections::HashSet<Uuid> = base.iter().map(|r| r.1).collect();
+		let mut s: std::collections::HashSet<Uuid> = base.iter().map(|r| r.group_id).collect();
 		s.drain().collect()
 	};
 	let mut last_success: HashMap<(Uuid, BackupType), Timestamp> = HashMap::new();
@@ -192,23 +252,22 @@ pub async fn scan_rows(db: &mut AsyncPgConnection) -> Result<Vec<ScanRow>> {
 
 	Ok(base
 		.into_iter()
-		.map(
-			|(server_id, group_id, is_monitored, device_id, ty, interval, created_at)| {
-				let r#type = BackupType::from(ty);
-				let last_success_at = last_success.get(&(server_id, r#type.clone())).copied();
-				ScanRow {
-					server_id,
-					group_id,
-					device_id,
-					r#type,
-					is_monitored,
-					expected_interval: interval.0,
-					config_created_at: Timestamp::from(created_at),
-					min_first_seen: min_first_seen.get(&server_id).copied(),
-					last_success_at,
-				}
-			},
-		)
+		.map(|row| {
+			let last_success_at = last_success
+				.get(&(row.server_id, row.r#type.clone()))
+				.copied();
+			ScanRow {
+				server_id: row.server_id,
+				group_id: row.group_id,
+				device_id: row.device_id,
+				r#type: row.r#type,
+				is_monitored: row.is_monitored,
+				expected_interval: row.expected_interval,
+				config_created_at: row.config_created_at,
+				min_first_seen: min_first_seen.get(&row.server_id).copied(),
+				last_success_at,
+			}
+		})
 		.collect())
 }
 

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -780,6 +780,29 @@ impl ServerGroupBackupSchedule {
 	}
 }
 
+/// Resolve the effective scheduled backup interval for one `(group, type)`.
+///
+/// The single source of truth for this precedence, shared by the schedulers,
+/// the staleness scan, and the admin API — they must agree or a pair can be
+/// commanded to back up on a cadence nothing then monitors (or vice versa).
+///
+/// An override *row* decides on its own: its `expected_interval` is the answer,
+/// including when it is NULL, which the model documents as manual-only. Only
+/// the absence of a row inherits the type's canopy-wide `default_interval`.
+/// `None` ⇒ no scheduled cadence (manual-only).
+pub async fn effective_interval(
+	db: &mut AsyncPgConnection,
+	group_id: Uuid,
+	r#type: &BackupType,
+) -> Result<Option<PgDuration>> {
+	match ServerGroupBackupSchedule::get(db, group_id, r#type).await? {
+		Some(schedule) => Ok(schedule.expected_interval),
+		None => Ok(BackupTypeDefault::get(db, r#type)
+			.await?
+			.and_then(|d| d.default_interval)),
+	}
+}
+
 // ---------------------------------------------------------------------------
 // backup_credential_issuances — audit log of every STS issuance
 // ---------------------------------------------------------------------------

--- a/crates/database/tests/it/backup_detection.rs
+++ b/crates/database/tests/it/backup_detection.rs
@@ -402,6 +402,77 @@ fn classify_restore_only_history_is_never() {
 }
 
 // ===========================================================================
+// Case 1b — the scan set resolves the effective interval like the schedulers
+// ===========================================================================
+
+/// The out-of-the-box path: no per-group override at all, so the pair inherits
+/// the canopy-wide `tamanu-postgres` default (6h, seeded by migration). The
+/// schedulers back this pair up on that cadence, so the scan must monitor it —
+/// skipping it would make every group without an explicit override an
+/// unmonitored backup blindspot.
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_includes_pair_inheriting_the_type_default_interval() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let group_id = insert_group(&mut conn, "inherits-default").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+		// Deliberately no `server_group_backup_schedule` row.
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		let row = rows
+			.iter()
+			.find(|r| r.server_id == server_id && r.r#type == pg)
+			.expect("pair inheriting the type default is in the scan set");
+		assert_eq!(
+			row.expected_interval,
+			SignedDuration::from_hours(6),
+			"the inherited interval is the type default",
+		);
+	})
+	.await;
+}
+
+/// An override row with a NULL interval is manual-only, which the type default
+/// must not resurrect: no cadence means nothing to be stale against.
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_excludes_pair_whose_override_makes_it_manual_only() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let group_id = insert_group(&mut conn, "manual-only").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+		ServerGroupBackupSchedule::upsert(
+			&mut conn,
+			NewServerGroupBackupSchedule {
+				group_id,
+				r#type: pg.clone(),
+				expected_interval: None,
+				retention: Some(retention()),
+				allow_below_floor: false,
+			},
+		)
+		.await
+		.expect("insert manual-only override");
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		assert!(
+			!rows.iter().any(|r| r.server_id == server_id),
+			"a manual-only pair has no cadence to be stale against",
+		);
+	})
+	.await;
+}
+
+// ===========================================================================
 // Case 2 — staleness::sweep files the right server-level events
 // ===========================================================================
 

--- a/crates/database/tests/it/backups.rs
+++ b/crates/database/tests/it/backups.rs
@@ -1467,6 +1467,89 @@ async fn schedule_upsert_and_get() {
 	.await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn effective_interval_precedence() {
+	TestDb::run(|mut conn, _url| async move {
+		let group_id = insert_group(&mut conn, "g").await;
+		let pg = BackupType::TamanuPostgres;
+
+		BackupTypeDefault::upsert(
+			&mut conn,
+			NewBackupTypeDefault {
+				r#type: pg.clone(),
+				default_interval: Some(PgDuration(SignedDuration::from_hours(6))),
+				default_retention: retention(),
+				auto_enable: false,
+				allow_below_floor: false,
+			},
+		)
+		.await
+		.unwrap();
+
+		// No override row: inherit the type default.
+		assert_eq!(
+			database::backups::effective_interval(&mut conn, group_id, &pg)
+				.await
+				.unwrap(),
+			Some(PgDuration(SignedDuration::from_hours(6))),
+		);
+
+		// An override row with an interval wins over the default.
+		ServerGroupBackupSchedule::upsert(
+			&mut conn,
+			NewServerGroupBackupSchedule {
+				group_id,
+				r#type: pg.clone(),
+				expected_interval: Some(PgDuration(SignedDuration::from_hours(12))),
+				retention: None,
+				allow_below_floor: false,
+			},
+		)
+		.await
+		.unwrap();
+		assert_eq!(
+			database::backups::effective_interval(&mut conn, group_id, &pg)
+				.await
+				.unwrap(),
+			Some(PgDuration(SignedDuration::from_hours(12))),
+		);
+
+		// An override row with a NULL interval is manual-only: it does *not*
+		// fall through to the default, unlike the same row's NULL retention.
+		ServerGroupBackupSchedule::upsert(
+			&mut conn,
+			NewServerGroupBackupSchedule {
+				group_id,
+				r#type: pg.clone(),
+				expected_interval: None,
+				retention: None,
+				allow_below_floor: false,
+			},
+		)
+		.await
+		.unwrap();
+		assert_eq!(
+			database::backups::effective_interval(&mut conn, group_id, &pg)
+				.await
+				.unwrap(),
+			None,
+			"a present-but-NULL interval means manual-only",
+		);
+
+		// Deleting the override restores inheritance.
+		ServerGroupBackupSchedule::delete(&mut conn, group_id, &pg)
+			.await
+			.unwrap();
+		assert_eq!(
+			database::backups::effective_interval(&mut conn, group_id, &pg)
+				.await
+				.unwrap(),
+			Some(PgDuration(SignedDuration::from_hours(6))),
+		);
+	})
+	.await;
+}
+
 // --- requests ---------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/private-server/src/fns/backups.rs
+++ b/crates/private-server/src/fns/backups.rs
@@ -591,18 +591,15 @@ impl RestoreWindowView {
 }
 
 /// Effective scheduled interval (seconds) for a `(group, type)`: the per-group
-/// override if set, else the canopy-wide default. `None` = manual-only.
+/// override row if there is one (a NULL interval there being manual-only), else
+/// the canopy-wide default. `None` = manual-only.
 async fn effective_interval_secs(
 	conn: &mut AsyncPgConnection,
 	group_id: Uuid,
 	ty: &BackupType,
 ) -> Result<Option<i64>> {
-	let over = ServerGroupBackupSchedule::get(conn, group_id, ty).await?;
-	let def = BackupTypeDefault::get(conn, ty).await?;
-	Ok(over
-		.as_ref()
-		.and_then(|s| s.expected_interval)
-		.or_else(|| def.as_ref().and_then(|d| d.default_interval))
+	Ok(database::backups::effective_interval(conn, group_id, ty)
+		.await?
 		.map(|pg| pg.0.as_secs()))
 }
 
@@ -1377,11 +1374,13 @@ pub async fn group_schedules(
 	for ty in types {
 		let over = ServerGroupBackupSchedule::get(&mut conn, args.server_group_id, &ty).await?;
 		let def = BackupTypeDefault::get(&mut conn, &ty).await?;
-		let effective_interval = over
-			.as_ref()
-			.and_then(|s| s.expected_interval)
-			.or_else(|| def.as_ref().and_then(|d| d.default_interval))
-			.map(|pg| pg.0.as_secs());
+		// An override row decides alone (NULL interval = manual-only); only its
+		// absence inherits the type default. Same precedence as the schedulers.
+		let effective_interval = match over.as_ref() {
+			Some(over) => over.expected_interval,
+			None => def.as_ref().and_then(|d| d.default_interval),
+		}
+		.map(|pg| pg.0.as_secs());
 		let effective_retention = over
 			.as_ref()
 			.and_then(|s| s.retention.as_ref())

--- a/crates/private-server/tests/it/backups.rs
+++ b/crates/private-server/tests/it/backups.rs
@@ -776,6 +776,45 @@ async fn group_schedules_reports_next_run_from_last_success_plus_interval() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn group_schedules_reports_manual_only_override_as_no_schedule() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group_id = seed_group(&mut conn).await;
+		let server_id = Uuid::new_v4();
+		// An override row with a NULL interval is manual-only, even though
+		// `tamanu-postgres` has a canopy-wide 6h default to inherit from.
+		conn.batch_execute(&format!(
+			"INSERT INTO servers (id, host, kind, group_id) VALUES \
+				('{server_id}', 'https://e.test', 'central', '{group_id}');
+			 INSERT INTO server_backup_capabilities (server_id, type, enabled) VALUES \
+				('{server_id}', 'tamanu-postgres', true);
+			 INSERT INTO server_group_backup_schedule (group_id, type, expected_interval) VALUES \
+				('{group_id}', 'tamanu-postgres', NULL);"
+		))
+		.await
+		.expect("seed manual-only override");
+
+		let resp = private
+			.post("/api/backups/group_schedules")
+			.json(&serde_json::json!({ "server_group_id": group_id }))
+			.await;
+		resp.assert_status_ok();
+		let body: serde_json::Value = resp.json();
+		let row = body
+			.as_array()
+			.unwrap()
+			.iter()
+			.find(|r| r["type"] == "tamanu-postgres")
+			.expect("the overridden type appears in schedule/retention");
+		assert!(
+			row["effective_interval"].is_null(),
+			"manual-only must not resurrect the type default",
+		);
+		assert!(row["next_run_at"].is_null());
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn group_schedules_includes_disabled_declared_types() {
 	commons_tests::server::run(async |mut conn, _public, private| {
 		let group_id = seed_group(&mut conn).await;


### PR DESCRIPTION
Fixes **C1** (critical) and **H3** (high) from the audit in #370. They're two halves of the same disagreement about what a backup schedule means, so they're one change.

## C1 — the staleness scan skipped every group on the inherited default

`backup::staleness::scan_rows` inner-joined `server_group_backup_schedule` and filtered `expected_interval IS NOT NULL`, with no fallback to the type default. A `(group, type)` with no override row — the out-of-the-box case, since `tamanu-postgres` ships a canopy-wide 6h default and rows are only written by an explicit `set_schedule` — was never in the scan set.

The schedulers back those pairs up happily via `backups_due_now_for_server`, but nothing then checked that the backups kept arriving. A device that stopped backing up raised no `backup-staleness` / `backup-never` issue, and because `reconcile::sweep` consumes the same rows, report-gap, size-mismatch and reconcile-missing never ran for it either.

## H3 — a manual-only schedule silently reverted to the default cadence

The three resolvers (`effective_interval_for_type`, `effective_interval_secs`, `group_schedules`) used `.and_then(|s| s.expected_interval).or_else(default)`, collapsing "no override row" (inherit) into "override row whose interval is NULL". The model and the `set_schedule` contract both document the latter as **manual-only**, deliberately unlike the same row's `retention: None` which does mean inherit.

So an operator setting `expected_interval: null` got a group that was still commanded to back up on the 6h default, still showed an interval and a `next_run_at` in `group_schedules` — and, because the scan honoured NULL as manual-only, could never raise a staleness alert either.

## The fix

One resolver, `database::backups::effective_interval`: an override row answers on its own, NULL included; only its absence inherits the type's `default_interval`. All three call sites now go through it.

`scan_rows` left-joins both `server_group_backup_schedule` and `backup_type_defaults` and resolves the same way in Rust — a SQL `COALESCE` can't express it, because it would flatten manual-only back into the default. The set that is commanded to back up and the set that is monitored are now one set.

## Tests

- `database`: `effective_interval_precedence` covers all four states (no row, row with interval, row with NULL, row deleted).
- `database`: `scan_includes_pair_inheriting_the_type_default_interval` — the C1 regression, asserting the inherited 6h shows up on the scan row.
- `database`: `scan_excludes_pair_whose_override_makes_it_manual_only` — the default must not resurrect a manual-only pair.
- `private-server`: `group_schedules_reports_manual_only_override_as_no_schedule` — the API surface of H3.

Ran green against a local Postgres 16 alongside the existing backup suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_