### PR TITLE
fix(errors): typed variants for documented 404s and 400s (audit L15, L16, L17)

### DIFF
--- a/crates/commons-errors/src/lib.rs
+++ b/crates/commons-errors/src/lib.rs
@@ -125,6 +125,14 @@ pub enum AppError {
 	#[error("invalid request: {0}")]
 	BadRequest(String),
 
+	/// A specific resource was looked up and not found, where the lookup
+	/// doesn't go through Diesel's own `NotFound` — an `Option` returned by a
+	/// directory, a cache, or a helper that already mapped its error away.
+	/// Maps to 404, and reuses the `resource-not-found` problem type so a
+	/// caller matches one slug for "not found" however the miss was produced.
+	#[error("not found: {0}")]
+	NotFound(String),
+
 	/// Resource conflict — e.g. attempting to import a ticket whose
 	/// canonical URL already belongs to a different server id. Maps
 	/// to 409.
@@ -227,6 +235,13 @@ impl Clone for AppError {
 }
 
 impl AppError {
+	/// The status each variant answers with.
+	///
+	/// Deliberately exhaustive — no `_` arm. A wildcard here is how
+	/// `VersionParse` and `Header`, both purely client-input errors, spent a
+	/// long time answering 500: adding a variant and forgetting its status
+	/// was silent. Now it doesn't compile, so the status is a decision
+	/// somebody makes rather than one that defaults.
 	fn to_http_status(&self) -> StatusCode {
 		match self {
 			Self::NotImplemented => StatusCode::NOT_IMPLEMENTED,
@@ -249,6 +264,7 @@ impl AppError {
 			Self::AuthTailnetIdentityMissing => StatusCode::UNAUTHORIZED,
 			Self::AuthTokenNotValid => StatusCode::UNAUTHORIZED,
 			Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+			Self::NotFound(_) => StatusCode::NOT_FOUND,
 			Self::Conflict(_) => StatusCode::CONFLICT,
 			Self::CertificateKeyCompromised(_) => StatusCode::CONFLICT,
 			Self::NameManagementPaused(_) => StatusCode::CONFLICT,
@@ -257,7 +273,20 @@ impl AppError {
 			Self::RateLimited => StatusCode::TOO_MANY_REQUESTS,
 			Self::Upstream(_) => StatusCode::BAD_GATEWAY,
 			Self::BackupRotationInProgress => StatusCode::SERVICE_UNAVAILABLE,
-			_ => StatusCode::INTERNAL_SERVER_ERROR,
+
+			// Everything below is a server-side fault or a non-HTTP context,
+			// and answers 500. Listed rather than wildcarded so a new variant
+			// has to be placed deliberately.
+			Self::Custom(_)
+			| Self::Problem(_)
+			| Self::Environment(_)
+			| Self::VersionParse(_)
+			| Self::Header(_)
+			| Self::DatabasePool(_)
+			| Self::DatabaseQuery(_)
+			| Self::Tera(_)
+			| Self::Io(_)
+			| Self::Timesync(_) => StatusCode::INTERNAL_SERVER_ERROR,
 		}
 	}
 
@@ -281,8 +310,8 @@ impl AppError {
 						Self::Header(_) => "header",
 						Self::VersionParse(_) => "version-parse",
 						Self::DatabasePool(_) => "database",
-						Self::DatabaseQuery(diesel::result::Error::NotFound) =>
-							"resource-not-found",
+						Self::DatabaseQuery(diesel::result::Error::NotFound)
+						| Self::NotFound(_) => "resource-not-found",
 						Self::DatabaseQuery(_) => "database",
 						Self::Tera(_) => "render",
 						Self::Io(_) => "io",

--- a/crates/private-server/src/fns/bestool.rs
+++ b/crates/private-server/src/fns/bestool.rs
@@ -182,7 +182,7 @@ pub async fn get_snippet(
 	let mut conn = state.db.get().await?;
 	let snippet = database::BestoolSnippet::get_by_id(&mut conn, args.id)
 		.await?
-		.ok_or_else(|| AppError::custom("Snippet not found"))?;
+		.ok_or_else(|| AppError::NotFound(format!("no snippet with id {}", args.id)))?;
 	Ok(Json(BestoolSnippetDetail {
 		id: snippet.id,
 		name: snippet.name,

--- a/crates/private-server/src/fns/devices.rs
+++ b/crates/private-server/src/fns/devices.rs
@@ -935,7 +935,7 @@ pub async fn attach_tailscale(
 		.resolve_identifier(&args.identifier)
 		.await
 		.map_err(|_| AppError::AuthTailnetDirectoryUnavailable)?
-		.ok_or_else(|| AppError::custom("no tailnet device matches that identifier"))?;
+		.ok_or_else(|| AppError::NotFound("no tailnet device matches that identifier".into()))?;
 
 	let mut conn = state.db.get().await?;
 	Device::attach_tailscale(

--- a/crates/private-server/src/fns/incidents.rs
+++ b/crates/private-server/src/fns/incidents.rs
@@ -518,7 +518,7 @@ pub async fn add_note(
 	Json(args): Json<IncidentAddNoteArgs>,
 ) -> Result<Json<IncidentNoteData>> {
 	if args.body.trim().is_empty() {
-		return Err(AppError::custom("note body is required"));
+		return Err(AppError::BadRequest("note body is required".into()));
 	}
 	let mut conn = state.db.get().await?;
 	let note = IncidentNote::add(&mut conn, args.incident_id, &admin.0.login, &args.body).await?;

--- a/crates/private-server/src/fns/issues.rs
+++ b/crates/private-server/src/fns/issues.rs
@@ -505,7 +505,7 @@ pub async fn submit_manual_event(
 	Json(args): Json<SubmitManualEventArgs>,
 ) -> Result<Json<IssueData>> {
 	if args.r#ref.trim().is_empty() {
-		return Err(AppError::custom("ref is required"));
+		return Err(AppError::BadRequest("ref is required".into()));
 	}
 
 	let observed = if args.active == Some(false) {
@@ -720,7 +720,7 @@ pub async fn add_note(
 	Json(args): Json<IssueAddNoteArgs>,
 ) -> Result<Json<IssueNoteData>> {
 	if args.body.trim().is_empty() {
-		return Err(AppError::custom("note body is required"));
+		return Err(AppError::BadRequest("note body is required".into()));
 	}
 	let mut conn = state.db.get().await?;
 	let note = IssueNote::add(&mut conn, args.issue_id, &admin.0.login, &args.body).await?;

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -992,7 +992,7 @@ pub async fn create(
 			.await
 			.map_err(|_| AppError::AuthTailnetDirectoryUnavailable)?
 			.ok_or_else(|| {
-				AppError::BadRequest("no tailnet device matches that identifier".into())
+				AppError::NotFound("no tailnet device matches that identifier".into())
 			})?;
 		let device = match Device::from_tailscale_node_id(&mut conn, &entry.node_id).await? {
 			Some(existing) => existing,
@@ -1324,7 +1324,7 @@ pub async fn attach_tailscale_device(
 		.resolve_identifier(&args.identifier)
 		.await
 		.map_err(|_| AppError::AuthTailnetDirectoryUnavailable)?
-		.ok_or_else(|| AppError::BadRequest("no tailnet device matches that identifier".into()))?;
+		.ok_or_else(|| AppError::NotFound("no tailnet device matches that identifier".into()))?;
 
 	let mut conn = state.db.get().await?;
 

--- a/crates/private-server/src/fns/versions.rs
+++ b/crates/private-server/src/fns/versions.rs
@@ -489,8 +489,10 @@ pub async fn update_version_status(
 	if version_record.status == VersionStatus::Published && new_status == VersionStatus::Draft {
 		let is_latest = Version::is_latest_in_minor(&mut conn, version.clone()).await?;
 		if !is_latest {
-			return Err(AppError::custom(
-				"Cannot change a published version to draft unless it is the latest in its minor version",
+			return Err(AppError::BadRequest(
+				"Cannot change a published version to draft unless it is the latest in its \
+				 minor version"
+					.into(),
 			));
 		}
 	}

--- a/crates/private-server/tests/it/bestool.rs
+++ b/crates/private-server/tests/it/bestool.rs
@@ -1,0 +1,25 @@
+use uuid::Uuid;
+
+/// `get_snippet` declares 404 for a snippet that isn't there, but built the
+/// miss with `AppError::custom`, which maps to 500 `/errors/other`. A client
+/// following the checked-in contract saw a server fault where it should have
+/// seen an ordinary miss.
+#[tokio::test(flavor = "multi_thread")]
+async fn get_snippet_is_404_for_an_unknown_id() {
+	commons_tests::server::run(async |_conn, _public, private| {
+		let resp = private
+			.post("/api/bestool/get_snippet")
+			.json(&serde_json::json!({ "id": Uuid::new_v4() }))
+			.await;
+
+		assert_eq!(resp.status_code().as_u16(), 404, "body: {}", resp.text());
+		let body: serde_json::Value = resp.json();
+		assert!(
+			body["type"]
+				.as_str()
+				.is_some_and(|t| t.ends_with("resource-not-found")),
+			"a miss should carry the resource-not-found problem type, got {body}",
+		);
+	})
+	.await
+}

--- a/crates/private-server/tests/it/device_admin_endpoints.rs
+++ b/crates/private-server/tests/it/device_admin_endpoints.rs
@@ -350,3 +350,53 @@ async fn resolve_tailnet_identifier_returns_null_for_unknown() {
 	})
 	.await
 }
+
+/// Both attach handlers document 404 for "identifier does not resolve to a
+/// known tailnet node". `devices::attach_tailscale` answered 500 (via
+/// `AppError::custom`) and `servers::attach_tailscale` answered 400 — so
+/// they disagreed with the spec and with each other.
+#[tokio::test(flavor = "multi_thread")]
+async fn attach_tailscale_is_404_for_an_unresolvable_identifier() {
+	TestDb::run(async |mut conn, url| {
+		let (_ip, _node_id, dir) = test_directory();
+		let private = private_with_directory(&url, dir).await;
+		let device_id = insert_device(&mut conn).await;
+
+		let resp = private
+			.post("/api/devices/attach_tailscale")
+			.json(&serde_json::json!({
+				"device_id": device_id,
+				"identifier": "100.64.99.99",
+			}))
+			.await;
+		assert_eq!(resp.status_code().as_u16(), 404, "body: {}", resp.text());
+	})
+	.await
+}
+
+/// The server-side attach handler documents the same 404 and must agree.
+#[tokio::test(flavor = "multi_thread")]
+async fn server_attach_tailscale_is_404_for_an_unresolvable_identifier() {
+	TestDb::run(async |mut conn, url| {
+		let (_ip, _node_id, dir) = test_directory();
+		let private = private_with_directory(&url, dir).await;
+
+		let server_id = Uuid::new_v4();
+		conn.batch_execute(&format!(
+			"INSERT INTO servers (id, host, kind) \
+			 VALUES ('{server_id}', 'https://attach.example.com', 'central');"
+		))
+		.await
+		.expect("insert server");
+
+		let resp = private
+			.post("/api/servers/attach_tailscale_device")
+			.json(&serde_json::json!({
+				"server_id": server_id,
+				"identifier": "100.64.99.99",
+			}))
+			.await;
+		assert_eq!(resp.status_code().as_u16(), 404, "body: {}", resp.text());
+	})
+	.await
+}

--- a/crates/private-server/tests/it/issues.rs
+++ b/crates/private-server/tests/it/issues.rs
@@ -1163,3 +1163,56 @@ async fn incident_resolve_metadata() {
 	})
 	.await;
 }
+
+/// Empty-input validation used `AppError::custom`, which maps to 500 —
+/// though all three endpoints document 400, and the codebase convention for
+/// exactly this check (`mcp_tokens::mint`'s empty-name guard) is
+/// `AppError::BadRequest`.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_validation_input_is_a_400_not_a_500() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		let server_id = Uuid::new_v4();
+		let group_id = Uuid::new_v4();
+		conn.batch_execute(&format!(
+			"INSERT INTO server_groups (id, name) VALUES ('{group_id}', 'g');
+			 INSERT INTO servers (id, host, kind, group_id) VALUES \
+				('{server_id}', 'https://validate.example.com', 'central', '{group_id}');
+			 INSERT INTO issues (id, server_id, source, \"ref\", check_name, observed_result, effective_result, message, active, first_seen, last_seen, last_degraded_at) VALUES \
+				('11111111-2222-3333-4444-555555555555', '{server_id}', 'src', 'r', 'r', 'failed', 'failed', 'm', true, NOW(), NOW(), NOW());"
+		))
+		.await
+		.expect("seed");
+
+		// A blank `ref` on a manual event.
+		let resp = private
+			.post("/api/issues/submit_manual_event")
+			.json(&serde_json::json!({
+				"ref": "   ",
+				"serverId": server_id,
+				"message": "m",
+			}))
+			.await;
+		assert_eq!(
+			resp.status_code().as_u16(),
+			400,
+			"blank ref: {}",
+			resp.text()
+		);
+
+		// A blank note body on an issue.
+		let resp = private
+			.post("/api/issues/add_note")
+			.json(&serde_json::json!({
+				"issue_id": "11111111-2222-3333-4444-555555555555",
+				"body": "  ",
+			}))
+			.await;
+		assert_eq!(
+			resp.status_code().as_u16(),
+			400,
+			"blank issue note: {}",
+			resp.text()
+		);
+	})
+	.await
+}

--- a/crates/private-server/tests/it/main.rs
+++ b/crates/private-server/tests/it/main.rs
@@ -5,6 +5,7 @@
 
 mod artifacts;
 mod backups;
+mod bestool;
 mod create_server;
 mod device_admin_endpoints;
 mod device_keys;


### PR DESCRIPTION
Audit findings [L15, L16, L17](https://github.com/beyondessential/canopy/pull/370) — one PR, because they're the same defect at four call sites and share a variant.

Each of these built a client-facing outcome with `AppError::custom`, which maps to 500 `/errors/other`, contradicting the handler's own checked-in OpenAPI contract:

| | declares | answered |
|---|---|---|
| **L15** `bestool::get_snippet`, missing snippet | 404 | 500 |
| **L16** `devices::attach_tailscale`, unresolvable identifier | 404 | 500 |
| **L16** `servers::attach_tailscale_device`, same | 404 | 400 |
| **L17** empty `ref` / note body in `issues`, `incidents` | 400 | 500 |

The two attach handlers disagreed with the spec *and* with each other.

## `AppError::NotFound(String)`

Added for a lookup that misses without going through Diesel's own `NotFound`, in the shape [`docs/apperror-variants-analysis.md`](https://github.com/beyondessential/canopy/commit/4efc8cd) proposes. It reuses the existing `resource-not-found` problem type, so a caller matches one slug for "not found" however the miss was produced — which is also why ERRORS.md needs no new heading.

## Making `to_http_status` exhaustive

Its trailing `_ => INTERNAL_SERVER_ERROR` is *exactly* how `VersionParse` and `Header` came to answer 500 (audit L11, #462): adding a variant and forgetting its status was silent. The slug match next door was already exhaustive, and it did catch the new variant at compile time while I was writing this. Now both do, so a status is a decision somebody makes rather than one that defaults.

Server-side faults are listed explicitly in one `|`-joined arm rather than wildcarded, so the next variant has to be placed deliberately.

## Also

`versions::update_version_status`'s demote guard, same defect (documents 400, answered 500), fixed while here. The analysis doc suggests `Unprocessable` or `Conflict` for it; I used `BadRequest` because that's what the endpoint's annotation actually declares, and changing the declared status would mean an OpenAPI regeneration for a finding that isn't about the status choice.

**No `#[utoipa::path]` annotation changed** — every one of these already declared the right status, so `openapi.json` and `api-types.ts` are untouched.

The four other variants the analysis doc proposes (`Forbidden`, `Unprocessable`, `Unavailable`, `Internal`) and their ~25 call sites aren't in this PR — that's a larger migration than these three findings, and the exhaustive match is the part that stops the class recurring.

## Testing

Four cases across `bestool.rs` (new file), `device_admin_endpoints.rs`, and `issues.rs`. Against the unfixed code:

```
test bestool::get_snippet_is_404_for_an_unknown_id ... FAILED            500 → 404
test issues::empty_validation_input_is_a_400_not_a_500 ... FAILED        500 → 400
test device_admin_endpoints::attach_tailscale_is_404_... ... FAILED      500 → 404
test device_admin_endpoints::server_attach_tailscale_is_404_... FAILED   400 → 404
```

The L15 test also asserts the problem type is `resource-not-found`, so the slug reuse is pinned.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_