### PR TITLE
fix(groups): un-archiving a group only restores what its archival took down (audit L6)

### DIFF
--- a/crates/database/src/server_groups.rs
+++ b/crates/database/src/server_groups.rs
@@ -243,6 +243,7 @@ impl ServerGroup {
 		use crate::schema::{server_groups::dsl, servers};
 		use diesel_async::AsyncConnection;
 
+		let archived_at = Timestamp::now();
 		db.transaction::<_, AppError, _>(async |conn| {
 			let member_ids: Vec<Uuid> = servers::table
 				.select(servers::id)
@@ -267,13 +268,24 @@ impl ServerGroup {
 				for id in &member_ids {
 					Server::soft_delete(conn, *id).await?;
 				}
+
+				// Stamp the whole cascade with the group's own archival time.
+				// `member_ids` is exactly the members that were live a moment
+				// ago, so every one of them was archived by *this* cascade —
+				// and matching timestamps is what lets `restore` tell them
+				// from a server an operator had already archived on its own.
+				diesel::update(servers::table.filter(servers::id.eq_any(&member_ids)))
+					.set(
+						servers::deleted_at
+							.eq(jiff_diesel::NullableTimestamp::from(Some(archived_at))),
+					)
+					.execute(conn)
+					.await
+					.map_err(AppError::from)?;
 			}
 
 			diesel::update(dsl::server_groups.filter(dsl::id.eq(group_id)))
-				.set(
-					dsl::deleted_at
-						.eq(jiff_diesel::NullableTimestamp::from(Some(Timestamp::now()))),
-				)
+				.set(dsl::deleted_at.eq(jiff_diesel::NullableTimestamp::from(Some(archived_at))))
 				.execute(conn)
 				.await
 				.map_err(AppError::from)?;
@@ -282,20 +294,43 @@ impl ServerGroup {
 		.await
 	}
 
-	/// Un-archive a group, cascading to restore its archived members (the
-	/// inverse of [`ServerGroup::soft_delete`]'s cascade).
+	/// Un-archive a group, cascading to restore the members its archival took
+	/// down with it — the exact inverse of [`ServerGroup::soft_delete`]'s
+	/// cascade.
+	///
+	/// Only those members. A server an operator archived deliberately *before*
+	/// the group was archived is not part of the cascade and stays archived:
+	/// resurrecting it would put a decommissioned box back into a group whose
+	/// `is_monitored` survived archival, so it would rejoin monitoring and
+	/// start filing "never reported" alerts nobody asked for. The cascade is
+	/// identified by `deleted_at` matching the group's, which `soft_delete`
+	/// stamps across the set it archives.
 	pub async fn restore(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<()> {
 		use crate::schema::{server_groups::dsl, servers};
 		use diesel_async::AsyncConnection;
 
 		db.transaction::<_, AppError, _>(async |conn| {
-			let archived_members: Vec<Uuid> = servers::table
-				.select(servers::id)
-				.filter(servers::group_id.eq(group_id))
-				.filter(servers::deleted_at.is_not_null())
-				.load(conn)
+			let archived_at: Option<Timestamp> = dsl::server_groups
+				.select(dsl::deleted_at)
+				.filter(dsl::id.eq(group_id))
+				.first::<jiff_diesel::NullableTimestamp>(conn)
 				.await
-				.map_err(AppError::from)?;
+				.map_err(AppError::from)?
+				.into();
+
+			// A group that isn't archived has no cascade to undo. Restoring
+			// its archived members would be the same resurrection by another
+			// route.
+			let archived_members: Vec<Uuid> = match archived_at {
+				Some(at) => servers::table
+					.select(servers::id)
+					.filter(servers::group_id.eq(group_id))
+					.filter(servers::deleted_at.eq(jiff_diesel::NullableTimestamp::from(Some(at))))
+					.load(conn)
+					.await
+					.map_err(AppError::from)?,
+				None => Vec::new(),
+			};
 			for id in &archived_members {
 				Server::restore(conn, *id).await?;
 			}

--- a/crates/database/tests/it/server_group_archival.rs
+++ b/crates/database/tests/it/server_group_archival.rs
@@ -218,3 +218,72 @@ async fn live_server_counts_excludes_archived() {
 	})
 	.await
 }
+
+/// Restore is the inverse of the archival *cascade*, not a blanket
+/// un-archive of everything in the group. A server an operator archived
+/// deliberately before the group was archived must stay archived: the group's
+/// `is_monitored` survives archival, so resurrecting a decommissioned box
+/// puts it straight back into monitoring and it starts filing "never
+/// reported" alerts.
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_leaves_individually_archived_members_archived() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "Group").await;
+		// Archived on its own, well before the group.
+		let retired = insert_server(&mut conn, group, true).await;
+		// Live, so the group's archival cascades over it.
+		let cascaded = insert_server(&mut conn, group, false).await;
+
+		ServerGroup::soft_delete(&mut conn, group).await.unwrap();
+		assert!(
+			Server::get_by_id(&mut conn, cascaded)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_some(),
+			"the live member is cascade-archived",
+		);
+
+		ServerGroup::restore(&mut conn, group).await.unwrap();
+
+		assert!(
+			Server::get_by_id(&mut conn, cascaded)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_none(),
+			"the cascade-archived member comes back",
+		);
+		assert!(
+			Server::get_by_id(&mut conn, retired)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_some(),
+			"the individually-archived member stays archived",
+		);
+	})
+	.await
+}
+
+/// The same resurrection by another route: restoring a group that was never
+/// archived must not un-archive its members either.
+#[tokio::test(flavor = "multi_thread")]
+async fn restoring_a_live_group_does_not_resurrect_its_archived_members() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "Group").await;
+		let retired = insert_server(&mut conn, group, true).await;
+
+		ServerGroup::restore(&mut conn, group).await.unwrap();
+
+		assert!(
+			Server::get_by_id(&mut conn, retired)
+				.await
+				.unwrap()
+				.deleted_at
+				.is_some(),
+			"nothing was cascaded, so nothing comes back",
+		);
+	})
+	.await
+}


### PR DESCRIPTION
Audit finding [L6](https://github.com/beyondessential/canopy/pull/370).

`ServerGroup::restore` is documented as the inverse of `soft_delete`'s cascade, but it restored *every* archived member of the group — including a server an operator had deliberately archived before the group ever was. `is_monitored` survives archival, so a decommissioned box came back into monitoring and started filing "never reported" alerts nobody asked for.

The two sets weren't distinguishable, so this makes them so without a migration: `soft_delete` stamps the members it archives with the group's own archival time. They're exactly the members that were live a moment earlier, so all of them are part of the cascade by construction. `restore` then restores the members whose `deleted_at` matches the group's; anything archived at another time was archived by someone else's decision and stays that way.

The same resurrection was reachable by a second route — calling `restore` on a group that was never archived, which un-archived its members anyway. With no cascade to undo, that now restores nothing.

## Testing

Two cases in `server_group_archival.rs`. Both fail against the unfixed code:

```
test server_group_archival::restore_leaves_individually_archived_members_archived ... FAILED
test server_group_archival::restoring_a_live_group_does_not_resurrect_its_archived_members ... FAILED
```

The existing `archiving_an_all_gone_group_cascades_and_restore_reverses` still passes, so the ordinary round trip is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_