### PR TITLE
fix(bestool): reject a backslash in a snippet name, not a trailing percent (audit M19)

### DIFF
--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -42,6 +42,7 @@ mod server_products;
 mod server_restore_window;
 mod silenced_health_checks;
 mod slack_outbox_enqueue;
+mod snippet_name_constraint;
 mod status_figures;
 mod statuses_device_fk;
 mod tag_reserved_prefix;

--- a/crates/database/tests/it/snippet_name_constraint.rs
+++ b/crates/database/tests/it/snippet_name_constraint.rs
@@ -1,0 +1,79 @@
+//! The `valid_snippet_name` CHECK. Snippet names become client-side filenames
+//! on Windows bestool, which is why the forbidden set is what it is.
+//!
+//! Backslash is LIKE's default escape character, so the clause meant to reject
+//! backslashes read as "does not end in a percent sign" instead — accepting
+//! exactly what it was there to stop, and rejecting something harmless.
+
+use commons_tests::db::TestDb;
+use database::bestool_snippets::BestoolSnippet;
+
+async fn create(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+	name: &str,
+) -> commons_errors::Result<BestoolSnippet> {
+	BestoolSnippet::create(
+		conn,
+		"op@bes".into(),
+		name.into(),
+		None,
+		"SELECT 1".into(),
+		None,
+	)
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_backslash_in_a_name_is_rejected() {
+	TestDb::run(|mut conn, _url| async move {
+		assert!(
+			create(&mut conn, r"report\daily").await.is_err(),
+			"a backslash makes an unusable filename on Windows",
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_percent_sign_in_a_name_is_allowed() {
+	TestDb::run(|mut conn, _url| async move {
+		create(&mut conn, "top100%")
+			.await
+			.expect("a percent sign was never on the forbidden list");
+		create(&mut conn, "50%-done")
+			.await
+			.expect("nor is one in the middle");
+	})
+	.await;
+}
+
+/// The rest of the forbidden set is unaffected by the fix.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_other_forbidden_names_are_still_rejected() {
+	TestDb::run(|mut conn, _url| async move {
+		for name in [
+			"has space",
+			"has.dot",
+			"has/slash",
+			"has<lt",
+			"has>gt",
+			"has:colon",
+			"has\"quote",
+			"has'apos",
+			"has|pipe",
+			"has?q",
+			"has*star",
+			"CON",
+			"lpt9",
+		] {
+			assert!(
+				create(&mut conn, name).await.is_err(),
+				"{name:?} must still be rejected",
+			);
+		}
+		create(&mut conn, "perfectly-fine_name1")
+			.await
+			.expect("an ordinary name is accepted");
+	})
+	.await;
+}

--- a/migrations/2026-08-01-090131-0000_fix_snippet_name_backslash_check/down.sql
+++ b/migrations/2026-08-01-090131-0000_fix_snippet_name_backslash_check/down.sql
@@ -1,0 +1,24 @@
+ALTER TABLE bestool_snippets
+	DROP CONSTRAINT valid_snippet_name;
+
+ALTER TABLE bestool_snippets
+	ADD CONSTRAINT valid_snippet_name CHECK (
+		name NOT LIKE '% %' AND
+		name NOT LIKE '%.%' AND
+		name NOT LIKE '%/%' AND
+		name NOT LIKE '%<%' AND
+		name NOT LIKE '%>%' AND
+		name NOT LIKE '%:%' AND
+		name NOT LIKE '%"%' AND
+		name NOT LIKE '%''%' AND
+		name NOT LIKE '%\%' AND
+		name NOT LIKE '%|%' AND
+		name NOT LIKE '%?%' AND
+		name NOT LIKE '%*%' AND
+		name !~ '[\x00-\x1f]' AND
+		LOWER(name) NOT IN (
+			'con', 'prn', 'aux', 'nul',
+			'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
+			'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9'
+		)
+	) NOT VALID;

--- a/migrations/2026-08-01-090131-0000_fix_snippet_name_backslash_check/up.sql
+++ b/migrations/2026-08-01-090131-0000_fix_snippet_name_backslash_check/up.sql
@@ -1,0 +1,46 @@
+-- Reject a backslash in a snippet name, not a trailing percent sign.
+--
+-- Backslash is LIKE's default escape character, so the `name NOT LIKE '%\%'`
+-- clause read as "does not end in a literal percent sign" — the opposite of
+-- what the comment above it claimed. Verified on Postgres 16:
+--   'foo\bar' LIKE '%\%'  -> false   (backslash names were accepted)
+--   'top100%' LIKE '%\%'  -> true    (percent names were rejected)
+-- while the intended '%\\%' gives true and false respectively.
+--
+-- Names become client-side filenames on Windows bestool, which is why
+-- backslash is on the forbidden list; a percent sign was never meant to be.
+--
+-- Added NOT VALID: the corrected clause is enforced on every insert and
+-- update from here on, but existing rows aren't scanned. A legacy name
+-- containing a backslash — accepted for as long as this constraint has been
+-- wrong — would otherwise fail the migration and block the deploy. Once the
+-- fleet is known clean, `ALTER TABLE bestool_snippets VALIDATE CONSTRAINT
+-- valid_snippet_name;` completes the job without taking a write lock.
+ALTER TABLE bestool_snippets
+	DROP CONSTRAINT valid_snippet_name;
+
+ALTER TABLE bestool_snippets
+	ADD CONSTRAINT valid_snippet_name CHECK (
+		-- No spaces
+		name NOT LIKE '% %' AND
+		-- No forbidden special characters: . / < > : " ' \ | ? *
+		name NOT LIKE '%.%' AND
+		name NOT LIKE '%/%' AND
+		name NOT LIKE '%<%' AND
+		name NOT LIKE '%>%' AND
+		name NOT LIKE '%:%' AND
+		name NOT LIKE '%"%' AND
+		name NOT LIKE '%''%' AND
+		name NOT LIKE '%\\%' AND
+		name NOT LIKE '%|%' AND
+		name NOT LIKE '%?%' AND
+		name NOT LIKE '%*%' AND
+		-- No control characters (U+0000-U+001F) - match any character in range
+		name !~ '[\x00-\x1f]' AND
+		-- Not Windows reserved names (case-insensitive)
+		LOWER(name) NOT IN (
+			'con', 'prn', 'aux', 'nul',
+			'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
+			'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9'
+		)
+	) NOT VALID;


### PR DESCRIPTION
Fixes **M19** (medium) from the audit in #370.

## The bug

Backslash is `LIKE`'s default escape character, so `name NOT LIKE '%\%'` reads as *"does not end in a literal percent sign"* — the opposite of the comment directly above it. Verified on Postgres 16:

| expression | result |
|---|---|
| `'foo\bar' LIKE '%\%'` | `false` — backslash names were **accepted** |
| `'top100%' LIKE '%\%'` | `true` — percent names were **rejected** |
| `'foo\bar' LIKE '%\\%'` | `true` |
| `'top100%' LIKE '%\\%'` | `false` |

So the one clause guarding against backslashes let them through, and a perfectly reasonable name like `top100%` was rejected with a raw constraint 500. Names become client-side filenames on Windows bestool, which is why backslash is on the forbidden list at all; a percent sign never was. There's no app-level validation, so this CHECK is the only guard.

## The fix

A migration replacing the constraint with `'%\\%'`.

**`NOT VALID`, deliberately.** The corrected clause is enforced on every insert and update from here on, but existing rows aren't scanned. A legacy name containing a backslash — accepted for as long as this constraint has been wrong — would otherwise fail the migration and block the deploy. Once the fleet is known clean, `ALTER TABLE bestool_snippets VALIDATE CONSTRAINT valid_snippet_name;` completes it without taking a write lock. Happy to make it a plain `ADD CONSTRAINT` instead if you'd rather find out loudly.

## Tests

New `crates/database/tests/it/snippet_name_constraint.rs`:
- `a_backslash_in_a_name_is_rejected`
- `a_percent_sign_in_a_name_is_allowed`
- `the_other_forbidden_names_are_still_rejected` — spaces, `. / < > : " ' | ? *`, and the Windows reserved names, plus an ordinary name that must be accepted.

The first two are confirmed to fail against the old constraint, one in each direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_