### PR TITLE
fix(statuses): don't 404 a group card when nothing is published (audit M6)

### DIFF
--- a/crates/private-server/src/fns/statuses.rs
+++ b/crates/private-server/src/fns/statuses.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use axum::Json;
 use axum::extract::State;
 use canopy_utoipa_axum::{router::OpenApiRouter, routes};
-use commons_errors::{ProblemDetailsSchema, Result};
+use commons_errors::{AppError, ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleUser;
 use commons_types::{
 	server::{
@@ -218,9 +218,15 @@ pub async fn group_details(
 	let group = ServerGroup::get_by_id(&mut conn, args.server_group_id).await?;
 	let servers = group.list_servers(&mut conn).await?;
 
-	let latest_version = Version::get_latest_matching(&mut conn, "*".parse()?)
-		.await?
-		.as_semver();
+	// A group card shouldn't 404 just because no versions are published yet
+	// (e.g. a fresh deployment, or every version still draft); treat "no match"
+	// as "unknown latest" so `version_distance` falls back to None. Same as
+	// `servers::get_detail` and `statuses::snapshot`.
+	let latest_version = match Version::get_latest_matching(&mut conn, "*".parse()?).await {
+		Ok(v) => Some(v.as_semver()),
+		Err(AppError::NoMatchingVersions) => None,
+		Err(e) => return Err(e),
+	};
 
 	let server_ids: Vec<Uuid> = servers.iter().map(|s| s.id).collect();
 	let status_map: HashMap<Uuid, Status> = Status::latest_for_servers(&mut conn, &server_ids)
@@ -242,7 +248,8 @@ pub async fn group_details(
 	let card_version = group.effective_version.clone();
 	let version_distance = card_version
 		.as_ref()
-		.map(|v| database::statuses::version_distance(&v.0, &latest_version));
+		.zip(latest_version.as_ref())
+		.map(|(current, latest)| database::statuses::version_distance(&current.0, latest));
 
 	let mut members: Vec<FacilityServerStatus> = servers
 		.into_iter()

--- a/crates/private-server/tests/it/group_card_version.rs
+++ b/crates/private-server/tests/it/group_card_version.rs
@@ -60,3 +60,37 @@ async fn group_card_version_is_from_highest_rank_kind_member() {
 	})
 	.await;
 }
+
+/// A fresh deployment — or one where every version is still draft — has no
+/// published version to measure against. That's an unknown distance, not a
+/// missing group: 404ing here blanks the whole status board.
+#[tokio::test(flavor = "multi_thread")]
+async fn group_card_is_served_when_no_version_is_published() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (major, minor, patch, changelog, status)
+				VALUES (2, 10, 0, 'unreleased', 'draft');
+			INSERT INTO server_groups (id, name)
+				VALUES ('bbbbbbbb-0000-0000-0000-000000000001', 'Fresh');
+			INSERT INTO servers (id, name, host, kind, rank, group_id) VALUES
+				('bbbbbbbb-0000-0000-0000-0000000000c0', 'central',
+				 'https://fresh.example.com', 'central', 'production',
+				 'bbbbbbbb-0000-0000-0000-000000000001');",
+		)
+		.await
+		.unwrap();
+
+		let resp = private
+			.post("/api/statuses/group_details")
+			.json(&json!({ "server_group_id": "bbbbbbbb-0000-0000-0000-000000000001" }))
+			.await;
+		resp.assert_status_ok();
+		let card: Value = resp.json();
+		assert_eq!(card["name"], "Fresh");
+		assert!(
+			card["version_distance"].is_null(),
+			"no published version to compare against means unknown distance",
+		);
+	})
+	.await;
+}


### PR DESCRIPTION
Fixes **M6** (medium) from the audit in #370.

## The bug

`group_details` resolved the latest published version with `Version::get_latest_matching(conn, "*")` and propagated the error with `?`. That call returns `NoMatchingVersions` — which maps to **404** — when nothing is published at all.

So on a fresh deployment, or one where every version is still draft, `group_details` 404s for *every* group and the fleet status board renders empty or errored. The group exists and is perfectly healthy; the only thing missing is a release to compare against.

The two sibling endpoints needing the same value, `servers::get_detail` and `statuses::snapshot`, already map this to `version_distance: None` with a comment saying a page shouldn't 404 just because no versions are published yet. `group_details` was the odd one out.

## The fix

Treat "no match" as "unknown latest", exactly as the siblings do: `latest_version` becomes an `Option`, and `version_distance` is `None` when either the card's version or the latest is unknown.

## Tests

`group_card_is_served_when_no_version_is_published` — a group with a healthy production central and only a draft version; asserts 200, the group's name, and a null `version_distance`. Confirmed to fail against the unfixed handler with `404 NoMatchingVersions`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_