### PR TITLE
fix(mcp): filter find_issues by server in SQL, not after the limit (audit M7)

### DIFF
--- a/crates/canopy-mcp/src/incidents.rs
+++ b/crates/canopy-mcp/src/incidents.rs
@@ -438,21 +438,19 @@ impl CanopyMcp {
 		let since = args.since_days.map(since_from_days);
 		let limit = args.limit.unwrap_or(100);
 
-		let mut issues = Issue::list(
+		let issues = Issue::list(
 			&mut conn,
 			IssueListFilters {
 				active_only: args.active_only.unwrap_or(true),
 				results,
 				server_group_id: group,
+				server_id: server,
 				since,
 			},
 			limit,
 		)
 		.await
 		.map_err(mcp_err)?;
-		if let Some(sid) = server {
-			issues.retain(|i| i.server_id == Some(sid));
-		}
 
 		let names = Server::names_by_ids(
 			&mut conn,

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -248,6 +248,8 @@ pub struct IssueListFilters {
 	pub results: Option<Vec<CheckResult>>,
 	/// Restrict to issues whose server belongs to this group.
 	pub server_group_id: Option<Uuid>,
+	/// Restrict to issues raised against this server.
+	pub server_id: Option<Uuid>,
 	/// When `Some`, restrict to issues last seen at or after this time.
 	pub since: Option<Timestamp>,
 }
@@ -2550,6 +2552,11 @@ impl Issue {
 	///   latest effective result is one of those.
 	/// - `server_group_id`: when `Some`, restrict to issues whose server is
 	///   in that group. A direct `IN (SELECT id FROM servers WHERE group_id = $)`.
+	/// - `server_id`: when `Some`, restrict to issues on that server.
+	///
+	/// Every filter is applied in SQL, so `limit` bounds the *filtered* set.
+	/// Narrowing a page after the fact would let a busy fleet push a quiet
+	/// server's issues off the end and report it clean.
 	pub async fn list(
 		db: &mut AsyncPgConnection,
 		filters: IssueListFilters,
@@ -2588,6 +2595,9 @@ impl Issue {
 				.load(db)
 				.await?;
 			q = q.filter(dsl::server_id.eq_any(server_ids));
+		}
+		if let Some(sid) = filters.server_id {
+			q = q.filter(dsl::server_id.eq(sid));
 		}
 		if let Some(since) = filters.since {
 			q = q.filter(dsl::last_seen.ge(jiff_diesel::Timestamp::from(since)));

--- a/crates/database/tests/it/issue_list_filters.rs
+++ b/crates/database/tests/it/issue_list_filters.rs
@@ -1,0 +1,101 @@
+//! `Issue::list` filters in SQL, so `limit` bounds the *filtered* set.
+//!
+//! Narrowing a page after the fact instead lets a busy fleet push a quiet
+//! server's issues past the limit, and the caller — the MCP `find_issues`
+//! tool — reports that server clean.
+
+use commons_tests::db::TestDb;
+use database::diesel_async::AsyncPgConnection;
+use database::issues::{Issue, IssueListFilters};
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_server(conn: &mut AsyncPgConnection) -> Uuid {
+	let host = format!("http://test.invalid/{}", Uuid::new_v4());
+	sql_query("INSERT INTO servers (host, kind) VALUES ($1, 'central') RETURNING id")
+		.bind::<sql_types::Text, _>(host)
+		.get_result::<RowId>(conn)
+		.await
+		.expect("insert server")
+		.id
+}
+
+/// Insert an active issue for `server_id`, with `last_seen` backdated by
+/// `age_secs` so the ordering the limit applies to is controllable.
+async fn insert_issue(conn: &mut AsyncPgConnection, server_id: Uuid, r#ref: &str, age_secs: i64) {
+	sql_query(
+		"INSERT INTO issues (server_id, source, \"ref\", message, active, last_seen, last_degraded_at) \
+		 VALUES ($1, 'test', $2, 'boom', true, NOW() - ($3 || ' seconds')::INTERVAL, NOW())",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(r#ref)
+	.bind::<sql_types::Text, _>(age_secs.to_string())
+	.execute(conn)
+	.await
+	.expect("insert issue");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_server_filter_is_applied_before_the_limit() {
+	TestDb::run(|mut conn, _url| async move {
+		let noisy = insert_server(&mut conn).await;
+		let quiet = insert_server(&mut conn).await;
+
+		// The quiet server's one issue was seen longest ago, so it sorts last
+		// and a limit applied before filtering would cut it off.
+		for i in 0..10 {
+			insert_issue(&mut conn, noisy, &format!("noisy-{i}"), i).await;
+		}
+		insert_issue(&mut conn, quiet, "quiet-1", 1000).await;
+
+		let found = Issue::list(
+			&mut conn,
+			IssueListFilters {
+				server_id: Some(quiet),
+				..Default::default()
+			},
+			5,
+		)
+		.await
+		.expect("list");
+
+		assert_eq!(
+			found.len(),
+			1,
+			"the quiet server's issue must survive a limit smaller than the fleet's issue count",
+		);
+		assert_eq!(found[0].r#ref, "quiet-1");
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_server_filter_excludes_other_servers() {
+	TestDb::run(|mut conn, _url| async move {
+		let a = insert_server(&mut conn).await;
+		let b = insert_server(&mut conn).await;
+		insert_issue(&mut conn, a, "a-1", 1).await;
+		insert_issue(&mut conn, b, "b-1", 2).await;
+
+		let found = Issue::list(
+			&mut conn,
+			IssueListFilters {
+				server_id: Some(a),
+				..Default::default()
+			},
+			100,
+		)
+		.await
+		.expect("list");
+		assert_eq!(found.len(), 1);
+		assert_eq!(found[0].server_id, Some(a));
+	})
+	.await;
+}

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -22,6 +22,7 @@ mod incident_linger;
 mod incident_reeval_queue;
 mod incident_result_semantics;
 mod incident_stats;
+mod issue_list_filters;
 mod mcp_tokens;
 mod migration_test_candidates;
 mod migration_test_reports;

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -346,6 +346,7 @@ pub async fn list(
 			active_only: args.active_only.unwrap_or(true),
 			results: args.results,
 			server_group_id: args.server_group_id,
+			server_id: None,
 			since: None,
 		},
 		args.limit.unwrap_or(DEFAULT_LIMIT),


### PR DESCRIPTION
Fixes **M7** (medium) from the audit in #370.

## The bug

`Issue::list` orders by `last_seen desc` with a SQL `LIMIT` (default 100). `find_issues` then applied its `server_id` filter in Rust — `issues.retain(…)` — on that already-truncated page. Every other filter, including `group_id`, is part of the query; only this one bit after the fact.

With more active issues fleet-wide than the limit, a server whose issues were seen slightly earlier than the top N returns `count: 0`. An agent triaging that server is told it's clean when it isn't — and the quieter the server, the likelier that is, which is exactly backwards.

## The fix

`server_id` joins the other fields on `IssueListFilters` and is applied in SQL, so the limit bounds the filtered set. `private-server`'s `issues::list` passes `None` and is unaffected.

## Tests

New `crates/database/tests/it/issue_list_filters.rs`:
- `the_server_filter_is_applied_before_the_limit` — a noisy server with 10 recent issues, a quiet one whose single issue was seen longest ago, and a limit of 5: the quiet server's issue still comes back.
- `the_server_filter_excludes_other_servers` — the filter does what it says.

This is one of four sites in the audit's "filter-after-LIMIT in the MCP layer" pattern (M7, M8, M9, L14); the others are separate PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_