### PR TITLE
fix(web): give IncidentsLink the group id it queries by (audit H8)

### DIFF
--- a/private-web/e2e/incidents-link.spec.ts
+++ b/private-web/e2e/incidents-link.spec.ts
@@ -1,0 +1,83 @@
+import {
+	resetSeededTables,
+	seedIssue,
+	seedServer,
+	seedServerGroup,
+} from "./seed";
+import { expect, test } from "./test-fixtures";
+
+// The server-detail header button into the incidents view. Its "active
+// issues?" question is answered by a group-scoped query, so it needs the
+// server's *group* id — feeding it the server id matches no group at all and
+// the button reports a clean server no matter what is wrong with it.
+test.describe("server detail incidents link", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("reports active issues and links to the group's incidents", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "link-group" });
+		const server = await seedServer(sql, {
+			name: "link-server",
+			groupId: group.id,
+		});
+		// An active issue but no incident — the state that distinguishes
+		// "Active issues" from "Past issues".
+		await seedIssue(sql, {
+			serverId: server.id,
+			ref: "health/postgres",
+			message: "postgres is down",
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		const link = page.getByRole("link", { name: "Active issues" });
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute(
+			"href",
+			`/incidents?group=${group.id}`,
+		);
+
+		// The linked page filters to a real group, so the issue is there.
+		await link.click();
+		await expect(page.getByText("postgres is down")).toBeVisible();
+	});
+
+	test("reports past issues when the group has nothing active", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "quiet-group" });
+		const server = await seedServer(sql, {
+			name: "quiet-server",
+			groupId: group.id,
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		const link = page.getByRole("link", { name: "Past issues" });
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute(
+			"href",
+			`/incidents?group=${group.id}&showAll=1`,
+		);
+	});
+
+	test("an ungrouped server links to the unfiltered incidents view", async ({
+		page,
+		sql,
+	}) => {
+		const server = await seedServer(sql, {
+			name: "ungrouped-server",
+			groupId: null,
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		// No group to filter by, so no group query parameter — and certainly
+		// not the server id standing in for one.
+		const link = page.getByRole("link", { name: "Past issues" });
+		await expect(link).toBeVisible();
+		await expect(link).toHaveAttribute("href", "/incidents?showAll=1");
+	});
+});

--- a/private-web/src/api.ts
+++ b/private-web/src/api.ts
@@ -79,11 +79,23 @@ export function useApi<
 	fn: F,
 	params: Record<string, unknown> = {},
 	deps: ReadonlyArray<unknown> = [],
+	/** `skip` leaves the hook idle without calling the endpoint, for when the
+	 * params aren't available yet (a filter the caller doesn't have). Hooks
+	 * can't be called conditionally, so the condition has to live here. */
+	options: { skip?: boolean } = {},
 ): ApiState<T> & { reload: () => void } {
 	const [state, setState] = useState<ApiState<T>>({ status: "idle" });
 	const tick = useRef(0);
+	const skip = options.skip ?? false;
 
 	const run = useCallback(() => {
+		if (skip) {
+			// Bump the tick so an in-flight response from before the skip
+			// can't land and present stale data as current.
+			tick.current++;
+			setState({ status: "idle" });
+			return;
+		}
 		const myTick = ++tick.current;
 		const controller = new AbortController();
 		// Keep prior data on screen during background refetches so the UI
@@ -106,7 +118,7 @@ export function useApi<
 			});
 		return () => controller.abort();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, deps);
+	}, [...deps, skip]);
 
 	useEffect(() => run(), [run]);
 

--- a/private-web/src/components/IncidentsLink.tsx
+++ b/private-web/src/components/IncidentsLink.tsx
@@ -5,20 +5,29 @@ import { useApi } from "../api";
 import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
 import { isIncidentLingering } from "../types";
 
-/** Server-detail header button into the incidents view. Any server id in
- * a group works — the backend resolves to the group root. Three states:
+/** Server-detail header button into the incidents view. Incidents are looked
+ * up by server (the backend resolves to the group root); issues are looked up
+ * by the server's group, which the caller must supply — `issues.list` matches
+ * `serverGroupId` against `servers.group_id` and does no server→group
+ * resolution of its own, so a server id there matches nothing at all. Three
+ * states:
  * - open incident exists → direct link to /incidents/:id (error-coloured;
  *   warning-coloured when the Slack notice is still inside the per-group
  *   cooldown window so the operator can tell at a glance that nobody else
  *   has been paged yet; info-coloured when the incident is lingering —
  *   every failure has recovered and it closes if things stay quiet)
  * - no open incident, but active issues → /incidents filtered to this group
- * - nothing active → same, with `showAll=1` so closed/inactive surface */
+ * - nothing active → same, with `showAll=1` so closed/inactive surface
+ *
+ * An ungrouped server has no group to filter by, so the issues query is
+ * skipped and the links fall back to the unfiltered incidents view. */
 export default function IncidentsLink({
 	serverId,
+	groupId,
 	refreshKey = 0,
 }: {
 	serverId: string;
+	groupId: string | null;
 	refreshKey?: number;
 }) {
 	const incidents = useApi(
@@ -35,10 +44,19 @@ export default function IncidentsLink({
 	const issues = useApi(
 		"issues",
 		"list",
-		{ activeOnly: true, serverGroupId: serverId, limit: 1 },
-		[serverId, refreshKey],
+		{ activeOnly: true, serverGroupId: groupId ?? undefined, limit: 1 },
+		[groupId, refreshKey],
+		{ skip: groupId === null },
 	);
 	const hasActive = issues.status === "ok" && issues.data.length > 0;
+
+	const incidentsHref = (showAll: boolean) => {
+		const params = new URLSearchParams();
+		if (groupId !== null) params.set("group", groupId);
+		if (showAll) params.set("showAll", "1");
+		const query = params.toString();
+		return query ? `/incidents?${query}` : "/incidents";
+	};
 
 	const heldUntilActive = useIsNotificationHeld(
 		openIncident?.notification_held_until ?? null,
@@ -67,7 +85,7 @@ export default function IncidentsLink({
 	if (hasActive) {
 		return (
 			<ActionButton
-				to={`/incidents?group=${serverId}`}
+				to={incidentsHref(false)}
 				icon={<OpenInNewIcon />}
 				label="Active issues"
 			/>
@@ -75,7 +93,7 @@ export default function IncidentsLink({
 	}
 	return (
 		<ActionButton
-			to={`/incidents?group=${serverId}&showAll=1`}
+			to={incidentsHref(true)}
 			icon={<OpenInNewIcon />}
 			label="Past issues"
 		/>

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -308,7 +308,11 @@ function Header({
 				{muninUrl && (
 					<ActionButton href={muninUrl} icon={<InsightsIcon />} label="Munin" />
 				)}
-				<IncidentsLink serverId={data.server.id} refreshKey={refreshTick} />
+				<IncidentsLink
+					serverId={data.server.id}
+					groupId={data.group?.id ?? null}
+					refreshKey={refreshTick}
+				/>
 				{isAdmin && (
 					<>
 						<ManualEventButton


### PR DESCRIPTION
Fixes **H8** (high) from the audit in #370.

## The bug

`ServerDetail` passed `data.server.id` to `IncidentsLink`, which fed it to `issues.list` as `serverGroupId`. That filter resolves as `servers.group_id = $` — and unlike `incidents.list_for_server`, `issues.list` does no server→group resolution. A server id never equals a group id, so the query matched zero servers and always returned `[]`.

Two visible consequences:

- `hasActive` was permanently false. A server with active issues but no open incident showed **"Past issues"**, and an operator reading that header concludes the server is clean when it isn't.
- Both `/incidents?group=${serverId}` links carried the same mismatch, so following one landed on a page filtering by a nonexistent group: "No issues match the current filters", plus an invalid value sitting in the group dropdown.

The component's doc-comment ("Any server id in a group works — the backend resolves to the group root") was true of the *incidents* query it sits next to, which is probably how the two got conflated.

## The fix

`IncidentsLink` now takes `groupId` explicitly and uses it for both the query and the links. `ServerDetail` already has it — it passes `data.group?.id` to `BackupCapabilitiesSection` a few lines earlier.

An ungrouped server has no group to filter by. Passing `serverGroupId: undefined` would silently widen the query to the whole fleet, so the query is skipped instead and the links drop the parameter. Hooks can't be called conditionally, hence the small `skip` option added to `useApi` (it also bumps the request tick, so a response in flight when `skip` flips can't land afterwards and present stale data).

## Tests

New `private-web/e2e/incidents-link.spec.ts`:
- active issue, no incident → button reads "Active issues", links to `/incidents?group=<group>`, and following it actually shows the issue;
- quiet group → "Past issues" with `group=<group>&showAll=1`;
- ungrouped server → `/incidents?showAll=1`, with no server id standing in for a group.

All three confirmed to fail against the unfixed component.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_