### PR TITLE
Withdrawing a plan keeps it (UPG)

### DIFF
--- a/.workhorse/specs/private-server/mcp.md
+++ b/.workhorse/specs/private-server/mcp.md
@@ -5,7 +5,7 @@ id: MCP
 # Fleet query interface
 
 A read-only query interface to the Canopy fleet, exposed for AI agents and other automated clients that operators run.
-It lets such a client discover servers and groups, read their status and health, learn what Tamanu versions exist and which are deployed, and inspect backup state and problems — without granting any ability to change the fleet.
+It lets such a client discover servers and groups, read their status and health, learn what Tamanu versions exist and which are deployed, see where each deployment plans to move next, and inspect backup state and problems — without granting any ability to change the fleet.
 
 ## Why it exists
 
@@ -70,6 +70,13 @@ When the result is truncated to its bound, the result says so, so the client doe
 **List versions** optionally includes drafts and returns the known Tamanu versions, each with its number, release status, head release date, a changelog summary, and how many live servers currently report running it.
 
 **Get version** takes a version and returns its detail: its changelog, its known issues, the later versions available as updates from it, and which servers and groups currently run it.
+
+### Planned upgrades
+
+**List upgrade plans** takes no input and returns where every deployment is going (see [UPG](upgrade-plans.md)): each group with an open plan, with the version it runs now, the version it plans to move to, the planned date where there is one, and whether that date has passed unmet; and separately the groups with nothing recorded, which pre-upgrade testing aims at the newest published version for.
+
+**Get upgrade plan history** takes a group identifier and returns every plan that group has had, newest first, each with its target, planned date, note, and how it stands: open, met, replaced by a later plan, or withdrawn.
+A plan carries the operator who recorded it, who last amended it, and who withdrew it, with the times of each.
 
 ### Fleet triage
 

--- a/.workhorse/specs/private-server/upgrade-plans.md
+++ b/.workhorse/specs/private-server/upgrade-plans.md
@@ -75,6 +75,10 @@ Groups with no plan are shown too: an unplanned deployment several minors behind
 A plan whose date has passed without being met is presented as late.
 Late is a presentational state and not an incident: an upgrade slipping is normal operational reality, and Canopy has no basis for treating a date someone typed as a failure of anything.
 
+The same view presents the plans that have closed, most recently closed first, so what a deployment planned before is readable beside what it plans now.
+Each shows where it was going, the date it was planned for, and how it closed: met, replaced by a later plan, or withdrawn with the operator who withdrew it and when.
+A withdrawn plan is otherwise unreadable anywhere, since a deployment that stopped going somewhere leaves no other mark on the fleet.
+
 ## Out of scope
 
 - Performing, scheduling, or triggering an upgrade.

--- a/.workhorse/specs/private-server/upgrade-plans.md
+++ b/.workhorse/specs/private-server/upgrade-plans.md
@@ -41,7 +41,8 @@ Changing the target is not an amendment: where a deployment is going is what the
 A plan that has been met or replaced is history and is no longer amendable.
 
 Plans are managed through the operator interface and are audited.
-Deleting a plan says the deployment is no longer going there; it does not say the upgrade happened.
+Withdrawing a plan says the deployment is no longer going there; it does not say the upgrade happened.
+A withdrawn plan is retained and records who withdrew it and when: a deployment that was going somewhere and stopped is part of the same history as one that arrived, and it frees the group to be planned somewhere else.
 
 A planned date is a plan, not a deadline.
 Canopy neither schedules nor blocks anything on it, and a date that passes changes only how the plan is presented.

--- a/crates/canopy-mcp/src/lib.rs
+++ b/crates/canopy-mcp/src/lib.rs
@@ -15,10 +15,11 @@
 //! so the verdicts match what the operator UI and the alerting sweep present.
 //!
 //! Tools are grouped into domain modules (`servers`, `groups`, `versions`,
-//! `fleet`, `backups`, `restore`, `incidents`), each contributing its own tool
-//! router (via rmcp's `#[tool_router(router = ..., vis = "pub(crate)")]`) that
-//! [`CanopyMcp::new`] combines into the single stored `ToolRouter`. `util`
-//! holds helpers shared across more than one of those modules.
+//! `fleet`, `backups`, `restore`, `incidents`, `upgrade_plans`), each
+//! contributing its own tool router (via rmcp's
+//! `#[tool_router(router = ..., vis = "pub(crate)")]`) that [`CanopyMcp::new`]
+//! combines into the single stored `ToolRouter`. `util` holds helpers shared
+//! across more than one of those modules.
 
 mod backups;
 mod fleet;
@@ -26,6 +27,7 @@ mod groups;
 mod incidents;
 mod restore;
 mod servers;
+mod upgrade_plans;
 mod util;
 mod versions;
 
@@ -56,7 +58,8 @@ impl CanopyMcp {
 				+ Self::fleet_router()
 				+ Self::backups_router()
 				+ Self::restore_router()
-				+ Self::incidents_router(),
+				+ Self::incidents_router()
+				+ Self::upgrade_plans_router(),
 		}
 	}
 
@@ -71,8 +74,14 @@ impl ServerHandler for CanopyMcp {
 		let mut info = ServerInfo::default();
 		info.instructions = Some(
 			"Read-only access to the Canopy fleet: servers, groups, health/status, Tamanu \
-			 versions, backups, and incidents/issues. All data is live. Use find_* to locate \
-			 entities and get_* for detail; fleet_summary and find_backup_problems for triage.\n\n\
+			 versions, planned upgrades, backups, and incidents/issues. All data is live. Use \
+			 find_* to locate entities and get_* for detail; fleet_summary and \
+			 find_backup_problems for triage.\n\n\
+			 Upgrade plans: a plan is a group's recorded intention to move to a version. A \
+			 planned date is a plan rather than a deadline, so one that has passed (`late`) is \
+			 normal operational reality rather than an incident. list_upgrade_plans gives what \
+			 every deployment is going to next; get_upgrade_plan_history gives what a group \
+			 planned before, including plans an operator withdrew.\n\n\
 			 Products: a server's `product` is the application it runs (tamanu, senaite, or \
 			 canopy itself), and its `kind` is its role within that product. The version tools \
 			 cover Tamanu's releases; a server whose product has no application version reports \

--- a/crates/canopy-mcp/src/upgrade_plans.rs
+++ b/crates/canopy-mcp/src/upgrade_plans.rs
@@ -1,0 +1,184 @@
+//! `list_upgrade_plans` / `get_upgrade_plan_history` tools.
+
+use std::collections::HashMap;
+
+use commons_types::{Uuid, version::VersionStr};
+use database::{
+	server_groups::ServerGroup,
+	upgrade_plans::{PlanOutcome, UpgradePlan},
+	versions::Version,
+};
+use jiff::{Timestamp, Zoned, civil::Date};
+use rmcp::{
+	handler::server::wrapper::Parameters,
+	model::{CallToolResult, ErrorData as McpError},
+	tool, tool_router,
+};
+use serde::Serialize;
+
+use crate::{
+	CanopyMcp,
+	groups::GroupIdArgs,
+	util::{EmptyArgs, mcp_err, not_found, ok_json, parse_uuid},
+};
+
+#[derive(Serialize)]
+struct PlanList {
+	plans: Vec<OpenPlan>,
+	groups_without_a_plan: Vec<GroupRef>,
+}
+
+#[derive(Serialize)]
+struct GroupRef {
+	group_id: Uuid,
+	group_name: String,
+	current_version: Option<VersionStr>,
+}
+
+#[derive(Serialize)]
+struct OpenPlan {
+	group_id: Uuid,
+	group_name: String,
+	current_version: Option<VersionStr>,
+	target_version: String,
+	planned_for: Option<Date>,
+	/// The planned day has passed and the deployment has not moved.
+	late: bool,
+	note: Option<String>,
+	recorded_by: Option<String>,
+	recorded_at: Timestamp,
+}
+
+#[derive(Serialize)]
+struct PlanHistory {
+	group_id: Uuid,
+	group_name: String,
+	current_version: Option<VersionStr>,
+	plans: Vec<HistoricPlan>,
+}
+
+#[derive(Serialize)]
+struct HistoricPlan {
+	target_version: String,
+	outcome: PlanOutcome,
+	planned_for: Option<Date>,
+	note: Option<String>,
+	recorded_by: Option<String>,
+	recorded_at: Timestamp,
+	amended_by: Option<String>,
+	amended_at: Option<Timestamp>,
+	withdrawn_by: Option<String>,
+	/// When the plan closed, absent while it is open.
+	ended_at: Option<Timestamp>,
+}
+
+#[tool_router(router = upgrade_plans_router, vis = "pub(crate)")]
+impl CanopyMcp {
+	#[tool(
+		description = "Where every deployment is going: each group's open upgrade plan with the \
+		               version it runs now, the version it plans to move to, the planned date, and \
+		               whether that date has passed unmet. Groups with nothing recorded are \
+		               returned separately."
+	)]
+	async fn list_upgrade_plans(
+		&self,
+		Parameters(_): Parameters<EmptyArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let today = Zoned::now().date();
+		let versions = version_names(&mut conn).await?;
+
+		let mut plans = Vec::new();
+		let mut unplanned = Vec::new();
+		for group in ServerGroup::list_all(&mut conn).await.map_err(mcp_err)? {
+			let plan = UpgradePlan::open_for_group(&mut conn, group.id)
+				.await
+				.map_err(mcp_err)?;
+			match plan {
+				Some(plan) => plans.push(OpenPlan {
+					group_id: group.id,
+					group_name: group.name,
+					current_version: group.effective_version,
+					target_version: version_name(&versions, plan.target_version_id),
+					planned_for: plan.planned_for,
+					late: database::upgrade_plans::is_late(&plan, today),
+					note: plan.note,
+					recorded_by: plan.created_by,
+					recorded_at: plan.created_at,
+				}),
+				None => unplanned.push(GroupRef {
+					group_id: group.id,
+					group_name: group.name,
+					current_version: group.effective_version,
+				}),
+			}
+		}
+
+		ok_json(&PlanList {
+			plans,
+			groups_without_a_plan: unplanned,
+		})
+	}
+
+	#[tool(
+		description = "Every upgrade plan one group has had, newest first, with how each stands: \
+		               open, met (the group reached the target), replaced by a later plan, or \
+		               withdrawn (an operator said the deployment is no longer going there)."
+	)]
+	async fn get_upgrade_plan_history(
+		&self,
+		Parameters(args): Parameters<GroupIdArgs>,
+	) -> Result<CallToolResult, McpError> {
+		let mut conn = self.conn().await?;
+		let id = parse_uuid(&args.group_id, "group_id")?;
+		let Ok(group) = ServerGroup::get_by_id(&mut conn, id).await else {
+			return Ok(not_found(format!("no group with id {id}")));
+		};
+
+		let versions = version_names(&mut conn).await?;
+		let plans = UpgradePlan::history_for_group(&mut conn, id)
+			.await
+			.map_err(mcp_err)?
+			.into_iter()
+			.map(|plan| HistoricPlan {
+				target_version: version_name(&versions, plan.target_version_id),
+				outcome: database::upgrade_plans::outcome(&plan),
+				ended_at: database::upgrade_plans::ended_at(&plan),
+				planned_for: plan.planned_for,
+				note: plan.note,
+				recorded_by: plan.created_by,
+				recorded_at: plan.created_at,
+				amended_by: plan.amended_by,
+				amended_at: plan.amended_at,
+				withdrawn_by: plan.withdrawn_by,
+			})
+			.collect();
+
+		ok_json(&PlanHistory {
+			group_id: group.id,
+			group_name: group.name,
+			current_version: group.effective_version,
+			plans,
+		})
+	}
+}
+
+/// Drafts included: a target yanked since the plan was recorded is still where
+/// the deployment was going.
+async fn version_names(
+	conn: &mut database::diesel_async::AsyncPgConnection,
+) -> Result<HashMap<Uuid, String>, McpError> {
+	Ok(Version::get_all_including_drafts(conn)
+		.await
+		.map_err(mcp_err)?
+		.into_iter()
+		.map(|version| (version.id, version.as_semver().to_string()))
+		.collect())
+}
+
+fn version_name(versions: &HashMap<Uuid, String>, id: Uuid) -> String {
+	versions
+		.get(&id)
+		.cloned()
+		.unwrap_or_else(|| "unknown".into())
+}

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -727,6 +727,8 @@ diesel::table! {
 		superseded_at -> Nullable<Timestamptz>,
 		amended_by -> Nullable<Text>,
 		amended_at -> Nullable<Timestamptz>,
+		withdrawn_at -> Nullable<Timestamptz>,
+		withdrawn_by -> Nullable<Text>,
 	}
 }
 

--- a/crates/database/src/upgrade_plans.rs
+++ b/crates/database/src/upgrade_plans.rs
@@ -52,6 +52,12 @@ pub struct UpgradePlan {
 	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
 	#[schema(value_type = Option<String>)]
 	pub amended_at: Option<Timestamp>,
+	/// When the plan was withdrawn, if it was.
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	#[schema(value_type = Option<String>)]
+	pub withdrawn_at: Option<Timestamp>,
+	/// The operator who withdrew it.
+	pub withdrawn_by: Option<String>,
 }
 
 impl UpgradePlan {
@@ -91,6 +97,7 @@ impl UpgradePlan {
 			.filter(dsl::group_id.eq(group_id))
 			.filter(dsl::met_at.is_null())
 			.filter(dsl::superseded_at.is_null())
+			.filter(dsl::withdrawn_at.is_null())
 			.set(dsl::superseded_at.eq(diesel::dsl::now))
 			.execute(db)
 			.await?;
@@ -130,6 +137,7 @@ impl UpgradePlan {
 			.filter(dsl::group_id.eq(group_id))
 			.filter(dsl::met_at.is_null())
 			.filter(dsl::superseded_at.is_null())
+			.filter(dsl::withdrawn_at.is_null())
 			.first(db)
 			.await
 			.optional()
@@ -162,6 +170,7 @@ impl UpgradePlan {
 			.select(Self::as_select())
 			.filter(dsl::met_at.is_null())
 			.filter(dsl::superseded_at.is_null())
+			.filter(dsl::withdrawn_at.is_null())
 			.order(dsl::created_at.desc())
 			.load(db)
 			.await
@@ -187,6 +196,7 @@ impl UpgradePlan {
 			.filter(dsl::id.eq(id))
 			.filter(dsl::met_at.is_null())
 			.filter(dsl::superseded_at.is_null())
+			.filter(dsl::withdrawn_at.is_null())
 			.set((
 				dsl::planned_for.eq(planned_for.map(jiff_diesel::Date::from)),
 				dsl::note.eq(note),
@@ -201,13 +211,32 @@ impl UpgradePlan {
 	}
 
 	/// Withdraw a plan: the deployment is no longer going there.
-	pub async fn delete(db: &mut AsyncPgConnection, id: Uuid) -> Result<()> {
+	///
+	/// The plan is retained. Where a deployment was going and the fact that it
+	/// stopped going there is what the history exists to record, and a withdrawn
+	/// plan reads differently from one that was met.
+	// spec: UPG#a-plan
+	pub async fn withdraw(
+		db: &mut AsyncPgConnection,
+		id: Uuid,
+		withdrawn_by: &str,
+	) -> Result<Option<Self>> {
 		use crate::schema::upgrade_plans::dsl;
 
-		diesel::delete(dsl::upgrade_plans.filter(dsl::id.eq(id)))
-			.execute(db)
-			.await?;
-		Ok(())
+		diesel::update(dsl::upgrade_plans)
+			.filter(dsl::id.eq(id))
+			.filter(dsl::met_at.is_null())
+			.filter(dsl::superseded_at.is_null())
+			.filter(dsl::withdrawn_at.is_null())
+			.set((
+				dsl::withdrawn_at.eq(diesel::dsl::now),
+				dsl::withdrawn_by.eq(withdrawn_by),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
 	}
 }
 
@@ -273,6 +302,7 @@ pub async fn planned_target(db: &mut AsyncPgConnection, group_id: Uuid) -> Resul
 pub fn is_late(plan: &UpgradePlan, today: Date) -> bool {
 	plan.met_at.is_none()
 		&& plan.superseded_at.is_none()
+		&& plan.withdrawn_at.is_none()
 		&& plan.planned_for.is_some_and(|date| date < today)
 }
 

--- a/crates/database/src/upgrade_plans.rs
+++ b/crates/database/src/upgrade_plans.rs
@@ -161,6 +161,28 @@ impl UpgradePlan {
 			.map_err(AppError::from)
 	}
 
+	/// Plans that have closed across the fleet, most recently closed first.
+	// spec: UPG#the-dashboard
+	pub async fn closed_recent(db: &mut AsyncPgConnection, limit: i64) -> Result<Vec<Self>> {
+		use crate::schema::upgrade_plans::dsl;
+
+		dsl::upgrade_plans
+			.select(Self::as_select())
+			.filter(
+				dsl::met_at
+					.is_not_null()
+					.or(dsl::superseded_at.is_not_null())
+					.or(dsl::withdrawn_at.is_not_null()),
+			)
+			.order(diesel::dsl::sql::<diesel::sql_types::Timestamptz>(
+				"greatest(met_at, superseded_at, withdrawn_at) desc",
+			))
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
 	/// Every open plan across the fleet, newest first.
 	// spec: UPG#the-dashboard
 	pub async fn all_open(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
@@ -238,6 +260,45 @@ impl UpgradePlan {
 			.optional()
 			.map_err(AppError::from)
 	}
+}
+
+/// How a plan stands: still where the group is going, or the way it closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum PlanOutcome {
+	/// Where the group is going.
+	Open,
+	/// The group's reported version reached the target.
+	Met,
+	/// A later plan took its place.
+	Replaced,
+	/// An operator said the deployment is no longer going there.
+	Withdrawn,
+}
+
+/// How a plan stands.
+///
+/// Met wins over the rest: a plan the group reached is met however it was
+/// stamped afterwards.
+// spec: UPG#a-plan
+pub fn outcome(plan: &UpgradePlan) -> PlanOutcome {
+	if plan.met_at.is_some() {
+		PlanOutcome::Met
+	} else if plan.withdrawn_at.is_some() {
+		PlanOutcome::Withdrawn
+	} else if plan.superseded_at.is_some() {
+		PlanOutcome::Replaced
+	} else {
+		PlanOutcome::Open
+	}
+}
+
+/// When a plan closed, for one that has.
+pub fn ended_at(plan: &UpgradePlan) -> Option<Timestamp> {
+	[plan.met_at, plan.withdrawn_at, plan.superseded_at]
+		.into_iter()
+		.flatten()
+		.max()
 }
 
 /// Close every open plan whose group has reached its target, returning how many

--- a/crates/database/tests/it/upgrade_plans.rs
+++ b/crates/database/tests/it/upgrade_plans.rs
@@ -389,3 +389,122 @@ async fn a_met_plan_is_not_amendable() {
 	})
 	.await
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_withdrawn_plan_leaves_the_group_unplanned_but_stays_in_its_history() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let target = publish(&mut conn, 61, 0).await;
+		let plan = UpgradePlan::record(&mut conn, group, target.id, None, None, "a@example.com")
+			.await
+			.expect("plan");
+
+		let withdrawn = UpgradePlan::withdraw(&mut conn, plan.id, "b@example.com")
+			.await
+			.expect("withdraw")
+			.expect("the open plan");
+		assert_eq!(withdrawn.withdrawn_by.as_deref(), Some("b@example.com"));
+		assert!(withdrawn.withdrawn_at.is_some());
+		assert!(
+			withdrawn.met_at.is_none(),
+			"withdrawing does not say the upgrade happened"
+		);
+
+		assert!(
+			UpgradePlan::open_for_group(&mut conn, group)
+				.await
+				.expect("open")
+				.is_none(),
+			"the group is no longer going anywhere"
+		);
+		assert!(
+			planned_target(&mut conn, group)
+				.await
+				.expect("target")
+				.is_none(),
+			"testing falls back to the newest published version"
+		);
+
+		let history = UpgradePlan::history_for_group(&mut conn, group)
+			.await
+			.expect("history");
+		assert_eq!(history.len(), 1, "the plan is retained");
+		assert_eq!(history[0].id, plan.id);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_withdrawn_plan_does_not_hold_the_group_s_open_slot() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let first = publish(&mut conn, 61, 0).await;
+		let second = publish(&mut conn, 62, 0).await;
+
+		let plan = UpgradePlan::record(&mut conn, group, first.id, None, None, "a@example.com")
+			.await
+			.expect("first plan");
+		UpgradePlan::withdraw(&mut conn, plan.id, "b@example.com")
+			.await
+			.expect("withdraw");
+
+		let replacement =
+			UpgradePlan::record(&mut conn, group, second.id, None, None, "a@example.com")
+				.await
+				.expect("a group that withdrew a plan can record another");
+		assert_eq!(
+			UpgradePlan::open_for_group(&mut conn, group)
+				.await
+				.expect("open")
+				.map(|p| p.id),
+			Some(replacement.id)
+		);
+
+		let withdrawn = UpgradePlan::history_for_group(&mut conn, group)
+			.await
+			.expect("history")
+			.into_iter()
+			.find(|p| p.id == plan.id)
+			.expect("the withdrawn plan is still history");
+		assert!(
+			withdrawn.superseded_at.is_none(),
+			"it was withdrawn, not replaced"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_withdrawn_plan_is_not_amendable_or_withdrawable_twice() {
+	TestDb::run(|mut conn, _url| async move {
+		let (group, _server) = group_running(&mut conn, "2.60.0").await;
+		let target = publish(&mut conn, 61, 0).await;
+		let plan = UpgradePlan::record(&mut conn, group, target.id, None, None, "a@example.com")
+			.await
+			.expect("plan");
+		UpgradePlan::withdraw(&mut conn, plan.id, "b@example.com")
+			.await
+			.expect("withdraw");
+
+		assert!(
+			UpgradePlan::amend(
+				&mut conn,
+				plan.id,
+				Some(date(2026, 8, 1)),
+				None,
+				"c@example.com"
+			)
+			.await
+			.is_err(),
+			"a withdrawn plan is history and stands as it was"
+		);
+		assert!(
+			UpgradePlan::withdraw(&mut conn, plan.id, "c@example.com")
+				.await
+				.expect("second withdraw")
+				.is_none(),
+			"withdrawing again changes nothing and does not restamp who withdrew it"
+		);
+	})
+	.await
+}

--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -1,19 +1,26 @@
+use std::collections::HashMap;
+
 use axum::Json;
 use axum::extract::State;
 use canopy_utoipa_axum::{router::OpenApiRouter, routes};
 use commons_errors::{ProblemDetailsSchema, Result};
 use commons_servers::tailscale_auth::TailscaleAdmin;
-use database::upgrade_plans::UpgradePlan;
-use jiff::{Zoned, civil::Date};
+use database::upgrade_plans::{PlanOutcome, UpgradePlan};
+use jiff::{Timestamp, Zoned, civil::Date};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::state::AppState;
 
+/// The history is for reading, not paging: enough to cover what the fleet has
+/// planned recently without shipping every plan ever recorded.
+const HISTORY_LIMIT: i64 = 100;
+
 pub fn routes() -> OpenApiRouter<AppState> {
 	OpenApiRouter::new()
 		.routes(routes!(fleet))
+		.routes(routes!(history))
 		.routes(routes!(targets))
 		.routes(routes!(for_group))
 		.routes(routes!(record))
@@ -141,6 +148,81 @@ fn roll_up(per_server: &[database::migration_tests::GroupVerdict]) -> &'static s
 		return "nottested";
 	}
 	"passed"
+}
+
+/// One plan that has closed, in the fleet's plan history.
+#[derive(Serialize, ToSchema)]
+pub struct PastPlan {
+	/// The plan itself.
+	pub plan: UpgradePlan,
+	/// The group it was for.
+	pub group_id: Uuid,
+	/// Its name, so the view reads without a second lookup.
+	pub group_name: String,
+	/// Where the plan was going, as semver.
+	pub target_version: String,
+	/// How it closed.
+	pub outcome: PlanOutcome,
+	/// When it closed.
+	#[schema(value_type = String)]
+	pub ended_at: Timestamp,
+}
+
+/// The plans that have closed, across the fleet.
+///
+/// A deployment that stopped going somewhere leaves no other mark on the fleet,
+/// so a withdrawn plan is readable here or nowhere.
+// spec: UPG#the-dashboard
+#[utoipa::path(
+	post,
+	path = "/history",
+	operation_id = "upgrade_plans_history",
+	tag = "upgrade_plans",
+	security(("tailscale-admin" = [])),
+	responses(
+		(status = 200, description = "Closed plans, most recently closed first.", body = Vec<PastPlan>),
+		(status = 401, body = ProblemDetailsSchema),
+		(status = 403, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn history(
+	State(state): State<AppState>,
+	_admin: TailscaleAdmin,
+) -> Result<Json<Vec<PastPlan>>> {
+	let mut conn = state.db.get().await?;
+	let plans = UpgradePlan::closed_recent(&mut conn, HISTORY_LIMIT).await?;
+
+	let group_ids: Vec<Uuid> = plans.iter().map(|plan| plan.group_id).collect();
+	let group_names: HashMap<Uuid, String> =
+		database::server_groups::ServerGroup::list_by_ids(&mut conn, &group_ids)
+			.await?
+			.into_iter()
+			.map(|group| (group.id, group.name))
+			.collect();
+	// Including drafts: a target yanked since the plan was recorded still has to
+	// render as the version the deployment was going to.
+	let versions: HashMap<Uuid, String> =
+		database::versions::Version::get_all_including_drafts(&mut conn)
+			.await?
+			.into_iter()
+			.map(|version| (version.id, version.as_semver().to_string()))
+			.collect();
+
+	Ok(Json(
+		plans
+			.into_iter()
+			.filter_map(|plan| {
+				Some(PastPlan {
+					group_id: plan.group_id,
+					group_name: group_names.get(&plan.group_id).cloned()?,
+					target_version: versions.get(&plan.target_version_id).cloned()?,
+					outcome: database::upgrade_plans::outcome(&plan),
+					ended_at: database::upgrade_plans::ended_at(&plan)?,
+					plan,
+				})
+			})
+			.collect(),
+	))
 }
 
 /// Request body for reading one group's plans. Named apart from the

--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -367,10 +367,10 @@ pub struct WithdrawArgs {
 )]
 pub async fn withdraw(
 	State(state): State<AppState>,
-	_admin: TailscaleAdmin,
+	admin: TailscaleAdmin,
 	Json(args): Json<WithdrawArgs>,
 ) -> Result<Json<()>> {
 	let mut conn = state.db.get().await?;
-	UpgradePlan::delete(&mut conn, args.id).await?;
+	UpgradePlan::withdraw(&mut conn, args.id, &admin.0.login).await?;
 	Ok(Json(()))
 }

--- a/crates/private-server/tests/it/mcp.rs
+++ b/crates/private-server/tests/it/mcp.rs
@@ -128,6 +128,8 @@ async fn initialize_and_list_tools() {
 			"find_restore_replicas",
 			"get_restore_replica",
 			"get_backup_defaults",
+			"list_upgrade_plans",
+			"get_upgrade_plan_history",
 		] {
 			assert!(body.contains(tool), "tools/list missing {tool}: {body}");
 		}
@@ -1051,6 +1053,64 @@ async fn get_restore_replica_checks_are_the_replicas_own_newest() {
 			"the quiet replica's own check must survive a noisy neighbour: {detail}",
 		);
 		assert_eq!(checks[0]["snapshot_id"], "quiet-snap");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upgrade_plans_list_the_open_ones_and_keep_the_withdrawn_in_history() {
+	commons_tests::server::run(async |mut conn, _public, private| {
+		seed(&mut conn).await;
+		conn.batch_execute(&format!(
+			"UPDATE server_groups SET effective_version = '2.34.1' WHERE id = '{GROUP}'; \
+			 INSERT INTO server_groups (id, name, effective_version) VALUES \
+				('44444444-4444-4444-4444-444444444444', 'Drifting', '2.34.1'); \
+			 INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES \
+				('55555555-5555-5555-5555-555555555555', 2, 36, 0, 'x', 'published'), \
+				('66666666-6666-6666-6666-666666666666', 2, 40, 0, 'x', 'published'); \
+			 INSERT INTO upgrade_plans (group_id, target_version_id, created_by, withdrawn_at, withdrawn_by) VALUES \
+				('{GROUP}', '66666666-6666-6666-6666-666666666666', 'someone@example.com', NOW(), 'someone@example.com'); \
+			 INSERT INTO upgrade_plans (group_id, target_version_id, planned_for, note, created_by) VALUES \
+				('{GROUP}', '55555555-5555-5555-5555-555555555555', DATE '2020-01-01', 'site can absorb 2.36 only', 'someone@example.com');"
+		))
+		.await
+		.expect("seed plans");
+
+		let list = call_tool!(private, "list_upgrade_plans", serde_json::json!({}));
+		let plans = list["plans"].as_array().expect("plans");
+		assert_eq!(plans.len(), 1, "one group has an open plan: {list}");
+		assert_eq!(plans[0]["group_name"], "Prod Group");
+		assert_eq!(plans[0]["current_version"], "2.34.1");
+		assert_eq!(plans[0]["target_version"], "2.36.0");
+		assert_eq!(plans[0]["planned_for"], "2020-01-01");
+		assert_eq!(plans[0]["late"], true, "the planned day has passed unmet");
+		assert_eq!(plans[0]["note"], "site can absorb 2.36 only");
+
+		// A group with nothing recorded is what testing aims at the newest
+		// version for, so it is returned rather than omitted.
+		let unplanned = list["groups_without_a_plan"]
+			.as_array()
+			.expect("unplanned groups");
+		assert!(
+			unplanned.iter().any(|g| g["group_name"] == "Drifting"),
+			"missing the unplanned group: {list}"
+		);
+
+		let history = call_tool!(
+			private,
+			"get_upgrade_plan_history",
+			serde_json::json!({ "group_id": GROUP })
+		);
+		let plans = history["plans"].as_array().expect("history");
+		assert_eq!(plans.len(), 2);
+		let withdrawn = plans
+			.iter()
+			.find(|p| p["outcome"] == "withdrawn")
+			.unwrap_or_else(|| panic!("no withdrawn plan in {history}"));
+		assert_eq!(withdrawn["target_version"], "2.40.0");
+		assert_eq!(withdrawn["withdrawn_by"], "someone@example.com");
+		assert!(!withdrawn["ended_at"].is_null());
+		assert!(plans.iter().any(|p| p["outcome"] == "open"));
 	})
 	.await
 }

--- a/crates/private-server/tests/it/upgrade_plans.rs
+++ b/crates/private-server/tests/it/upgrade_plans.rs
@@ -247,3 +247,84 @@ async fn amending_a_withdrawn_plan_is_refused() {
 	})
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_history_view_shows_a_withdrawn_plan_beside_a_replaced_one() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+				('cccccccc-0000-0000-0000-0000000000f1', 2, 61, 0, 'x', 'published'),
+				('cccccccc-0000-0000-0000-0000000000f2', 2, 63, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');",
+		)
+		.await
+		.unwrap();
+
+		let replaced: Value = private
+			.post("/api/upgrade_plans/record")
+			.json(&json!({
+				"group_id": GROUP,
+				"target_version_id": "cccccccc-0000-0000-0000-0000000000f1",
+				"planned_for": "2020-01-01",
+				"note": "site can absorb 2.61 only",
+			}))
+			.await
+			.json();
+
+		let withdrawn: Value = private
+			.post("/api/upgrade_plans/record")
+			.json(&json!({
+				"group_id": GROUP,
+				"target_version_id": "cccccccc-0000-0000-0000-0000000000f2",
+			}))
+			.await
+			.json();
+		private
+			.post("/api/upgrade_plans/withdraw")
+			.json(&json!({ "id": withdrawn["id"] }))
+			.await
+			.assert_status_ok();
+
+		let history: Vec<Value> = private
+			.post("/api/upgrade_plans/history")
+			.json(&json!({}))
+			.await
+			.json();
+		assert_eq!(history.len(), 2, "both closed plans are readable");
+
+		// Most recently closed first: the withdrawal happened after the
+		// replacement it followed.
+		assert_eq!(history[0]["plan"]["id"], withdrawn["id"]);
+		assert_eq!(history[0]["outcome"], "withdrawn");
+		assert_eq!(history[0]["target_version"], "2.63.0");
+		assert_eq!(history[0]["group_name"], "kamaka");
+		assert!(
+			!history[0]["plan"]["withdrawn_by"].is_null(),
+			"who withdrew it is part of the record"
+		);
+		assert_eq!(history[0]["ended_at"], history[0]["plan"]["withdrawn_at"]);
+
+		assert_eq!(history[1]["plan"]["id"], replaced["id"]);
+		assert_eq!(history[1]["outcome"], "replaced");
+		assert_eq!(history[1]["plan"]["planned_for"], "2020-01-01");
+		assert_eq!(history[1]["plan"]["note"], "site can absorb 2.61 only");
+
+		// An open plan is not history.
+		private
+			.post("/api/upgrade_plans/record")
+			.json(&json!({
+				"group_id": GROUP,
+				"target_version_id": "cccccccc-0000-0000-0000-0000000000f1",
+			}))
+			.await
+			.assert_status_ok();
+		let history: Vec<Value> = private
+			.post("/api/upgrade_plans/history")
+			.json(&json!({}))
+			.await
+			.json();
+		assert_eq!(history.len(), 2);
+	})
+	.await;
+}

--- a/migrations/2026-08-03-010611-0000_add_upgrade_plan_withdrawal/down.sql
+++ b/migrations/2026-08-03-010611-0000_add_upgrade_plan_withdrawal/down.sql
@@ -1,0 +1,14 @@
+-- DESTRUCTIVE: withdrawn plans are dropped rather than reopened, since
+-- restoring the narrower index would fail for a group that has withdrawn one
+-- plan and recorded another.
+DELETE FROM upgrade_plans WHERE withdrawn_at IS NOT NULL;
+
+DROP INDEX upgrade_plans_one_open_per_group;
+
+CREATE UNIQUE INDEX upgrade_plans_one_open_per_group
+	ON upgrade_plans (group_id)
+	WHERE met_at IS NULL AND superseded_at IS NULL;
+
+ALTER TABLE upgrade_plans
+	DROP COLUMN withdrawn_at,
+	DROP COLUMN withdrawn_by;

--- a/migrations/2026-08-03-010611-0000_add_upgrade_plan_withdrawal/up.sql
+++ b/migrations/2026-08-03-010611-0000_add_upgrade_plan_withdrawal/up.sql
@@ -1,0 +1,13 @@
+-- Withdrawing a plan says the deployment is no longer going there. That
+-- decision is part of the upgrade history, so the plan is retained rather than
+-- removed.
+ALTER TABLE upgrade_plans
+	ADD COLUMN withdrawn_at TIMESTAMPTZ,
+	ADD COLUMN withdrawn_by TEXT;
+
+-- A withdrawn plan is history, so it must not hold the group's one open slot.
+DROP INDEX upgrade_plans_one_open_per_group;
+
+CREATE UNIQUE INDEX upgrade_plans_one_open_per_group
+	ON upgrade_plans (group_id)
+	WHERE met_at IS NULL AND superseded_at IS NULL AND withdrawn_at IS NULL;

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -1224,8 +1224,20 @@ export async function seedUpgradePlan(
 		plannedFor?: string | null;
 		note?: string | null;
 		createdBy?: string;
+		/** Retire the group's open plan first, as recording a second one does.
+		 * A group holds one open plan at a time, so a second insert without this
+		 * breaks the unique index. */
+		supersedes?: boolean;
 	},
 ): Promise<void> {
+	if (opts.supersedes) {
+		await sql.query(
+			`UPDATE upgrade_plans SET superseded_at = NOW()
+			 WHERE group_id = $1
+			   AND met_at IS NULL AND superseded_at IS NULL AND withdrawn_at IS NULL`,
+			[opts.groupId],
+		);
+	}
 	await sql.query(
 		`INSERT INTO upgrade_plans (group_id, target_version_id, planned_for, note, created_by)
 		 VALUES ($1, $2, $3::date, $4, $5)`,

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -111,6 +111,49 @@ test.describe("upgrades dashboard", () => {
 		await expect(page.getByTestId("planned-upgrades")).toContainText(
 			"No deployment has a recorded plan",
 		);
+
+		// The plan is kept, so where kamaka was going stays readable.
+		const past = page
+			.getByTestId("past-plan-row")
+			.filter({ hasText: "kamaka" });
+		await expect(past).toContainText("2.61.0");
+		await expect(past).toContainText("withdrawn");
+	});
+
+	test("a plan replaced by a later one reads as replaced, not withdrawn", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "kamaka" });
+		await sql.query(
+			"UPDATE server_groups SET effective_version = '2.60.0' WHERE id = $1",
+			[group.id],
+		);
+		const first = await seedVersion(sql, { major: 2, minor: 61, patch: 0 });
+		const second = await seedVersion(sql, { major: 2, minor: 63, patch: 0 });
+		await seedUpgradePlan(sql, {
+			groupId: group.id,
+			targetVersionId: first.id,
+			note: "site can absorb 2.61 only",
+		});
+		await seedUpgradePlan(sql, {
+			groupId: group.id,
+			targetVersionId: second.id,
+			supersedes: true,
+		});
+
+		await page.goto("/upgrades");
+
+		const past = page.getByTestId("past-plan-row").filter({ hasText: "kamaka" });
+		await expect(past).toHaveCount(1);
+		await expect(past).toContainText("2.61.0");
+		await expect(past).toContainText("replaced");
+		await expect(past).toContainText("site can absorb 2.61 only");
+		// The plan that replaced it is where the deployment is going, so it stays
+		// out of the history.
+		await expect(
+			page.getByTestId("planned-upgrade-row").filter({ hasText: "kamaka" }),
+		).toContainText("2.63.0");
 	});
 
 	test("amending a plan changes its date and note but not where it is going", async ({

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -6907,6 +6907,56 @@
         ]
       }
     },
+    "/api/upgrade_plans/history": {
+      "post": {
+        "tags": [
+          "upgrade_plans"
+        ],
+        "summary": "The plans that have closed, across the fleet.",
+        "description": "A deployment that stopped going somewhere leaves no other mark on the fleet,\nso a withdrawn plan is readable here or nowhere.",
+        "operationId": "upgrade_plans_history",
+        "responses": {
+          "200": {
+            "description": "Closed plans, most recently closed first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PastPlan"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
     "/api/upgrade_plans/record": {
       "post": {
         "tags": [
@@ -12072,6 +12122,45 @@
           }
         }
       },
+      "PastPlan": {
+        "type": "object",
+        "description": "One plan that has closed, in the fleet's plan history.",
+        "required": [
+          "plan",
+          "group_id",
+          "group_name",
+          "target_version",
+          "outcome",
+          "ended_at"
+        ],
+        "properties": {
+          "ended_at": {
+            "type": "string",
+            "description": "When it closed."
+          },
+          "group_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The group it was for."
+          },
+          "group_name": {
+            "type": "string",
+            "description": "Its name, so the view reads without a second lookup."
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/PlanOutcome",
+            "description": "How it closed."
+          },
+          "plan": {
+            "$ref": "#/components/schemas/UpgradePlan",
+            "description": "The plan itself."
+          },
+          "target_version": {
+            "type": "string",
+            "description": "Where the plan was going, as semver."
+          }
+        }
+      },
       "PauseArgs": {
         "type": "object",
         "description": "Why a server is being paused.",
@@ -12127,6 +12216,16 @@
             "description": "Backup type requested."
           }
         }
+      },
+      "PlanOutcome": {
+        "type": "string",
+        "description": "How a plan stands: still where the group is going, or the way it closed.",
+        "enum": [
+          "open",
+          "met",
+          "replaced",
+          "withdrawn"
+        ]
       },
       "PlannableVersion": {
         "type": "object",

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -15956,6 +15956,20 @@
             "type": "string",
             "format": "uuid",
             "description": "The version it intends to move to."
+          },
+          "withdrawn_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "When the plan was withdrawn, if it was."
+          },
+          "withdrawn_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The operator who withdrew it."
           }
         }
       },

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -3534,6 +3534,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/upgrade_plans/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * The plans that have closed, across the fleet.
+         * @description A deployment that stopped going somewhere leaves no other mark on the fleet,
+         *     so a withdrawn plan is readable here or nowhere.
+         */
+        post: operations["upgrade_plans_history"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/upgrade_plans/record": {
         parameters: {
             query?: never;
@@ -6692,6 +6713,24 @@ export interface components {
             slack_open_delay?: number | null;
             tags?: null | components["schemas"]["TagMap"];
         };
+        /** @description One plan that has closed, in the fleet's plan history. */
+        PastPlan: {
+            /** @description When it closed. */
+            ended_at: string;
+            /**
+             * Format: uuid
+             * @description The group it was for.
+             */
+            group_id: string;
+            /** @description Its name, so the view reads without a second lookup. */
+            group_name: string;
+            /** @description How it closed. */
+            outcome: components["schemas"]["PlanOutcome"];
+            /** @description The plan itself. */
+            plan: components["schemas"]["UpgradePlan"];
+            /** @description Where the plan was going, as semver. */
+            target_version: string;
+        };
         /** @description Why a server is being paused. */
         PauseArgs: {
             /** @description Why, recorded so whoever finds the pause later knows what it was for. */
@@ -6727,6 +6766,11 @@ export interface components {
             /** @description Backup type requested. */
             type: string;
         };
+        /**
+         * @description How a plan stands: still where the group is going, or the way it closed.
+         * @enum {string}
+         */
+        PlanOutcome: "open" | "met" | "replaced" | "withdrawn";
         /** @description A version a group could be planned onto. */
         PlannableVersion: {
             /**
@@ -13988,6 +14032,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UpgradePlan"][];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    upgrade_plans_history: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Closed plans, most recently closed first. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PastPlan"][];
                 };
             };
             401: {

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -9120,6 +9120,10 @@ export interface components {
              * @description The version it intends to move to.
              */
             target_version_id: string;
+            /** @description When the plan was withdrawn, if it was. */
+            withdrawn_at?: string | null;
+            /** @description The operator who withdrew it. */
+            withdrawn_by?: string | null;
         };
         /**
          * @description Request to declaratively create or update a group's backup configuration,

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -25,8 +25,12 @@ import {
 import { useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
+import TimeAgo from "../components/TimeAgo";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
+import type { ApiResponse } from "../types";
+
+type PastPlan = ApiResponse<"upgrade_plans", "history">[number];
 
 /// Where every deployment is going. A group with no plan is listed too: one
 /// several minors behind with nothing recorded is what this view exists to
@@ -37,6 +41,7 @@ export default function Upgrades() {
 	const isAdmin = useIsAdmin() === true;
 	const [tick, setTick] = useState(0);
 	const fleet = useApi("upgrade_plans", "fleet", {}, [tick]);
+	const past = useApi("upgrade_plans", "history", {}, [tick]);
 
 	if (fleet.status === "loading" || fleet.status === "idle") {
 		return <LinearProgress />;
@@ -173,7 +178,102 @@ export default function Upgrades() {
 					</Table>
 				)}
 			</Paper>
+
+			<PastPlans plans={past.status === "ok" ? past.data : []} />
 		</Stack>
+	);
+}
+
+/// What each deployment planned before, and how it ended. A withdrawn plan is
+/// readable here or nowhere: a deployment that stopped going somewhere leaves
+/// no other mark on the fleet.
+// spec: UPG#the-dashboard
+function PastPlans({ plans }: { plans: PastPlan[] }) {
+	if (plans.length === 0) return null;
+
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }} data-testid="past-plans">
+			<Stack direction="row" spacing={1} sx={{ mb: 1, alignItems: "baseline" }}>
+				<Typography variant="h6" component="h2">
+					Past plans
+				</Typography>
+				<Typography variant="body2" color="text.secondary">
+					where each deployment was going before, and how it ended
+				</Typography>
+			</Stack>
+			<Table size="small">
+				<TableHead>
+					<TableRow>
+						<TableCell>Deployment</TableCell>
+						<TableCell>Was going to</TableCell>
+						<TableCell>Planned for</TableCell>
+						<TableCell>Ended</TableCell>
+						<TableCell>Note</TableCell>
+					</TableRow>
+				</TableHead>
+				<TableBody>
+					{plans.map((row) => (
+						<TableRow key={row.plan.id} data-testid="past-plan-row">
+							<TableCell>
+								<RouterLink to={`/servers/groups/${row.group_id}`}>
+									{row.group_name}
+								</RouterLink>
+							</TableCell>
+							<TableCell>{row.target_version}</TableCell>
+							<TableCell>{row.plan.planned_for ?? ""}</TableCell>
+							<TableCell>
+								<Stack
+									direction="row"
+									spacing={0.5}
+									sx={{ alignItems: "center" }}
+								>
+									<OutcomeChip
+										outcome={row.outcome}
+										withdrawnBy={row.plan.withdrawn_by}
+									/>
+									<Typography variant="body2" color="text.secondary">
+										<TimeAgo timestamp={row.ended_at} />
+									</Typography>
+								</Stack>
+							</TableCell>
+							<TableCell>{row.plan.note ?? ""}</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</Paper>
+	);
+}
+
+/// How a plan ended. Withdrawn reads differently from met: the deployment
+/// stopped going there rather than arriving.
+function OutcomeChip({
+	outcome,
+	withdrawnBy,
+}: {
+	outcome: PastPlan["outcome"];
+	withdrawnBy: string | null;
+}) {
+	if (outcome === "met") {
+		return <Chip size="small" color="success" label="met" />;
+	}
+	if (outcome === "withdrawn") {
+		return (
+			<Tooltip
+				title={
+					withdrawnBy
+						? `withdrawn by ${withdrawnBy}; the upgrade did not happen`
+						: "the deployment stopped going there; the upgrade did not happen"
+				}
+			>
+				<Chip size="small" color="warning" variant="outlined" label="withdrawn" />
+			</Tooltip>
+		);
+	}
+	return (
+		<Tooltip title="a later plan took its place">
+			<Chip size="small" variant="outlined" label="replaced" />
+		</Tooltip>
 	);
 }
 


### PR DESCRIPTION
Follow-up to #423. Withdrawing a plan hard-deleted the row, so "we were going to 2.61 in March, then dropped it" left no trace of ever having been decided.

Everything else in UPG is retained: a replaced plan keeps `superseded_at`, a met plan keeps `met_at`, and that history is what makes "how long do our upgrades really take" answerable. Withdrawal was the one hole in it.

Now a topical soft delete, `withdrawn_at` / `withdrawn_by`, with every open-plan query filtering on `withdrawn_at IS NULL`.

Two things worth arguing with:

**The partial unique index had to move.** `upgrade_plans_one_open_per_group` was `WHERE met_at IS NULL AND superseded_at IS NULL`. Left as it was, a withdrawn plan keeps holding the group's one open slot and blocks recording a replacement, which is the opposite of what withdrawing is for. The migration drops and recreates it with `withdrawn_at IS NULL` in the predicate.

**The down migration deletes withdrawn plans rather than reopening them**, and is marked DESTRUCTIVE. Reopening them would fail the restored narrower index for any group that withdrew one plan and then recorded another.

`withdraw()` returns `Option<Self>` and filters on the plan still being open, so withdrawing twice is a no-op rather than restamping who did it.

Nothing changes for the operator. The fleet view keys off `all_open`, so a withdrawn plan drops to the unplanned list exactly as before, and the existing Playwright test for that passes untouched.