### PR TITLE
fix(admins): re-adding an existing admin is a success, not a 404 (audit L1)

### DIFF
--- a/crates/database/src/admins.rs
+++ b/crates/database/src/admins.rs
@@ -34,11 +34,20 @@ impl Admin {
 			.map_err(AppError::from)
 	}
 
+	/// Add an admin, returning the row whether it was just created or already
+	/// existed.
+	///
+	/// `DO NOTHING` would insert no row on a conflict, and `get_result` on no
+	/// rows is `NotFound` — a 404 out of an endpoint documented as idempotent.
+	/// A no-op `DO UPDATE` on the same column returns the existing row instead,
+	/// leaving its original `created_at` intact.
 	pub async fn add(db: &mut AsyncPgConnection, email: &str) -> Result<Self> {
 		use crate::schema::admins::dsl;
 		diesel::insert_into(dsl::admins)
 			.values(dsl::email.eq(email))
-			.on_conflict_do_nothing()
+			.on_conflict(dsl::email)
+			.do_update()
+			.set(dsl::email.eq(email))
 			.get_result(db)
 			.await
 			.map_err(AppError::from)

--- a/crates/database/tests/it/admins.rs
+++ b/crates/database/tests/it/admins.rs
@@ -1,0 +1,34 @@
+use database::admins::Admin;
+
+/// `Admin::add` is documented as idempotent, and the `/api/admins/add`
+/// endpoint declares only success and auth failures — no 404. With
+/// `on_conflict_do_nothing` the second add inserted no row, and `get_result`
+/// over no rows is `NotFound`, so re-adding an existing admin 404'd.
+#[tokio::test(flavor = "multi_thread")]
+async fn adding_an_existing_admin_succeeds_and_keeps_the_original_row() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let first = Admin::add(&mut conn, "someone@example.com")
+			.await
+			.expect("first add");
+
+		let again = Admin::add(&mut conn, "someone@example.com")
+			.await
+			.expect("re-adding an existing admin must not fail");
+
+		assert_eq!(again.email, first.email);
+		assert_eq!(
+			again.created_at, first.created_at,
+			"the original row is returned, not a fresh one",
+		);
+
+		let all = Admin::list(&mut conn).await.expect("list");
+		assert_eq!(
+			all.iter()
+				.filter(|a| a.email == "someone@example.com")
+				.count(),
+			1,
+			"no duplicate row",
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -3,6 +3,7 @@
 // file, which keeps rebuilds from swamping the machine with I/O.
 // Nextest still runs every #[tokio::test] in parallel as usual.
 
+mod admins;
 mod backfill_registered_at_migration;
 mod backup_detection;
 mod backups;


### PR DESCRIPTION
Audit finding [L1](https://github.com/beyondessential/canopy/pull/370).

`Admin::add` used `on_conflict_do_nothing()`, which inserts no row when the email is already an admin. `get_result` over zero rows is Diesel's `NotFound`, which `AppError` maps to HTTP 404 — out of a handler whose OpenAPI response set is `200 / 401 / 403` and whose doc comment says "idempotent".

A no-op `DO UPDATE` on the conflicting column returns the existing row instead. The second add succeeds, no duplicate is created, and the original `created_at` is preserved rather than being bumped.

## Testing

New `crates/database/tests/it/admins.rs`. Verified it fails against the unfixed code:

```
test admins::adding_an_existing_admin_succeeds_and_keeps_the_original_row ... FAILED
```

and passes with the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_