### PR TITLE
fix(reachability): stop capping down-for thresholds at the status window (audit L3, L4)

### DIFF
--- a/crates/database/src/statuses.rs
+++ b/crates/database/src/statuses.rs
@@ -297,8 +297,27 @@ impl Status {
 		// Backstop for servers with no counted source (never reported, or
 		// only reached by pingtask): the latest status row, any source.
 		let statuses = Self::latest_for_servers(db, &server_ids).await?;
-		let status_map: HashMap<Uuid, Status> =
+		let mut status_map: HashMap<Uuid, Status> =
 			statuses.into_iter().map(|s| (s.server_id, s)).collect();
+
+		// A server absent from that seven-day window has not necessarily never
+		// reported — it may have reported longer ago than the window looks.
+		// Taking absence for "never" capped every per-server
+		// `alert_when_down_for` at seven days (a threshold of ten days could
+		// never be measured, so the server was down the moment it passed
+		// seven) and labelled the issue "has never reported" for a server with
+		// years of history. Probe the stragglers without a floor; there are
+		// few of them, and the fleet-wide fast path above is untouched.
+		let unseen: Vec<Uuid> = server_ids
+			.iter()
+			.copied()
+			.filter(|id| !status_map.contains_key(id))
+			.collect();
+		if !unseen.is_empty() {
+			for status in Self::latest_ever_for_servers(db, &unseen).await? {
+				status_map.insert(status.server_id, status);
+			}
+		}
 
 		let existing_issues =
 			Issue::list_by_source_ref(db, CANOPY_SOURCE, REACHABILITY_REF, &server_ids).await?;
@@ -603,6 +622,35 @@ impl Status {
 				SELECT * FROM statuses \
 				WHERE server_id = s.id \
 				AND created_at >= NOW() - INTERVAL '7 days' \
+				AND id != '00000000-0000-0000-0000-000000000000' \
+				ORDER BY created_at DESC LIMIT 1 \
+			 ) st",
+		)
+		.bind::<diesel::sql_types::Array<diesel::sql_types::Uuid>, _>(server_ids);
+
+		query.load::<Status>(db).await.map_err(AppError::from)
+	}
+
+	/// The most recent status for each server, however long ago it was.
+	///
+	/// [`Self::latest_for_servers`] caps its search at seven days so Postgres
+	/// can prune every partition older than that, which is what keeps the
+	/// fleet-wide sweep cheap. This one has no floor, so it costs an index
+	/// probe per partition per server. Use it for the few servers that fast
+	/// path didn't find — not in place of it.
+	pub async fn latest_ever_for_servers(
+		db: &mut AsyncPgConnection,
+		server_ids: &[Uuid],
+	) -> Result<Vec<Status>> {
+		if server_ids.is_empty() {
+			return Ok(Vec::new());
+		}
+
+		let query = diesel::sql_query(
+			"SELECT st.* FROM unnest($1) AS s(id) \
+			 CROSS JOIN LATERAL ( \
+				SELECT * FROM statuses \
+				WHERE server_id = s.id \
 				AND id != '00000000-0000-0000-0000-000000000000' \
 				ORDER BY created_at DESC LIMIT 1 \
 			 ) st",

--- a/crates/database/tests/it/reachability_sweep.rs
+++ b/crates/database/tests/it/reachability_sweep.rs
@@ -505,3 +505,91 @@ async fn sweep_closes_issue_when_server_returns() {
 	})
 	.await
 }
+
+async fn insert_status_days_ago(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	days_ago: i32,
+) {
+	sql_query(
+		r#"
+			INSERT INTO statuses (server_id, created_at, extra)
+			VALUES ($1, NOW() - ($2 || ' days')::INTERVAL, '{}'::jsonb)
+		"#,
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(days_ago.to_string())
+	.execute(conn)
+	.await
+	.expect("insert backdated status");
+}
+
+/// The sweep's backstop read the latest status through a fixed seven-day
+/// window, and took "absent from the window" for "never reported". That
+/// capped every per-server `alert_when_down_for` at seven days: a server
+/// allowed to be quiet for twenty was reported down the moment it passed
+/// seven.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_threshold_longer_than_the_status_window_is_honoured() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		// Allowed to be quiet for 20 days; last reported 10 days ago.
+		let id = insert_server(&mut conn, "http://slow.invalid/", 20 * 86400).await;
+		insert_status_days_ago(&mut conn, id, 10).await;
+
+		let filed = Status::sweep_staleness(&mut conn).await.expect("sweep");
+
+		assert_eq!(filed, 0, "10 days quiet is inside a 20-day threshold");
+		assert!(issue_for(&mut conn, id).await.is_none());
+	})
+	.await
+}
+
+/// And when such a server *is* past its threshold, the issue must say how
+/// long it has been quiet rather than claiming it never reported at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_long_quiet_server_is_not_reported_as_never_having_reported() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		// Allowed 9 days; last reported 12 days ago.
+		let id = insert_server(&mut conn, "http://quiet.invalid/", 9 * 86400).await;
+		insert_status_days_ago(&mut conn, id, 12).await;
+
+		let filed = Status::sweep_staleness(&mut conn).await.expect("sweep");
+		assert_eq!(filed, 1);
+
+		let issue = issue_for(&mut conn, id).await.expect("issue exists");
+		assert_eq!(issue.effective_result, Some(CheckResult::Failed));
+		assert!(
+			!issue.message.contains("has never reported"),
+			"this server has reported, 12 days ago: {}",
+			issue.message,
+		);
+		assert!(
+			issue.message.contains("has not reported for 12d"),
+			"expected the real elapsed time, got: {}",
+			issue.message,
+		);
+	})
+	.await
+}
+
+/// A server that genuinely has no status row at all still reads as never
+/// having reported — the unbounded probe finds nothing rather than nothing
+/// being looked for.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_server_with_no_status_at_all_still_reads_as_never_reported() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let id = insert_server(&mut conn, "http://silent.invalid/", 30 * 86400).await;
+
+		let filed = Status::sweep_staleness(&mut conn).await.expect("sweep");
+		assert_eq!(filed, 1);
+
+		let issue = issue_for(&mut conn, id).await.expect("issue exists");
+		assert_eq!(issue.effective_result, Some(CheckResult::Failed));
+		assert!(
+			issue.message.contains("has never reported"),
+			"got: {}",
+			issue.message,
+		);
+	})
+	.await
+}

--- a/crates/database/tests/it/reported_detail.rs
+++ b/crates/database/tests/it/reported_detail.rs
@@ -528,3 +528,45 @@ async fn merge_by_server_keeps_servers_apart() {
 	})
 	.await
 }
+
+/// An archived production server has stopped being part of the fleet, so
+/// what it last reported must not be counted among the versions in
+/// production. The `deleted_at` filter every sibling query carries was
+/// missing here at one point, letting an archived server contribute for as
+/// long as its last report stayed inside the active window.
+#[tokio::test(flavor = "multi_thread")]
+async fn production_versions_excludes_archived_servers() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let live = insert_production_server(&mut conn).await;
+		let archived = insert_production_server(&mut conn).await;
+
+		for (server, version) in [(live, "2.34.1"), (archived, "2.11.0")] {
+			ReportedDetail::record(
+				&mut conn,
+				server,
+				"alertd",
+				&json!({}),
+				Some(&version.parse().unwrap()),
+			)
+			.await
+			.unwrap();
+		}
+
+		database::servers::Server::soft_delete(&mut conn, archived)
+			.await
+			.expect("archive the server");
+
+		let versions: Vec<String> = ReportedDetail::production_versions(&mut conn)
+			.await
+			.expect("production versions")
+			.iter()
+			.map(ToString::to_string)
+			.collect();
+		assert_eq!(
+			versions,
+			vec!["2.34.1"],
+			"an archived server is not running anything",
+		);
+	})
+	.await
+}


### PR DESCRIPTION
Audit findings [L3 and L4](https://github.com/beyondessential/canopy/pull/370).

## L3 — the seven-day window leaked into "never reported"

`sweep_staleness`'s backstop (the arm for servers with no counted source) read each server's latest status through `Status::latest_for_servers`, which looks back exactly seven days, and treated absence from that window as "has never reported". Two consequences:

- **Every per-server `alert_when_down_for` was silently capped at seven days.** A server allowed to be quiet for twenty was reported unreachable the moment it crossed seven, because there was no elapsed time to compare against the threshold — `elapsed = None` goes straight to `down = true`.
- **The issue text was wrong.** A server with years of history read as "has never reported".

The seven-day floor is deliberate — it's what lets Postgres prune partitions and keeps the fleet-wide read cheap — so it stays. Servers that read doesn't find are re-probed by a new `latest_ever_for_servers`, which is the same LATERAL shape without the floor. That set is the handful of long-silent servers, not the fleet, so the fast path is untouched. A server with genuinely no status row still finds nothing and still reads as never having reported.

## L4 — already fixed, now pinned

The audit put `production_versions` at `statuses.rs:521-535` without the `deleted_at IS NULL` filter its siblings carry. The query has since moved to `reported_detail.rs` (0e12ea4, 2026-07-28) and does carry the filter. Rather than take that on faith I added the regression test; it passes on current main. No production code changed for L4.

## Testing

Three new cases in `reachability_sweep.rs`. Against the unfixed `statuses.rs`:

```
test reachability_sweep::a_threshold_longer_than_the_status_window_is_honoured ... FAILED
test reachability_sweep::a_long_quiet_server_is_not_reported_as_never_having_reported ... FAILED
```

The third (`a_server_with_no_status_at_all_still_reads_as_never_reported`) passes either way by design — it's there to prove the unbounded probe didn't erase the genuine never-reported case.

One in `reported_detail.rs` for L4, passing on main as explained above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_