### PR TITLE
fix(mcp): a replica's recent checks are its own, not its group's (audit L14)

### DIFF
--- a/crates/canopy-mcp/src/restore.rs
+++ b/crates/canopy-mcp/src/restore.rs
@@ -164,12 +164,9 @@ impl CanopyMcp {
 				.find(|d| d.intent == replica.intent);
 
 		let relevant: Vec<BackupRestoreCheck> =
-			BackupRestoreCheck::list_recent_for_group(&mut conn, replica.group_id, 50)
+			BackupRestoreCheck::list_recent_for_replica(&mut conn, replica.id, 50)
 				.await
-				.map_err(mcp_err)?
-				.into_iter()
-				.filter(|c| c.replica_id == Some(replica.id))
-				.collect();
+				.map_err(mcp_err)?;
 		let check_server_names = Server::names_by_ids(
 			&mut conn,
 			&unique(relevant.iter().filter_map(|c| c.server_id)),

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -705,6 +705,28 @@ impl BackupRestoreCheck {
 			.map_err(AppError::from)
 	}
 
+	/// Recent reports for one replica, newest first.
+	///
+	/// Not [`Self::list_recent_for_group`] filtered afterwards: the limit has
+	/// to bite the replica's own checks, or a low-frequency replica sharing a
+	/// group with a chatty one has every one of its reports pushed out of the
+	/// window and reads as never checked.
+	pub async fn list_recent_for_replica(
+		db: &mut AsyncPgConnection,
+		replica_id: Uuid,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::backup_restore_checks::dsl;
+		dsl::backup_restore_checks
+			.select(Self::as_select())
+			.filter(dsl::replica_id.eq(Some(replica_id)))
+			.order(dsl::observed_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
 	/// Recent reports across all groups, newest first.
 	pub async fn list_recent(db: &mut AsyncPgConnection, limit: i64) -> Result<Vec<Self>> {
 		use crate::schema::backup_restore_checks::dsl;

--- a/crates/private-server/tests/it/mcp.rs
+++ b/crates/private-server/tests/it/mcp.rs
@@ -959,3 +959,45 @@ async fn check_stability_returns_full_records_for_pairs() {
 	})
 	.await
 }
+
+/// `get_restore_replica` took the group's 50 newest checks and *then* kept
+/// the ones belonging to this replica — filter-after-limit. A replica
+/// checked rarely, alongside a chatty one in the same group, had every one
+/// of its reports pushed out of the window and read as never checked.
+#[tokio::test(flavor = "multi_thread")]
+async fn get_restore_replica_checks_are_the_replicas_own_newest() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed_backup_runs(&mut conn).await;
+		seed_restore_replicas(&mut conn).await;
+
+		// The group-wide replica reports rarely; give it one old check, then
+		// bury it under a run of newer checks from its noisy neighbour.
+		let mut rows = format!(
+			"INSERT INTO backup_restore_checks \
+			 (replica_id, consumer_device_id, group_id, server_id, type, intent, snapshot_id, outcome, replica_healthy, observed_at) \
+			 VALUES ('{REPLICA_GROUP_WIDE}', '{CONSUMER}', '{RGROUP}', NULL, 'tamanu-postgres', 'verify', 'quiet-snap', 'success', true, NOW() - interval '10 days');"
+		);
+		for i in 0..60 {
+			rows.push_str(&format!(
+				"INSERT INTO backup_restore_checks \
+				 (replica_id, consumer_device_id, group_id, server_id, type, intent, snapshot_id, outcome, replica_healthy, observed_at) \
+				 VALUES ('{REPLICA_SERVER_SCOPED}', '{CONSUMER}', '{RGROUP}', '{RSERVER}', 'tamanu-postgres', 'verify', 'noisy-{i}', 'success', true, NOW() - interval '{i} minutes');"
+			));
+		}
+		conn.batch_execute(&rows).await.expect("seed noisy checks");
+
+		let detail = call_tool!(
+			private,
+			"get_restore_replica",
+			serde_json::json!({ "replica_id": REPLICA_GROUP_WIDE })
+		);
+		let checks = detail["recent_checks"].as_array().expect("recent_checks");
+		assert_eq!(
+			checks.len(),
+			1,
+			"the quiet replica's own check must survive a noisy neighbour: {detail}",
+		);
+		assert_eq!(checks[0]["snapshot_id"], "quiet-snap");
+	})
+	.await
+}


### PR DESCRIPTION
Audit finding [L14](https://github.com/beyondessential/canopy/pull/370) — the last of the filter-after-LIMIT cluster (M7, M8, M9 landed earlier).

`get_restore_replica` fetched the *group's* 50 newest restore checks and then kept the ones belonging to this replica, so the `LIMIT` bit the unfiltered set. A replica checked rarely, sharing a group with a chatty one, had every one of its reports pushed out of the window and reported `recent_checks: []` — reading as never checked.

`BackupRestoreCheck::list_recent_for_replica` pushes the predicate into the query so the limit applies to the replica's own checks.

## Testing

New case in `crates/private-server/tests/it/mcp.rs`: give the quiet group-wide replica one check, bury it under 60 newer ones from its noisy neighbour in the same group, then read the quiet replica back. Against the unfixed code:

```
assertion `left == right` failed: the quiet replica's own check must survive a noisy neighbour
  ... "recent_checks":[] ...
  left: 0
 right: 1
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_