### PR TITLE
fix(backup): derive reconcile inventory freshness from the group's inspection (audit H2)

### DIFF
--- a/crates/database/src/backup/reconcile.rs
+++ b/crates/database/src/backup/reconcile.rs
@@ -74,6 +74,19 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 	};
 	let snaps = snapshot_info(db, &group_ids).await?;
 
+	// Inventory freshness is a property of the *group's* inspection, not of any
+	// one pair's snapshot row: the inspection Job only writes a row for sources
+	// it actually finds, so the pair with nothing in the repo — precisely the
+	// one the "missing" verdict exists for — has no row of its own to date.
+	let mut inspected_at: HashMap<Uuid, Timestamp> = HashMap::new();
+	for gid in &group_ids {
+		if let Some(at) =
+			crate::backups::BackupRepoSnapshot::last_inspected_at_for_group(db, *gid).await?
+		{
+			inspected_at.insert(*gid, at);
+		}
+	}
+
 	// Latest comparable (reported, observed) sizes per (server, type). A server
 	// belongs to one group, so keys don't collide across groups.
 	let mut sized: HashMap<(Uuid, BackupType), (i64, i64)> = HashMap::new();
@@ -94,8 +107,9 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 		let snapshot_fresh = snap
 			.and_then(|s| s.latest_snapshot_at)
 			.is_some_and(|t| now.duration_since(t) <= grace);
-		let inventory_fresh =
-			snap.is_some_and(|s| now.duration_since(s.observed_at) <= INVENTORY_STALE_AFTER);
+		let inventory_fresh = inspected_at
+			.get(&row.group_id)
+			.is_some_and(|at| now.duration_since(*at) <= INVENTORY_STALE_AFTER);
 
 		let missing_ref = format!("{}:{}", refs::RECONCILE_MISSING, row.r#type);
 		let gap_ref = format!("{}:{}", refs::RECONCILE_REPORT_GAP, row.r#type);

--- a/crates/database/tests/it/backup_detection.rs
+++ b/crates/database/tests/it/backup_detection.rs
@@ -661,6 +661,112 @@ async fn reconcile_files_missing_when_report_fresh_but_no_snapshot() {
 	.await;
 }
 
+/// The case the "missing" verdict exists for: a device reports success while
+/// nothing lands in the repo, so the inspection job — which only writes rows
+/// for sources it actually finds — never creates a snapshot row for the pair.
+/// Inventory freshness has to come from the *group's* last inspection, not
+/// from the absent row, or the alert can never fire.
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_files_missing_when_report_fresh_and_the_pair_has_no_snapshot_row() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let interval = SignedDuration::from_hours(12);
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let other_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+
+		// Fresh report for our server...
+		insert_backup_success_aged(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(2),
+		)
+		.await;
+		// ...and the inspector ran recently, but only found another server's
+		// source — nothing for ours.
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{other_id}:/data"),
+			Some(other_id),
+			Some(&pg),
+			Some(Timestamp::now() - SignedDuration::from_hours(2)),
+		)
+		.await
+		.expect("upsert other server's snapshot");
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("reconcile sweep");
+
+		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
+		let issue = group_issue(&mut conn, group_id, &mref)
+			.await
+			.expect("reconcile-missing issue filed for the pair with no snapshot");
+		assert_eq!(issue.effective_result.as_deref(), Some("failed"));
+		assert!(issue.active);
+	})
+	.await;
+}
+
+/// The freshness guard still holds: a group the inspector has never run
+/// against has no inventory to conclude "nothing landed" from, so the missing
+/// verdict defers to the inspection job's own failure surfacing.
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_skips_missing_when_the_group_was_never_inspected() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let interval = SignedDuration::from_hours(12);
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+		insert_backup_success_aged(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(2),
+		)
+		.await;
+		// No `backup_repo_snapshots` rows at all for the group.
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("reconcile sweep");
+
+		assert!(
+			group_issue(
+				&mut conn,
+				group_id,
+				&typed_ref(refs::RECONCILE_MISSING, &pg)
+			)
+			.await
+			.is_none(),
+			"an uninspected group must not be accused of losing backups",
+		);
+	})
+	.await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn reconcile_clears_report_gap_when_report_and_snapshot_agree() {
 	TestDb::run(|mut conn, _url| async move {


### PR DESCRIPTION
Fixes **H2** (high) from the audit in #370.

## The bug

`backup-reconcile-missing` — the headline "the device's report is false, or the upload didn't persist" alert — could never fire in the exact case it exists for.

`reconcile::sweep` derived inventory freshness from the per-`(server, type)` `backup_repo_snapshots` row's `observed_at`, and treated the **absence** of that row as "inventory stale → skip". But the inspection job (`jobs/src/backup/complete.rs`) writes a snapshot row only for sources it actually finds in the repo. A pair with nothing in the repo has no row of its own, so `inventory_fresh` was false and the `(true, false)` match fell into the empty arm.

So a device reporting `outcome=success` every cycle while uploading nothing looked healthy from every angle: inspection ran fine against the group's other sources, staleness saw fresh successes, and the one check designed to catch a lying report stayed silent. The loss surfaces at restore time.

The group-level signal the module doc already describes (`last_inspected_at_for_group`) was never consulted.

## The fix

Freshness is now a property of the group's last inspection — the newest `observed_at` across its sources — resolved once per scanned group. Per-pair `snapshot_fresh` is unchanged, so the absent row correctly reads as "nothing landed" rather than "we don't know".

The guard itself still holds: a group the inspector has never run against has no inventory to conclude from, and keeps deferring to the inspection job's own failure surfacing.

## Tests

- `reconcile_files_missing_when_report_fresh_and_the_pair_has_no_snapshot_row` — fresh report, inspector ran 2h ago but only found *another* server's source; asserts the missing issue is filed. Confirmed to fail against the unfixed sweep.
- `reconcile_skips_missing_when_the_group_was_never_inspected` — pins the freshness guard so the fix doesn't turn into "always alert".

The existing reconcile suite (report-gap, size-mismatch, clear paths) passes unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_