### PR TITLE
docs: the client-certificate header is a single configurable switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,8 @@ pub async fn add(
 - Database tests: `commons_tests::db::TestDb::run(|mut conn, _url| async move { ... })`
 - HTTP tests: `commons_tests::server::run(|conn, public, private| async move { ... })`
 - Device auth tests: `commons_tests::server::run_with_device_auth("role", |conn, cert, device_id, public, private| async move { ... })`
-- In public-server, for authenticated tests, add `mtls-certificate` header: `.add_header("mtls-certificate", &cert)`
-- In public-server, use `.add_header("mtls-certificate", &cert)` on test requests, do not set it on `public` or `private` server directly (these should not be `mut` in tests)
+- In public-server, authenticate a test request with the client-certificate header the harness trusts. Only one header is read, chosen per server; the test harness selects Envoy/XFCC, so it is `.add_header("x-forwarded-client-cert", &format!("Cert={}", cert))`. A test that needs the nginx path instead (`mtls-certificate`) selects it explicitly with `commons_tests::server::run_with_device_auth_on(ClientCertHeader::Mtls, "role", …)`. Setting the wrong header is a 401, not a fallback.
+- In public-server, set that header on the individual test request, not on the `public` or `private` server directly (these should not be `mut` in tests)
 - Test both success and error scenarios (especially 404 cases for non-existent resources)
 - For database tests, use direct model functions instead of HTTP endpoints
 - Always include `use database::ModelName;` imports in test files

--- a/README.md
+++ b/README.md
@@ -146,7 +146,16 @@ $ just download-db canopy canopy-prod
 The `public-server` binary serves the public API and views, which are expected to be exposed to
 the internet (in production behind an ingress gateway or reverse proxy).
 
-The `mtls-certificate` (or `ssl-client-cert`) header should contain a PEM-encoded (optionally URL-encoded) X509 certificate.
+A client is identified by an X509 certificate presented in a header, PEM-encoded and optionally URL-encoded.
+
+Which header carries it depends on what terminates TLS in front of the server, and is chosen by `CANOPY_DEVICE_AUTH_CERT_HEADER`:
+
+- `mtls` (or `nginx`) — the `mtls-certificate` header, falling back to `ssl-client-cert`. The default, and the live ingress path.
+- `xfcc` (or `envoy`) — the `x-forwarded-client-cert` header, in Envoy's format.
+
+Exactly one header is read. The other is ignored rather than tried as a fallback, so a client that can set a header it isn't meant to cannot present an enrolled device's certificate and be resolved as that device — the certificate is a public key, not a secret, and nothing at this layer proves possession. An unrecognised value for the setting keeps the default rather than guessing.
+
+For the same reason, an `x-forwarded-client-cert` chain is read from its **last** element, which is the one the terminating proxy appended; an element a client put there first is not trusted.
 
 To get a certificate, run:
 
@@ -168,12 +177,19 @@ and then use curl like:
 $ curl -H "mtls-certificate: $MTLS_CERT" ...
 ```
 
+Against a server configured for XFCC, the same certificate goes in the Envoy header instead:
+
+```console
+$ curl -H "x-forwarded-client-cert: Cert=$MTLS_CERT" ...
+```
+
 #### In production
 
 In production, the header should be set from a client certificate, as terminated by a reverse proxy or load balancer, and any matching header on the incoming requests should be stripped.
 
 - Nginx: use the `$ssl_client_escaped_cert` variable.
 - Caddy: use the `{http.request.tls.client.certificate_pem}` placeholder.
+- Envoy: enable `forward_client_cert_details` with `set_current_client_cert_details.cert`, and set `CANOPY_DEVICE_AUTH_CERT_HEADER=xfcc` so that header is the one trusted.
 
 ### MCP
 


### PR DESCRIPTION
🤖 Follow-up to #469, where this bit us: `AGENTS.md` still told agents to authenticate public-server tests with `mtls-certificate`, which the test harness stopped trusting when it moved to Envoy/XFCC. Tests written from the doc get a 401 with nothing in the failure pointing at the header, and a rebase merges them in without conflict.

`README.md` had the matching gap in the other direction: it described `mtls-certificate` as *the* header, with no mention that which header is trusted is now a setting.

## What the docs now say

Both describe the actual shape: exactly one client-certificate header is read, chosen by `CANOPY_DEVICE_AUTH_CERT_HEADER` — nginx (`mtls-certificate`, falling back to `ssl-client-cert`, the default and live path) or Envoy (`x-forwarded-client-cert`).

The README carries the reasoning too, since it's the part that makes the design make sense rather than look fussy: the other header is ignored rather than tried as a fallback, because a certificate is a public key and nothing at this layer proves possession — anything able to set a believed header could otherwise present an enrolled device's certificate and be resolved as that device. Same reason an XFCC chain is read from its last element.

`AGENTS.md` names the harness default and points at `run_with_device_auth_on` for the handful of tests that pin the nginx path, and says plainly that the wrong header is a 401 rather than a fallback.

Also adds the Envoy line to the production terminator list, and a curl example for the XFCC form.

No spec changes: the specs describe the transport as "a client certificate" without naming a header, which is the right altitude and isn't stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
