### PR TITLE
fix(slack): commit each outbox delivery on its own, not per batch (audit M11)

### DIFF
--- a/crates/jobs/src/bin/slacker_outbox.rs
+++ b/crates/jobs/src/bin/slacker_outbox.rs
@@ -6,9 +6,13 @@
 //! `slack_outbox` row is already the flat JSON the workflow expects — we
 //! POST it verbatim.
 //!
-//! Each loop iteration claims up to [`BATCH`] pending rows with
-//! `FOR UPDATE SKIP LOCKED`, posts them one at a time, and marks them
-//! delivered or failed inside the same transaction.
+//! Each loop iteration drains up to [`BATCH`] rows, one per transaction: a
+//! row is claimed with `FOR UPDATE SKIP LOCKED` (the lock is what keeps
+//! concurrent drainers off it), posted, and marked delivered or failed, then
+//! that transaction commits before the next row is claimed. Per-row rather
+//! than per-batch because the POST is irreversible — one transaction around
+//! the whole batch meant a late DB error rolled back the `delivered_at` of
+//! rows already posted, and the next tick posted them again.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -159,10 +163,23 @@ fn spawn(cfg: Config) -> JoinHandle<()> {
 				continue;
 			};
 
-			let result = db
-				.transaction::<_, commons_errors::AppError, _>(async |conn| {
-					let claimed = SlackOutbox::claim_pending(conn, BATCH).await?;
-					for row in claimed {
+			// One transaction per row, not one per batch. The HTTP POST is
+			// irreversible, so a row's `delivered_at` must commit on its own:
+			// batching them meant a late DB error (or a failed commit) rolled
+			// back the stamps of rows already posted, and the next tick posted
+			// them again — duplicate incident pages from a single hiccup.
+			//
+			// The transaction still wraps claim-post-mark, because
+			// `claim_pending` claims by row lock (`FOR UPDATE SKIP LOCKED`)
+			// and that lock is what keeps concurrent drainers off the same
+			// row. Claiming one row at a time keeps that exclusion while
+			// bounding the blast radius of a failure to the row that failed.
+			for _ in 0..BATCH {
+				let result = db
+					.transaction::<_, commons_errors::AppError, _>(async |conn| {
+						let Some(row) = SlackOutbox::claim_pending(conn, 1).await?.pop() else {
+							return Ok(false);
+						};
 						match deliver(&client, &cfg, &row).await {
 							Ok(body) => {
 								info!(
@@ -222,12 +239,23 @@ fn spawn(cfg: Config) -> JoinHandle<()> {
 								}
 							}
 						}
+						Ok(true)
+					})
+					.await;
+				match result {
+					// Queue drained (or every remaining row is another
+					// drainer's); nothing to do until the next tick.
+					Ok(false) => break,
+					Ok(true) => {}
+					Err(err) => {
+						// This row is untouched — its claim lock is released
+						// and it stays pending, so the next tick retries it.
+						// Rows already delivered in this tick keep their
+						// stamps.
+						error!("slack outbox row failed: {err}");
+						break;
 					}
-					Ok(())
-				})
-				.await;
-			if let Err(err) = result {
-				error!("slack outbox tx failed: {err}");
+				}
 			}
 		}
 	})


### PR DESCRIPTION
Fixes **M11** (medium) from the audit in #370.

## The bug

The drainer wrapped the whole batch — the claim, up to 10 **irreversible** HTTP POSTs, and every status write — in a single transaction. Any later failure in the loop, or a failed commit, rolled back the `delivered_at` stamps of rows that had already been posted to Slack. The next tick re-claimed them and posted them again.

The audit's scenario: a batch of 5, rows 1–4 post fine, `mark_delivered` for row 5 hits a connection drop → whole tx rolls back → rows 1–4 re-posted → duplicate incident pages from one blip.

## The fix

One transaction per row. The transaction still wraps claim-post-mark, deliberately: `claim_pending` claims *by row lock* (`FOR UPDATE SKIP LOCKED`), and that lock is the only thing keeping concurrent drainers off the same row — so moving the POST outside the transaction would trade duplicate-on-error for duplicate-on-concurrency. Claiming one row at a time keeps the exclusion while bounding a failure's blast radius to the row that failed.

The loop breaks early when a claim returns nothing, so an idle queue still costs one query per tick rather than ten.

Side benefit: row locks are no longer held across up to `BATCH * REQUEST_TIMEOUT` (150s) of network I/O.

The residual at-least-once window is unchanged and inherent without idempotency keys — a POST that succeeds and whose mark-delivered then fails will be retried. Previously that window covered *every row in the batch*; now it covers one.

## Tests

None. The audit rates this hard (mid-transaction fault injection), and the drainer loop is an untested `spawn` in a binary — testing it needs a fake Slack endpoint, a live loop, and an injected DB fault. The change is a control-flow restructure whose correctness is visible in the diff; the 11 existing `slack_outbox_enqueue` tests pass unchanged, covering the enqueue side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_