### PR TITLE
fix(errors): malformed client input is a 400, not a 500 (audit L11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,6 +1754,7 @@ dependencies = [
  "axum",
  "axum-client-ip",
  "axum-server-timing",
+ "axum-test",
  "chbs",
  "commons-errors",
  "commons-types",

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -8,11 +8,14 @@ This should never be exposed over the API.
 
 ## Header
 
-Issued when an HTTP Header is missing or malformed.
+Issued when an HTTP Header is missing or malformed. **400 Bad Request** — the
+header came from the client, so nothing on the server is at fault and
+retrying the same request cannot succeed.
 
 ## Version Parse
 
 Issued when a version or version range in URLs or API bodies is not parseable.
+**400 Bad Request**, for the same reason as [Header](#header).
 
 ## Database
 

--- a/crates/commons-errors/src/lib.rs
+++ b/crates/commons-errors/src/lib.rs
@@ -242,6 +242,9 @@ impl AppError {
 	/// long time answering 500: adding a variant and forgetting its status
 	/// was silent. Now it doesn't compile, so the status is a decision
 	/// somebody makes rather than one that defaults.
+	///
+	/// Note the arms are ordered, so a variant listed twice silently takes
+	/// the first match. Keep each one in exactly one arm.
 	fn to_http_status(&self) -> StatusCode {
 		match self {
 			Self::NotImplemented => StatusCode::NOT_IMPLEMENTED,
@@ -285,8 +288,6 @@ impl AppError {
 			Self::Custom(_)
 			| Self::Problem(_)
 			| Self::Environment(_)
-			| Self::VersionParse(_)
-			| Self::Header(_)
 			| Self::DatabasePool(_)
 			| Self::DatabaseQuery(_)
 			| Self::Tera(_)

--- a/crates/commons-errors/src/lib.rs
+++ b/crates/commons-errors/src/lib.rs
@@ -232,6 +232,11 @@ impl AppError {
 			Self::NotImplemented => StatusCode::NOT_IMPLEMENTED,
 			Self::NoMatchingVersions => StatusCode::NOT_FOUND,
 			Self::UnusableRange => StatusCode::BAD_REQUEST,
+			// Both arise purely from what a client sent: a version segment in
+			// a URL path, or the `X-Version` header. Nothing on the server is
+			// wrong, and retrying the same request can never succeed.
+			Self::VersionParse(_) => StatusCode::BAD_REQUEST,
+			Self::Header(_) => StatusCode::BAD_REQUEST,
 			Self::DatabaseQuery(diesel::result::Error::NotFound) => StatusCode::NOT_FOUND,
 			Self::AuthMissingHeader(_) => StatusCode::UNAUTHORIZED,
 			Self::AuthMissingCertificate => StatusCode::UNAUTHORIZED,

--- a/crates/commons-servers/Cargo.toml
+++ b/crates/commons-servers/Cargo.toml
@@ -59,3 +59,6 @@ tracing.workspace = true
 # `verify` gives `verify_signature` on a parsed CSR — proof the sender holds the
 # key it asks Canopy to certify. Backed by ring, already a dependency here.
 x509-parser = { version = "0.18.1", features = ["verify"] }
+
+[dev-dependencies]
+axum-test = { workspace = true }

--- a/crates/commons-servers/src/headers.rs
+++ b/crates/commons-servers/src/headers.rs
@@ -51,3 +51,45 @@ where
 			.map(Some)
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use axum::{Router, routing::get};
+
+	async fn handler(v: Option<VersionHeader>) -> String {
+		format!("{:?}", v.map(|v| v.0.to_string()))
+	}
+
+	#[tokio::test]
+	async fn a_malformed_version_header_rejects_rather_than_reading_as_absent() {
+		let app = Router::new().route("/", get(handler));
+		let server = axum_test::TestServer::new(app);
+
+		assert_eq!(
+			server.get("/").await.status_code().as_u16(),
+			200,
+			"absent is fine"
+		);
+		assert_eq!(
+			server
+				.get("/")
+				.add_header("x-version", "2.3.4")
+				.await
+				.status_code()
+				.as_u16(),
+			200,
+			"a good version is fine",
+		);
+		assert_eq!(
+			server
+				.get("/")
+				.add_header("x-version", "garbage")
+				.await
+				.status_code()
+				.as_u16(),
+			400,
+			"a garbage version is a client bug, not an absent header",
+		);
+	}
+}

--- a/crates/public-server/tests/it/versions.rs
+++ b/crates/public-server/tests/it/versions.rs
@@ -824,3 +824,25 @@ async fn artifact_create_range_no_auth() {
 	})
 	.await
 }
+
+/// A malformed version in a URL path is a client mistake, not a server
+/// fault: `AppError::VersionParse` fell through to the catch-all 500 arm,
+/// so bad input polluted 5xx monitoring and told clients to retry something
+/// that can never succeed.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_malformed_version_in_the_path_is_a_400() {
+	commons_tests::server::run(async |_conn, public, _| {
+		for path in [
+			"/versions/update-for/not-a-version",
+			"/versions/not-a-version",
+		] {
+			let response = public.get(path).await;
+			assert_eq!(
+				response.status_code(),
+				StatusCode::BAD_REQUEST,
+				"{path} should be a 400",
+			);
+		}
+	})
+	.await
+}


### PR DESCRIPTION
Audit finding [L11](https://github.com/beyondessential/canopy/pull/370).

`AppError::VersionParse` and `AppError::Header` fell through to the catch-all `_ => INTERNAL_SERVER_ERROR` arm, though both arise purely from what a client sent — a version segment in a URL path, or the `X-Version` header. So `GET /versions/update-for/not-a-version` and a device sending `X-Version: garbage` both 500'd, polluting 5xx monitoring with client mistakes and telling the caller to retry something that can never succeed. The sibling `UnusableRange`, which arises the same way, was already a 400.

Both now map to 400, and ERRORS.md says so.

## Testing

- `crates/public-server/tests/it/versions.rs` — `/versions/not-a-version` and `/versions/update-for/not-a-version`. 500 → 400.
- `crates/commons-servers/src/headers.rs` — a unit test on the `VersionHeader` extractor itself: absent is `None`, good parses, garbage is a 400. Also 500 → 400.

### A note on where the header test lives

I first wrote the header case as a public-server integration test and it returned 200, not 400 — which looked like the extractor silently swallowing a malformed header, contradicting its own doc comment. It isn't. `commons_tests::server::run*` sets a default `X-Version: 3.4.5` on the public test server, so a per-request `add_header` appends a *second* value and `HeaderMap::get` returns the first. The harness's valid version was being parsed, not mine.

Rather than fight the harness (clearing its defaults would weaken every other test that relies on them), the header case is a unit test against the extractor directly, which is where the behaviour actually lives. That needed `axum-test` as a dev-dependency of `commons-servers`.

## Pre-existing test failures, unrelated

Running the full `public-server` and `private-server` suites under `cargo test` shows failures in `server_enrollment::`, `names::`, and `domains::`. These reproduce identically on clean `main`, and the `domains::` set varies between runs — order-dependence under `cargo test`'s thread parallelism, which the repo's own guidance warns about (`nextest` runs process-per-test). CI uses nextest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_