### PR TITLE
fix(slack): back off between failed outbox deliveries (audit H4)

### DIFF
--- a/crates/database/src/slack_outbox/mod.rs
+++ b/crates/database/src/slack_outbox/mod.rs
@@ -25,7 +25,7 @@
 use commons_errors::{AppError, Result};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
-use jiff::Timestamp;
+use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
@@ -42,6 +42,27 @@ pub const KIND_INCIDENT_RESOLVE: &str = "incident_resolve";
 pub const KIND_SELF_ALERT_OPEN: &str = "self_alert_open";
 /// Legacy: see [`KIND_SELF_ALERT_OPEN`].
 pub const KIND_SELF_ALERT_RESOLVE: &str = "self_alert_resolve";
+
+/// Delay after the first failed attempt; doubles from there.
+pub const RETRY_BACKOFF_BASE: SignedDuration = SignedDuration::from_secs(15);
+/// Ceiling on the retry backoff, so the tail of a long outage is retried
+/// on a steady cadence rather than an ever-lengthening one.
+pub const RETRY_BACKOFF_CAP: SignedDuration = SignedDuration::from_mins(15);
+
+/// How long to hold a row back after its `attempts`th failed delivery:
+/// [`RETRY_BACKOFF_BASE`] doubling per attempt, capped at
+/// [`RETRY_BACKOFF_CAP`].
+///
+/// With the drainer's 10-attempt budget this spends about an hour before
+/// giving up (15s, 30s, 1m, 2m, 4m, 8m, then 15m a few times), which covers
+/// a routine Slack incident. The naive "retry on the next tick" schedule
+/// spent the same budget in well under two minutes.
+pub fn retry_backoff(attempts: i32) -> SignedDuration {
+	let doublings = attempts.clamp(1, 20) - 1;
+	RETRY_BACKOFF_BASE
+		.saturating_mul(2i32.saturating_pow(doublings as u32))
+		.min(RETRY_BACKOFF_CAP)
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name = crate::schema::slack_outbox)]
@@ -258,6 +279,15 @@ impl SlackOutbox {
 		Ok(())
 	}
 
+	/// Record a failed delivery attempt and hold the row back until its
+	/// backoff has elapsed. Returns the new attempt count.
+	///
+	/// Advancing `deliver_after` is what makes the retry budget a *duration*
+	/// rather than a handful of ticks: the drainer re-claims on a 5-second
+	/// tick, so without it every attempt is burnt inside a minute and a
+	/// routine Slack incident permanently drops every page enqueued during
+	/// it.
+	///
 	/// `response` is the HTTP body Slack returned for this attempt, if we
 	/// got one (network errors before any response leave this `None`).
 	pub async fn mark_failed(
@@ -265,18 +295,26 @@ impl SlackOutbox {
 		id: Uuid,
 		error: &str,
 		response: Option<&str>,
-	) -> Result<()> {
+	) -> Result<i32> {
 		use crate::schema::slack_outbox::dsl;
-		diesel::update(dsl::slack_outbox.filter(dsl::id.eq(id)))
+		let attempts: i32 = diesel::update(dsl::slack_outbox.filter(dsl::id.eq(id)))
 			.set((
 				dsl::attempts.eq(dsl::attempts + 1),
 				dsl::last_error.eq(error),
 				dsl::last_response.eq(response),
 			))
+			.returning(dsl::attempts)
+			.get_result(db)
+			.await
+			.map_err(AppError::from)?;
+
+		let next_try = Timestamp::now() + retry_backoff(attempts);
+		diesel::update(dsl::slack_outbox.filter(dsl::id.eq(id)))
+			.set(dsl::deliver_after.eq(jiff_diesel::Timestamp::from(next_try)))
 			.execute(db)
 			.await
 			.map_err(AppError::from)?;
-		Ok(())
+		Ok(attempts)
 	}
 
 	/// Mark the row as terminally given-up — the drainer will not retry

--- a/crates/database/tests/it/slack_outbox_enqueue.rs
+++ b/crates/database/tests/it/slack_outbox_enqueue.rs
@@ -471,6 +471,90 @@ async fn mark_given_up_removes_row_from_claim_pending() {
 	.await
 }
 
+/// The retry budget has to be a duration, not a handful of ticks. The
+/// drainer re-claims every 5 seconds, so a failed row that stays immediately
+/// claimable burns all ten attempts inside a couple of minutes and is given
+/// up permanently — any Slack outage longer than that silently drops every
+/// page enqueued during it.
+#[tokio::test(flavor = "multi_thread")]
+async fn mark_failed_holds_the_row_back_for_its_backoff() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, "http://backoff.invalid/").await;
+		let stamp = database::issues::CheckStateStamp {
+			check: "ref-b".into(),
+			observed: CheckResult::Failed,
+			effective: CheckResult::Failed,
+			escalates: false,
+			detail: None,
+		};
+		let event = NewEvent {
+			source: "test".into(),
+			r#ref: "ref-b".into(),
+			description: None,
+			message: "boom".into(),
+			active: Some(true),
+			occurred_at: None,
+		};
+		event
+			.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
+			.await
+			.expect("save");
+		expire_deliver_after(&mut conn).await;
+		let row = SlackOutbox::claim_pending(&mut conn, 10)
+			.await
+			.expect("claim")
+			.into_iter()
+			.next()
+			.expect("one pending row");
+
+		let attempts = SlackOutbox::mark_failed(&mut conn, row.id, "slack 503", Some("upstream"))
+			.await
+			.expect("mark_failed");
+		assert_eq!(attempts, 1);
+
+		let still_pending = SlackOutbox::claim_pending(&mut conn, 10)
+			.await
+			.expect("claim again");
+		assert!(
+			still_pending.iter().all(|r| r.id != row.id),
+			"a failed row must not be reclaimable on the very next tick",
+		);
+
+		// It comes back once the backoff has elapsed.
+		expire_deliver_after(&mut conn).await;
+		let after_backoff = SlackOutbox::claim_pending(&mut conn, 10)
+			.await
+			.expect("claim after backoff");
+		assert!(
+			after_backoff.iter().any(|r| r.id == row.id),
+			"the row is still owed once its backoff passes — failure is not give-up",
+		);
+	})
+	.await
+}
+
+#[test]
+fn retry_backoff_doubles_then_holds_at_the_cap() {
+	use database::slack_outbox::{RETRY_BACKOFF_CAP, retry_backoff};
+
+	assert_eq!(retry_backoff(1), SignedDuration::from_secs(15));
+	assert_eq!(retry_backoff(2), SignedDuration::from_secs(30));
+	assert_eq!(retry_backoff(3), SignedDuration::from_mins(1));
+	assert_eq!(retry_backoff(6), SignedDuration::from_mins(8));
+	assert_eq!(retry_backoff(7), RETRY_BACKOFF_CAP);
+	assert_eq!(retry_backoff(100), RETRY_BACKOFF_CAP);
+
+	// The drainer's 10-attempt budget must span a routine Slack incident,
+	// not a couple of minutes' worth of ticks.
+	let total: SignedDuration = (1..10)
+		.map(retry_backoff)
+		.fold(SignedDuration::ZERO, |acc, d| acc + d);
+	assert!(
+		total >= SignedDuration::from_mins(45),
+		"ten attempts should span most of an hour, got {total}",
+	);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn claim_pending_skips_rows_whose_deliver_after_is_in_the_future() {
 	// Direct check on the drainer's claim filter: an open row that's

--- a/crates/jobs/src/bin/slacker_outbox.rs
+++ b/crates/jobs/src/bin/slacker_outbox.rs
@@ -208,6 +208,9 @@ fn spawn(cfg: Config) -> JoinHandle<()> {
 										kind = %row.kind,
 										incident_id = ?row.incident_id,
 										attempts = next_attempts,
+										retry_in = %database::slack_outbox::retry_backoff(
+											next_attempts
+										),
 										err = %err.msg,
 										response = ?err.body,
 										"slack delivery failed; will retry"


### PR DESCRIPTION
Fixes **H4** (high) from the audit in #370.

## The bug

`SlackOutbox::mark_failed` incremented `attempts` and recorded the error, but never touched `deliver_after` — the column `claim_pending` filters on. A failed row was immediately claimable again, and the drainer ticks every 5 seconds, so all `MAX_ATTEMPTS = 10` were burnt in roughly 45–90 seconds. After that the row is stamped `gave_up_at` and never retried.

The retry budget was effectively a count of ticks rather than a span of time. A Slack outage of a few minutes — a routine occurrence — permanently dropped every incident open and resolve enqueued during it, and nobody was paged for them once Slack came back.

(The give-up escalation goes out through the same failing path, so it's dropped the same way. That's a separate concern and not addressed here.)

## The fix

`mark_failed` now advances `deliver_after` by `retry_backoff(attempts)`: 15s, doubling per attempt, capped at 15 minutes. The same ten attempts now span about an hour (15s, 30s, 1m, 2m, 4m, 8m, then 15m a few times), which rides out a routine Slack incident.

The schedule is a plain function in `database::slack_outbox`, so it's unit-testable and the drainer can log the wait alongside its retry warning. `mark_failed` also returns the new attempt count.

Nothing about give-up changes: a row that exhausts its attempts is still abandoned, it just takes an hour of real outage to get there instead of a minute.

## Tests

- `mark_failed_holds_the_row_back_for_its_backoff` — after `mark_failed` the row is not reclaimable on the next tick, and *is* reclaimable once its backoff has elapsed (failure is not give-up).
- `retry_backoff_doubles_then_holds_at_the_cap` — the schedule itself, including the assertion that the ten-attempt budget spans at least 45 minutes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_