### PR TITLE
Every plannable version is offered (UPG)

### DIFF
--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -300,22 +300,22 @@ pub async fn targets(
 		.await?
 		.effective_version;
 
-	let mut out: Vec<PlannableVersion> = database::versions::Version::get_all(&mut conn)
-		.await?
-		.into_iter()
-		.filter(|version| {
-			running
-				.as_ref()
-				.is_none_or(|running| version.as_semver() > running.0)
-		})
-		.map(|version| PlannableVersion {
-			id: version.id,
-			version: version.as_semver().to_string(),
-		})
-		.collect();
 	// get_all is already newest-first; keep that for the picker.
-	out.truncate(50);
-	Ok(Json(out))
+	Ok(Json(
+		database::versions::Version::get_all(&mut conn)
+			.await?
+			.into_iter()
+			.filter(|version| {
+				running
+					.as_ref()
+					.is_none_or(|running| version.as_semver() > running.0)
+			})
+			.map(|version| PlannableVersion {
+				id: version.id,
+				version: version.as_semver().to_string(),
+			})
+			.collect(),
+	))
 }
 
 /// Request body for recording where a group is going.

--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -269,6 +269,10 @@ pub struct PlannableVersion {
 	pub id: Uuid,
 	/// Its semver.
 	pub version: String,
+	/// Whether it is clear of unresolved known issues, the same gate that keeps
+	/// a version off the public listings. A flagged version is still offered:
+	/// the issue may be resolved well before the planned date.
+	pub ready: bool,
 }
 
 /// The versions a group could be planned onto: published, and ahead of what it
@@ -301,16 +305,26 @@ pub async fn targets(
 		.effective_version;
 
 	// get_all is already newest-first; keep that for the picker.
+	let ahead: Vec<database::versions::Version> = database::versions::Version::get_all(&mut conn)
+		.await?
+		.into_iter()
+		.filter(|version| {
+			running
+				.as_ref()
+				.is_none_or(|running| version.as_semver() > running.0)
+		})
+		.collect();
+
+	let ids: Vec<Uuid> = ahead.iter().map(|version| version.id).collect();
+	let flagged =
+		database::version_known_issues::VersionKnownIssue::affected_versions(&mut conn, &ids)
+			.await?;
+
 	Ok(Json(
-		database::versions::Version::get_all(&mut conn)
-			.await?
+		ahead
 			.into_iter()
-			.filter(|version| {
-				running
-					.as_ref()
-					.is_none_or(|running| version.as_semver() > running.0)
-			})
 			.map(|version| PlannableVersion {
+				ready: !flagged.contains(&version.id),
 				id: version.id,
 				version: version.as_semver().to_string(),
 			})

--- a/crates/private-server/tests/it/upgrade_plans.rs
+++ b/crates/private-server/tests/it/upgrade_plans.rs
@@ -366,3 +366,44 @@ async fn every_version_ahead_is_offered_however_far_behind_the_group_is() {
 	})
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_target_under_an_open_known_issue_is_offered_but_flagged() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (major, minor, patch, changelog, status) VALUES
+				(2, 61, 0, 'x', 'published'),
+				(2, 61, 1, 'x', 'published'),
+				(2, 62, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');
+			INSERT INTO version_known_issues (author, description, min_major, min_minor, min_patch)
+				VALUES ('someone@example.com', 'breaks on upgrade', 2, 61, 1);",
+		)
+		.await
+		.unwrap();
+
+		let targets: Vec<Value> = private
+			.post("/api/upgrade_plans/targets")
+			.json(&json!({ "group_id": GROUP }))
+			.await
+			.json();
+
+		let ready = |version: &str| {
+			targets
+				.iter()
+				.find(|v| v["version"] == version)
+				.unwrap_or_else(|| panic!("{version} is not offered: {targets:?}"))["ready"]
+				.as_bool()
+				.expect("ready")
+		};
+
+		// The issue covers 2.61.1 and every later patch in that minor; a
+		// deployment may still plan for it, so it is offered rather than hidden.
+		assert!(!ready("2.61.1"));
+		// Earlier patches and other minors are untouched by it.
+		assert!(ready("2.61.0"));
+		assert!(ready("2.62.0"));
+	})
+	.await;
+}

--- a/crates/private-server/tests/it/upgrade_plans.rs
+++ b/crates/private-server/tests/it/upgrade_plans.rs
@@ -328,3 +328,41 @@ async fn the_history_view_shows_a_withdrawn_plan_beside_a_replaced_one() {
 	})
 	.await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn every_version_ahead_is_offered_however_far_behind_the_group_is() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		// Ten minors of patch releases sit between the group and the newest, so
+		// the version it is actually going to is a long way down the list.
+		let mut rows = vec!["(2, 54, 0, 'x', 'published')".to_owned()];
+		for minor in 56..=65 {
+			for patch in 0..=5 {
+				rows.push(format!("(2, {minor}, {patch}, 'x', 'published')"));
+			}
+		}
+		conn.batch_execute(&format!(
+			"INSERT INTO versions (major, minor, patch, changelog, status) VALUES {};
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.53.0');",
+			rows.join(", ")
+		))
+		.await
+		.unwrap();
+
+		let targets: Vec<Value> = private
+			.post("/api/upgrade_plans/targets")
+			.json(&json!({ "group_id": GROUP }))
+			.await
+			.json();
+
+		assert!(
+			targets.iter().any(|v| v["version"] == "2.54.0"),
+			"a deployment moving to an older minor cannot pick it: offered {:?}",
+			targets
+				.iter()
+				.map(|v| v["version"].as_str().unwrap_or(""))
+				.collect::<Vec<_>>()
+		);
+	})
+	.await;
+}

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,7 +47,7 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, migration_tests, migration_timings, upgrade_plans, recovery_vault_writes, server_names, server_certificates, compromised_keys RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, migration_tests, migration_timings, upgrade_plans, version_known_issues, recovery_vault_writes, server_names, server_certificates, compromised_keys RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
 	// self-alerts attach to that row, so put it back. `kind = 'canopy'` is the
@@ -634,6 +634,35 @@ export interface SeededVersion {
 	major: number;
 	minor: number;
 	patch: number;
+}
+
+/** Flag a version and every later patch in its minor as carrying a known issue.
+ * Pass `fixedIn` to close the range at the first unaffected patch. */
+export async function seedVersionKnownIssue(
+	sql: Sql,
+	opts: {
+		major: number;
+		minor: number;
+		patch: number;
+		fixedIn?: number;
+		description?: string;
+	},
+): Promise<void> {
+	await sql.query(
+		`INSERT INTO version_known_issues
+			(author, description, min_major, min_minor, min_patch, max_major, max_minor, max_patch)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		[
+			"e2e@example.com",
+			opts.description ?? "breaks on upgrade",
+			opts.major,
+			opts.minor,
+			opts.patch,
+			opts.fixedIn == null ? null : opts.major,
+			opts.fixedIn == null ? null : opts.minor,
+			opts.fixedIn ?? null,
+		],
+	);
 }
 
 export async function seedVersion(

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -235,4 +235,36 @@ test.describe("upgrades dashboard", () => {
 		// No date means nothing to be late against.
 		await expect(row).not.toContainText("late");
 	});
+
+	test("a version far behind the newest can still be planned", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "kamaka" });
+		await sql.query(
+			"UPDATE server_groups SET effective_version = '2.53.0' WHERE id = $1",
+			[group.id],
+		);
+		// Ten minors of patch releases sit between the deployment and the newest, so the
+		// version it is going to is a long way down the list.
+		await seedVersion(sql, { major: 2, minor: 54, patch: 0 });
+		for (let minor = 56; minor <= 65; minor++) {
+			for (let patch = 0; patch <= 5; patch++) {
+				await seedVersion(sql, { major: 2, minor, patch });
+			}
+		}
+
+		await page.goto("/upgrades");
+		const form = page.getByTestId("record-plan");
+		await form.getByLabel("Deployment").click();
+		await page.getByRole("option", { name: "kamaka" }).click();
+
+		await form.getByLabel("Going to").fill("2.54");
+		await page.getByRole("option", { name: "2.54.0" }).click();
+		await form.getByRole("button", { name: "Record" }).click();
+
+		await expect(
+			page.getByTestId("planned-upgrade-row").filter({ hasText: "kamaka" }),
+		).toContainText("2.54.0");
+	});
 });

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -259,6 +259,14 @@ test.describe("upgrades dashboard", () => {
 		await form.getByLabel("Deployment").click();
 		await page.getByRole("option", { name: "kamaka" }).click();
 
+		// Unfiltered, the list is the newest patch of each of the last ten minors:
+		// short enough to scroll, so the hundreds of plannable patches don't have
+		// to be.
+		await form.getByLabel("Going to").click();
+		await expect(page.getByRole("option")).toHaveCount(10);
+		await expect(page.getByRole("option").first()).toHaveText("2.65.5");
+		await expect(page.getByRole("option", { name: "2.54.0" })).toHaveCount(0);
+
 		await form.getByLabel("Going to").fill("2.54");
 		await page.getByRole("option", { name: "2.54.0" }).click();
 		await form.getByRole("button", { name: "Record" }).click();

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -4,6 +4,7 @@ import {
 	seedServerGroup,
 	seedUpgradePlan,
 	seedVersion,
+	seedVersionKnownIssue,
 } from "./seed";
 
 test.describe("upgrades dashboard", () => {
@@ -274,5 +275,37 @@ test.describe("upgrades dashboard", () => {
 		await expect(
 			page.getByTestId("planned-upgrade-row").filter({ hasText: "kamaka" }),
 		).toContainText("2.54.0");
+	});
+
+	test("a minor is suggested at its newest patch clear of known issues", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "kamaka" });
+		await sql.query(
+			"UPDATE server_groups SET effective_version = '2.60.0' WHERE id = $1",
+			[group.id],
+		);
+		await seedVersion(sql, { major: 2, minor: 61, patch: 0 });
+		await seedVersion(sql, { major: 2, minor: 61, patch: 1 });
+		await seedVersion(sql, { major: 2, minor: 61, patch: 2 });
+		await seedVersionKnownIssue(sql, { major: 2, minor: 61, patch: 2 });
+
+		await page.goto("/upgrades");
+		const form = page.getByTestId("record-plan");
+		await form.getByLabel("Deployment").click();
+		await page.getByRole("option", { name: "kamaka" }).click();
+		await form.getByLabel("Going to").click();
+
+		// The newest patch carries the issue, so the minor is suggested one back.
+		await expect(page.getByRole("option")).toHaveCount(1);
+		await expect(page.getByRole("option")).toHaveText("2.61.1");
+
+		// Still reachable by typing, and marked: an issue may be resolved well
+		// before the planned date.
+		await form.getByLabel("Going to").fill("2.61.2");
+		await expect(
+			page.getByRole("option").filter({ hasText: "2.61.2" }),
+		).toContainText("known issue");
 	});
 });

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -12232,13 +12232,18 @@
         "description": "A version a group could be planned onto.",
         "required": [
           "id",
-          "version"
+          "version",
+          "ready"
         ],
         "properties": {
           "id": {
             "type": "string",
             "format": "uuid",
             "description": "The version's identifier, for `record`."
+          },
+          "ready": {
+            "type": "boolean",
+            "description": "Whether it is clear of unresolved known issues, the same gate that keeps\na version off the public listings. A flagged version is still offered:\nthe issue may be resolved well before the planned date."
           },
           "version": {
             "type": "string",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -6778,6 +6778,12 @@ export interface components {
              * @description The version's identifier, for `record`.
              */
             id: string;
+            /**
+             * @description Whether it is clear of unresolved known issues, the same gate that keeps
+             *     a version off the public listings. A flagged version is still offered:
+             *     the issue may be resolved well before the planned date.
+             */
+            ready: boolean;
             /** @description Its semver. */
             version: string;
         };

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -24,7 +24,7 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
 import TimeAgo from "../components/TimeAgo";
@@ -371,10 +371,11 @@ function recentMinors(options: PlannableVersion[]): PlannableVersion[] {
 function helperText(
 	groupId: string,
 	options: PlannableVersion[],
+	shortlist: PlannableVersion[],
 ): string | undefined {
 	if (!groupId) return undefined;
 	if (options.length === 0) return "already on the newest";
-	if (options.length > recentMinors(options).length) return "type for older";
+	if (options.length > shortlist.length) return "type for older";
 	return undefined;
 }
 
@@ -401,6 +402,7 @@ function RecordPlan({
 	);
 
 	const options = targets.status === "ok" ? targets.data : [];
+	const shortlist = useMemo(() => recentMinors(options), [options]);
 
 	const submit = async () => {
 		if (!groupId || !versionId) return;
@@ -449,9 +451,7 @@ function RecordPlan({
 					getOptionLabel={(option) => option.version}
 					isOptionEqualToValue={(a, b) => a.id === b.id}
 					filterOptions={(all, state) =>
-						state.inputValue === ""
-							? recentMinors(all)
-							: matchVersion(all, state)
+						state.inputValue === "" ? shortlist : matchVersion(all, state)
 					}
 					renderOption={(props, option) => (
 						<li {...props} key={option.id}>
@@ -476,7 +476,7 @@ function RecordPlan({
 						<TextField
 							{...params}
 							label="Going to"
-							helperText={helperText(groupId, options)}
+							helperText={helperText(groupId, options, shortlist)}
 						/>
 					)}
 				/>

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -5,6 +5,7 @@ import {
 	Autocomplete,
 	Button,
 	Chip,
+	createFilterOptions,
 	Dialog,
 	DialogActions,
 	DialogContent,
@@ -342,6 +343,37 @@ function PlannedFor({ date, late }: { date: string | null; late: boolean }) {
 	);
 }
 
+const SHORTLIST_MINORS = 10;
+
+const matchVersion = createFilterOptions<PlannableVersion>({
+	stringify: (option) => option.version,
+});
+
+/// The newest patch of each of the last ten minors. Every published version
+/// ahead is plannable, which runs to hundreds, so the list an operator scrolls
+/// is the recent releases and typing reaches the rest.
+function recentMinors(options: PlannableVersion[]): PlannableVersion[] {
+	const newest = new Map<string, PlannableVersion>();
+	for (const option of options) {
+		const minor = option.version.split(".").slice(0, 2).join(".");
+		if (!newest.has(minor)) {
+			newest.set(minor, option);
+			if (newest.size === SHORTLIST_MINORS) break;
+		}
+	}
+	return [...newest.values()];
+}
+
+function helperText(
+	groupId: string,
+	options: PlannableVersion[],
+): string | undefined {
+	if (!groupId) return undefined;
+	if (options.length === 0) return "already on the newest";
+	if (options.length > recentMinors(options).length) return "type for older";
+	return undefined;
+}
+
 /// Record where a deployment is going. The version picker offers only valid
 /// targets, so the operator cannot pick one the API would refuse.
 // spec: UPG#a-plan
@@ -412,15 +444,16 @@ function RecordPlan({
 					onChange={(_, option) => setVersionId(option?.id ?? "")}
 					getOptionLabel={(option) => option.version}
 					isOptionEqualToValue={(a, b) => a.id === b.id}
+					filterOptions={(all, state) =>
+						state.inputValue === ""
+							? recentMinors(all)
+							: matchVersion(all, state)
+					}
 					renderInput={(params) => (
 						<TextField
 							{...params}
 							label="Going to"
-							helperText={
-								groupId && options.length === 0
-									? "already on the newest"
-									: undefined
-							}
+							helperText={helperText(groupId, options)}
 						/>
 					)}
 				/>

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -349,19 +349,23 @@ const matchVersion = createFilterOptions<PlannableVersion>({
 	stringify: (option) => option.version,
 });
 
-/// The newest patch of each of the last ten minors. Every published version
-/// ahead is plannable, which runs to hundreds, so the list an operator scrolls
-/// is the recent releases and typing reaches the rest.
+/// The newest ready patch of each of the last ten minors. Every published
+/// version ahead is plannable, which runs to hundreds, so the list an operator
+/// scrolls is the recent releases and typing reaches the rest.
+///
+/// A minor with nothing clear of known issues still gets a row, flagged, rather
+/// than dropping out of the list unexplained.
 function recentMinors(options: PlannableVersion[]): PlannableVersion[] {
-	const newest = new Map<string, PlannableVersion>();
+	const picked = new Map<string, PlannableVersion>();
 	for (const option of options) {
 		const minor = option.version.split(".").slice(0, 2).join(".");
-		if (!newest.has(minor)) {
-			newest.set(minor, option);
-			if (newest.size === SHORTLIST_MINORS) break;
+		const held = picked.get(minor);
+		if (held ? held.ready || !option.ready : picked.size === SHORTLIST_MINORS) {
+			continue;
 		}
+		picked.set(minor, option);
 	}
-	return [...newest.values()];
+	return [...picked.values()];
 }
 
 function helperText(
@@ -449,6 +453,25 @@ function RecordPlan({
 							? recentMinors(all)
 							: matchVersion(all, state)
 					}
+					renderOption={(props, option) => (
+						<li {...props} key={option.id}>
+							<Stack
+								direction="row"
+								spacing={1}
+								sx={{ alignItems: "center" }}
+							>
+								<span>{option.version}</span>
+								{!option.ready && (
+									<Chip
+										size="small"
+										color="warning"
+										variant="outlined"
+										label="known issue"
+									/>
+								)}
+							</Stack>
+						</li>
+					)}
 					renderInput={(params) => (
 						<TextField
 							{...params}

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -2,6 +2,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import {
 	Alert,
+	Autocomplete,
 	Button,
 	Chip,
 	Dialog,
@@ -31,6 +32,7 @@ import { usePageTitle } from "../hooks/usePageTitle";
 import type { ApiResponse } from "../types";
 
 type PastPlan = ApiResponse<"upgrade_plans", "history">[number];
+type PlannableVersion = ApiResponse<"upgrade_plans", "targets">[number];
 
 /// Where every deployment is going. A group with no plan is listed too: one
 /// several minors behind with nothing recorded is what this view exists to
@@ -401,26 +403,27 @@ function RecordPlan({
 						</MenuItem>
 					))}
 				</TextField>
-				<TextField
-					select
+				<Autocomplete<PlannableVersion, false, false, false>
 					size="small"
-					label="Going to"
-					value={versionId}
+					sx={{ minWidth: 180 }}
 					disabled={!groupId || options.length === 0}
-					onChange={(e) => setVersionId(e.target.value)}
-					sx={{ minWidth: 140 }}
-					helperText={
-						groupId && options.length === 0
-							? "already on the newest"
-							: undefined
-					}
-				>
-					{options.map((option) => (
-						<MenuItem key={option.id} value={option.id}>
-							{option.version}
-						</MenuItem>
-					))}
-				</TextField>
+					options={options}
+					value={options.find((option) => option.id === versionId) ?? null}
+					onChange={(_, option) => setVersionId(option?.id ?? "")}
+					getOptionLabel={(option) => option.version}
+					isOptionEqualToValue={(a, b) => a.id === b.id}
+					renderInput={(params) => (
+						<TextField
+							{...params}
+							label="Going to"
+							helperText={
+								groupId && options.length === 0
+									? "already on the newest"
+									: undefined
+							}
+						/>
+					)}
+				/>
 				<TextField
 					size="small"
 					type="date"


### PR DESCRIPTION
The version picker on the plan screen capped its list at the 50 newest plannable versions. With around six patches per minor that is roughly ten minors of headroom, so a deployment further behind than that could not be planned onto the version it was actually going to: the list just stopped. Reported from a deployment on an older minor that couldn't select the release it was headed for.

The cap is gone, so `targets` returns every published version ahead of what the group runs, which is what the endpoint already claimed to do.

That is hundreds of rows for a deployment a long way back, so the "Going to" field is now a combo. Closed, it lists one row per minor for the last ten minors, at that minor's newest patch clear of known issues. Typing filters across every plannable version, so anything older is two keystrokes away rather than absent.

`targets` now carries a `ready` flag per version, from the same `affected_versions` gate the public listings use, so we never suggest a patch under an open known issue. Flagged versions are still offered, marked, rather than hidden: an issue may be resolved well before the planned date, and hiding one from an admin surface is how you get an operator who can't record the plan they've already agreed to. A minor with nothing clear keeps its row, flagged, rather than vanishing from the list.

The ahead-of-what-it-runs filter is untouched and still deliberate: planning a deployment onto a version behind the one it runs is a downgrade, which `record` refuses. If that's the thing we actually want, it's a spec change rather than a picker change.