### PR TITLE
fix(versions): banner skips known-issue versions; changelog cap is a MiB (audit L7, L8)

### DIFF
--- a/crates/public-server/src/versions.rs
+++ b/crates/public-server/src/versions.rs
@@ -285,8 +285,10 @@ async fn create(
 	use commons_types::version::VersionStatus;
 
 	let mut db = db.get().await?;
-	let mut stream = data.take(1024 * 1024 * 1024); // up to a MiB
-	let mut changelog = String::with_capacity(data.len().min(1024 * 1024 * 1024));
+	const CHANGELOG_LIMIT: usize = 1024 * 1024; // a MiB, as documented
+
+	let mut stream = data.take(CHANGELOG_LIMIT as u64);
+	let mut changelog = String::with_capacity(data.len().min(CHANGELOG_LIMIT));
 	stream.read_to_string(&mut changelog).await?;
 	let version_str = VersionStr::from_str(&version)?;
 	let device_id = device.0.0.id;
@@ -405,18 +407,25 @@ async fn view_artifacts(
 	version.changelog = parse_markdown(&version.changelog);
 	let artifacts = Artifact::get_for_version(&mut db, version.id).await?;
 
-	// Check if this is the latest published version in its minor
+	// The latest *ready* version in this minor. The page's own version came
+	// through `latest_matching_ready`, so the banner has to use the same set:
+	// a version a known issue still covers is hidden from every listing and
+	// its own page 404s, so recommending one — and linking to it — sends the
+	// reader nowhere.
 	let latest_in_minor = {
 		use database::schema::versions::dsl::*;
-		versions
+		let published: Vec<Version> = versions
 			.filter(major.eq(version.major))
 			.filter(minor.eq(version.minor))
 			.filter(status.eq(VersionStatus::Published))
 			.order_by(patch.desc())
 			.select(Version::as_select())
-			.first(&mut db)
+			.load(&mut db)
 			.await
-			.ok()
+			.map_err(AppError::from)?;
+		// `filter_ready` keeps the order it's given, so the first survivor is
+		// the highest ready patch.
+		filter_ready(&mut db, published).await?.into_iter().next()
 	};
 
 	let is_latest = latest_in_minor

--- a/crates/public-server/tests/it/versions.rs
+++ b/crates/public-server/tests/it/versions.rs
@@ -824,3 +824,75 @@ async fn artifact_create_range_no_auth() {
 	})
 	.await
 }
+
+/// The "newer version available" banner on a version page filtered only on
+/// `Published`, while the page's own version comes through
+/// `latest_matching_ready`, which also excludes anything a known issue
+/// covers. So the banner could recommend — and link to — a version hidden
+/// from every listing, whose own page 404s.
+#[tokio::test(flavor = "multi_thread")]
+async fn version_page_banner_does_not_recommend_a_known_issue_version() {
+	commons_tests::server::run(async |mut conn, public, _| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+			('22222222-2222-2222-2222-222222222200', 2, 0, 0, 'old', 'published'),
+			('22222222-2222-2222-2222-222222222201', 2, 0, 1, 'fine', 'published'),
+			('22222222-2222-2222-2222-222222222202', 2, 0, 2, 'broken', 'published');
+			INSERT INTO version_known_issues (author, description, min_major, min_minor, min_patch)
+			VALUES ('admin', 'broken', 2, 0, 2)",
+		)
+		.await
+		.unwrap();
+
+		// Sanity: the covered version really is hidden from the public site.
+		public
+			.get("/versions/2.0.2")
+			.await
+			.assert_status_not_found();
+
+		let body = public.get("/versions/2.0.0").await.text();
+		assert!(
+			!body.contains("2.0.2"),
+			"the banner must not point at a version a known issue covers: {body}",
+		);
+		assert!(
+			body.contains("2.0.1"),
+			"it should point at the newest ready patch instead: {body}",
+		);
+	})
+	.await
+}
+
+/// The changelog cap was written `1024 * 1024 * 1024` next to a comment
+/// saying "up to a MiB" — a GiB, so the intended limit was never enforced.
+#[tokio::test(flavor = "multi_thread")]
+async fn changelog_is_capped_at_a_mebibyte() {
+	use database::versions::Version;
+
+	const MIB: usize = 1024 * 1024;
+
+	commons_tests::server::run_with_device_auth(
+		"releaser",
+		async |mut conn, cert, _device_id, public, _| {
+			// Comfortably over the cap, all single-byte characters so the
+			// byte count and the character count agree.
+			let oversized = "x".repeat(MIB + 4096);
+			let response = public
+				.post("/versions/3.1.4")
+				.add_header("x-forwarded-client-cert", &format!("Cert={}", cert))
+				.text(&oversized)
+				.await;
+			response.assert_status_ok();
+
+			let version = Version::get_by_version(&mut conn, "3.1.4".parse().unwrap())
+				.await
+				.unwrap();
+			assert_eq!(
+				version.changelog.len(),
+				MIB,
+				"the changelog should be truncated to a MiB, not stored whole",
+			);
+		},
+	)
+	.await
+}


### PR DESCRIPTION
Audit findings [L7 and L8](https://github.com/beyondessential/canopy/pull/370). Same file, so one PR.

## L7 — the banner recommended versions the site hides

A version page resolves its own version through `latest_matching_ready`, which excludes anything a known issue still covers. The "newer version available" banner picked the latest in the minor filtering only on `Published`, so it could recommend — and link to — a version that's hidden from every listing and whose own page 404s.

The banner now runs the same candidates through `filter_ready`. That preserves the order it's given, so the first survivor is the highest *ready* patch.

## L8 — the cap was a GiB

`data.take(1024 * 1024 * 1024)` sat next to the comment `// up to a MiB`. A ×1024 unit slip, so the documented limit was never enforced. Both the `take` and the `with_capacity` beside it now use one named `CHANGELOG_LIMIT`.

## Testing

Two cases in `crates/public-server/tests/it/versions.rs`, both failing against the unfixed code:

```
test versions::version_page_banner_does_not_recommend_a_known_issue_version ... FAILED
  the banner must not point at a version a known issue covers

test versions::changelog_is_capped_at_a_mebibyte ... FAILED
  left: 1052672
 right: 1048576
```

The L7 test also asserts the banner points at the newest *ready* patch rather than simply omitting the banner, and sanity-checks that the covered version really does 404 on the public site.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_