### PR TITLE
fix(bestool): don't attribute a snippet to nobody when identity fails (audit M15)

### DIFF
--- a/crates/private-server/src/fns/bestool.rs
+++ b/crates/private-server/src/fns/bestool.rs
@@ -124,15 +124,15 @@ pub struct SaveArgs {
 	request_body = SaveArgs,
 	responses(
 		(status = 200, body = BestoolSnippetDetail),
+		(status = 401, body = ProblemDetailsSchema),
 		(status = 500, body = ProblemDetailsSchema),
 	),
 )]
 pub async fn save_snippet(
 	State(state): State<AppState>,
-	user: std::result::Result<TailscaleUser, AppError>,
+	user: TailscaleUser,
 	Json(args): Json<SaveArgs>,
 ) -> Result<Json<BestoolSnippetDetail>> {
-	let user = user.unwrap_or_default();
 	let mut conn = state.db.get().await?;
 	let snippet = database::BestoolSnippet::create(
 		&mut conn,

--- a/crates/private-server/tests/it/bestool_snippets.rs
+++ b/crates/private-server/tests/it/bestool_snippets.rs
@@ -1,0 +1,35 @@
+//! Snippet authorship. A snippet is attributed to the Tailscale user who
+//! saved it, and that attribution is the whole audit trail for the SQL the
+//! snippet carries.
+//!
+//! Note on coverage: the extractor short-circuits to `admin@localhost` under
+//! `cfg!(debug_assertions)`, so these tests cannot exercise the
+//! missing-identity path — that only exists in release builds. They pin the
+//! observable contract (the editor is the caller, and is never blank); the
+//! release-only behaviour is enforced by the extractor's type, not by a test.
+
+use serde_json::{Value, json};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_saved_snippet_is_attributed_to_its_author() {
+	commons_tests::server::run(async |_conn, _public, private| {
+		let resp = private
+			.post("/api/bestool/save_snippet")
+			.json(&json!({
+				"name": "daily-counts",
+				"description": "row counts by table",
+				"sql": "SELECT 1",
+			}))
+			.await;
+		resp.assert_status_ok();
+		let snippet: Value = resp.json();
+
+		let editor = snippet["editor"].as_str().expect("editor is a string");
+		assert!(
+			!editor.is_empty(),
+			"a snippet with a blank author has no audit trail",
+		);
+		assert_eq!(editor, "admin@localhost", "attributed to the caller");
+	})
+	.await
+}

--- a/crates/private-server/tests/it/main.rs
+++ b/crates/private-server/tests/it/main.rs
@@ -5,6 +5,7 @@
 
 mod artifacts;
 mod backups;
+mod bestool_snippets;
 mod create_server;
 mod device_admin_endpoints;
 mod device_keys;

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -1672,6 +1672,16 @@
               }
             }
           },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
           "500": {
             "description": "",
             "content": {

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -10075,6 +10075,14 @@ export interface operations {
                     "application/json": components["schemas"]["BestoolSnippetDetail"];
                 };
             };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
             500: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Fixes **M15** from the audit in #370. **M16 is deliberately not fixed here** — see below, it needs your call.

## The bug

`save_snippet` took `Result<TailscaleUser, AppError>` and then `unwrap_or_default()`, so failing to resolve the caller's Tailscale identity produced a blank `login` and the snippet was stored with an empty `editor`. Its own doc-comment promises "recorded under the caller's Tailscale identity", and the spec declares `security(("tailscale-user" = []))`.

Attribution is the entire audit trail for the SQL a snippet carries, so a blank author is worse than a rejection. Now takes the plain extractor; the spec advertises the 401 it can return; `openapi.json` and `api-types.ts` regenerated.

`sql.rs` had the same two `unwrap_or_default()` sites — already handled on the `h9-sql-auth` branch, so untouched here.

## Tests

`a_saved_snippet_is_attributed_to_its_author`, plus a note in the file about what it can't cover: the extractor short-circuits to `admin@localhost` under `cfg!(debug_assertions)`, so the missing-identity path only exists in release builds and no debug-harness test can reach it. The test pins the observable contract; the release behaviour is enforced by the extractor's type. Same limitation the audit flagged for H9.

## M16, and what the sweep actually found

I swept every `#[utoipa::path]` in `crates/private-server/src/fns/` for handlers declaring a security scheme without the matching extractor. It found **22** beyond M15 — far more than M16's two — but they are not random oversights:

| module | enforce (have extractor) | don't enforce |
|---|---|---|
| `backups.rs` | all 21 mutations | `get`, `list`, `group_schedules`, `type_defaults`, `stats`, `run_progress`, `capabilities` |
| `server_groups.rs` | `create`, `update`, `delete`, `restore` | `list`, `server_counts`, `get`, `list_archived`, `search` |
| `silenced_refs.rs` (M16) | `silence_*`, `unsilence_*` | `list_for_server`, `list_for_group` |
| `certificates.rs` | `set_profile`, `pause`, `resume`, `revoke` | `for_server`, `for_group`, `authority` |
| `domains.rs` | `claim`, `release` | `zones`, `for_group`, `grant_availability` |
| `restore_replicas.rs` | `create`, `update`, `delete` | `for_group`, `consumers`, `checks` |

Every mutation enforces; every read doesn't. That is a convention, not an accident. And the whole admin API already sits behind `reject_tagged_devices` (`crates/private-server/src/lib.rs:37`), so these reads are reachable only by humans on the tailnet — the extractor adds per-user identity resolution, not network reachability.

So M16 is really a documentation question with two defensible answers, and picking one changes 22 endpoints' behaviour:

1. **Add the extractors** — every endpoint enforces what it declares. Costs a 401 in release for any caller not presenting Tailscale identity headers.
2. **Drop the `security` annotations from the reads** — the spec stops claiming an auth requirement the code never had, and the read/write split becomes explicit.

I'd lean (2), since the reads look intentionally open and the tailnet guard already covers them, but that's a product decision about your API contract rather than a bug fix, so I've left it out rather than guess. Happy to push either as a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_