### PR TITLE
fix(restore): recover a replica's alert when the declaration is disabled (audit M10)

### DIFF
--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -218,9 +218,10 @@ impl RestoreReplica {
 	/// that collides with another declaration's `(consumer, group, type,
 	/// intent, server)`, or a name already used by another of the consumer's
 	/// declarations, maps to `409`, same as [`Self::create`]. If the scope
-	/// (group, server, or type/intent) moves, any active restore-verification
-	/// alert keyed to the *old* scope is recovered — the overdue sweep only
-	/// walks current declarations, so a stale key would otherwise never clear.
+	/// (group, server, or type/intent) moves, or the declaration is disabled,
+	/// any active restore-verification alert keyed to the *old* scope is
+	/// recovered — the overdue sweep only walks current *enabled* declarations,
+	/// so a stale key would otherwise never clear.
 	pub async fn update(
 		db: &mut AsyncPgConnection,
 		id: Uuid,
@@ -261,7 +262,13 @@ impl RestoreReplica {
 			|| existing.server_id != result.server_id
 			|| existing.r#type != result.r#type
 			|| existing.intent != result.intent;
-		if scope_changed {
+		// Disabling drops the declaration out of the overdue sweep exactly as
+		// deleting it does (`sweep_overdue` filters `enabled = true`), and a
+		// disabled replica generates no consumer work, so `record_report` can't
+		// clear the alert either. Left alone, the alert and its incident stay
+		// open forever.
+		let disabled = existing.enabled && !result.enabled;
+		if scope_changed || disabled {
 			recover_old_scope_alerts(
 				db,
 				existing.group_id,

--- a/crates/database/tests/it/restore.rs
+++ b/crates/database/tests/it/restore.rs
@@ -855,6 +855,128 @@ async fn update_moving_scope_recovers_stale_alert_at_old_key() {
 	.await;
 }
 
+/// Disabling a declaration drops it out of the overdue sweep exactly as
+/// deleting it does, and a disabled replica generates no consumer work, so
+/// nothing can clear its alert. Decommissioning by disabling must not leave
+/// the operator paged forever.
+#[tokio::test(flavor = "multi_thread")]
+async fn disabling_recovers_the_stale_alert() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn, "g").await;
+		let server = insert_server(&mut conn, group).await;
+		let r = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				Some(server),
+				RestoreIntent::from("verify"),
+				"n",
+			),
+		)
+		.await
+		.expect("create");
+
+		BackupRestoreCheck::record_report(
+			&mut conn,
+			new_check(
+				consumer,
+				group,
+				server,
+				RestoreIntent::from("verify"),
+				RunOutcome::Failure,
+				false,
+			),
+		)
+		.await
+		.expect("record failure");
+		assert_eq!(active_restore_issues(&mut conn, group).await, 1);
+
+		RestoreReplica::update(
+			&mut conn,
+			r.id,
+			RestoreReplicaUpdate {
+				enabled: false,
+				..update_from(&r)
+			},
+		)
+		.await
+		.expect("disable");
+		assert_eq!(
+			active_restore_issues(&mut conn, group).await,
+			0,
+			"a disabled declaration's alert is recovered, not left open forever"
+		);
+	})
+	.await;
+}
+
+/// Re-enabling is not a recovery event of its own: the sweep picks the
+/// declaration back up and re-raises if it is still overdue.
+#[tokio::test(flavor = "multi_thread")]
+async fn re_enabling_does_not_recover_anything() {
+	TestDb::run(|mut conn, _url| async move {
+		let consumer = insert_consumer(&mut conn).await;
+		let group = insert_group(&mut conn, "g").await;
+		let server = insert_server(&mut conn, group).await;
+		let r = RestoreReplica::create(
+			&mut conn,
+			new_replica(
+				consumer,
+				group,
+				Some(server),
+				RestoreIntent::from("verify"),
+				"n",
+			),
+		)
+		.await
+		.expect("create");
+		let disabled = RestoreReplica::update(
+			&mut conn,
+			r.id,
+			RestoreReplicaUpdate {
+				enabled: false,
+				..update_from(&r)
+			},
+		)
+		.await
+		.expect("disable");
+
+		BackupRestoreCheck::record_report(
+			&mut conn,
+			new_check(
+				consumer,
+				group,
+				server,
+				RestoreIntent::from("verify"),
+				RunOutcome::Failure,
+				false,
+			),
+		)
+		.await
+		.expect("record failure");
+		assert_eq!(active_restore_issues(&mut conn, group).await, 1);
+
+		RestoreReplica::update(
+			&mut conn,
+			disabled.id,
+			RestoreReplicaUpdate {
+				enabled: true,
+				..update_from(&disabled)
+			},
+		)
+		.await
+		.expect("re-enable");
+		assert_eq!(
+			active_restore_issues(&mut conn, group).await,
+			1,
+			"re-enabling must not silently clear a live alert"
+		);
+	})
+	.await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn delete_recovers_stale_alert_for_removed_scope() {
 	TestDb::run(|mut conn, _url| async move {


### PR DESCRIPTION
Fixes **M10** (medium) from the audit in #370.

## The bug

`RestoreReplica::update` recovers stale alerts when a declaration's scope moves, and `delete` recovers them too — both with the same reasoning in their doc-comments: *"the overdue sweep only walks current declarations, so a stale key would otherwise never clear."*

Flipping `enabled` to false removes the declaration from that sweep in exactly the same way — `sweep_overdue` filters `enabled = true` — but triggered no recovery. And a disabled replica generates no consumer work, so `record_report` can't clear the alert either.

The result is that the ordinary decommissioning move — a verification goes overdue and pages, the operator disables the declaration — leaves the alert and its incident open indefinitely, with nothing left in the system that could ever close them.

## The fix

An enabled→disabled transition takes the same recovery path as a scope change.

Re-enabling deliberately recovers nothing: the sweep picks the declaration back up and re-raises if it's still overdue, so clearing on re-enable would just hide a live problem.

## Tests

- `disabling_recovers_the_stale_alert` — raise an alert, disable, assert it's cleared. Confirmed to fail against the unfixed code (alert stays active).
- `re_enabling_does_not_recover_anything` — pins the other direction so the fix doesn't turn into "any `enabled` write clears alerts".

The existing 21-test restore suite passes unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_