### PR TITLE
fix(versions): rank only published rows in the version_updates view (audit M2)

### DIFF
--- a/crates/database/src/versions.rs
+++ b/crates/database/src/versions.rs
@@ -147,6 +147,13 @@ impl Version {
 			.map_err(AppError::from)
 	}
 
+	/// The newest published patch of every `(major, minor)` line above
+	/// `version`, within the same major.
+	///
+	/// The `version_updates` view ranks published rows only, so a line whose
+	/// newest patch is draft or yanked still offers its newest *published*
+	/// patch rather than dropping out entirely. The `status` filter below is
+	/// belt-and-braces on top of that.
 	pub async fn get_updates_for_version(
 		db: &mut AsyncPgConnection,
 		version: VersionStr,

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -46,3 +46,4 @@ mod status_figures;
 mod statuses_device_fk;
 mod tag_reserved_prefix;
 mod version_known_issue_provenance;
+mod version_updates_view;

--- a/crates/database/tests/it/version_updates_view.rs
+++ b/crates/database/tests/it/version_updates_view.rs
@@ -1,0 +1,69 @@
+//! The `version_updates` view: one row per `(major, minor)` line, and which
+//! row that is when the newest patch in a line isn't published.
+
+use commons_tests::db::TestDb;
+use commons_types::version::VersionStr;
+use database::versions::Version;
+use diesel_async::SimpleAsyncConnection;
+
+async fn updates_from(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	from: &str,
+) -> Vec<(i32, i32, i32)> {
+	Version::get_updates_for_version(conn, from.parse::<VersionStr>().expect("parse version"))
+		.await
+		.expect("updates")
+		.into_iter()
+		.map(|v| (v.major, v.minor, v.patch))
+		.collect()
+}
+
+/// A line's newest patch being draft (or yanked) must not take the whole line
+/// with it: the update on offer is the line's newest *published* patch. The
+/// view reduces each line to one row, so filtering status after that reduction
+/// is too late.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_line_offers_its_newest_published_patch_not_nothing() {
+	TestDb::run(|mut conn, _url| async move {
+		conn.batch_execute(
+			"INSERT INTO versions (major, minor, patch, changelog, status) VALUES
+			(2, 45, 0, 'v2.45.0', 'published'),
+			(2, 46, 1, 'v2.46.1', 'published'),
+			(2, 46, 2, 'v2.46.2', 'published'),
+			(2, 46, 3, 'v2.46.3', 'draft'),
+			(2, 47, 0, 'v2.47.0', 'published'),
+			(2, 47, 1, 'v2.47.1', 'yanked')",
+		)
+		.await
+		.expect("seed versions");
+
+		assert_eq!(
+			updates_from(&mut conn, "2.45.0").await,
+			vec![(2, 46, 2), (2, 47, 0)],
+			"each line offers its newest published patch",
+		);
+	})
+	.await;
+}
+
+/// A line with nothing published in it offers nothing, rather than leaking an
+/// unpublished version as an available update.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_wholly_unpublished_line_offers_nothing() {
+	TestDb::run(|mut conn, _url| async move {
+		conn.batch_execute(
+			"INSERT INTO versions (major, minor, patch, changelog, status) VALUES
+			(3, 0, 0, 'v3.0.0', 'published'),
+			(3, 1, 0, 'v3.1.0', 'draft'),
+			(3, 1, 1, 'v3.1.1', 'draft')",
+		)
+		.await
+		.expect("seed versions");
+
+		assert!(
+			updates_from(&mut conn, "3.0.0").await.is_empty(),
+			"a draft-only line is not an available update",
+		);
+	})
+	.await;
+}

--- a/migrations/2026-08-01-082529-0000_version_updates_published_only/down.sql
+++ b/migrations/2026-08-01-082529-0000_version_updates_published_only/down.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW version_updates AS
+WITH ranked_versions AS (
+	SELECT *, ROW_NUMBER() OVER (PARTITION BY major, minor ORDER BY patch DESC) as rn
+	FROM versions
+)
+SELECT id, major, minor, patch, status, changelog
+FROM ranked_versions
+WHERE rn = 1;

--- a/migrations/2026-08-01-082529-0000_version_updates_published_only/up.sql
+++ b/migrations/2026-08-01-082529-0000_version_updates_published_only/up.sql
@@ -1,0 +1,19 @@
+-- Rank only published versions when reducing each minor line to one row.
+--
+-- The view exists to answer "what can this version update to", and reduced
+-- each (major, minor) to its single highest-patch row with no status filter.
+-- Callers then filter on status, which is too late: if the newest patch in a
+-- line is draft or yanked, that row is the only one the view exposes for the
+-- line, so the filter drops the whole minor rather than falling back to its
+-- newest published patch. With 2.46.2 published and 2.46.3 draft, nothing in
+-- the 2.46 line was offered as an update at all — even though the public
+-- update endpoint, which filters before it reduces, offers 2.46.2.
+CREATE OR REPLACE VIEW version_updates AS
+WITH ranked_versions AS (
+	SELECT *, ROW_NUMBER() OVER (PARTITION BY major, minor ORDER BY patch DESC) as rn
+	FROM versions
+	WHERE status = 'published'
+)
+SELECT id, major, minor, patch, status, changelog
+FROM ranked_versions
+WHERE rn = 1;


### PR DESCRIPTION
Fixes **M2** (medium) from the audit in #370.

## The bug

`version_updates` reduces each `(major, minor)` line to its single highest-patch row (`ROW_NUMBER() … WHERE rn = 1`) with **no status filter inside**. `get_updates_for_version` then filters `status = 'published'` — too late. If the newest patch in a line is draft or yanked, that row is the only one the view exposes for the line, so the caller's filter drops the entire minor rather than falling back to the line's newest published patch.

MCP's `get_version` reads this, so `available_updates` silently omitted whole release lines. The public `update_for` endpoint does filter-then-reduce in Rust and offers the version fine, so the two disagree.

## The fix

A migration redefining the view to rank published rows only — filter before the reduction, matching what `update_for` already does. A line with nothing published in it still contributes nothing, so an unpublished version can't leak out as an available update. The caller keeps its `status` filter as belt-and-braces.

## Tests

New `crates/database/tests/it/version_updates_view.rs`:
- `a_line_offers_its_newest_published_patch_not_nothing` — 2.46.{1,2} published + 2.46.3 draft, and 2.47.0 published + 2.47.1 yanked; updates from 2.45.0 are `[2.46.2, 2.47.0]`.
- `a_wholly_unpublished_line_offers_nothing`.

Confirmed against the unfixed view: updates from 2.45.0 come back **empty** — both lines vanish, not just the draft-topped one. Slightly worse than the audit described.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_