### PR TITLE
fix(ping): a non-2xx ping response means unreachable, not reachable (audit M5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 name = "database"
 version = "6.6.6"
 dependencies = [
+ "axum",
  "base64 0.22.1",
  "bestool-postgres",
  "clap",

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -47,5 +47,7 @@ bestool-postgres = "1.0.9"
 getrandom = "0.4.2"
 
 [dev-dependencies]
+axum = { workspace = true }
 commons-tests = { path = "../commons-tests" }
 rcgen = "0.14.8"
+tokio = { workspace = true, features = ["net"] }

--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -178,12 +178,27 @@ impl Status {
 		let start = Instant::now();
 		let url = host.join("/api/public/ping").unwrap();
 		debug!(%url, "pinging");
-		match client.get(url).send().await.map(|res| {
-			res.headers()
-				.get("X-Version")
-				.and_then(|value| value.to_str().ok())
-				.and_then(|value| VersionStr::from_str(value).ok())
-		}) {
+		// `send()` resolves to `Ok` for *any* HTTP response, so only transport
+		// failures (DNS, refused, timeout) land in the `Err` arm. A reverse
+		// proxy answering 502 because the app behind it is down is exactly the
+		// outage this sweep exists to catch, so a non-2xx status is a ping
+		// failure, not a reachable server with no version header.
+		match client
+			.get(url)
+			.send()
+			.await
+			.map_err(|err| err.to_string())
+			.and_then(|res| {
+				let status = res.status();
+				if !status.is_success() {
+					return Err(format!("ping endpoint returned {status}"));
+				}
+				Ok(res
+					.headers()
+					.get("X-Version")
+					.and_then(|value| value.to_str().ok())
+					.and_then(|value| VersionStr::from_str(value).ok()))
+			}) {
 			Ok(version) => {
 				let latency = start.elapsed().as_millis().try_into().unwrap_or(i32::MAX);
 				info!(server=%server.id, host=%host, %latency, "ping success");

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -26,6 +26,7 @@ mod mcp_tokens;
 mod migration_test_candidates;
 mod migration_test_reports;
 mod partitions;
+mod ping_reachability;
 mod reachability_sweep;
 mod recovery_vault;
 mod reported_detail;

--- a/crates/database/tests/it/ping_reachability.rs
+++ b/crates/database/tests/it/ping_reachability.rs
@@ -1,0 +1,106 @@
+//! `Status::ping_server` decides whether a server counts as reachable.
+//!
+//! `reqwest`'s `send()` resolves to `Ok` for any HTTP response, so a naive
+//! match treats a 502 from a reverse proxy — the app behind it being down,
+//! which is precisely the outage the reachability sweep exists to catch — as
+//! a successful ping.
+
+use axum::http::StatusCode;
+use commons_tests::db::TestDb;
+use database::servers::Server;
+use database::statuses::Status;
+use diesel_async::SimpleAsyncConnection;
+use uuid::Uuid;
+
+/// Spawn a one-route server on a random port that answers `/api/public/ping`
+/// with `status`, and return its base URL.
+async fn ping_endpoint_returning(status: StatusCode, version: Option<&'static str>) -> String {
+	let app = axum::Router::new().route(
+		"/api/public/ping",
+		axum::routing::get(move || async move {
+			let mut resp = axum::response::Response::builder().status(status);
+			if let Some(v) = version {
+				resp = resp.header("X-Version", v);
+			}
+			resp.body(axum::body::Body::empty()).unwrap()
+		}),
+	);
+	let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let addr = listener.local_addr().unwrap();
+	tokio::spawn(async move {
+		axum::serve(listener, app.into_make_service()).await.ok();
+	});
+	format!("http://{addr}/")
+}
+
+async fn seed_server(conn: &mut database::diesel_async::AsyncPgConnection, host: &str) -> Server {
+	let id = Uuid::new_v4();
+	conn.batch_execute(&format!(
+		"INSERT INTO servers (id, host, name, kind) VALUES ('{id}', '{host}', 'pinged', 'central');"
+	))
+	.await
+	.expect("seed server");
+	Server::get_by_id(conn, id).await.expect("fetch server")
+}
+
+async fn ping(server: &Server) -> Option<Status> {
+	let client = reqwest::ClientBuilder::new()
+		.timeout(std::time::Duration::from_secs(5))
+		.build()
+		.unwrap();
+	Status::ping_server(&client, server).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_5xx_from_the_ping_endpoint_is_not_reachable() {
+	TestDb::run(|mut conn, _url| async move {
+		let host = ping_endpoint_returning(StatusCode::BAD_GATEWAY, None).await;
+		let server = seed_server(&mut conn, &host).await;
+		assert!(
+			ping(&server).await.is_none(),
+			"a 502 means the app behind the proxy is down, not that the server is up",
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_404_from_the_ping_endpoint_is_not_reachable() {
+	TestDb::run(|mut conn, _url| async move {
+		let host = ping_endpoint_returning(StatusCode::NOT_FOUND, None).await;
+		let server = seed_server(&mut conn, &host).await;
+		assert!(
+			ping(&server).await.is_none(),
+			"nothing answered the ping endpoint, so nothing is confirmed reachable",
+		);
+	})
+	.await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_200_is_reachable_and_carries_the_version() {
+	TestDb::run(|mut conn, _url| async move {
+		let host = ping_endpoint_returning(StatusCode::OK, Some("2.31.0")).await;
+		let server = seed_server(&mut conn, &host).await;
+		let status = ping(&server).await.expect("a 200 is a reachable server");
+		assert!(status.healthy);
+		assert_eq!(
+			status.version.map(|v| v.to_string()),
+			Some("2.31.0".to_string()),
+		);
+	})
+	.await;
+}
+
+/// A 200 without the header is still reachable — the version is simply
+/// unknown. This is the case the old code conflated every failure with.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_200_without_a_version_header_is_still_reachable() {
+	TestDb::run(|mut conn, _url| async move {
+		let host = ping_endpoint_returning(StatusCode::OK, None).await;
+		let server = seed_server(&mut conn, &host).await;
+		let status = ping(&server).await.expect("reachable");
+		assert!(status.version.is_none());
+	})
+	.await;
+}


### PR DESCRIPTION
Fixes **M5** (medium) from the audit in #370.

## The bug

`reqwest`'s `send()` resolves to `Ok` for *any* HTTP response — only transport failures (DNS, connection refused, timeout) reach the `Err` arm. `ping_server` matched on that result directly, so **every** HTTP status, 502 included, was logged as `ping success` and written as a fresh status row.

A reverse proxy answering 502 because the app behind it is down is exactly the outage this sweep exists to catch. Instead the status row kept the server's source freshness current, so `sweep_staleness` saw a live server and the `reachability` check stayed green for as long as the proxy kept answering. The failure mode is silent and indefinite: the server is down, the dashboard says it's up.

## The fix

A non-2xx status is a ping failure. A 200 without `X-Version` is still reachable, with an unknown version — that's the case the old code conflated every failure with, and it's preserved.

## Tests

New `crates/database/tests/it/ping_reachability.rs`, each spawning a one-route axum server on a random port:
- `a_5xx_from_the_ping_endpoint_is_not_reachable`
- `a_404_from_the_ping_endpoint_is_not_reachable`
- `a_200_is_reachable_and_carries_the_version`
- `a_200_without_a_version_header_is_still_reachable`

The first two are confirmed to fail against the unfixed code; the last two pass both ways and pin the behaviour that must not change. Adds `axum` and `tokio/net` as dev-dependencies of the `database` crate for the fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_