### PR TITLE
fix(sql): time the query, not the endpoint around it (audit L18)

### DIFF
--- a/crates/private-server/src/fns/sql.rs
+++ b/crates/private-server/src/fns/sql.rs
@@ -45,9 +45,14 @@ pub struct SqlResult {
 	/// Number of rows returned.
 	pub row_count: usize,
 	/// How long the query took to run, in milliseconds. Timing starts
-	/// just before execution begins (immediately after the query has
-	/// been recorded to the shared history) and stops once every value
+	/// immediately before the query is sent and stops once every value
 	/// has been read back, including any text conversions.
+	///
+	/// Endpoint overhead is deliberately outside the window: both pool
+	/// checkouts, the write to the shared history, and the transaction
+	/// setup. Those are not what the operator is measuring when they time
+	/// a query, and the read-only pool's checkout in particular can
+	/// dominate under contention.
 	pub execution_time_ms: u64,
 }
 
@@ -132,7 +137,6 @@ pub async fn execute_query(
 	};
 
 	let query = args.query;
-	let start_time = Instant::now();
 
 	let mut conn = state.db.get().await?;
 	SqlPlaygroundHistory::create(&mut conn, query.query.clone(), user.login.clone())
@@ -161,6 +165,12 @@ pub async fn execute_query(
 			))
 		})?;
 
+	// The clock starts here, not before the pool checkouts, the history
+	// write, and the transaction setup. Those are endpoint overhead, and
+	// under contention for the read-only pool they dominated what was
+	// reported as the query's own time.
+	let start_time = Instant::now();
+
 	let rows = tokio::time::timeout(
 		Duration::from_secs(60),
 		transaction.query(&query.query, &[]),
@@ -174,14 +184,12 @@ pub async fn execute_query(
 		.await
 		.map_err(|e| AppError::custom(format_db_error(&e, None)))?;
 
-	let execution_time = start_time.elapsed();
-
 	if rows.is_empty() {
 		return Ok(Json(SqlResult {
 			columns: Vec::new(),
 			rows: Vec::new(),
 			row_count: 0,
-			execution_time_ms: execution_time.as_millis() as u64,
+			execution_time_ms: start_time.elapsed().as_millis() as u64,
 		}));
 	}
 
@@ -221,11 +229,13 @@ pub async fn execute_query(
 		}
 	}
 
+	// After the text conversions, which the field documents as included —
+	// they are a second round-trip and the operator is paying for them.
 	Ok(Json(SqlResult {
 		columns,
 		rows: all_values,
 		row_count: rows.len(),
-		execution_time_ms: execution_time.as_millis() as u64,
+		execution_time_ms: start_time.elapsed().as_millis() as u64,
 	}))
 }
 

--- a/crates/private-server/tests/it/main.rs
+++ b/crates/private-server/tests/it/main.rs
@@ -26,6 +26,7 @@ mod provision_credential;
 mod restore_replicas;
 mod server_products;
 mod server_version_distance;
+mod sql;
 mod tagged_device_guard;
 mod tailnet_device_auth;
 mod tailnet_key_expiry_sweep;

--- a/crates/private-server/tests/it/sql.rs
+++ b/crates/private-server/tests/it/sql.rs
@@ -1,0 +1,78 @@
+//! The SQL playground's read-only query endpoint. Needs a real read-only
+//! pool, which the shared harness doesn't build (it mirrors production with
+//! `RO_DATABASE_URL` unset), so these stand up their own state.
+
+use axum_client_ip::ClientIpSource;
+use commons_servers::router;
+use commons_tests::axum_test::TestServer;
+use commons_tests::db::TestDb;
+
+async fn private_with_ro_pool(url: &str) -> TestServer {
+	let db = database::init_to(url);
+	let ro_pool = bestool_postgres::pool::create_pool(url, "canopy-playground-test")
+		.await
+		.expect("read-only pool");
+	let router = router(
+		private_server::routes(private_server::state::AppState {
+			client_cert_header: commons_servers::device_auth::mtls::ClientCertHeader::Xfcc,
+			db: db.clone(),
+			db_read: db,
+			ro_pool: Some(ro_pool),
+			tailnet_directory: None,
+			kube: None,
+			sts: None,
+			prober: private_server::backup_probe::BucketProber::fake(
+				private_server::backup_probe::ProbeState::Empty,
+			),
+			recovery_recipients: None,
+			recovery_challenge: std::sync::Arc::new(std::sync::Mutex::new(None)),
+			dns_zones: Vec::new(),
+			acme: None,
+			acme_directory: None,
+		})
+		.unwrap(),
+		ClientIpSource::RightmostForwarded,
+	);
+	let mut server = TestServer::new(router);
+	server.add_header("Forwarded", "for=192.0.2.10");
+	server
+}
+
+/// `execution_time_ms` is documented as the query's own time. It used to
+/// start before both pool checkouts, the history INSERT, and the
+/// transaction setup, and to stop before the values were decoded — so it
+/// measured endpoint overhead at one end and missed real work at the other.
+///
+/// The window now brackets the execution itself. A query that sleeps for a
+/// known time is the one thing that pins that from outside: the reported
+/// figure has to account for the sleep, and a trivial query next to it has
+/// to come back far below it.
+#[tokio::test(flavor = "multi_thread")]
+async fn execution_time_measures_the_query_not_the_endpoint() {
+	TestDb::run(async |_conn, url| {
+		let private = private_with_ro_pool(&url).await;
+
+		let slow: serde_json::Value = private
+			.post("/api/sql/execute_query")
+			.json(&serde_json::json!({ "query": { "query": "SELECT pg_sleep(0.5)" } }))
+			.await
+			.json();
+		let slow_ms = slow["execution_time_ms"].as_u64().expect("timing");
+		assert!(
+			slow_ms >= 450,
+			"a half-second query must be reported as such, got {slow_ms}ms: {slow}",
+		);
+
+		let fast: serde_json::Value = private
+			.post("/api/sql/execute_query")
+			.json(&serde_json::json!({ "query": { "query": "SELECT 1 AS n" } }))
+			.await
+			.json();
+		let fast_ms = fast["execution_time_ms"].as_u64().expect("timing");
+		assert!(
+			fast_ms < 250,
+			"a trivial query must not be reported as slow, got {fast_ms}ms: {fast}",
+		);
+	})
+	.await
+}

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -14582,7 +14582,7 @@
           "execution_time_ms": {
             "type": "integer",
             "format": "int64",
-            "description": "How long the query took to run, in milliseconds. Timing starts\njust before execution begins (immediately after the query has\nbeen recorded to the shared history) and stops once every value\nhas been read back, including any text conversions.",
+            "description": "How long the query took to run, in milliseconds. Timing starts\nimmediately before the query is sent and stops once every value\nhas been read back, including any text conversions.\n\nEndpoint overhead is deliberately outside the window: both pool\ncheckouts, the write to the shared history, and the transaction\nsetup. Those are not what the operator is measuring when they time\na query, and the read-only pool's checkout in particular can\ndominate under contention.",
             "minimum": 0
           },
           "row_count": {

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -8384,9 +8384,14 @@ export interface components {
             /**
              * Format: int64
              * @description How long the query took to run, in milliseconds. Timing starts
-             *     just before execution begins (immediately after the query has
-             *     been recorded to the shared history) and stops once every value
+             *     immediately before the query is sent and stops once every value
              *     has been read back, including any text conversions.
+             *
+             *     Endpoint overhead is deliberately outside the window: both pool
+             *     checkouts, the write to the shared history, and the transaction
+             *     setup. Those are not what the operator is measuring when they time
+             *     a query, and the read-only pool's checkout in particular can
+             *     dominate under contention.
              */
             execution_time_ms: number;
             /** @description Number of rows returned. */


### PR DESCRIPTION
Audit finding [L18](https://github.com/beyondessential/canopy/pull/370).

`execution_time_ms` is documented as starting "just before execution begins (immediately after the query has been recorded to the shared history)" and stopping "once every value has been read back, including any text conversions". It did neither.

- **Start**: the clock was taken before the main-pool checkout, the history INSERT, the read-only pool checkout, and the transaction BEGIN. All endpoint overhead — and under contention for the read-only pool that overhead dominates what gets reported as the query's own time. This is what the audit flagged.
- **End**: it stopped at the rollback, before any value was decoded and before the `TextCaster` round-trip the doc explicitly says is included. The audit didn't flag this one; it's wrong in the opposite direction, so the two errors partly masked each other.

The window now brackets what it claims to: opens immediately before the query is sent, closes after the conversions. The doc comment now names the work that's deliberately outside it rather than leaving it to be inferred.

## Testing

New `crates/private-server/tests/it/sql.rs`. The shared harness sets `ro_pool: None` (mirroring production with `RO_DATABASE_URL` unset), so the playground had no test coverage at all; this stands up its own state with a real read-only pool, which also makes the rest of the endpoint testable in future.

The test asserts a `pg_sleep(0.5)` query reports ≥450ms and a trivial one reports <250ms — the window brackets execution and isn't dominated by fixed overhead.

**It passes against the unfixed code too, and I'm not claiming otherwise.** The difference this change makes is overhead that only appears under read-only-pool contention, which a single-caller test can't force; and the end-of-window difference is a couple of milliseconds. The test is a guard on the property, not a reproduction of the bug. If you'd rather see a contention-based reproduction I can build one, but it would be timing-sensitive and I'd expect it to be flaky in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_