### PR TITLE
fix(chrome): order Chrome majors numerically, not lexicographically (audit L2)

### DIFF
--- a/crates/database/src/chrome_releases.rs
+++ b/crates/database/src/chrome_releases.rs
@@ -38,6 +38,19 @@ impl NewChromeRelease {
 	}
 }
 
+/// `version` is TEXT holding a Chrome major, so ordering it as text puts
+/// `"100"` before `"99"`. Sort on the number it spells instead.
+///
+/// Anything that isn't a run of digits sorts last (Postgres puts NULLs last on
+/// an ascending sort), which matches how the value is read back: a version that
+/// won't `parse::<u32>()` is treated as no version at all.
+fn version_as_number()
+-> diesel::expression::SqlLiteral<diesel::sql_types::Nullable<diesel::sql_types::BigInt>> {
+	diesel::dsl::sql::<diesel::sql_types::Nullable<diesel::sql_types::BigInt>>(
+		"case when version ~ '^[0-9]+$' then version::bigint end",
+	)
+}
+
 impl ChromeRelease {
 	pub async fn get_min_version_at_date(
 		db: &mut AsyncPgConnection,
@@ -52,7 +65,7 @@ impl ChromeRelease {
 			.select(version)
 			.filter(release_date.le(&date_str))
 			.filter(is_eol.eq(false).or(eol_from.gt(&date_str)))
-			.order_by(version.asc())
+			.order_by(version_as_number().asc())
 			.limit(1)
 			.first(db)
 			.await
@@ -75,7 +88,7 @@ impl ChromeRelease {
 		use crate::schema::chrome_releases::*;
 
 		table
-			.order_by(version.asc())
+			.order_by(version_as_number().asc())
 			.load(db)
 			.await
 			.map_err(AppError::from)

--- a/crates/database/tests/it/chrome_releases.rs
+++ b/crates/database/tests/it/chrome_releases.rs
@@ -1,0 +1,83 @@
+use database::chrome_releases::{ChromeRelease, NewChromeRelease};
+use jiff::Timestamp;
+
+async fn seed(conn: &mut diesel_async::AsyncPgConnection, version: &str, released: &str) {
+	NewChromeRelease {
+		version: version.to_string(),
+		release_date: released.to_string(),
+		is_eol: false,
+		eol_from: None,
+	}
+	.save(conn)
+	.await
+	.expect("seed chrome release");
+}
+
+fn at(date: &str) -> Timestamp {
+	format!("{date}T00:00:00Z").parse().expect("timestamp")
+}
+
+/// `version` is TEXT, so `ORDER BY version` is lexicographic: `"100"` sorts
+/// before `"99"`. Whenever two majors of differing digit-length are live at
+/// once — 99 and 100, and again at 999/1000 — the "oldest live major" came
+/// back as the longer string rather than the smaller number.
+#[tokio::test(flavor = "multi_thread")]
+async fn min_version_is_the_smallest_number_not_the_smallest_string() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		seed(&mut conn, "99", "2026-01-01").await;
+		seed(&mut conn, "100", "2026-02-01").await;
+		seed(&mut conn, "101", "2026-03-01").await;
+
+		let min = ChromeRelease::get_min_version_at_date(&mut conn, at("2026-04-01"))
+			.await
+			.expect("min version");
+
+		// The reported minimum is one below the oldest live major.
+		assert_eq!(min, Some(98), "99 is the oldest live major, not 100");
+	})
+	.await
+}
+
+/// The same ordering backs the catalog listing.
+#[tokio::test(flavor = "multi_thread")]
+async fn get_all_is_ordered_numerically() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		for (v, d) in [
+			("100", "2026-02-01"),
+			("9", "2025-11-01"),
+			("99", "2026-01-01"),
+			("1000", "2026-05-01"),
+		] {
+			seed(&mut conn, v, d).await;
+		}
+
+		let all = ChromeRelease::get_all(&mut conn).await.expect("get all");
+		let versions: Vec<&str> = all.iter().map(|r| r.version.as_str()).collect();
+
+		assert_eq!(versions, vec!["9", "99", "100", "1000"]);
+	})
+	.await
+}
+
+/// A row whose `version` isn't a plain number can't be read back as one
+/// (`parse::<u32>()` drops it), so it must not be able to win the minimum
+/// either — it sorts last rather than poisoning the query with a cast error.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_non_numeric_version_does_not_break_or_win_the_ordering() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		seed(&mut conn, "not-a-version", "2025-01-01").await;
+		seed(&mut conn, "120", "2026-01-01").await;
+
+		let min = ChromeRelease::get_min_version_at_date(&mut conn, at("2026-04-01"))
+			.await
+			.expect("min version must not error on a non-numeric row");
+		assert_eq!(min, Some(119));
+
+		let all = ChromeRelease::get_all(&mut conn).await.expect("get all");
+		assert_eq!(
+			all.last().map(|r| r.version.as_str()),
+			Some("not-a-version"),
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -12,6 +12,7 @@ mod check_policies;
 mod check_policy_rules;
 mod check_severity_map;
 mod check_stability;
+mod chrome_releases;
 mod consolidated_checks;
 mod event_validation;
 mod fleet_check_detail;


### PR DESCRIPTION
Audit finding [L2](https://github.com/beyondessential/canopy/pull/370).

`chrome_releases.version` is TEXT holding a Chrome major, and `get_min_version_at_date` ordered it as text — so `"100"` sorts before `"99"` and the "oldest live major" comes back as whichever string is lexicographically smallest. At any date where two majors of differing digit-length are both live, `min_chrome_version` is wrong. It bites at 99/100 and recurs at 999/1000.

`get_all` had the same `ORDER BY`, so the catalog listing was mis-ordered too. Both now sort on the number the string spells.

Non-numeric values sort last rather than raising a cast error. That matches how the value is read back — `min_version.and_then(|v| v.parse::<u32>().ok())` already discards anything that isn't a plain number, so a junk row shouldn't be able to win the minimum, and it shouldn't be able to break the query for every other row either.

## Testing

New `crates/database/tests/it/chrome_releases.rs`, three cases. Against the unfixed code:

```
test chrome_releases::min_version_is_the_smallest_number_not_the_smallest_string ... FAILED
test chrome_releases::get_all_is_ordered_numerically ... FAILED
test chrome_releases::a_non_numeric_version_does_not_break_or_win_the_ordering ... ok
```

The third passes either way — text ordering happened to sort `"not-a-version"` last too. It's there as a regression guard on the cast this change introduces, not as a reproduction of the bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_