### PR TITLE
fix(mcp): retain the version of a long-offline server in listings (audit L13)

### DIFF
--- a/crates/canopy-mcp/src/groups.rs
+++ b/crates/canopy-mcp/src/groups.rs
@@ -174,13 +174,6 @@ impl CanopyMcp {
 		let last_versions = ReportedDetail::last_versions(&mut conn, &missed)
 			.await
 			.map_err(mcp_err)?;
-		let last_ever: HashMap<Uuid, Timestamp> =
-			Status::latest_ever_for_servers(&mut conn, &missed)
-				.await
-				.map_err(mcp_err)?
-				.into_iter()
-				.map(|s| (s.server_id, s.created_at))
-				.collect();
 		let member_groups: Vec<(Uuid, Option<Uuid>)> =
 			members.iter().map(|s| (s.id, s.group_id)).collect();
 		let health = database::issues::health_from_check_state(&mut conn, &member_groups)
@@ -193,7 +186,6 @@ impl CanopyMcp {
 					s,
 					st_by.get(&s.id).copied(),
 					Retained {
-						last_seen: last_ever.get(&s.id).copied(),
 						version: last_versions.get(&s.id).cloned(),
 					},
 					Some(group.name.clone()),

--- a/crates/canopy-mcp/src/groups.rs
+++ b/crates/canopy-mcp/src/groups.rs
@@ -13,6 +13,7 @@ use database::{
 		BackupMaintenanceRun, BackupRepoSnapshot, BackupRepoStats, BackupRun,
 		ServerGroupBackupConfig, ServerGroupBackupSchedule,
 	},
+	reported_detail::ReportedDetail,
 	server_groups::ServerGroup,
 	statuses::Status,
 };
@@ -27,7 +28,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
 	CanopyMcp,
-	servers::{ServerSummary, summarize},
+	servers::{Retained, ServerSummary, summarize},
 	util::{mcp_err, not_found, ok_json, parse_uuid},
 };
 
@@ -162,6 +163,24 @@ impl CanopyMcp {
 			.await
 			.map_err(mcp_err)?;
 		let st_by: HashMap<Uuid, &Status> = statuses.iter().map(|s| (s.server_id, s)).collect();
+		// Same retained-version resolution as `find_servers`: a member quiet
+		// for more than the status window still ran something last time
+		// anyone heard from it.
+		let missed: Vec<Uuid> = mids
+			.iter()
+			.copied()
+			.filter(|id| !st_by.contains_key(id))
+			.collect();
+		let last_versions = ReportedDetail::last_versions(&mut conn, &missed)
+			.await
+			.map_err(mcp_err)?;
+		let last_ever: HashMap<Uuid, Timestamp> =
+			Status::latest_ever_for_servers(&mut conn, &missed)
+				.await
+				.map_err(mcp_err)?
+				.into_iter()
+				.map(|s| (s.server_id, s.created_at))
+				.collect();
 		let member_groups: Vec<(Uuid, Option<Uuid>)> =
 			members.iter().map(|s| (s.id, s.group_id)).collect();
 		let health = database::issues::health_from_check_state(&mut conn, &member_groups)
@@ -173,6 +192,10 @@ impl CanopyMcp {
 				summarize(
 					s,
 					st_by.get(&s.id).copied(),
+					Retained {
+						last_seen: last_ever.get(&s.id).copied(),
+						version: last_versions.get(&s.id).cloned(),
+					},
 					Some(group.name.clone()),
 					health.get(&s.id).copied().unwrap_or_default(),
 				)

--- a/crates/canopy-mcp/src/servers.rs
+++ b/crates/canopy-mcp/src/servers.rs
@@ -191,12 +191,13 @@ impl CanopyMcp {
 		let st_by: HashMap<Uuid, &Status> = statuses.iter().map(|s| (s.server_id, s)).collect();
 
 		// `version` is documented as retained even when long offline, and
-		// `get_server` implements that. Sourcing it from the status window
-		// alone made `find_servers` disagree: a server quiet for more than a
-		// week reported no version and no last-seen at all, so a fleet version
-		// survey run through this tool undercounted exactly the servers most
-		// worth noticing. Only the servers the window missed are looked up
-		// again.
+		// `get_server` implements that through `ReportedDetail::last_version`.
+		// Sourcing it from the status window alone made `find_servers`
+		// disagree: a server quiet for more than a week reported no version at
+		// all, so a fleet version survey run through this tool undercounted
+		// exactly the servers most worth noticing. Only the servers the window
+		// missed are looked up again, and only against the projection table —
+		// status history stays windowed.
 		let missed: Vec<Uuid> = ids
 			.iter()
 			.copied()
@@ -205,13 +206,6 @@ impl CanopyMcp {
 		let last_versions = ReportedDetail::last_versions(&mut conn, &missed)
 			.await
 			.map_err(mcp_err)?;
-		let last_ever: HashMap<Uuid, Timestamp> =
-			Status::latest_ever_for_servers(&mut conn, &missed)
-				.await
-				.map_err(mcp_err)?
-				.into_iter()
-				.map(|s| (s.server_id, s.created_at))
-				.collect();
 
 		let group_names = Server::group_names_by_server_ids(&mut conn, &ids)
 			.await
@@ -229,7 +223,6 @@ impl CanopyMcp {
 					s,
 					st_by.get(&s.id).copied(),
 					Retained {
-						last_seen: last_ever.get(&s.id).copied(),
 						version: last_versions.get(&s.id).cloned(),
 					},
 					group_names.get(&s.id).cloned().flatten(),
@@ -359,17 +352,22 @@ impl CanopyMcp {
 /// Shared with the groups module, for member listings on [`crate::groups::GroupDetail`].
 /// `health` is the server's check-state rollup (silenced checks already
 /// skipped).
-/// What a server last told canopy, from before the status window if that's
-/// where it lives.
+/// What a server last told canopy, read from the current-state projection
+/// rather than from status history.
 ///
-/// `reachability` deliberately isn't in here. `ShortStatus::Gone` is produced
-/// only by the absence of a status inside the seven-day window — nothing
-/// `short_status()` returns means "long offline" — so it is the signal a fleet
-/// survey reads to spot a server that has dropped off, and resolving it
-/// against an older row would erase it.
+/// Only the version. `last_seen` and `reachability` stay sourced from the
+/// windowed status read: `statuses` is partitioned by week and a predicate on
+/// `server_id` alone can't be pruned, so answering "when was it last seen,
+/// however long ago" means scanning every partition — the cost
+/// `statuses::GRACE_LOOKBACK_SQL` exists to refuse. `server_reported_detail`
+/// has no such problem: one row per (server, source), which is why
+/// `last_version` is already unbounded there.
+///
+/// So a server past the window still reports what it was running, and still
+/// reads as `gone` with no last-seen. That is the documented trade, not an
+/// oversight.
 #[derive(Default)]
 pub(crate) struct Retained {
-	pub last_seen: Option<Timestamp>,
 	pub version: Option<VersionStr>,
 }
 
@@ -391,7 +389,7 @@ pub(crate) fn summarize(
 		group_name,
 		is_monitored: s.is_monitored,
 		archived: s.deleted_at.is_some(),
-		last_seen: st.map(|s| s.created_at).or(retained.last_seen),
+		last_seen: st.map(|s| s.created_at),
 		// A product with no application version carries none rather than a
 		// stale value from a status that predates its classification.
 		// spec: APP#versions

--- a/crates/canopy-mcp/src/servers.rs
+++ b/crates/canopy-mcp/src/servers.rs
@@ -189,6 +189,30 @@ impl CanopyMcp {
 			.await
 			.map_err(mcp_err)?;
 		let st_by: HashMap<Uuid, &Status> = statuses.iter().map(|s| (s.server_id, s)).collect();
+
+		// `version` is documented as retained even when long offline, and
+		// `get_server` implements that. Sourcing it from the status window
+		// alone made `find_servers` disagree: a server quiet for more than a
+		// week reported no version and no last-seen at all, so a fleet version
+		// survey run through this tool undercounted exactly the servers most
+		// worth noticing. Only the servers the window missed are looked up
+		// again.
+		let missed: Vec<Uuid> = ids
+			.iter()
+			.copied()
+			.filter(|id| !st_by.contains_key(id))
+			.collect();
+		let last_versions = ReportedDetail::last_versions(&mut conn, &missed)
+			.await
+			.map_err(mcp_err)?;
+		let last_ever: HashMap<Uuid, Timestamp> =
+			Status::latest_ever_for_servers(&mut conn, &missed)
+				.await
+				.map_err(mcp_err)?
+				.into_iter()
+				.map(|s| (s.server_id, s.created_at))
+				.collect();
+
 		let group_names = Server::group_names_by_server_ids(&mut conn, &ids)
 			.await
 			.map_err(mcp_err)?;
@@ -204,6 +228,10 @@ impl CanopyMcp {
 				summarize(
 					s,
 					st_by.get(&s.id).copied(),
+					Retained {
+						last_seen: last_ever.get(&s.id).copied(),
+						version: last_versions.get(&s.id).cloned(),
+					},
 					group_names.get(&s.id).cloned().flatten(),
 					health.get(&s.id).copied().unwrap_or_default(),
 				)
@@ -331,9 +359,24 @@ impl CanopyMcp {
 /// Shared with the groups module, for member listings on [`crate::groups::GroupDetail`].
 /// `health` is the server's check-state rollup (silenced checks already
 /// skipped).
+/// What a server last told canopy, from before the status window if that's
+/// where it lives.
+///
+/// `reachability` deliberately isn't in here. `ShortStatus::Gone` is produced
+/// only by the absence of a status inside the seven-day window — nothing
+/// `short_status()` returns means "long offline" — so it is the signal a fleet
+/// survey reads to spot a server that has dropped off, and resolving it
+/// against an older row would erase it.
+#[derive(Default)]
+pub(crate) struct Retained {
+	pub last_seen: Option<Timestamp>,
+	pub version: Option<VersionStr>,
+}
+
 pub(crate) fn summarize(
 	s: &Server,
 	st: Option<&Status>,
+	retained: Retained,
 	group_name: Option<String>,
 	health: HealthState,
 ) -> ServerSummary {
@@ -348,12 +391,13 @@ pub(crate) fn summarize(
 		group_name,
 		is_monitored: s.is_monitored,
 		archived: s.deleted_at.is_some(),
-		last_seen: st.map(|s| s.created_at),
+		last_seen: st.map(|s| s.created_at).or(retained.last_seen),
 		// A product with no application version carries none rather than a
 		// stale value from a status that predates its classification.
 		// spec: APP#versions
 		version: st
 			.and_then(|st| st.version.clone())
+			.or(retained.version)
 			.filter(|_| s.product.has_versions()),
 		reachability: st.map_or(ShortStatus::Gone, |s| s.short_status()),
 		health,

--- a/crates/database/src/reported_detail.rs
+++ b/crates/database/src/reported_detail.rs
@@ -152,6 +152,37 @@ impl ReportedDetail {
 		Ok(version.flatten())
 	}
 
+	/// The last version each of `server_ids` reported, however long ago — the
+	/// batch form of [`Self::last_version`], and unbounded for the same
+	/// reason: this answers "what was it running", which stays true while a
+	/// server is offline. Servers that have never reported a version are
+	/// absent from the map.
+	pub async fn last_versions(
+		db: &mut AsyncPgConnection,
+		server_ids: &[Uuid],
+	) -> Result<std::collections::HashMap<Uuid, VersionStr>> {
+		use crate::schema::server_reported_detail::dsl;
+
+		if server_ids.is_empty() {
+			return Ok(std::collections::HashMap::new());
+		}
+
+		let rows: Vec<(Uuid, Option<VersionStr>)> = dsl::server_reported_detail
+			.select((dsl::server_id, dsl::version))
+			.filter(dsl::server_id.eq_any(server_ids))
+			.filter(dsl::version.is_not_null())
+			.distinct_on(dsl::server_id)
+			.order((dsl::server_id, dsl::reported_at.desc()))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+
+		Ok(rows
+			.into_iter()
+			.filter_map(|(id, version)| version.map(|v| (id, v)))
+			.collect())
+	}
+
 	/// The application version each still-reporting production server runs,
 	/// one per server.
 	///

--- a/crates/private-server/tests/it/mcp.rs
+++ b/crates/private-server/tests/it/mcp.rs
@@ -965,12 +965,9 @@ const SRV_OFFLINE: &str = "44444444-4444-4444-4444-444444444444";
 /// `ServerSummary.version` is documented "retained even when long offline",
 /// and `get_server` implements that via `ReportedDetail::last_version`.
 /// `find_servers` took it from the status row instead, which is read through
-/// a seven-day window — so a server quiet for longer reported no version and
-/// no last-seen at all, and a fleet version survey run through this tool
-/// undercounted exactly the servers most worth noticing.
-///
-/// `reachability` is deliberately still `gone`: nothing `short_status()`
-/// returns means "long offline", so that absence is the signal.
+/// a seven-day window — so a server quiet for longer reported no version at
+/// all, and a fleet version survey run through this tool undercounted
+/// exactly the servers most worth noticing.
 #[tokio::test(flavor = "multi_thread")]
 async fn find_servers_retains_the_version_of_a_long_offline_server() {
 	commons_tests::server::run(async |mut conn, _public, private| {
@@ -999,9 +996,14 @@ async fn find_servers_retains_the_version_of_a_long_offline_server() {
 			s["version"], "2.30.0",
 			"the last version it reported is retained, got {s}",
 		);
+		// Both still come from the windowed status read. Answering
+		// "when, however long ago" against `statuses` means scanning every
+		// weekly partition, which is exactly what the lookback cap exists to
+		// refuse; `server_reported_detail` carries the version without that
+		// cost. So the version is retained and these two are not.
 		assert!(
-			!s["last_seen"].is_null(),
-			"it was last seen 30 days ago, not never: {s}",
+			s["last_seen"].is_null(),
+			"last_seen stays bounded by the status window: {s}",
 		);
 		assert_eq!(
 			s["reachability"], "gone",

--- a/crates/private-server/tests/it/mcp.rs
+++ b/crates/private-server/tests/it/mcp.rs
@@ -959,3 +959,54 @@ async fn check_stability_returns_full_records_for_pairs() {
 	})
 	.await
 }
+
+const SRV_OFFLINE: &str = "44444444-4444-4444-4444-444444444444";
+
+/// `ServerSummary.version` is documented "retained even when long offline",
+/// and `get_server` implements that via `ReportedDetail::last_version`.
+/// `find_servers` took it from the status row instead, which is read through
+/// a seven-day window — so a server quiet for longer reported no version and
+/// no last-seen at all, and a fleet version survey run through this tool
+/// undercounted exactly the servers most worth noticing.
+///
+/// `reachability` is deliberately still `gone`: nothing `short_status()`
+/// returns means "long offline", so that absence is the signal.
+#[tokio::test(flavor = "multi_thread")]
+async fn find_servers_retains_the_version_of_a_long_offline_server() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		conn.batch_execute(&format!(
+			"INSERT INTO servers (id, host, name, kind, rank) VALUES \
+				('{SRV_OFFLINE}', 'https://long-gone', 'Long Gone', 'central', 'production'); \
+			 INSERT INTO statuses (server_id, version, healthy, health, extra, created_at) VALUES \
+				('{SRV_OFFLINE}', '2.30.0', true, '[]'::jsonb, '{{}}'::jsonb, \
+				 NOW() - interval '30 days'); \
+			 INSERT INTO server_reported_detail (server_id, source, extra, version, reported_at) VALUES \
+				('{SRV_OFFLINE}', 'alertd', '{{}}'::jsonb, '2.30.0', NOW() - interval '30 days');"
+		))
+		.await
+		.expect("seed long-offline server");
+
+		let found = call_tool!(
+			private,
+			"find_servers",
+			serde_json::json!({ "query": "Long Gone" })
+		);
+		let servers = found["servers"].as_array().unwrap();
+		assert_eq!(servers.len(), 1, "seeded server should match");
+		let s = &servers[0];
+
+		assert_eq!(
+			s["version"], "2.30.0",
+			"the last version it reported is retained, got {s}",
+		);
+		assert!(
+			!s["last_seen"].is_null(),
+			"it was last seen 30 days ago, not never: {s}",
+		);
+		assert_eq!(
+			s["reachability"], "gone",
+			"a server outside the status window is still gone",
+		);
+	})
+	.await
+}


### PR DESCRIPTION
Audit finding [L13](https://github.com/beyondessential/canopy/pull/370).

> **Reworked and rebased onto `main`** after #455 was closed. It was stacked on that branch and inherited the unbounded status probe — see below.

`ServerSummary.version` is documented "retained even when long offline", and `get_server` implements that through `ReportedDetail::last_version`. `find_servers` sourced it from the status row instead, which is read through `latest_for_servers`' seven-day window — so a server quiet for longer reported `version: null`, and the two tools disagreed about the same server. A fleet version survey run through `find_servers` undercounted exactly the servers most worth noticing. `get_group` decorates its members through the same `summarize` and had the same gap.

Both now read the version from `server_reported_detail`, in batch, for the servers the window missed.

## What changed after #455

The original version of this PR also restored `last_seen`, using an unbounded `Status::latest_ever_for_servers` added in #455. That's gone. `statuses::GRACE_LOOKBACK_SQL` documents why it can't exist:

> A predicate on `server_id` alone cannot be partition-pruned, so a query with no lower bound on `created_at` degrades into a scan of every partition — measured at 217s in production for a single row. Worse, the pruning-free plan reads far more than `shared_buffers` holds, so it evicts the buffer pool and drags every unrelated query down with it.

I'd read that cap as an oversight the partitioning had outgrown. It's the opposite — it's the mitigation, and my probe was the thing it exists to prevent.

The version half needs none of that. `server_reported_detail` is the current-state projection built for this exact question: one row per (server, source), not partitioned. That's why `last_version` is already unbounded there, and why `get_server` can honour the documented contract without paying the scan.

So `last_seen` and `reachability` stay bounded by the window. A server past it reports what it was running, and still reads as `gone` with no last-seen. The test now asserts that explicitly rather than leaving it implied.

## Testing

`crates/private-server/tests/it/mcp.rs`. Against `main`:

```
test mcp::find_servers_retains_the_version_of_a_long_offline_server ... FAILED
  left: Null
 right: "2.30.0"
```

Full `mcp::` suite: 19 passed.