### PR TITLE
fix(jobs): don't busy-loop ownstatus on a persistent error (audit M12)

### DIFF
--- a/crates/jobs/src/bin/ownstatus.rs
+++ b/crates/jobs/src/bin/ownstatus.rs
@@ -39,11 +39,15 @@ pub fn spawn() -> JoinHandle<()> {
 	let start = Instant::now();
 	task::spawn(async move {
 		loop {
+			// Sleep at the top, like `pingtask`: a `continue` from the error
+			// path must not skip it. With the sleep at the bottom, a
+			// persistent, fast-failing error (the database unreachable, no
+			// `Server::own` row) spins as fast as the query can fail, burning
+			// a connection attempt and an `error!` line each time.
+			sleep(Duration::from_secs(60)).await;
 			if let Err(err) = record_own_status(pool.clone(), start).await {
 				error!("Failed to record own status: {err}");
-				continue;
 			}
-			sleep(Duration::from_secs(60)).await;
 		}
 	})
 }


### PR DESCRIPTION
Fixes **M12** (medium) from the audit in #370.

## The bug

The loop slept at the *bottom* and `continue`d on error, so the error path skipped the sleep entirely:

```rust
loop {
    if let Err(err) = record_own_status(…).await {
        error!(…);
        continue;          // ← straight back to the top
    }
    sleep(Duration::from_secs(60)).await;
}
```

A persistent, fast-failing error — the database unreachable, a missing `Server::own` row — then spins as fast as the query can fail: thousands of connection attempts and `error!` lines a minute, hammering the database it's already failing to reach and burying the logs.

## The fix

The sleep moves to the top, which is where the sibling `pingtask` puts it for exactly this reason. There's nothing left to `continue` past, so the error path just logs and falls through to the next tick.

One behaviour change worth noting: the first status is now recorded 60s after start rather than immediately. That matches `pingtask`, and the job's own cadence is a minute, so nothing downstream distinguishes the two.

No test: this is a `loop { sleep }` in a `spawn`, and asserting on it needs time control the audit rates as moderate-to-hard for a one-line ordering fix. The change is a straight comparison with the sibling job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_