### PR TITLE
test(ui): pin the healthcheck link builders' encoding (audit L21)

### DIFF
--- a/private-web/src/lib/healthcheckPath.test.ts
+++ b/private-web/src/lib/healthcheckPath.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { healthcheckPath, healthcheckSettingsPath } from "../types";
+
+// Check names are arbitrary strings a device chose, not restricted to
+// URL-safe characters. A name carrying `/`, `?`, `#`, or `%` routes to the
+// wrong page — or nowhere — unless every link builder encodes it, which is
+// what these two helpers exist to guarantee.
+describe("healthcheck link builders", () => {
+	const awkward: [string, string][] = [
+		["a/b", "a%2Fb"],
+		["what?", "what%3F"],
+		["frag#ment", "frag%23ment"],
+		["100%", "100%25"],
+		["with space", "with%20space"],
+	];
+
+	it.each(awkward)("encodes %j in the affected-servers path", (raw, encoded) => {
+		expect(healthcheckPath("alertd", raw)).toBe(`/healthchecks/alertd/${encoded}`);
+	});
+
+	it.each(awkward)("encodes %j in the settings path", (raw, encoded) => {
+		expect(healthcheckSettingsPath("alertd", raw)).toBe(
+			`/settings/healthchecks/alertd/${encoded}`,
+		);
+	});
+
+	it("encodes the source too", () => {
+		expect(healthcheckPath("a/b", "disk")).toBe("/healthchecks/a%2Fb/disk");
+		expect(healthcheckSettingsPath("a/b", "disk")).toBe("/settings/healthchecks/a%2Fb/disk");
+	});
+
+	it("leaves an ordinary name alone", () => {
+		expect(healthcheckPath("alertd", "disk_free")).toBe("/healthchecks/alertd/disk_free");
+	});
+});


### PR DESCRIPTION
Audit finding [L21](https://github.com/beyondessential/canopy/pull/370) — **already fixed**, now pinned.

The finding reported `Healthchecks.tsx` interpolating raw check names into URLs at three sites, where `types.ts` documents that every link builder must go through `healthcheckPath`. That was fixed by bf25c4c (2026-07-20, four days after the audit was written), which routed all three through `healthcheckSettingsPath`. A sweep of `private-web/src/` finds no raw `` `/healthchecks/...` `` or `` `/settings/healthchecks/...` `` template outside `types.ts` itself.

So there's no production change here. But the property the two helpers exist to guarantee had nothing holding it, which is how it slipped in the first place. This adds that: names carrying `/`, `?`, `#`, `%`, or a space encode correctly, in both builders, in both the source and the check position — plus an ordinary name to catch over-eager encoding.

`npm run test` → 4 files, 32 tests, all passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_