### PR TITLE
fix(statuses): a duplicated check name files one consistent entry (audit L10)

### DIFF
--- a/crates/public-server/src/statuses.rs
+++ b/crates/public-server/src/statuses.rs
@@ -497,13 +497,12 @@ async fn file_health_events(
 
 	// Grade every check in the push through its policy.
 	let mut effective: BTreeMap<&String, GradedResult> = BTreeMap::new();
-	for (check, result) in &curr_check_results {
-		let entry = find_health_entry(&status.health, check);
+	for (check, (result, entry)) in &curr_check_results {
 		// Strip the reserved `check` / `healthy` keys, and replace any
 		// wire-form `result` with the normalised value so rules see a
 		// uniform `check.result` even for legacy (`healthy: bool`)
 		// payloads.
-		let mut check_extra = entry.cloned().unwrap_or_default();
+		let mut check_extra = (*entry).clone();
 		check_extra.remove("check");
 		check_extra.remove("healthy");
 		check_extra.insert(
@@ -627,13 +626,13 @@ async fn file_health_events(
 				}),
 			),
 		};
-		let entry = find_health_entry(&status.health, check);
+		let (observed, entry) = curr_check_results[*check];
 		let stamp = CheckStateStamp {
 			check: (*check).clone(),
-			observed: curr_check_results[*check],
+			observed,
 			effective,
 			escalates,
-			detail: entry.cloned().map(serde_json::Value::Object),
+			detail: Some(serde_json::Value::Object(entry.clone())),
 		};
 		NewEvent {
 			source: status.source.clone(),
@@ -695,7 +694,9 @@ async fn file_health_events(
 /// looking at our own well-formed data or at historical pre-contract
 /// rows where missing means absent. Reads both the `result` enum form
 /// and the legacy `healthy: bool` form via [`CheckResult::from_entry`].
-fn collect_check_results(health: &serde_json::Value) -> BTreeMap<String, CheckResult> {
+fn collect_check_results(
+	health: &serde_json::Value,
+) -> BTreeMap<String, (CheckResult, &serde_json::Map<String, serde_json::Value>)> {
 	let Some(arr) = health.as_array() else {
 		return BTreeMap::new();
 	};
@@ -704,26 +705,12 @@ fn collect_check_results(health: &serde_json::Value) -> BTreeMap<String, CheckRe
 			let obj = e.as_object()?;
 			let check = obj.get("check")?.as_str()?;
 			let result = CheckResult::from_entry(obj)?;
-			Some((check.to_string(), result))
+			Some((check.to_string(), (result, obj)))
 		})
 		.collect()
 }
 
-fn find_health_entry<'a>(
-	health: &'a serde_json::Value,
-	name: &str,
-) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
-	health.as_array()?.iter().find_map(|e| {
-		let obj = e.as_object()?;
-		let check = obj.get("check")?.as_str()?;
-		(check == name).then_some(obj)
-	})
-}
-
-fn per_check_description(
-	entry: Option<&serde_json::Map<String, serde_json::Value>>,
-) -> Option<String> {
-	let entry = entry?;
+fn per_check_description(entry: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
 	let mut lines = Vec::new();
 	for (k, v) in entry.iter() {
 		if k == "check" || k == "healthy" || k == "result" {

--- a/crates/public-server/tests/it/statuses.rs
+++ b/crates/public-server/tests/it/statuses.rs
@@ -3187,3 +3187,52 @@ async fn push_records_the_source_s_current_detail() {
 	)
 	.await
 }
+
+/// Validation permits two `health[]` entries with the same `check` name.
+/// The result came from a map (last wins) while the message, extras, and
+/// severity-rule context came from a linear search (first wins), so the
+/// filed issue mixed one entry's verdict with another entry's data.
+#[tokio::test(flavor = "multi_thread")]
+async fn duplicate_check_names_file_one_consistent_entry() {
+	commons_tests::server::run_with_device_auth(
+		"server",
+		async |mut conn, cert, device_id, public, _| {
+			let server_id = insert_health_test_server(&mut conn, device_id).await;
+
+			public
+				.post(&format!("/status/{}", server_id))
+				.add_header("x-forwarded-client-cert", &format!("Cert={}", cert))
+				.json(&serde_json::json!({
+					"health": [
+						{ "check": "disk", "result": "passed", "free_pct": 80 },
+						{ "check": "disk", "result": "failed", "free_pct": 2 },
+					],
+				}))
+				.await
+				.assert_status_ok();
+
+			let issue = fetch_issue(&mut conn, server_id, "alertd", "health/disk")
+				.await
+				.expect("the check filed an issue");
+
+			// The map keeps the last entry's result, so the message and extras
+			// have to come from that same entry.
+			assert_eq!(
+				issue.observed_result.as_deref(),
+				Some("failed"),
+				"the later entry supersedes the earlier one",
+			);
+			assert!(
+				issue.message.contains("`2`"),
+				"the detail must come from the entry the result came from, got: {}",
+				issue.message,
+			);
+			assert!(
+				!issue.message.contains("`80`"),
+				"the superseded entry's detail must not be reported: {}",
+				issue.message,
+			);
+		},
+	)
+	.await
+}


### PR DESCRIPTION
Audit finding [L10](https://github.com/beyondessential/canopy/pull/370).

Validation permits two `health[]` entries naming the same check. The result was resolved through `collect_check_results` — a `BTreeMap`, so the **last** entry won — while the message, extras, and the severity rule's `EvaluationContext` came from `find_health_entry`, a linear search, so the **first** entry won. The filed issue carried one entry's verdict alongside another entry's data, and a value-based severity rule graded numbers that didn't belong to the result being graded.

The obvious fix is to make `find_health_entry` search backwards. I didn't do that, for two reasons: it leaves two independent resolutions free to drift apart again, and it isn't actually equivalent — `collect_check_results` skips entries whose result doesn't parse, so when the last entry is malformed the map falls back to an earlier one and a `.rev()` search would disagree all over again.

Instead `collect_check_results` now carries the entry it took each result from, so there's one resolution and nothing to diverge. `find_health_entry` is deleted. Last-wins is unchanged in behaviour and is now the documented reading: a later entry supersedes an earlier one.

## Testing

New case in `crates/public-server/tests/it/statuses.rs`, submitting `disk` twice — `passed` with `free_pct: 80`, then `failed` with `free_pct: 2`. Against the unfixed code:

```
test statuses::duplicate_check_names_file_one_consistent_entry ... FAILED
  the detail must come from the entry the result came from, got: - **free_pct**: `80`
```

— a `failed` issue carrying the passing entry's numbers, exactly as described. The other 59 tests in `statuses::` still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_