### PR TITLE
test(partitions): pin that concurrent provisioning doesn't collide (audit L23)

### DIFF
--- a/crates/database/tests/it/partitions.rs
+++ b/crates/database/tests/it/partitions.rs
@@ -290,3 +290,58 @@ async fn runway_alert_warns_fails_and_recovers() {
 	})
 	.await;
 }
+
+/// Two callers provisioning at once must not collide. The functions this
+/// replaced probed for a partition and then created it without a lock or an
+/// `IF NOT EXISTS`, so two concurrent invocations — the in-process loop and
+/// the external schedule named in the old COMMENTs, or two schedulers —
+/// could both pass the check and one would abort on the `CREATE`, rolling
+/// back every week it had already provisioned in that call.
+///
+/// Both callers must come back clean, and every week must end up attached.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_provisioning_does_not_collide() {
+	commons_tests::db::TestDb::run(async |mut conn, url| {
+		// Leave real work to race over.
+		assert!(drop_partitions_from(&mut conn, "statuses", 7).await > 0);
+		let before = days_remaining(&mut conn, "statuses").await;
+
+		let pool = database::init_to(&url);
+		let mut first = pool.get().await.expect("first connection");
+		let mut second = pool.get().await.expect("second connection");
+
+		// Genuinely concurrent: both futures are in flight together, so
+		// whichever reaches the existence probe first, the other is inside
+		// the same window.
+		let (a, b) = tokio::join!(
+			partitions::ensure_runway(&mut first, 6),
+			partitions::ensure_runway(&mut second, 6),
+		);
+		let a = a.expect("first caller must not error");
+		let b = b.expect("second caller must not error");
+
+		assert!(
+			a.iter().chain(b.iter()).all(|week| !week.failed()),
+			"a caller reported a failed week: {a:?} / {b:?}",
+		);
+		assert!(
+			a.iter()
+				.chain(b.iter())
+				.any(|week| week.action == "created"),
+			"nothing was provisioned, so the test proved nothing: {a:?} / {b:?}",
+		);
+
+		// The point of the whole exercise: the runway really was extended,
+		// and no week was left behind by a rolled-back call.
+		let after = days_remaining(&mut conn, "statuses").await;
+		assert!(
+			after > before,
+			"runway did not grow ({before} -> {after} days)",
+		);
+		assert!(
+			after >= 6 * 7 - 7,
+			"six weeks were asked for, got {after} days"
+		);
+	})
+	.await;
+}


### PR DESCRIPTION
Audit finding [L23](https://github.com/beyondessential/canopy/pull/370) — **already fixed**, now pinned.

The finding: the partition-creation functions probed for a partition and then created it with no `IF NOT EXISTS` and no lock, so two concurrent invocations (the in-process loop and the external schedule named in the old COMMENTs, or two scheduler replicas) could both pass the check and the loser would abort — rolling back the whole call, including weeks it had already provisioned.

`2026-07-30-111221_partition_runway` fixed both halves, and says so in its header: an advisory transaction lock single-flights callers, and each week runs in its own subtransaction so one week failing doesn't undo the rest. No production change is needed here.

What was missing is anything holding that property. Two callers now race `ensure_runway` under `tokio::join!`; both must return clean, some week must actually have been created (so the test can't pass by doing nothing), and the runway must really have grown.

## The assertion isn't vacuous

A passing concurrency test proves little on its own, so I checked it detects the bug: with `pg_try_advisory_xact_lock` stripped out of the function, one of the two callers reports a failed week on every run.

```
PROBE failed-weeks a=0 b=1
PROBE failed-weeks a=1 b=0
PROBE failed-weeks a=0 b=1
```

It surfaces as a *failed week* rather than an error because the per-week subtransactions — the other half of the fix — keep the call itself alive. The test asserts `all(|week| !week.failed())`, so it catches it either way.

I didn't try to reproduce against the original pre-runway functions: they no longer exist under that name, so the test would need a hand-written shim of deleted code, which proves less than removing the guard from the real function does.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGfH1cdFKPnKpM7ytRThft)_