### PR TITLE
fix(mcp): check the failed-auth budget before the lookup it bounds (audit L9)

### DIFF
--- a/crates/public-server/src/mcp.rs
+++ b/crates/public-server/src/mcp.rs
@@ -23,10 +23,16 @@ use std::time::Duration;
 
 use crate::state::AppState;
 
-/// Failed-auth budget within a 1-minute window, per source IP. Successful
-/// requests don't count against it, so a busy legitimate agent is unaffected;
+/// Failed-auth budget within a 1-minute window, per source IP. Only failures
+/// spend it, so an agent presenting a working token never approaches it;
 /// a token-guesser is blunted. Guessing is hopeless anyway (tokens are 256-bit
 /// CSPRNG), this just bounds the DB lookups it can burn.
+///
+/// Once an IP has spent the budget it is turned away for the rest of the
+/// window whatever it presents, valid token included. That is the cost of
+/// bounding the lookups: whether a token is good is exactly what the lookup
+/// answers. It only bites an IP already producing thirty auth failures a
+/// minute.
 const RL_WINDOW: Duration = Duration::from_secs(60);
 const RL_PER_IP: u32 = 30;
 
@@ -50,6 +56,17 @@ async fn require_bearer_token(
 	req: Request,
 	next: Next,
 ) -> Result<Response, AppError> {
+	// Before anything that costs: an IP that has already spent its budget is
+	// turned away without a connection checkout or a query. `refuse` consults
+	// the same budget, but by the time it runs `find_active` has been and
+	// gone — so the budget bounded the *responses* a guesser got, not the
+	// database work it burned, which is what it is documented to bound.
+	let key = format!("mcp:{ip}");
+	if state.rate_limiter.exceeded(&key, RL_PER_IP, RL_WINDOW) {
+		tracing::warn!(target: "mcp_auth", %ip, "mcp auth rate limit exceeded");
+		return Err(AppError::RateLimited);
+	}
+
 	let presented = req
 		.headers()
 		.get(header::AUTHORIZATION)

--- a/crates/public-server/src/ratelimit.rs
+++ b/crates/public-server/src/ratelimit.rs
@@ -26,6 +26,19 @@ impl RateLimiter {
 	/// caller has exceeded the limit. Expired windows reset on access; entries
 	/// for keys idle longer than `window` are pruned opportunistically to keep
 	/// the map bounded.
+	/// Whether `key` has already exhausted `limit` within the current
+	/// `window`, **without** recording a hit.
+	///
+	/// [`Self::check`] can only report an exhausted budget by spending one,
+	/// which means the caller has to do the work first. This lets a caller
+	/// turn a client away before doing the work the budget exists to bound.
+	pub fn exceeded(&self, key: &str, limit: u32, window: Duration) -> bool {
+		let now = Instant::now();
+		let map = self.windows.lock().expect("rate-limiter mutex");
+		map.get(key)
+			.is_some_and(|w| now.duration_since(w.start) <= window && w.count >= limit)
+	}
+
 	pub fn check(&self, key: &str, limit: u32, window: Duration) -> bool {
 		let now = Instant::now();
 		let mut map = self.windows.lock().expect("rate-limiter mutex");

--- a/crates/public-server/tests/it/mcp.rs
+++ b/crates/public-server/tests/it/mcp.rs
@@ -151,3 +151,49 @@ async fn oauth_discovery_is_404() {
 	})
 	.await
 }
+
+/// The budget is documented as bounding "the DB lookups a token-guesser can
+/// burn", but it was only consulted inside `refuse` — after
+/// `McpToken::find_active` had already taken a pool connection and run its
+/// query. So an over-budget IP still cost a lookup per guess.
+///
+/// Proved by making the lookup impossible: with the table gone, any code
+/// path that still reaches the database errors into a 500. A 429 means the
+/// request was turned away before it got there.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_over_budget_ip_is_refused_without_a_database_lookup() {
+	commons_tests::server::run(async |mut conn, public, _private| {
+		let guess = async || {
+			public
+				.post("/mcp")
+				.add_header("accept", ACCEPT)
+				.add_header("mcp-protocol-version", PROTO)
+				.add_header("authorization", "Bearer canopy_mcp_guess")
+				.json(&fleet_summary_call())
+				.await
+				.status_code()
+				.as_u16()
+		};
+
+		// Spend the budget.
+		let mut spent = false;
+		for _ in 0..40 {
+			if guess().await == 429 {
+				spent = true;
+				break;
+			}
+		}
+		assert!(spent, "failed attempts never rate limited");
+
+		diesel_async::SimpleAsyncConnection::batch_execute(&mut conn, "DROP TABLE mcp_tokens")
+			.await
+			.expect("drop the token table");
+
+		assert_eq!(
+			guess().await,
+			429,
+			"an over-budget IP must be refused before the lookup, not after it",
+		);
+	})
+	.await
+}


### PR DESCRIPTION
Audit finding [L9](https://github.com/beyondessential/canopy/pull/370).

The module documents the per-IP failed-auth budget as bounding "the DB lookups a token-guesser can burn". It was only consulted inside `refuse()` — after `McpToken::find_active` had already taken a pool connection and run its query. So an over-budget IP still cost a full checkout and lookup per guess: the budget bounded the *responses* a guesser got, not the database work it burned.

`RateLimiter::exceeded` reports an exhausted budget without spending one, so the middleware can turn the request away before touching anything. `refuse` still spends the budget on each failure, so the counting is unchanged and nothing is double-counted — failures 1–30 get 401, the 31st gets 429, and subsequent ones get 429 without a lookup.

### One consequence worth flagging

An IP that has spent its budget is now turned away for the rest of the window **whatever it presents, valid token included**. That's unavoidable given the goal: whether a token is good is exactly what the lookup answers, so you can't both skip the lookup and honour a valid token.

I think that's the right trade — it only bites an IP already producing thirty auth failures a minute, and an agent with a working token spends nothing and never approaches the budget — but it does contradict the old constant's claim that "successful requests don't count against it, so a busy legitimate agent is unaffected". I've rewritten that comment to say what actually happens rather than leave it stale. Happy to revert to the old behaviour if you'd rather keep valid tokens working through a burst of failures from a shared NAT.

## Testing

New case in `crates/public-server/tests/it/mcp.rs`. It proves the absence of the lookup by making the lookup impossible: spend the budget, `DROP TABLE mcp_tokens`, then guess once more. Any path that still reaches the database errors into a 500; a 429 means the request was turned away first.

```
test mcp::an_over_budget_ip_is_refused_without_a_database_lookup ... FAILED
  left: 500
 right: 429
```

The existing `failed_attempts_rate_limit_per_ip` still passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_