### PR TITLE
fix(slack): don't suppress a resolve when only the escalation open was pending (audit M3)

### DIFF
--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -2447,7 +2447,16 @@ async fn enqueue_slack_resolve_inner(
 		"cancelled: incident resolved before the open had been delivered to Slack",
 	)
 	.await?;
-	if cancelled > 0 {
+	// Having cancelled something is not proof Slack is unaware. Escalation
+	// enqueues a *second* `incident_open` for the same incident, so a
+	// delivered original can coexist with a pending escalation open — and
+	// cancelling the latter would then suppress the resolve for an incident
+	// Slack is actively showing as open, permanently. What matters is whether
+	// any open was ever delivered.
+	let ever_delivered = crate::slack_outbox::SlackOutbox::delivered_open_ids(conn, &[incident.id])
+		.await?
+		.contains(&incident.id);
+	if cancelled > 0 && !ever_delivered {
 		return Ok(());
 	}
 	let label = match incident.server_group_id {

--- a/crates/database/tests/it/slack_outbox_enqueue.rs
+++ b/crates/database/tests/it/slack_outbox_enqueue.rs
@@ -322,6 +322,101 @@ async fn resolving_before_open_ships_cancels_open_and_skips_resolve() {
 	.await
 }
 
+/// Escalation enqueues a *second* `incident_open` for the same incident. If
+/// the incident resolves before the drainer ships that escalation row,
+/// cancelling it is right — but skipping the resolve is not: Slack is still
+/// showing the original open, and would show it as unresolved forever.
+#[tokio::test(flavor = "multi_thread")]
+async fn resolve_is_still_sent_when_only_the_escalation_open_was_pending() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, "http://escalate.invalid/").await;
+
+		// An Error-severity failure opens the incident.
+		let stamp = database::issues::CheckStateStamp {
+			check: "ref-error".into(),
+			observed: CheckResult::Failed,
+			effective: CheckResult::Failed,
+			escalates: false,
+			detail: None,
+		};
+		NewEvent {
+			source: "test".into(),
+			r#ref: "ref-error".into(),
+			description: None,
+			message: "boom".into(),
+			active: Some(true),
+			occurred_at: None,
+		}
+		.save_with_state(&mut conn, server_id, None, Some(&stamp), false)
+		.await
+		.expect("save error issue");
+
+		let incident = Incident::list_for_server(&mut conn, server_id, false, 10)
+			.await
+			.expect("list incidents")
+			.into_iter()
+			.next()
+			.expect("incident opened");
+
+		// Slack has now seen the incident.
+		mark_open_delivered(&mut conn, incident.id).await;
+
+		// An escalating failure joins, enqueuing a second open row.
+		let escalating = database::issues::CheckStateStamp {
+			check: "ref-critical".into(),
+			observed: CheckResult::Failed,
+			effective: CheckResult::Failed,
+			escalates: true,
+			detail: None,
+		};
+		NewEvent {
+			source: "test".into(),
+			r#ref: "ref-critical".into(),
+			description: None,
+			message: "worse".into(),
+			active: Some(true),
+			occurred_at: None,
+		}
+		.save_with_state(&mut conn, server_id, None, Some(&escalating), false)
+		.await
+		.expect("save escalating issue");
+
+		let opens: Vec<_> = pending_for_incident(&mut conn, incident.id)
+			.await
+			.into_iter()
+			.filter(|r| r.kind == KIND_INCIDENT_OPEN)
+			.collect();
+		assert_eq!(opens.len(), 2, "escalation enqueues a second open");
+		assert!(
+			opens.iter().any(|r| r.delivered_at.is_none()),
+			"the escalation open is still pending",
+		);
+
+		// Resolving now cancels the pending escalation open — but Slack is
+		// showing the delivered original, so it is owed a resolve.
+		Incident::resolve(
+			&mut conn,
+			incident.id,
+			"operator@example.test",
+			ResolvedReason::Fixed,
+		)
+		.await
+		.expect("resolve");
+
+		let rows = pending_for_incident(&mut conn, incident.id).await;
+		let resolves: Vec<_> = rows
+			.iter()
+			.filter(|r| r.kind == KIND_INCIDENT_RESOLVE)
+			.collect();
+		assert_eq!(
+			resolves.len(),
+			1,
+			"Slack saw the open, so it must see the resolve: {rows:#?}",
+		);
+	})
+	.await
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn cascade_close_via_issue_resolve_attributes_to_operator() {
 	// When the operator resolves the last live issue and the cascade


### PR DESCRIPTION
Fixes **M3** (medium) from the audit in #370.

## The bug

`enqueue_slack_resolve_inner` treats "`cancel_pending_open` affected rows" as "Slack never heard about this incident" and skips the resolve. That inference held when an incident had at most one open row — but escalation enqueues a **second** `incident_open` for the same incident once the first has shipped (`issues.rs:1558-1576`).

Sequence:
1. Incident opens at Error; the open is delivered to Slack.
2. A Critical issue joins → escalation open enqueued.
3. The incident resolves before the drainer ships the escalation row.

The cancel affects one row, so the resolve is skipped — and Slack shows the incident as **open forever**. The operator's channel silently disagrees with canopy, with nothing to prompt a re-check.

## The fix

Cancelling is no longer taken as proof Slack is unaware. The resolve is skipped only when nothing was ever delivered (`delivered_open_ids` is empty for the incident), which is the condition flap-suppression actually wants. The one-open case behaves exactly as before.

## Tests

`resolve_is_still_sent_when_only_the_escalation_open_was_pending` — walks the whole sequence: asserts the escalation really does produce a second open row with one still pending, then that resolving enqueues a resolve. Confirmed to fail against the unfixed code with **zero** resolve rows.

The existing `resolving_before_open_ships_cancels_open_and_skips_resolve` still passes, so genuine flap suppression is intact; all 11 tests in the file pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_