### PR TITLE
fix(artifacts): de-duplicate by key, not by adjacency (audit M1)

### DIFF
--- a/crates/database/src/artifacts.rs
+++ b/crates/database/src/artifacts.rs
@@ -94,8 +94,14 @@ impl Artifact {
 		// Sort by specificity to handle conflicts
 		Self::sort_by_specificity(&mut artifacts);
 
-		// Remove duplicates by platform+artifact_type, keeping the most specific one
-		artifacts.dedup_by_key(|a| (a.artifact_type.clone(), a.platform.clone()));
+		// Keep the first (most specific) artifact per platform+artifact_type.
+		// Not `dedup_by_key`: that only drops *consecutive* duplicates, and the
+		// specificity sort has just destroyed the adjacency the SQL `ORDER BY`
+		// gave us — every exact artifact now precedes every range one, so two
+		// artifacts of the same type+platform are only neighbours when they
+		// happen to be equally specific.
+		let mut seen = std::collections::HashSet::new();
+		artifacts.retain(|a| seen.insert((a.artifact_type.clone(), a.platform.clone())));
 
 		Ok(artifacts)
 	}

--- a/crates/public-server/tests/it/versions.rs
+++ b/crates/public-server/tests/it/versions.rs
@@ -623,6 +623,53 @@ async fn artifact_specificity_conflict_resolution() {
 	.await
 }
 
+/// Deduplication has to be by key, not by adjacency. The SQL `ORDER BY` groups
+/// each type+platform together, but the specificity sort then hoists every
+/// exact artifact ahead of every range one. Any other exact artifact sorting
+/// after the duplicated key therefore lands between its exact and range rows,
+/// and they stop being neighbours.
+#[tokio::test(flavor = "multi_thread")]
+async fn artifact_specificity_dedups_non_adjacent_duplicates() {
+	commons_tests::server::run(async |mut conn, public, _| {
+		let version_id = "cccccccc-cccc-cccc-cccc-ccccccccccc1";
+		let exact_windows = "dddddddd-dddd-dddd-dddd-ddddddddddd1";
+		let range_windows = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1";
+		let exact_android = "ffffffff-ffff-ffff-ffff-fffffffffff1";
+
+		// installer/windows is duplicated; mobile/android sorts after it, so the
+		// specificity sort yields [installer-exact, mobile-exact, installer-range]
+		// and the two installer rows are no longer adjacent.
+		conn.batch_execute(&format!(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+			('{version_id}', 1, 0, 1, 'v1.0.1', 'published');
+
+			INSERT INTO artifacts (id, version_id, platform, artifact_type, download_url, version_range_pattern) VALUES
+			('{exact_windows}', '{version_id}', 'windows', 'installer', 'https://example.com/exact.exe', NULL),
+			('{range_windows}', NULL, 'windows', 'installer', 'https://example.com/1x.exe', '1.x'),
+			('{exact_android}', '{version_id}', 'android', 'mobile', 'https://example.com/exact.apk', NULL)",
+		))
+		.await
+		.unwrap();
+
+		let response = public.get("/versions/1.0.1/artifacts").await;
+		response.assert_status_ok();
+		let artifacts: Vec<Artifact> = response.json();
+		let installers: Vec<&Artifact> = artifacts
+			.iter()
+			.filter(|a| a.platform == "windows" && a.artifact_type == "installer")
+			.collect();
+		assert_eq!(
+			installers.len(),
+			1,
+			"one entry per type+platform; got conflicting download URLs: {:?}",
+			installers.iter().map(|a| &a.download_url).collect::<Vec<_>>(),
+		);
+		assert_eq!(installers[0].id.to_string(), exact_windows.to_lowercase());
+		assert_eq!(artifacts.len(), 2, "windows installer + android mobile");
+	})
+	.await
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn artifact_range_specificity_conflict_resolution() {
 	commons_tests::server::run(async |mut conn, public, _| {


### PR DESCRIPTION
Fixes **M1** (medium) from the audit in #370.

## The bug

`Artifact::get_for_version` promises one artifact per `(artifact_type, platform)` — the most specific one. It sorted by specificity and then called `Vec::dedup_by_key`, which only removes *consecutive* duplicates.

The SQL `ORDER BY artifact_type, platform` does group each key together, but `sort_by_specificity` then hoists every exact artifact ahead of every range one. A key's exact and range rows stay adjacent only when no *other* exact artifact sorts between them — so the bug needs a second type or platform to show up, which is why the existing tests (single type+platform, pair necessarily adjacent) pass either way.

Concretely: an `installer/windows` exact + range pair, plus a `mobile/android` exact, sorts to `[installer-exact, mobile-exact, installer-range]`. Both installer artifacts are returned, with conflicting download URLs, to the public artifact list, the HTML artifact pages, and `/mobile`.

Worth noting the audit's own worked example is arranged the other way round and happens *not* to reproduce — the sort is stable, so the duplicated key has to sort before the separator. Took a corrected fixture to actually trigger it.

## The fix

Keep the first occurrence per key using a seen-set, which drops the adjacency assumption entirely. The specificity sort still decides which one that is, and the resulting order is unchanged for every case that was already correct.

## Tests

`artifact_specificity_dedups_non_adjacent_duplicates` — the arrangement above; asserts one entry for the duplicated key, that it's the exact one, and that the unrelated artifact survives. Confirmed to fail against the unfixed code (returns both URLs) and pass with it. The existing artifact suite is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_