### PR TITLE
fix(mcp): scan the whole window for backup problems, not the newest rows (audit M9)

### DIFF
--- a/crates/canopy-mcp/src/fleet.rs
+++ b/crates/canopy-mcp/src/fleet.rs
@@ -9,7 +9,10 @@ use commons_types::{
 };
 use database::{
 	backup::staleness::{StalenessVerdict, scan_rows},
-	backups::{BackupMaintenanceRun, BackupRun, ServerGroupBackupConfig},
+	backups::{
+		BackupMaintenanceRun, BackupMaintenanceRunFilters, BackupRun, BackupRunFilters,
+		MaintenanceOutcomeFilter, ServerGroupBackupConfig,
+	},
 	server_groups::ServerGroup,
 	servers::Server,
 	statuses::Status,
@@ -32,6 +35,11 @@ use crate::{
 const STUCK_MAINTENANCE_AFTER: SignedDuration = SignedDuration::from_hours(6);
 /// Only the last day of failed runs is surfaced, to bound noise.
 const FAILED_RUN_WINDOW: SignedDuration = SignedDuration::from_hours(24);
+/// Cap on how many problem rows of one kind a single group can contribute,
+/// so one pathological group can't drown out the rest of the fleet. Applied
+/// to the already-filtered set, so it bounds real problems rather than
+/// deciding which ones get looked at.
+const PROBLEM_LIMIT: i64 = 20;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct FindBackupProblemsArgs {
@@ -233,34 +241,53 @@ impl CanopyMcp {
 					since: None,
 				});
 			}
-			for run in BackupRun::list_for_group(&mut conn, c.group_id, 20)
-				.await
-				.map_err(mcp_err)?
+			// Failures within the window, selected in SQL. Scanning the N
+			// newest runs and time-filtering afterwards shrinks the advertised
+			// 24h window for exactly the groups that back up most often: a
+			// failure eight hours ago disappears behind the successes that
+			// followed it.
+			for run in BackupRun::list_filtered(
+				&mut conn,
+				BackupRunFilters {
+					group_id: Some(c.group_id),
+					outcome: Some(RunOutcome::Failure),
+					since: Some(now - FAILED_RUN_WINDOW),
+					..Default::default()
+				},
+				PROBLEM_LIMIT,
+			)
+			.await
+			.map_err(mcp_err)?
 			{
-				if run.outcome == RunOutcome::Failure
-					&& now.duration_since(run.reported_at) <= FAILED_RUN_WINDOW
-				{
-					problems.push(BackupProblem {
-						kind: "failed_run",
-						severity: "warning",
-						group_id: c.group_id,
-						server_id: run.server_id,
-						r#type: Some(run.r#type.to_string()),
-						detail: run
-							.error
-							.clone()
-							.unwrap_or_else(|| "backup run failed".into()),
-						since: Some(run.reported_at),
-					});
-				}
+				problems.push(BackupProblem {
+					kind: "failed_run",
+					severity: "warning",
+					group_id: c.group_id,
+					server_id: run.server_id,
+					r#type: Some(run.r#type.to_string()),
+					detail: run
+						.error
+						.clone()
+						.unwrap_or_else(|| "backup run failed".into()),
+					since: Some(run.reported_at),
+				});
 			}
-			for m in BackupMaintenanceRun::list_for_group(&mut conn, c.group_id, 5)
-				.await
-				.map_err(mcp_err)?
+			// Same shape: still-running maintenance is selected in SQL rather
+			// than found among the few newest runs, so a stuck run can't be
+			// pushed out of view by later ones.
+			for m in BackupMaintenanceRun::list_filtered(
+				&mut conn,
+				BackupMaintenanceRunFilters {
+					group_id: Some(c.group_id),
+					outcome: Some(MaintenanceOutcomeFilter::Running),
+					..Default::default()
+				},
+				PROBLEM_LIMIT,
+			)
+			.await
+			.map_err(mcp_err)?
 			{
-				if m.finished_at.is_none()
-					&& now.duration_since(m.started_at) > STUCK_MAINTENANCE_AFTER
-				{
+				if now.duration_since(m.started_at) > STUCK_MAINTENANCE_AFTER {
 					problems.push(BackupProblem {
 						kind: "stuck_maintenance",
 						severity: "warning",

--- a/crates/private-server/tests/it/mcp.rs
+++ b/crates/private-server/tests/it/mcp.rs
@@ -508,6 +508,67 @@ async fn backup_problems_scan_runs() {
 	.await
 }
 
+/// The advertised window is "failed runs in the last 24h". Inspecting only the
+/// N newest runs and time-filtering afterwards shrinks that window for exactly
+/// the groups that back up most often — a real failure vanishes behind the
+/// successes reported since.
+#[tokio::test(flavor = "multi_thread")]
+async fn backup_problems_finds_a_failure_behind_many_later_successes() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let group = "cccccccc-0000-0000-0000-000000000001";
+		let server = "cccccccc-0000-0000-0000-000000000002";
+		let device = "cccccccc-0000-0000-0000-000000000003";
+
+		let mut sql = format!(
+			"INSERT INTO server_groups (id, name) VALUES ('{group}', 'Chatty'); \
+			 INSERT INTO servers (id, host, name, kind, group_id) VALUES \
+				('{server}', 'https://chatty', 'Chatty', 'central', '{group}'); \
+			 INSERT INTO devices (id, role) VALUES ('{device}', 'server'); \
+			 INSERT INTO server_group_backup_config \
+				(group_id, bucket, prefix, target_role_arn, maintenance_role_arn, \
+				 repo_password_ref, status, mode, placement) \
+				VALUES ('{group}', 'b', '', 'arn', 'maint', 'pw', 'ready', 'from_birth', 'external'); \
+			 INSERT INTO backup_runs \
+				(id, device_id, group_id, server_id, type, purpose, outcome, error, reported_at) \
+			  VALUES ('{}', '{device}', '{group}', '{server}', 'tamanu-postgres', 'backup', \
+				'failure', 'disk full', NOW() - interval '8 hours');",
+			uuid::Uuid::new_v4()
+		);
+		// 30 later successes — more than any per-group row cap — all inside the
+		// same 24h window, each newer than the failure.
+		for i in 0..30 {
+			sql.push_str(&format!(
+				"INSERT INTO backup_runs \
+					(id, device_id, group_id, server_id, type, purpose, outcome, reported_at) \
+				  VALUES ('{}', '{device}', '{group}', '{server}', 'tamanu-postgres', 'backup', \
+					'success', NOW() - interval '{i} minutes');",
+				uuid::Uuid::new_v4()
+			));
+		}
+		conn.batch_execute(&sql).await.expect("seed chatty group");
+
+		let p = call_tool!(
+			private,
+			"find_backup_problems",
+			serde_json::json!({ "group_id": group })
+		);
+		let failures: Vec<&serde_json::Value> = p["problems"]
+			.as_array()
+			.unwrap()
+			.iter()
+			.filter(|x| x["kind"] == "failed_run")
+			.collect();
+		assert_eq!(
+			failures.len(),
+			1,
+			"the 8h-old failure is inside the 24h window: {}",
+			p["problems"]
+		);
+		assert_eq!(failures[0]["detail"], "disk full");
+	})
+	.await
+}
+
 // --- backup runs, maintenance runs, restore replicas, backup defaults -------
 
 const RGROUP: &str = "bbbbbbbb-0000-0000-0000-000000000001";


### PR DESCRIPTION
Fixes **M9** (medium) from the audit in #370.

## The bug

`find_backup_problems` advertises "failed runs in the last 24h", but only inspected the **20 newest runs per group** (5 for maintenance), applying the time and outcome tests in Rust afterwards. The row cap therefore decided which runs got looked at, and the effective window shrank in proportion to how often a group backs up.

A group reporting ~120 runs/day with a failure 8h ago followed by more than 20 successes reports no `failed_run` at all — the failure is squarely inside the advertised window. The busier the group, the smaller its window, which is the opposite of what an operator would assume. Same shape for `stuck_maintenance` behind its cap of 5.

## The fix

Both scans use the existing filtered queries — `BackupRunFilters { outcome: Failure, since: now - 24h }` and `MaintenanceOutcomeFilter::Running` — so selection happens in SQL. The per-group cap survives as a noise bound (`PROBLEM_LIMIT`), but it now bounds *real problems* rather than deciding which ones are visible.

## Tests

`backup_problems_finds_a_failure_behind_many_later_successes` (private-server, through the real `/api/mcp` endpoint) — a ready group with a failure 8h ago and 30 later successes, all inside the window. Confirmed to fail against the unfixed scan, which reports `problems: []`.

Last of four in the audit's "filter-after-LIMIT in the MCP layer" pattern (M7, M8, M9, L14).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_