### PR TITLE
A plan is what asks for migration testing (RST, UPG)

### DIFF
--- a/.workhorse/specs/private-server/mcp.md
+++ b/.workhorse/specs/private-server/mcp.md
@@ -73,7 +73,7 @@ When the result is truncated to its bound, the result says so, so the client doe
 
 ### Planned upgrades
 
-**List upgrade plans** takes no input and returns where every deployment is going (see [UPG](upgrade-plans.md)): each group with an open plan, with the version it runs now, the version it plans to move to, the planned date where there is one, and whether that date has passed unmet; and separately the groups with nothing recorded, which pre-upgrade testing aims at the newest published version for.
+**List upgrade plans** takes no input and returns where every deployment is going (see [UPG](upgrade-plans.md)): each group with an open plan, with the version it runs now, the version it plans to move to, the planned date where there is one, and whether that date has passed unmet; and separately the groups with nothing recorded, which pre-upgrade testing does not cover.
 
 **Get upgrade plan history** takes a group identifier and returns every plan that group has had, newest first, each with its target, planned date, note, and how it stands: open, met, replaced by a later plan, or withdrawn.
 A plan carries the operator who recorded it, who last amended it, and who withdrew it, with the times of each.

--- a/.workhorse/specs/private-server/upgrade-plans.md
+++ b/.workhorse/specs/private-server/upgrade-plans.md
@@ -20,7 +20,7 @@ Canopy already knows what every server runs and every version that exists.
 What it cannot derive is where a deployment is going: which minor a deployment moves to next is a decision made by people, weighing what the release contains against what the site can absorb.
 
 Left unrecorded, that decision costs twice.
-Pre-upgrade migration testing has to guess, and guesses the newest published version, which is the right default and the wrong answer for a deployment deliberately moving to something older (see [RST](../public-server/restore-replicas.md)).
+Pre-upgrade migration testing has nothing to aim at, so a deployment gets no answer about its own data until it says where it is going (see [RST](../public-server/restore-replicas.md)).
 And nobody can see at a glance which deployments are mid-plan, which are overdue to move, and which have no plan at all.
 
 ## A plan
@@ -59,8 +59,8 @@ The record of what a deployment planned, when it planned it for, and when it act
 
 ## What reads a plan
 
-Pre-upgrade migration testing takes its target from the open plan when a group has one, and falls back to the newest published version when it does not.
-A deployment planning to move to an older minor is then tested against that minor, and no restore is spent on a version nobody intends to apply.
+Pre-upgrade migration testing takes its target from the open plan, and a group with no plan is not tested at all.
+Recording a plan is what asks for the testing, and no restore is spent on a version nobody intends to apply.
 
 A plan changes what is tested, so changing one invalidates nothing already recorded: earlier verdicts stand against the versions they named, and the new target simply becomes the one that has not been tested yet.
 

--- a/.workhorse/specs/public-server/restore-replicas.md
+++ b/.workhorse/specs/public-server/restore-replicas.md
@@ -222,15 +222,15 @@ Canopy knows the version each server reports running and the upgrade path it wou
 
 Canopy decides which versions are tested against which servers, rather than an operator naming each pair.
 
-A server's candidate is the version its group plans to move to, when a plan is open (see [UPG](../private-server/upgrade-plans.md)).
-Without a plan it is the newest published version the server could upgrade to: newer than the version it reports running, and on the upgrade path Canopy would serve it.
+A server's candidate is the version its group's open plan moves it to (see [UPG](../private-server/upgrade-plans.md)).
+A group with no open plan has no candidate, so none of its servers are tested.
+
+Recording a plan is what asks for the testing.
+A run costs hours of a consumer's capacity per server, and which minor a deployment moves to is not something Canopy can derive, so aiming at whatever is newest would spend that capacity on versions nobody has decided to take.
+A deployment that wants its data tested says where it is going, and gets an answer about the version it will actually apply.
 
 One candidate, not one per version along the path.
-Migrations are applied to the restored snapshot in sequence, so a run targeting the newest version applies every migration between the snapshot's version and that one, and exercises the whole chain an upgrade would.
-
-Which minor a deployment moves to is not something Canopy can derive, and testing every minor ahead of a server would cost a full restore each to cover the ones it does not choose.
-It does not need to: coverage accumulates on its own.
-Snapshots arrive daily and releases far less often, so every version is tested against a deployment's data while it is the newest, and a deployment that later settles on an older minor already has a result from when that version was current.
+Migrations are applied to the restored snapshot in sequence, so a run targeting the planned version applies every migration between the snapshot's version and that one, and exercises the whole chain an upgrade would.
 Where a chain does break, the failing migration named in the report identifies the step without a second run.
 
 Only a published version is a candidate, because a version's migrations reach a consumer as its published artefacts, and an unpublished version has none to fetch.
@@ -248,7 +248,7 @@ That window is where the answer is still cheap: the fleet is not moving yet, and
 It carries `check` alongside, so a single restore reports the replica's health and the migrations' outcome as two signals from one report.
 
 An intent carrying `migrate` is withheld from a server with no candidate version.
-An intent that verifies backups therefore does not also migrate: it would go undispatched for every server without a candidate, leaving the backups of any non-Tamanu product, and of any deployment already on the newest version available to it, unverified.
+An intent that verifies backups therefore does not also migrate: it would go undispatched for every server without a candidate, leaving the backups of any non-Tamanu product, and of every deployment with no plan open, unverified.
 An intent that keeps a replica queryable does not migrate either: a migrated replica sits at a version its deployment is not running, so a declaration promoted to it would give an operator a schema that does not match production.
 
 A verifying intent and a migrating intent restore the same snapshot separately.

--- a/crates/database/src/migration_tests.rs
+++ b/crates/database/src/migration_tests.rs
@@ -9,7 +9,6 @@ use commons_types::{
 	backup::{BackupType, RestoreIntent, RunOutcome},
 	server::product::Product,
 	status::CheckResult,
-	version::{VersionStatus, VersionStr},
 };
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -21,7 +20,6 @@ use crate::{
 	backup::refs,
 	issues::{CheckFiling, Scope, file_check},
 	pg_duration::PgDuration,
-	reported_detail::ReportedDetail,
 	restore::BackupRestoreCheck,
 	restore::NewBackupRestoreCheck,
 	servers::Server,
@@ -37,65 +35,25 @@ pub struct Candidate {
 	pub version_id: Uuid,
 }
 
-/// The newest published version `reported` could upgrade to, if any.
-///
-/// Stays within the reported major, matching the update path Canopy serves a
-/// server. One version rather than every step along the path: migrations run
-/// against the restored snapshot in sequence, so targeting the newest applies
-/// every migration in between and exercises the whole chain.
-// spec: RST#candidate-versions
-pub fn upgrade_target(reported: &VersionStr, versions: &[Version]) -> Option<Uuid> {
-	let current = &reported.0;
-
-	versions
-		.iter()
-		.filter(|version| {
-			version.status == VersionStatus::Published && version.major == current.major as i32
-		})
-		.filter(|version| {
-			version.minor > current.minor as i32
-				|| (version.minor == current.minor as i32 && version.patch > current.patch as i32)
-		})
-		.max_by_key(|version| (version.minor, version.patch))
-		.map(|version| version.id)
-}
-
 /// The version `server` should be tested against, if any.
 ///
-/// Its group's planned target where there is one (see [`crate::upgrade_plans`]),
-/// otherwise the newest published version it could upgrade to.
+/// Its group's open plan names it (see [`crate::upgrade_plans`]), and a group
+/// with no plan has no candidate: a restore costs hours, and it is only worth
+/// spending on a version a deployment has said it intends to apply.
 ///
 /// Tamanu servers only: the migrations under test are Tamanu's, so no other
-/// product's server has an upgrade path through them. `None` also when the
-/// server has never reported a version, or is already on the newest published
-/// one.
+/// product's server has an upgrade path through them.
 // spec: RST#candidate-versions
 pub async fn candidate_for(db: &mut AsyncPgConnection, server: &Server) -> Result<Option<Version>> {
 	if server.product != Product::Tamanu {
 		return Ok(None);
 	}
 
-	// Where the deployment says it is going beats where Canopy would guess: a
-	// group deliberately moving to an older minor is held against that minor,
-	// and no restore is spent on a version nobody intends to apply.
-	if let Some(group_id) = server.group_id
-		&& let Some(planned) = crate::upgrade_plans::planned_target(db, group_id).await?
-	{
-		return Ok(Some(planned));
-	}
-
-	let Some(reported) = ReportedDetail::last_version(db, server.id).await? else {
+	let Some(group_id) = server.group_id else {
 		return Ok(None);
 	};
 
-	let versions = Version::get_all(db).await?;
-	let Some(version_id) = upgrade_target(&reported, &versions) else {
-		return Ok(None);
-	};
-
-	Ok(versions
-		.into_iter()
-		.find(|version| version.id == version_id))
+	crate::upgrade_plans::planned_target(db, group_id).await
 }
 
 /// Every candidate across the fleet, at most one per server.
@@ -471,9 +429,9 @@ async fn file_outcome(
 
 /// Where every server in `group` stands against the version it would take next.
 ///
-/// One row per server that has a candidate at all: a server on the newest
-/// version, running another product, or yet to report one has nothing to be
-/// tested against and so nothing to show.
+/// One row per server that has a candidate at all: with no open plan, or
+/// running another product, there is nothing to be tested against and so
+/// nothing to show.
 // spec: RST#verdicts
 pub async fn verdicts_for_group(
 	db: &mut AsyncPgConnection,

--- a/crates/database/tests/it/migration_test_candidates.rs
+++ b/crates/database/tests/it/migration_test_candidates.rs
@@ -1,14 +1,11 @@
 //! Candidate derivation: which version a server is asked to be tested against.
-//! The newest published one it could upgrade to, within its major, and only for
-//! Tamanu servers that have reported a version.
+//! The version its group's open plan names, and only for Tamanu servers.
 
-use commons_types::{
-	server::product::Product,
-	version::{VersionStatus, VersionStr},
-};
+use commons_tests::db::TestDb;
+use commons_types::{server::product::Product, version::VersionStatus};
 use database::{
-	migration_tests::{Candidate, candidates, upgrade_target},
-	reported_detail::ReportedDetail,
+	migration_tests::{Candidate, candidates},
+	upgrade_plans::UpgradePlan,
 	versions::{NewVersion, Version},
 };
 use diesel::{QueryableByName, SelectableHelper, sql_query, sql_types};
@@ -21,23 +18,18 @@ struct RowId {
 	id: Uuid,
 }
 
-fn reported(text: &str) -> VersionStr {
-	text.parse().expect("parse reported version")
-}
-
-async fn add_version(
+async fn publish(
 	conn: &mut diesel_async::AsyncPgConnection,
 	major: i32,
 	minor: i32,
 	patch: i32,
-	status: VersionStatus,
 ) -> Version {
 	diesel::insert_into(database::schema::versions::table)
 		.values(NewVersion {
 			major,
 			minor,
 			patch,
-			status,
+			status: VersionStatus::Published,
 			changelog: String::new(),
 			device_id: None,
 		})
@@ -47,28 +39,25 @@ async fn add_version(
 		.expect("insert version")
 }
 
-async fn publish(
-	conn: &mut diesel_async::AsyncPgConnection,
-	major: i32,
-	minor: i32,
-	patch: i32,
-) -> Version {
-	add_version(conn, major, minor, patch, VersionStatus::Published).await
+async fn insert_group(conn: &mut diesel_async::AsyncPgConnection, name: &str) -> Uuid {
+	let group: RowId = sql_query("INSERT INTO server_groups (name) VALUES ($1) RETURNING id")
+		.bind::<sql_types::Text, _>(name)
+		.get_result(conn)
+		.await
+		.expect("group");
+	group.id
 }
 
 async fn insert_server(
 	conn: &mut diesel_async::AsyncPgConnection,
+	group: Uuid,
 	host: &str,
 	product: Product,
 ) -> Uuid {
-	let group: RowId = sql_query("INSERT INTO server_groups (name) VALUES ('kamaka') RETURNING id")
-		.get_result(conn)
-		.await
-		.expect("group");
 	let server: RowId =
 		sql_query("INSERT INTO servers (host, group_id, product) VALUES ($1, $2, $3) RETURNING id")
 			.bind::<sql_types::Text, _>(host)
-			.bind::<sql_types::Uuid, _>(group.id)
+			.bind::<sql_types::Uuid, _>(group)
 			.bind::<sql_types::Text, _>(product.to_string())
 			.get_result(conn)
 			.await
@@ -76,94 +65,123 @@ async fn insert_server(
 	server.id
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn the_newest_published_version_ahead_of_the_server() {
-	commons_tests::db::TestDb::run(async |mut conn, _url| {
-		publish(&mut conn, 2, 61, 0).await;
-		publish(&mut conn, 2, 62, 1).await;
-		publish(&mut conn, 2, 62, 4).await;
-		publish(&mut conn, 2, 63, 0).await;
-		let newest = publish(&mut conn, 2, 63, 2).await;
-		publish(&mut conn, 3, 0, 0).await;
-
-		let versions = Version::get_all(&mut conn).await.expect("versions");
-
-		assert_eq!(
-			upgrade_target(&reported("2.62.0"), &versions),
-			Some(newest.id),
-			"the newest patch of the newest minor, and nothing outside the major"
-		);
-	})
-	.await
+async fn plan(conn: &mut diesel_async::AsyncPgConnection, group: Uuid, target: &Version) {
+	UpgradePlan::record(conn, group, target.id, None, None, "someone@example.com")
+		.await
+		.expect("record plan");
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn a_newer_patch_of_the_current_minor_counts() {
-	commons_tests::db::TestDb::run(async |mut conn, _url| {
-		let patch = publish(&mut conn, 2, 62, 4).await;
-		let versions = Version::get_all(&mut conn).await.expect("versions");
-
-		assert_eq!(
-			upgrade_target(&reported("2.62.0"), &versions),
-			Some(patch.id),
-			"a patch upgrade is still an upgrade worth testing"
-		);
-	})
-	.await
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn a_server_on_the_newest_version_has_no_candidates() {
-	commons_tests::db::TestDb::run(async |mut conn, _url| {
-		publish(&mut conn, 2, 62, 0).await;
-		let versions = Version::get_all(&mut conn).await.expect("versions");
-
-		assert!(upgrade_target(&reported("2.62.0"), &versions).is_none());
-	})
-	.await
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn drafts_are_not_candidates_on_their_own() {
-	commons_tests::db::TestDb::run(async |mut conn, _url| {
-		let draft = add_version(&mut conn, 2, 63, 0, VersionStatus::Draft).await;
-
-		let all = Version::get_all_including_drafts(&mut conn)
-			.await
-			.expect("versions");
-		assert_ne!(
-			upgrade_target(&reported("2.62.0"), &all),
-			Some(draft.id),
-			"an unpublished version has no artefacts to fetch, so nothing to test"
-		);
-	})
-	.await
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn only_tamanu_servers_that_reported_a_version() {
-	commons_tests::db::TestDb::run(async |mut conn, _url| {
+async fn every_server_in_a_planned_group_is_a_candidate() {
+	TestDb::run(|mut conn, _url| async move {
 		let target = publish(&mut conn, 2, 63, 0).await;
+		let group = insert_group(&mut conn, "kamaka").await;
+		let central = insert_server(
+			&mut conn,
+			group,
+			"https://central.kamaka.example",
+			Product::Tamanu,
+		)
+		.await;
+		let facility = insert_server(
+			&mut conn,
+			group,
+			"https://facility.kamaka.example",
+			Product::Tamanu,
+		)
+		.await;
+		plan(&mut conn, group, &target).await;
 
-		let tamanu =
-			insert_server(&mut conn, "https://central.kamaka.example", Product::Tamanu).await;
-		let senaite =
-			insert_server(&mut conn, "https://lims.kamaka.example", Product::Senaite).await;
-		let silent =
-			insert_server(&mut conn, "https://quiet.kamaka.example", Product::Tamanu).await;
+		let mut found = candidates(&mut conn).await.expect("candidates");
+		found.sort_by_key(|c| c.server_id);
+		let mut want = vec![
+			Candidate {
+				server_id: central,
+				version_id: target.id,
+			},
+			Candidate {
+				server_id: facility,
+				version_id: target.id,
+			},
+		];
+		want.sort_by_key(|c| c.server_id);
 
-		let running = reported("2.62.0");
-		for server in [tamanu, senaite] {
-			ReportedDetail::record(
-				&mut conn,
-				server,
-				"test",
-				&serde_json::json!({}),
-				Some(&running),
-			)
+		assert_eq!(found, want, "the plan covers the whole deployment");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_group_with_no_plan_has_no_candidates() {
+	TestDb::run(|mut conn, _url| async move {
+		publish(&mut conn, 2, 63, 0).await;
+		let group = insert_group(&mut conn, "drifting").await;
+		insert_server(
+			&mut conn,
+			group,
+			"https://central.drifting.example",
+			Product::Tamanu,
+		)
+		.await;
+
+		assert!(
+			candidates(&mut conn).await.expect("candidates").is_empty(),
+			"a restore costs hours, and nobody has said this deployment is moving"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_withdrawn_plan_stops_the_testing() {
+	TestDb::run(|mut conn, _url| async move {
+		let target = publish(&mut conn, 2, 63, 0).await;
+		let group = insert_group(&mut conn, "kamaka").await;
+		insert_server(
+			&mut conn,
+			group,
+			"https://central.kamaka.example",
+			Product::Tamanu,
+		)
+		.await;
+		plan(&mut conn, group, &target).await;
+
+		let open = UpgradePlan::open_for_group(&mut conn, group)
 			.await
-			.expect("record detail");
-		}
+			.expect("open plan")
+			.expect("a plan is open");
+		UpgradePlan::withdraw(&mut conn, open.id, "someone@example.com")
+			.await
+			.expect("withdraw");
+
+		assert!(
+			candidates(&mut conn).await.expect("candidates").is_empty(),
+			"the deployment stopped going there, so there is nothing to hold its data against"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn only_tamanu_servers() {
+	TestDb::run(|mut conn, _url| async move {
+		let target = publish(&mut conn, 2, 63, 0).await;
+		let group = insert_group(&mut conn, "kamaka").await;
+		let tamanu = insert_server(
+			&mut conn,
+			group,
+			"https://central.kamaka.example",
+			Product::Tamanu,
+		)
+		.await;
+		let senaite = insert_server(
+			&mut conn,
+			group,
+			"https://lims.kamaka.example",
+			Product::Senaite,
+		)
+		.await;
+		plan(&mut conn, group, &target).await;
 
 		let found = candidates(&mut conn).await.expect("candidates");
 
@@ -177,10 +195,6 @@ async fn only_tamanu_servers_that_reported_a_version() {
 		assert!(
 			!found.iter().any(|c| c.server_id == senaite),
 			"another product has no path through Tamanu's migrations"
-		);
-		assert!(
-			!found.iter().any(|c| c.server_id == silent),
-			"nothing to compare against without a reported version"
 		);
 	})
 	.await

--- a/crates/database/tests/it/migration_test_reports.rs
+++ b/crates/database/tests/it/migration_test_reports.rs
@@ -452,6 +452,19 @@ async fn record_snapshot(
 	.expect("record backup run");
 }
 
+/// The group's open plan, which is what names the version to migrate to.
+async fn plan_upgrade(conn: &mut AsyncPgConnection, group: Uuid, target: &Version) {
+	sql_query(
+		"INSERT INTO upgrade_plans (group_id, target_version_id, created_by)
+		 VALUES ($1, $2, 'test@example.com')",
+	)
+	.bind::<sql_types::Uuid, _>(group)
+	.bind::<sql_types::Uuid, _>(target.id)
+	.execute(conn)
+	.await
+	.expect("plan upgrade");
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn an_untried_candidate_goes_overdue_and_a_tested_one_does_not() {
 	TestDb::run(|mut conn, _url| async move {
@@ -459,16 +472,7 @@ async fn an_untried_candidate_goes_overdue_and_a_tested_one_does_not() {
 		let group = insert_group(&mut conn).await;
 		let server = insert_server(&mut conn, group).await;
 		let target = insert_version(&mut conn, 63).await;
-		let running: commons_types::version::VersionStr = "2.62.0".parse().expect("parse");
-		database::reported_detail::ReportedDetail::record(
-			&mut conn,
-			server,
-			"test",
-			&serde_json::json!({}),
-			Some(&running),
-		)
-		.await
-		.expect("report version");
+		plan_upgrade(&mut conn, group, &target).await;
 		declare_migrate(&mut conn, consumer, group, 3600).await;
 		record_snapshot(&mut conn, consumer, group, server, "snap-old", 7200).await;
 
@@ -518,27 +522,8 @@ async fn a_group_shows_where_each_server_stands() {
 		let group = insert_group(&mut conn).await;
 		let tested = insert_server(&mut conn, group).await;
 		let untested = insert_server(&mut conn, group).await;
-		let current = insert_server(&mut conn, group).await;
 		let target = insert_version(&mut conn, 63).await;
-
-		let behind: commons_types::version::VersionStr = "2.62.0".parse().expect("parse");
-		let newest: commons_types::version::VersionStr = "2.63.0".parse().expect("parse");
-		for (server, running) in [
-			(tested, &behind),
-			(untested, &behind),
-			// Already on the newest published version, so nothing to test.
-			(current, &newest),
-		] {
-			database::reported_detail::ReportedDetail::record(
-				&mut conn,
-				server,
-				"test",
-				&serde_json::json!({}),
-				Some(running),
-			)
-			.await
-			.expect("report version");
-		}
+		plan_upgrade(&mut conn, group, &target).await;
 
 		let mut failing = report(consumer, group, tested, RunOutcome::Success);
 		failing.snapshot_id = Some("snap-1".into());
@@ -561,7 +546,7 @@ async fn a_group_shows_where_each_server_stands() {
 			.await
 			.expect("verdicts");
 
-		assert_eq!(verdicts.len(), 2, "the up-to-date server has no row");
+		assert_eq!(verdicts.len(), 2, "one row per server the plan covers");
 		let by_server: std::collections::HashMap<Uuid, _> =
 			verdicts.into_iter().map(|v| (v.server_id, v)).collect();
 

--- a/crates/database/tests/it/upgrade_plans.rs
+++ b/crates/database/tests/it/upgrade_plans.rs
@@ -83,19 +83,19 @@ async fn group_running(conn: &mut AsyncPgConnection, running: &str) -> (Uuid, Se
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn a_plan_overrides_the_newest_version_as_the_test_target() {
+async fn a_plan_is_what_makes_a_version_the_test_target() {
 	TestDb::run(|mut conn, _url| async move {
 		let (group, server) = group_running(&mut conn, "2.60.0").await;
 		let intended = publish(&mut conn, 61, 2).await;
-		let newest = publish(&mut conn, 63, 0).await;
+		publish(&mut conn, 63, 0).await;
 
-		// With no plan, testing aims at the newest published version.
 		assert_eq!(
 			candidate_for(&mut conn, &server)
 				.await
 				.expect("candidate")
 				.map(|v| v.id),
-			Some(newest.id),
+			None,
+			"a newer version existing is not a reason to spend a restore on it"
 		);
 
 		UpgradePlan::record(
@@ -109,14 +109,13 @@ async fn a_plan_overrides_the_newest_version_as_the_test_target() {
 		.await
 		.expect("record plan");
 
-		// With one, it aims where the deployment says it is going.
 		assert_eq!(
 			candidate_for(&mut conn, &server)
 				.await
 				.expect("candidate")
 				.map(|v| v.id),
 			Some(intended.id),
-			"no restore is spent on a version nobody intends to apply"
+			"testing aims where the deployment says it is going"
 		);
 	})
 	.await

--- a/crates/private-server/src/fns/migration_tests.rs
+++ b/crates/private-server/src/fns/migration_tests.rs
@@ -24,9 +24,9 @@ pub struct ForGroupArgs {
 /// Where each of a group's servers stands against the version it would take
 /// next.
 ///
-/// One entry per server that has a candidate version. A server already on the
-/// newest published version, running another product, or yet to report a
-/// version has nothing to be tested against and is absent.
+/// One entry per server that has a candidate version, which is the version its
+/// group's open plan names. A group with no plan, and a server running another
+/// product, have nothing to be tested against and are absent.
 // spec: RST#verdicts
 #[utoipa::path(
 	post,

--- a/crates/private-server/tests/it/mcp.rs
+++ b/crates/private-server/tests/it/mcp.rs
@@ -1086,8 +1086,8 @@ async fn upgrade_plans_list_the_open_ones_and_keep_the_withdrawn_in_history() {
 		assert_eq!(plans[0]["late"], true, "the planned day has passed unmet");
 		assert_eq!(plans[0]["note"], "site can absorb 2.36 only");
 
-		// A group with nothing recorded is what testing aims at the newest
-		// version for, so it is returned rather than omitted.
+		// A group with nothing recorded gets no pre-upgrade testing, so it is
+		// returned rather than omitted.
 		let unplanned = list["groups_without_a_plan"]
 			.as_array()
 			.expect("unplanned groups");

--- a/crates/private-server/tests/it/migration_tests.rs
+++ b/crates/private-server/tests/it/migration_tests.rs
@@ -5,27 +5,32 @@ use commons_tests::diesel_async::SimpleAsyncConnection;
 use serde_json::{Value, json};
 
 const GROUP: &str = "bbbbbbbb-0000-0000-0000-000000000001";
-const BEHIND: &str = "bbbbbbbb-0000-0000-0000-0000000000a0";
-const CURRENT: &str = "bbbbbbbb-0000-0000-0000-0000000000b0";
+const CENTRAL: &str = "bbbbbbbb-0000-0000-0000-0000000000a0";
+const FACILITY: &str = "bbbbbbbb-0000-0000-0000-0000000000b0";
+
+const FLEET: &str = "INSERT INTO versions (major, minor, patch, changelog, status)
+		VALUES (2, 62, 0, 'x', 'published'), (2, 63, 0, 'x', 'published');
+	INSERT INTO server_groups (id, name)
+		VALUES ('bbbbbbbb-0000-0000-0000-000000000001', 'Kamaka');
+	INSERT INTO servers (id, name, host, kind, group_id) VALUES
+		('bbbbbbbb-0000-0000-0000-0000000000a0', 'central',
+		 'https://central.example.com', 'central',
+		 'bbbbbbbb-0000-0000-0000-000000000001'),
+		('bbbbbbbb-0000-0000-0000-0000000000b0', 'facility',
+		 'https://facility.example.com', 'facility',
+		 'bbbbbbbb-0000-0000-0000-000000000001');
+	INSERT INTO server_reported_detail (server_id, source, extra, version) VALUES
+		('bbbbbbbb-0000-0000-0000-0000000000a0', 'test', '{}'::jsonb, '2.62.0'),
+		('bbbbbbbb-0000-0000-0000-0000000000b0', 'test', '{}'::jsonb, '2.62.0');";
 
 #[tokio::test(flavor = "multi_thread")]
-async fn for_group_reports_a_verdict_per_candidate() {
+async fn for_group_reports_a_verdict_per_server() {
 	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(FLEET).await.unwrap();
 		conn.batch_execute(
-			"INSERT INTO versions (major, minor, patch, changelog, status)
-				VALUES (2, 62, 0, 'x', 'published'), (2, 63, 0, 'x', 'published');
-			INSERT INTO server_groups (id, name)
-				VALUES ('bbbbbbbb-0000-0000-0000-000000000001', 'Kamaka');
-			INSERT INTO servers (id, name, host, kind, group_id) VALUES
-				('bbbbbbbb-0000-0000-0000-0000000000a0', 'behind',
-				 'https://behind.example.com', 'central',
-				 'bbbbbbbb-0000-0000-0000-000000000001'),
-				('bbbbbbbb-0000-0000-0000-0000000000b0', 'current',
-				 'https://current.example.com', 'facility',
-				 'bbbbbbbb-0000-0000-0000-000000000001');
-			INSERT INTO server_reported_detail (server_id, source, extra, version) VALUES
-				('bbbbbbbb-0000-0000-0000-0000000000a0', 'test', '{}'::jsonb, '2.62.0'),
-				('bbbbbbbb-0000-0000-0000-0000000000b0', 'test', '{}'::jsonb, '2.63.0');",
+			"INSERT INTO upgrade_plans (group_id, target_version_id, created_by)
+				SELECT 'bbbbbbbb-0000-0000-0000-000000000001', id, 'test@example.com'
+				FROM versions WHERE major = 2 AND minor = 63 AND patch = 0;",
 		)
 		.await
 		.unwrap();
@@ -39,18 +44,37 @@ async fn for_group_reports_a_verdict_per_candidate() {
 
 		assert_eq!(
 			verdicts.len(),
-			1,
-			"only the server with somewhere to upgrade to: got {verdicts:?}"
+			2,
+			"the plan covers the whole deployment: got {verdicts:?}"
 		);
-		assert_eq!(verdicts[0]["server_id"], BEHIND);
-		assert_eq!(verdicts[0]["target_version"], "2.63.0");
-		assert_eq!(verdicts[0]["verdict"], "nottested");
-		assert!(verdicts[0]["latest"].is_null());
+		for id in [CENTRAL, FACILITY] {
+			let entry = verdicts
+				.iter()
+				.find(|v| v["server_id"] == id)
+				.unwrap_or_else(|| panic!("no entry for {id}: {verdicts:?}"));
+			assert_eq!(entry["target_version"], "2.63.0");
+			assert_eq!(entry["verdict"], "nottested");
+			assert!(entry["latest"].is_null());
+		}
+	})
+	.await;
+}
 
-		let current_absent = verdicts.iter().all(|v| v["server_id"] != CURRENT);
+#[tokio::test(flavor = "multi_thread")]
+async fn for_group_reports_nothing_without_a_plan() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(FLEET).await.unwrap();
+
+		let resp = private
+			.post("/api/migration_tests/for_group")
+			.json(&json!({ "group_id": GROUP }))
+			.await;
+		resp.assert_status_ok();
+		let verdicts: Vec<Value> = resp.json();
+
 		assert!(
-			current_absent,
-			"a server already on the newest version has nothing to test"
+			verdicts.is_empty(),
+			"a newer version existing is not what asks for a test: {verdicts:?}"
 		);
 	})
 	.await;

--- a/crates/public-server/tests/it/restore.rs
+++ b/crates/public-server/tests/it/restore.rs
@@ -842,6 +842,19 @@ async fn report_version(conn: &mut AsyncPgConnection, server_id: Uuid, version: 
 	.expect("report version");
 }
 
+/// The group's open plan, which is what names the version to migrate to.
+async fn plan_upgrade(conn: &mut AsyncPgConnection, group: Uuid, version_id: Uuid) {
+	sql_query(
+		"INSERT INTO upgrade_plans (group_id, target_version_id, created_by)
+		 VALUES ($1, $2, 'test@example.com')",
+	)
+	.bind::<sql_types::Uuid, _>(group)
+	.bind::<sql_types::Uuid, _>(version_id)
+	.execute(conn)
+	.await
+	.expect("plan upgrade");
+}
+
 /// One intent that both verifies the restore and applies the migrations: the
 /// `migrate` semantic rides on the verifying intent so a single restore answers
 /// both questions.
@@ -857,7 +870,7 @@ async fn register_migrate_intent(public: &axum_test::TestServer, cert: &str) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn a_migrate_entry_names_the_newest_version_the_server_could_take() {
+async fn a_migrate_entry_names_the_planned_version() {
 	commons_tests::server::run_with_device_auth(
 		"backup-restore",
 		async |mut conn, cert, device_id, public, _| {
@@ -867,7 +880,8 @@ async fn a_migrate_entry_names_the_newest_version_the_server_could_take() {
 			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
 			report_version(&mut conn, server, "2.62.0").await;
 			publish_version(&mut conn, 62, 0).await;
-			let newest = publish_version(&mut conn, 63, 2).await;
+			let planned = publish_version(&mut conn, 63, 2).await;
+			plan_upgrade(&mut conn, group, planned).await;
 			declare_replica(&mut conn, device_id, group, "verify").await;
 			register_migrate_intent(&public, &cert).await;
 
@@ -880,7 +894,7 @@ async fn a_migrate_entry_names_the_newest_version_the_server_could_take() {
 
 			assert_eq!(entries.len(), 1, "got {entries:?}");
 			assert_eq!(entries[0]["target_version"], "2.63.2");
-			assert_eq!(entries[0]["target_version_id"], newest.to_string());
+			assert_eq!(entries[0]["target_version_id"], planned.to_string());
 			assert_eq!(entries[0]["snapshot_id"], "snap-1");
 		},
 	)
@@ -888,7 +902,7 @@ async fn a_migrate_entry_names_the_newest_version_the_server_could_take() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn a_server_already_on_the_newest_version_gets_no_migrate_entry() {
+async fn a_group_with_no_plan_gets_no_migrate_entry() {
 	commons_tests::server::run_with_device_auth(
 		"backup-restore",
 		async |mut conn, cert, device_id, public, _| {
@@ -896,7 +910,7 @@ async fn a_server_already_on_the_newest_version_gets_no_migrate_entry() {
 			make_config(&mut conn, group, "ready").await;
 			let server = make_server(&mut conn, group).await;
 			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
-			report_version(&mut conn, server, "2.63.2").await;
+			report_version(&mut conn, server, "2.62.0").await;
 			publish_version(&mut conn, 63, 2).await;
 			declare_replica(&mut conn, device_id, group, "verify").await;
 			register_migrate_intent(&public, &cert).await;
@@ -910,7 +924,7 @@ async fn a_server_already_on_the_newest_version_gets_no_migrate_entry() {
 
 			assert!(
 				entries.is_empty(),
-				"nothing to migrate to, so no entry: got {entries:?}"
+				"nobody has said this deployment is moving, so no entry: got {entries:?}"
 			);
 		},
 	)
@@ -927,7 +941,8 @@ async fn a_failed_verdict_settles_the_snapshot_and_version_pair() {
 			let server = make_server(&mut conn, group).await;
 			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
 			report_version(&mut conn, server, "2.62.0").await;
-			let newest = publish_version(&mut conn, 63, 2).await;
+			let planned = publish_version(&mut conn, 63, 2).await;
+			plan_upgrade(&mut conn, group, planned).await;
 			declare_replica(&mut conn, device_id, group, "verify").await;
 			register_migrate_intent(&public, &cert).await;
 
@@ -969,7 +984,7 @@ async fn a_failed_verdict_settles_the_snapshot_and_version_pair() {
 					redaction_error: None,
 				},
 				database::migration_tests::NewMigrationTest {
-					target_version_id: newest,
+					target_version_id: planned,
 					total_elapsed: database::pg_duration::PgDuration(
 						jiff::SignedDuration::from_secs(30),
 					),
@@ -1006,7 +1021,8 @@ async fn a_reported_migration_test_lands_and_settles_the_entry() {
 			let server = make_server(&mut conn, group).await;
 			make_success_run(&mut conn, device_id, group, server, "snap-1").await;
 			report_version(&mut conn, server, "2.62.0").await;
-			let newest = publish_version(&mut conn, 63, 2).await;
+			let planned = publish_version(&mut conn, 63, 2).await;
+			plan_upgrade(&mut conn, group, planned).await;
 			declare_replica(&mut conn, device_id, group, "verify").await;
 			register_migrate_intent(&public, &cert).await;
 
@@ -1049,7 +1065,7 @@ async fn a_reported_migration_test_lands_and_settles_the_entry() {
 
 			// The verdict is readable, and the timings survived the round trip.
 			assert_eq!(
-				database::migration_tests::verdict(&mut conn, server, newest)
+				database::migration_tests::verdict(&mut conn, server, planned)
 					.await
 					.expect("verdict"),
 				database::migration_tests::Verdict::Passed

--- a/private-web/e2e/migration-tests.spec.ts
+++ b/private-web/e2e/migration-tests.spec.ts
@@ -6,6 +6,7 @@ import {
 	seedServer,
 	seedServerGroup,
 	seedStatus,
+	seedUpgradePlan,
 	seedVersion,
 } from "./seed";
 
@@ -34,6 +35,10 @@ test.describe("pre-upgrade migration tests on the group page", () => {
 		for (const server of [failed, untested]) {
 			await seedStatus(sql, { serverId: server.id, version: "2.62.0" });
 		}
+		await seedUpgradePlan(sql, {
+			groupId: group.id,
+			targetVersionId: target.id,
+		});
 
 		// One server has been tried and its migrations failed; the other has not
 		// been tried yet.
@@ -72,17 +77,17 @@ test.describe("pre-upgrade migration tests on the group page", () => {
 		await expect(untestedRow).toContainText("not yet tested");
 	});
 
-	test("says so when every server is already on the newest version", async ({
+	test("says so when the deployment has no open plan", async ({
 		page,
 		sql,
 	}) => {
-		const group = await seedServerGroup(sql, { name: "current" });
+		const group = await seedServerGroup(sql, { name: "unplanned" });
 		await seedVersion(sql, { major: 2, minor: 63, patch: 0 });
 		const server = await seedServer(sql, {
-			name: "up-to-date",
+			name: "unplanned-central",
 			groupId: group.id,
 		});
-		await seedStatus(sql, { serverId: server.id, version: "2.63.0" });
+		await seedStatus(sql, { serverId: server.id, version: "2.62.0" });
 
 		await page.goto(`/groups/${group.id}`);
 

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -101,8 +101,7 @@ test.describe("upgrades dashboard", () => {
 			.getByRole("button", { name: "Withdraw kamaka's plan" })
 			.click();
 
-		// Withdrawn, so it moves to the unplanned list and testing goes back to
-		// aiming at the newest version.
+		// Withdrawn, so it moves to the unplanned list and stops being tested.
 		await expect(
 			page
 				.getByTestId("unplanned-upgrade-row")

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4631,7 +4631,7 @@
           "migration_tests"
         ],
         "summary": "Where each of a group's servers stands against the version it would take\nnext.",
-        "description": "One entry per server that has a candidate version. A server already on the\nnewest published version, running another product, or yet to report a\nversion has nothing to be tested against and is absent.",
+        "description": "One entry per server that has a candidate version, which is the version its\ngroup's open plan names. A group with no plan, and a server running another\nproduct, have nothing to be tested against and are absent.",
         "operationId": "migration_tests_for_group",
         "requestBody": {
           "content": {

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2337,9 +2337,9 @@ export interface paths {
         /**
          * Where each of a group's servers stands against the version it would take
          *     next.
-         * @description One entry per server that has a candidate version. A server already on the
-         *     newest published version, running another product, or yet to report a
-         *     version has nothing to be tested against and is absent.
+         * @description One entry per server that has a candidate version, which is the version its
+         *     group's open plan names. A group with no plan, and a server running another
+         *     product, have nothing to be tested against and are absent.
          */
         post: operations["migration_tests_for_group"];
         delete?: never;

--- a/private-web/src/components/MigrationTestsSection.tsx
+++ b/private-web/src/components/MigrationTestsSection.tsx
@@ -62,8 +62,8 @@ export default function MigrationTestsSection({
 			<Paper variant="outlined" sx={{ p: 2 }} data-testid="migration-tests">
 				<SectionHeading />
 				<Typography variant="body2" color="text.secondary">
-					Every server here is on the newest version it can take, so there is
-					nothing to test against.
+					No upgrade plan is open for this deployment, so there is nothing to
+					test against.
 				</Typography>
 			</Paper>
 		);

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -148,7 +148,8 @@ export default function Upgrades() {
 						No plan recorded
 					</Typography>
 					<Typography variant="body2" color="text.secondary">
-						pre-upgrade testing aims at the newest version for these
+						these get no pre-upgrade testing until a plan says where they are
+						going
 					</Typography>
 				</Stack>
 				{unplanned.length === 0 ? (
@@ -572,7 +573,7 @@ function WithdrawPlan({
 	const onClick = async () => {
 		if (
 			!window.confirm(
-				`Withdraw ${groupName}'s plan to move to ${targetVersion}? Pre-upgrade testing goes back to aiming at the newest version.`,
+				`Withdraw ${groupName}'s plan to move to ${targetVersion}? Pre-upgrade testing stops for this deployment until a new plan is recorded.`,
 			)
 		)
 			return;


### PR DESCRIPTION
Pre-upgrade migration testing aimed at the newest published version for any group with no plan. A `migrate` declaration on such a group would spend a full restore plus migration run, hours per server, on a version nobody has decided to take.

Now the group's open plan is the only source of a candidate: no plan, no candidate, no worklist entry, no verdict row. Recording a plan is what asks for the testing.

Two things a reviewer might read as mistakes:

- The plan applies to every server in the group, including one already running the target version. That was already the behaviour wherever a plan existed, since the plan branch never looked at what a server reports running. It is just more visible now that the plan is the only path, and it costs a redundant restore for a server that is already there.
- `upgrade_target` is deleted rather than kept behind the new rule. It had one caller.

Nothing in the fleet changes today: no registered consumer advertises a `migrate` semantic, so no migrate entry has ever been dispatched and `migration_tests` is empty.

Copy follows the rule. The Upgrades page's "No plan recorded" section now says those deployments get no testing until a plan says where they are going, and withdrawing a plan warns that testing stops rather than falling back.
