### PR TITLE
fix(versions): don't report a DB error as "is the latest in its minor" (audit L5)

### DIFF
--- a/crates/database/src/versions.rs
+++ b/crates/database/src/versions.rs
@@ -320,6 +320,12 @@ impl Version {
 
 		let version_record = Self::get_by_version(db, version.clone()).await?;
 
+		// `.optional()`, not `.ok()`: the latter folded every Diesel error —
+		// a dropped connection, a serialisation failure — into `None`, and
+		// `None` here reports "yes, latest". That is the permissive answer,
+		// and it is the one guarding the publish-to-draft demotion in
+		// `fns::versions::update_version_status`, so a transient database
+		// fault would wave through a demotion the guard exists to refuse.
 		let latest_in_minor: Option<Version> = versions
 			.filter(major.eq(version_record.major))
 			.filter(minor.eq(version_record.minor))
@@ -328,7 +334,8 @@ impl Version {
 			.select(Version::as_select())
 			.first(db)
 			.await
-			.ok();
+			.optional()
+			.map_err(AppError::from)?;
 
 		Ok(latest_in_minor
 			.as_ref()

--- a/crates/database/tests/it/versions.rs
+++ b/crates/database/tests/it/versions.rs
@@ -62,3 +62,58 @@ async fn latest_matching_finds_a_higher_minor_as_the_sole_candidate() {
 	})
 	.await;
 }
+
+/// `is_latest_in_minor` folded any Diesel error into `None` and then reported
+/// `None` as "yes, latest" — the permissive answer, and the one guarding the
+/// publish-to-draft demotion. These pin the answers the guard actually
+/// depends on, so the swap from `.ok()` to `.optional()?` is behaviour-
+/// preserving everywhere except the error path.
+#[tokio::test(flavor = "multi_thread")]
+async fn is_latest_in_minor_answers_within_the_minor_line() {
+	TestDb::run(|mut conn, _url| async move {
+		seed(&mut conn, &[(3, 4, 0), (3, 4, 1), (3, 5, 0)]).await;
+
+		assert!(
+			Version::is_latest_in_minor(&mut conn, "3.4.1".parse().unwrap())
+				.await
+				.expect("query"),
+			"3.4.1 is the highest published patch in 3.4",
+		);
+		assert!(
+			!Version::is_latest_in_minor(&mut conn, "3.4.0".parse().unwrap())
+				.await
+				.expect("query"),
+			"3.4.0 is behind 3.4.1",
+		);
+		assert!(
+			Version::is_latest_in_minor(&mut conn, "3.5.0".parse().unwrap())
+				.await
+				.expect("query"),
+			"a later minor line is judged on its own",
+		);
+	})
+	.await
+}
+
+/// A draft version has no published sibling to lose to, so it still reads as
+/// latest — the genuine empty-result case, which must stay distinct from the
+/// error case.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_minor_line_with_nothing_published_reads_as_latest() {
+	TestDb::run(|mut conn, _url| async move {
+		conn.batch_execute(
+			"INSERT INTO versions (major, minor, patch, changelog, status) \
+			 VALUES (4, 0, 0, 'v4.0.0', 'draft')",
+		)
+		.await
+		.expect("seed draft");
+
+		assert!(
+			Version::is_latest_in_minor(&mut conn, "4.0.0".parse().unwrap())
+				.await
+				.expect("query"),
+			"nothing published in 4.0 to be behind",
+		);
+	})
+	.await
+}


### PR DESCRIPTION
Audit finding [L5](https://github.com/beyondessential/canopy/pull/370).

`Version::is_latest_in_minor` ended its query with `.ok()`, which folds *every* Diesel error — a dropped connection, a serialisation failure, a statement timeout — into `None`. `unwrap_or(true)` then reports `None` as "yes, this is the latest".

That's the permissive answer, and it's the one guarding the publish-to-draft demotion in `fns::versions::update_version_status`. That guard refuses to demote a published version unless it's the latest in its minor line — so a transient database fault waved through exactly the demotion the guard exists to refuse. And because the version under test there has already been checked as `Published` on the line above, the query is guaranteed to match at least that row: an empty result was only ever reachable via a genuine error.

`.optional()?` separates the two cases. "No published version in this minor" still reads as latest; an error is now returned.

## Testing

Two cases in `crates/database/tests/it/versions.rs`, pinning the answers the guard depends on — latest patch in the line, an earlier patch, a separate minor line, and a draft with no published sibling (the genuine empty-result case, which must stay distinct from the error case).

I did not write a test that induces the error itself. Both queries in this function read the same table, so anything that breaks the second — dropping the table, aborting the transaction, revoking access — breaks `get_by_version` on the line above first, and the function returns `Err` either way. Such a test would pass against the unfixed code and prove nothing. The audit rated this one "test: hard" for the same reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_