### PR TITLE
fix(migration): map roots to groups by id, not by name (audit M20)

### DIFF
--- a/migrations/2026-05-22-120000-0000_server_groups/up.sql
+++ b/migrations/2026-05-22-120000-0000_server_groups/up.sql
@@ -43,21 +43,26 @@ WITH roots_needing_groups AS (
 		OR EXISTS (SELECT 1 FROM incidents i WHERE i.server_id = s.id)
 	  )
 ),
-inserted AS (
-	INSERT INTO server_groups (name)
-	SELECT COALESCE(r.name, 'server-' || substr(r.id::text, 1, 8))
+-- Mint each root's group id up front, so the root→group mapping is carried
+-- rather than reconstructed. Pairing them by name afterwards is wrong:
+-- `servers.name` is not unique, so two roots sharing a name each insert a
+-- group with that name, the join produces the full cross product, and the
+-- final UPDATE picks arbitrary rows. Reproduced on Postgres 16 with two
+-- roots named "Fiji", one child each: both roots landed in one group and
+-- both children in the other, separating servers from their own parents.
+-- MATERIALIZED so `gen_random_uuid()` is evaluated exactly once per root,
+-- not re-evaluated per reference.
+root_to_group AS MATERIALIZED (
+	SELECT
+		r.id AS server_id,
+		gen_random_uuid() AS group_id,
+		COALESCE(r.name, 'server-' || substr(r.id::text, 1, 8)) AS group_name
 	FROM roots_needing_groups r
-	RETURNING id, name
 ),
--- Pair each root's id with the newly-inserted group id by name. Group names
--- come from the root's name (or an id-derived fallback when the root is
--- unnamed); both halves of the join produce the same string in the same row
--- order so the mapping is unambiguous.
-root_to_group AS (
-	SELECT r.id AS server_id, ig.id AS group_id
-	FROM roots_needing_groups r
-	JOIN inserted ig
-		ON ig.name = COALESCE(r.name, 'server-' || substr(r.id::text, 1, 8))
+inserted AS (
+	INSERT INTO server_groups (id, name)
+	SELECT rtg.group_id, rtg.group_name
+	FROM root_to_group rtg
 )
 -- Walk the tree from each root, assigning group_id to the root itself and
 -- every descendant.


### PR DESCRIPTION
Fixes **M20** (medium) from the audit in #370. ⚠️ **Read the prod-data section — this fixes future runs but repairs nothing already migrated.**

## The bug

The backfill inserted one group per root, then joined the inserted rows back to the roots **by name** to recover the mapping. `servers.name` is not unique, so two roots sharing a name each insert a group with that name, the join produces the full cross product, and the final `UPDATE … FROM` picks arbitrary rows.

Reproduced live on Postgres 16 — two roots named `Fiji`, one child each:

```
     name     |   grp
--------------+----------
 Fiji         | 77ec6076
 Fiji         | 77ec6076     ← both roots in one group
 Fiji-child-A | c7538047
 Fiji-child-B | c7538047     ← both children in the other
```

Every server separated from its own parent, and `incidents` then rekeyed to the wrong group.

## The fix

Each root mints its own group id up front and carries it through to both the insert and the recursive descent — no name join, nothing to collide. `MATERIALIZED` pins `gen_random_uuid()` to one evaluation per root across both references.

Verified on the same fixture, plus an unnamed root (the `server-<prefix>` fallback path) and a standalone root:

```
    server     |   grp    |    grp_name
---------------+----------+-----------------
 Fiji          | 1b39382c | Fiji
 Fiji-child-A  | 1b39382c | Fiji
 Fiji          | f1e1783f | Fiji
 Fiji-child-B  | f1e1783f | Fiji
 (unnamed)     | c1e55040 | server-33333333
 unnamed-child | c1e55040 | server-33333333
 Standalone    |          |
```

children sharing their parent's group: **3 of 3**. All 304 `database` tests pass, so the migration still applies cleanly.

## Editing an applied migration

Deliberate. Diesel tracks migrations by version, not content, so this never re-runs anywhere it has already run — but every fresh deploy and every throwaway test database *does* run it, and shipping a known-wrong backfill to those is worse than the usual argument for immutability.

## Prod data — needs your call

`parent_server_id` is dropped by this same migration, so **the original tree is not recoverable from the current schema**. No automated repair is possible; it would need a pre-migration backup.

To find out whether a deployment was affected, look for groups that came from same-named roots:

```sql
SELECT name, count(*) AS groups_with_this_name
FROM server_groups GROUP BY name HAVING count(*) > 1;
```

Any name returned means the roots behind those groups collided and their memberships were shuffled between them. Zero rows means the deployment was never affected and nothing needs doing. If rows do come back, the members of those groups need reassigning by hand (or from a backup taken before 2026-05-22).

I haven't written a repair migration because the correct assignment isn't derivable — happy to write one if you can supply the pre-migration mapping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_