### PR TITLE
fix(groups): repair the group version cache the June backfill mis-derived (audit L22)

### DIFF
--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -30,6 +30,7 @@ mod migration_test_reports;
 mod partitions;
 mod reachability_sweep;
 mod recovery_vault;
+mod repair_group_version_cache_migration;
 mod reported_detail;
 mod restore;
 mod rotation_interlock;

--- a/crates/database/tests/it/repair_group_version_cache_migration.rs
+++ b/crates/database/tests/it/repair_group_version_cache_migration.rs
@@ -1,0 +1,222 @@
+//! The `2026-08-02-011917-0000_repair_group_version_cache` migration
+//! re-derives each group's canonical member, undoing what the original
+//! backfill in `2026-06-02-071412` got wrong: its rank `CASE` listed only the
+//! canonical spellings (so `live` / `prod` / `staging` fell to the
+//! lowest-priority bucket), and it selected among archived servers too.
+//!
+//! Seeds the states that backfill mis-handled, writes the cache it would have
+//! left, and replays the repair's SQL.
+
+use commons_tests::db::TestDb;
+use diesel::{sql_query, sql_types};
+use diesel_async::{RunQueryDsl, SimpleAsyncConnection as _};
+use uuid::Uuid;
+
+const REPAIR_UP: &str =
+	include_str!("../../../../migrations/2026-08-02-011917-0000_repair_group_version_cache/up.sql");
+
+#[derive(diesel::QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+async fn insert_group(conn: &mut diesel_async::AsyncPgConnection, name: &str) -> Uuid {
+	let row: RowId = sql_query("INSERT INTO server_groups (name) VALUES ($1) RETURNING id")
+		.bind::<sql_types::Text, _>(name)
+		.get_result(conn)
+		.await
+		.expect("insert group");
+	row.id
+}
+
+/// A member with a raw `rank` string — the point is to seed spellings the
+/// original backfill didn't recognise, so this deliberately doesn't go
+/// through `ServerRank`.
+async fn insert_member(
+	conn: &mut diesel_async::AsyncPgConnection,
+	group_id: Uuid,
+	kind: &str,
+	rank: &str,
+	archived: bool,
+) -> Uuid {
+	let host = format!("http://repair.invalid/{}", Uuid::new_v4());
+	let row: RowId = sql_query(
+		"INSERT INTO servers (host, kind, rank, group_id, product, deleted_at) \
+		 VALUES ($1, $2, $3, $4, 'tamanu', CASE WHEN $5 THEN now() ELSE NULL END) \
+		 RETURNING id",
+	)
+	.bind::<sql_types::Text, _>(host)
+	.bind::<sql_types::Text, _>(kind)
+	.bind::<sql_types::Text, _>(rank)
+	.bind::<sql_types::Uuid, _>(group_id)
+	.bind::<sql_types::Bool, _>(archived)
+	.get_result(conn)
+	.await
+	.expect("insert member");
+	row.id
+}
+
+async fn report_version(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	version: &str,
+) {
+	sql_query(
+		"INSERT INTO server_reported_detail (server_id, source, version, reported_at) \
+		 VALUES ($1, 'alertd', $2, now())",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(version)
+	.execute(conn)
+	.await
+	.expect("report version");
+}
+
+async fn set_cache(
+	conn: &mut diesel_async::AsyncPgConnection,
+	group_id: Uuid,
+	server_id: Option<Uuid>,
+	version: Option<&str>,
+) {
+	sql_query(
+		"UPDATE server_groups SET version_server_id = $2, effective_version = $3 WHERE id = $1",
+	)
+	.bind::<sql_types::Uuid, _>(group_id)
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(server_id)
+	.bind::<sql_types::Nullable<sql_types::Text>, _>(version)
+	.execute(conn)
+	.await
+	.expect("set cache");
+}
+
+async fn cache(
+	conn: &mut diesel_async::AsyncPgConnection,
+	group_id: Uuid,
+) -> (Option<Uuid>, Option<String>) {
+	use database::schema::server_groups::dsl;
+	use diesel::{ExpressionMethods, QueryDsl};
+	dsl::server_groups
+		.select((dsl::version_server_id, dsl::effective_version))
+		.filter(dsl::id.eq(group_id))
+		.first(conn)
+		.await
+		.expect("load cache")
+}
+
+/// The audit's example: a `live` central beside a `test` box. The original
+/// backfill sent `live` to the `ELSE 5` bucket, so the test server outranked
+/// the production one and spoke for the group.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_repair_prefers_an_aliased_production_rank() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "aliased").await;
+		let live = insert_member(&mut conn, group, "central", "live", false).await;
+		let test = insert_member(&mut conn, group, "central", "test", false).await;
+		report_version(&mut conn, live, "2.40.0").await;
+		report_version(&mut conn, test, "1.0.0-test").await;
+
+		// What the original backfill left behind.
+		set_cache(&mut conn, group, Some(test), Some("1.0.0-test")).await;
+
+		conn.batch_execute(REPAIR_UP).await.expect("replay repair");
+
+		let (vsid, ver) = cache(&mut conn, group).await;
+		assert_eq!(vsid, Some(live), "`live` is a production rank");
+		assert_eq!(ver.as_deref(), Some("2.40.0"));
+	})
+	.await
+}
+
+/// `staging` and `prod` are the other two spellings `ServerRank::from_str`
+/// accepts and the original `CASE` didn't.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_repair_handles_the_other_rank_aliases() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "more-aliases").await;
+		let prod = insert_member(&mut conn, group, "central", "prod", false).await;
+		let staging = insert_member(&mut conn, group, "central", "staging", false).await;
+		report_version(&mut conn, prod, "3.0.0").await;
+		report_version(&mut conn, staging, "3.1.0-rc").await;
+
+		set_cache(&mut conn, group, Some(staging), Some("3.1.0-rc")).await;
+		conn.batch_execute(REPAIR_UP).await.expect("replay repair");
+
+		let (vsid, _) = cache(&mut conn, group).await;
+		assert_eq!(vsid, Some(prod), "`prod` outranks `staging`");
+	})
+	.await
+}
+
+/// The other half of the finding: the original selected among all servers,
+/// so an archived one could be chosen as canonical.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_repair_ignores_archived_members() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "archived").await;
+		let gone = insert_member(&mut conn, group, "central", "production", true).await;
+		let alive = insert_member(&mut conn, group, "facility", "production", false).await;
+		report_version(&mut conn, gone, "1.0.0").await;
+		report_version(&mut conn, alive, "2.0.0").await;
+
+		set_cache(&mut conn, group, Some(gone), Some("1.0.0")).await;
+		conn.batch_execute(REPAIR_UP).await.expect("replay repair");
+
+		let (vsid, ver) = cache(&mut conn, group).await;
+		assert_eq!(
+			vsid,
+			Some(alive),
+			"an archived server can't speak for a group"
+		);
+		assert_eq!(ver.as_deref(), Some("2.0.0"));
+	})
+	.await
+}
+
+/// A group left with no eligible member keeps a stale pointer forever: the
+/// original backfill's UPDATE only touched groups its CTE matched, so it
+/// could never clear one.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_repair_clears_a_group_with_no_eligible_member() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "emptied").await;
+		let gone = insert_member(&mut conn, group, "central", "production", true).await;
+		report_version(&mut conn, gone, "1.0.0").await;
+
+		set_cache(&mut conn, group, Some(gone), Some("1.0.0")).await;
+		conn.batch_execute(REPAIR_UP).await.expect("replay repair");
+
+		let (vsid, ver) = cache(&mut conn, group).await;
+		assert_eq!(vsid, None, "no live member, so no canonical member");
+		assert_eq!(ver, None);
+	})
+	.await
+}
+
+/// And the repair agrees with the live code it mirrors: recomputing after it
+/// changes nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_repair_agrees_with_recompute_version() {
+	TestDb::run(async |mut conn, _| {
+		let group = insert_group(&mut conn, "agreement").await;
+		let live = insert_member(&mut conn, group, "central", "live", false).await;
+		insert_member(&mut conn, group, "facility", "dev", false).await;
+		insert_member(&mut conn, group, "central", "production", true).await;
+		report_version(&mut conn, live, "4.5.6").await;
+
+		conn.batch_execute(REPAIR_UP).await.expect("replay repair");
+		let after_repair = cache(&mut conn, group).await;
+
+		database::server_groups::ServerGroup::recompute_version(&mut conn, group)
+			.await
+			.expect("recompute");
+		let after_recompute = cache(&mut conn, group).await;
+
+		assert_eq!(
+			after_repair, after_recompute,
+			"the migration must not disagree with the code it mirrors",
+		);
+		assert_eq!(after_repair.0, Some(live));
+	})
+	.await
+}

--- a/migrations/2026-08-02-011917-0000_repair_group_version_cache/down.sql
+++ b/migrations/2026-08-02-011917-0000_repair_group_version_cache/down.sql
@@ -1,0 +1,5 @@
+-- Nothing to undo. This migration only recomputes a cache from data that is
+-- still present, so reverting it would mean restoring values that were wrong
+-- — and the app recomputes the same answer on the next membership change
+-- either way.
+SELECT 1;

--- a/migrations/2026-08-02-011917-0000_repair_group_version_cache/up.sql
+++ b/migrations/2026-08-02-011917-0000_repair_group_version_cache/up.sql
@@ -1,0 +1,86 @@
+-- Re-derive each group's canonical member, repairing what the original
+-- backfill in 2026-06-02-071412 got wrong.
+--
+-- That backfill's rank `CASE` claimed to mirror the Rust helpers but listed
+-- only the canonical spellings, sending the `live` / `prod` / `staging`
+-- aliases — which `ServerRank::from_str` accepts, and which the pre-2026
+-- `latest_statuses` view explicitly handled, so they really are in the data —
+-- to the lowest-priority `ELSE` bucket. It also selected among *all* servers
+-- rather than live ones, so an archived box could speak for its group. A
+-- group whose central server is `rank='live'` beside a `rank='test'` box got
+-- the test server as its `version_server_id`.
+--
+-- The trigger installed alongside it carries no rank logic, and the
+-- app-level `ServerGroup::recompute_version` has always been correct. So the
+-- damage is confined to groups that haven't been recomputed since June — but
+-- for those it persists, and unlike a lost column it is fully recoverable
+-- from current data.
+--
+-- Mirrors `ServerGroup::recompute_version` as it stands:
+--   * live members only (`deleted_at IS NULL`),
+--   * only products canopy holds a release train for (`tracks_versions`,
+--     which today is tamanu alone — a group of others has no headline
+--     version rather than a meaningless one),
+--   * ordered by rank priority, then kind priority, tie-broken by id,
+--   * version read from `server_reported_detail`, the current-state
+--     projection that function uses, not from `statuses`.
+WITH canonical AS (
+    SELECT DISTINCT ON (group_id)
+        group_id,
+        id AS server_id
+    FROM servers
+    WHERE group_id IS NOT NULL
+      AND deleted_at IS NULL
+      AND product = 'tamanu'
+    ORDER BY
+        group_id,
+        -- Same buckets as `rank_priority`, with every spelling
+        -- `ServerRank::from_str` accepts folded onto its variant. An
+        -- unrecognised or absent rank sorts last, as `None` does there.
+        CASE LOWER(rank)
+            WHEN 'production' THEN 0
+            WHEN 'prod' THEN 0
+            WHEN 'live' THEN 0
+            WHEN 'clone' THEN 1
+            WHEN 'staging' THEN 1
+            WHEN 'demo' THEN 2
+            WHEN 'test' THEN 3
+            WHEN 'dev' THEN 4
+            ELSE 5
+        END,
+        -- `kind_priority`. Note the original listed a `canopy` kind that no
+        -- longer exists; the kinds are central, facility, standalone.
+        CASE kind
+            WHEN 'central' THEN 0
+            WHEN 'facility' THEN 1
+            WHEN 'standalone' THEN 2
+            ELSE 3
+        END,
+        id
+)
+UPDATE server_groups g
+SET version_server_id = c.server_id,
+    effective_version = (
+        SELECT d.version
+        FROM server_reported_detail d
+        WHERE d.server_id = c.server_id AND d.version IS NOT NULL
+        ORDER BY d.reported_at DESC
+        LIMIT 1
+    )
+FROM canonical c
+WHERE g.id = c.group_id;
+
+-- A group with no eligible member at all has no canonical member, and the
+-- original backfill couldn't clear one it had wrongly set: its UPDATE only
+-- touched groups the CTE matched.
+UPDATE server_groups g
+SET version_server_id = NULL,
+    effective_version = NULL
+WHERE g.version_server_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM servers s
+      WHERE s.group_id = g.id
+        AND s.deleted_at IS NULL
+        AND s.product = 'tamanu'
+  );


### PR DESCRIPTION
Audit finding [L22](https://github.com/beyondessential/canopy/pull/370).

The one-time backfill in `2026-06-02-071412` said its rank `CASE` mirrored the Rust helpers, but listed only the canonical spellings. `live`, `prod` and `staging` — all accepted by `ServerRank::from_str`, and all explicitly handled by the pre-2026 `latest_statuses` view, so they really are in the data — fell to the lowest-priority `ELSE` bucket. It also selected among *every* server rather than live ones. A group whose central server is `rank='live'` beside a `rank='test'` box got the test server as its `version_server_id`, and an archived box could speak for its group.

## Why this is a repair and not a note

This is the same shape as M20 (#451, closed as already-applied), so I checked whether it was worth acting on before writing anything.

**The live code was never wrong.** The trigger installed alongside the backfill carries no rank logic at all, and `ServerGroup::recompute_version` filters archived members and works on a deserialised `ServerRank`, where the aliases are already normalised. So this isn't an ongoing bug.

**But the damage persists.** Nothing recomputes on read — `recompute_version` runs on membership and rank changes. A group untouched since June still carries whatever the backfill decided. And unlike M20, where the source column was dropped by the same migration, every input here is still present, so the correct answer is fully recoverable.

Hence a repair migration. It mirrors `recompute_version` as it stands today:

- live members only (`deleted_at IS NULL`)
- only products canopy holds a release train for (`tracks_versions`, today tamanu alone — the original had no product filter, and listed a `canopy` kind that no longer exists)
- ordered by rank priority, then kind priority, tie-broken by id, with every alias folded onto its variant
- version read from `server_reported_detail`, the current-state projection that function uses, not from `statuses`

It also clears groups left pointing at a member that no longer qualifies: the original's `UPDATE ... FROM canonical` only touched groups its CTE matched, so it could never clear a stale pointer.

## Testing

New `crates/database/tests/it/repair_group_version_cache_migration.rs`, following the existing `backfill_registered_at_migration.rs` pattern — `include_str!` the migration, seed the pre-repair state, replay it.

Five cases: the audit's own `live`-beside-`test` example, the `prod`/`staging` aliases, an archived member being chosen, a group left with no eligible member, and one asserting the migration and `recompute_version` produce the *same* answer — so the SQL can't quietly drift from the code it mirrors, which is how the original went wrong.

Repointing the same tests at the original backfill's SQL fails all five:

```
test ..::the_repair_prefers_an_aliased_production_rank ... FAILED
test ..::the_repair_handles_the_other_rank_aliases ... FAILED
test ..::the_repair_ignores_archived_members ... FAILED
test ..::the_repair_clears_a_group_with_no_eligible_member ... FAILED
test ..::the_repair_agrees_with_recompute_version ... FAILED
```

Full `database` suite: 334 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_