### PR TITLE
fix(backup): reconcile-missing is about one server, not its group

### DIFF
--- a/.workhorse/specs/jobs/backup.md
+++ b/.workhorse/specs/jobs/backup.md
@@ -70,8 +70,12 @@ Canopy reconciles three sources — what a device reported, what credentials wer
 
 Backup alerts are raised at one of two scopes:
 
-- **Per-server** signals (staleness, never-backed-up, the report-gap, the size discrepancy) are subject to the server's monitoring gate: still recorded for visibility, but they contribute to an incident only when the server is monitored, because some servers are intentionally intermittent.
-- **Group-level** signals (repo corruption, maintenance failure, missing-snapshot reconciliation, preflight failures, and restore-verification — see the managed restore replicas spec, `RST`) page regardless of any member's monitoring state, because they are control-plane or data-safety concerns that belong to no single server.
+- **Per-server** signals (staleness, never-backed-up, the report-gap, the size discrepancy, the missing-snapshot reconciliation, and restore-verification — see the managed restore replicas spec, `RST`) are subject to the server's monitoring gate: still recorded for visibility, but they contribute to an incident only when the server is monitored, because some servers are intentionally intermittent.
+- **Group-level** signals (repo corruption, maintenance failure, preflight failures) page regardless of any member's monitoring state, because they are control-plane concerns that belong to no single server.
+
+A signal about one server is raised against that server, even when the condition it detects is a disagreement between the device's report and the group's repository.
+Two servers in a group failing the same check hold two separate alerts, and one server's recovery never clears another's.
 
 Each signal has a stable key by which operators silence or snooze it and by which the interface and notifications refer to it; the keys are a contract and are not renamed without migrating stored silences.
+Where an alert's text names the server it concerns, it names it the way an operator knows it, falling back to an identifier only when the server has neither a name nor a host.
 A signal recovers when the condition that raised it clears.

--- a/crates/database/src/backup/reconcile.rs
+++ b/crates/database/src/backup/reconcile.rs
@@ -6,9 +6,12 @@
 //! `backup_repo_snapshots`:
 //!
 //! - **report success but no recent snapshot** → `backup-reconcile-missing`
-//!   (`Error`, group-level, pages regardless of monitored). The case the
-//!   reports alone cannot catch — a device lying about success or data not
-//!   persisting.
+//!   (`Error`, per-server). The case the reports alone cannot catch — a device
+//!   lying about success or data not persisting. Detecting it needs the
+//!   group's repo inventory, but the finding is about the one server whose
+//!   report didn't hold up, so it is filed against that server: two servers in
+//!   a group can fail it independently, and one recovering must not clear the
+//!   other.
 //! - **recent snapshot but no report** → `backup-reconcile-report-gap`
 //!   (`Warning`, per-server, non-paging). The reporting path is broken, not
 //!   the backup.
@@ -87,6 +90,20 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 		}
 	}
 
+	// How each scanned server is named in alert text, resolved in one query
+	// rather than per finding.
+	let labels: HashMap<Uuid, String> = {
+		let ids: Vec<Uuid> = {
+			let mut s: std::collections::HashSet<Uuid> = rows.iter().map(|r| r.server_id).collect();
+			s.drain().collect()
+		};
+		Server::get_by_ids(db, &ids)
+			.await?
+			.iter()
+			.map(|s| (s.id, crate::backup::staleness::server_label(s)))
+			.collect()
+	};
+
 	// Latest comparable (reported, observed) sizes per (server, type). A server
 	// belongs to one group, so keys don't collide across groups.
 	let mut sized: HashMap<(Uuid, BackupType), (i64, i64)> = HashMap::new();
@@ -113,6 +130,12 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 
 		let missing_ref = format!("{}:{}", refs::RECONCILE_MISSING, row.r#type);
 		let gap_ref = format!("{}:{}", refs::RECONCILE_REPORT_GAP, row.r#type);
+		// A scanned server always exists (the scan joins servers), so the
+		// fallback is unreachable in practice — it just avoids a panic path.
+		let label = labels
+			.get(&row.server_id)
+			.cloned()
+			.unwrap_or_else(|| row.server_id.to_string());
 
 		match (report_fresh, snapshot_fresh) {
 			// Report says success but the data didn't land (or its row is
@@ -123,18 +146,17 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 					db,
 					CheckFiling {
 						source: crate::statuses::CANOPY_SOURCE,
-						scope: Scope::Group(row.group_id),
-						device_id: None,
+						scope: Scope::Server(row.server_id),
+						device_id: row.device_id,
 						check: &missing_ref,
 						observed: CheckResult::Failed,
 						title: None,
 						message: &format!(
-							"Server {} reported a successful {} backup but no matching repo snapshot landed",
-							row.server_id, row.r#type,
+							"Server {label} reported a successful {} backup but no matching repo snapshot landed",
+							row.r#type,
 						),
 						detail: Some(serde_json::json!({
 							"type": row.r#type.to_string(),
-							"server_id": row.server_id,
 						})),
 						default_ceiling: CheckResult::Failed,
 						default_escalates: false,
@@ -146,19 +168,24 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 			}
 			// Both agree it's fine → clear any open missing alert.
 			(true, true) => {
-				if open_group_active(db, row.group_id, &missing_ref).await? {
+				if crate::backup::staleness::open_server_issue_active(
+					db,
+					row.server_id,
+					&missing_ref,
+				)
+				.await?
+				{
 					file_check(
 						db,
 						CheckFiling {
 							source: crate::statuses::CANOPY_SOURCE,
-							scope: Scope::Group(row.group_id),
-							device_id: None,
+							scope: Scope::Server(row.server_id),
+							device_id: row.device_id,
 							check: &missing_ref,
 							observed: CheckResult::Passed,
 							title: None,
 							message: &format!(
-								"Server {} backup report and repo snapshot agree again",
-								row.server_id
+								"Server {label} backup report and repo snapshot agree again"
 							),
 							detail: None,
 							default_ceiling: CheckResult::Failed,
@@ -169,12 +196,11 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 					.await?;
 					filed += 1;
 				}
-				filed += clear_report_gap(db, row, &gap_ref).await?;
+				filed += clear_report_gap(db, row, &label, &gap_ref).await?;
 			}
 			// Snapshot landed but no recent report → the reporting path is
 			// broken. Per-server warning (non-paging).
 			(false, true) => {
-				let server = Server::get_by_id(db, row.server_id).await?;
 				file_check(
 					db,
 					CheckFiling {
@@ -185,8 +211,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 						observed: CheckResult::Warning,
 						title: None,
 						message: &format!(
-							"A fresh {} repo snapshot exists for {} but no backup run was reported",
-							row.r#type, server.id,
+							"A fresh {} repo snapshot exists for {label} but no backup run was reported",
+							row.r#type,
 						),
 						detail: Some(serde_json::json!({
 							"type": row.r#type.to_string(),
@@ -202,7 +228,7 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 			// Neither fresh → the staleness scan owns it; clear stale reconcile
 			// alerts.
 			(false, false) => {
-				filed += clear_report_gap(db, row, &gap_ref).await?;
+				filed += clear_report_gap(db, row, &label, &gap_ref).await?;
 			}
 			// (true, false) but the repo inventory is stale: skip the missing
 			// verdict.
@@ -214,7 +240,6 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 		let size_ref = format!("{}:{}", refs::RECONCILE_SIZE_MISMATCH, row.r#type);
 		match sized.get(&(row.server_id, row.r#type.clone())) {
 			Some(&(reported, observed)) if reported != observed => {
-				let server = Server::get_by_id(db, row.server_id).await?;
 				file_check(
 					db,
 					CheckFiling {
@@ -225,8 +250,8 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 						observed: CheckResult::Warning,
 						title: None,
 						message: &format!(
-							"Server {} reported a {} snapshot size of {reported} bytes but the repo holds {observed}",
-							server.id, row.r#type,
+							"Server {label} reported a {} snapshot size of {reported} bytes but the repo holds {observed}",
+							row.r#type,
 						),
 						detail: Some(serde_json::json!({
 							"type": row.r#type.to_string(),
@@ -243,7 +268,7 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 			}
 			// Agree, or no comparable run → clear any open mismatch.
 			_ => {
-				filed += clear_size_mismatch(db, row, &size_ref).await?;
+				filed += clear_size_mismatch(db, row, &label, &size_ref).await?;
 			}
 		}
 	}
@@ -255,6 +280,7 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 async fn clear_size_mismatch(
 	db: &mut AsyncPgConnection,
 	row: &ScanRow,
+	label: &str,
 	size_ref: &str,
 ) -> Result<usize> {
 	if !crate::backup::staleness::open_server_issue_active(db, row.server_id, size_ref).await? {
@@ -270,8 +296,8 @@ async fn clear_size_mismatch(
 			observed: CheckResult::Passed,
 			title: None,
 			message: &format!(
-				"Reported and repo {} snapshot sizes for {} agree again",
-				row.r#type, row.server_id
+				"Reported and repo {} snapshot sizes for {label} agree again",
+				row.r#type
 			),
 			detail: None,
 			default_ceiling: CheckResult::Warning,
@@ -288,6 +314,7 @@ async fn clear_size_mismatch(
 async fn clear_report_gap(
 	db: &mut AsyncPgConnection,
 	row: &ScanRow,
+	label: &str,
 	gap_ref: &str,
 ) -> Result<usize> {
 	if !crate::backup::staleness::open_server_issue_active(db, row.server_id, gap_ref).await? {
@@ -302,10 +329,7 @@ async fn clear_report_gap(
 			check: gap_ref,
 			observed: CheckResult::Passed,
 			title: None,
-			message: &format!(
-				"Backup reporting for {} ({}) recovered",
-				row.server_id, row.r#type
-			),
+			message: &format!("Backup reporting for {label} ({}) recovered", row.r#type),
 			detail: None,
 			default_ceiling: CheckResult::Warning,
 			default_escalates: false,
@@ -314,14 +338,6 @@ async fn clear_report_gap(
 	)
 	.await?;
 	Ok(1)
-}
-
-async fn open_group_active(
-	db: &mut AsyncPgConnection,
-	group_id: Uuid,
-	r#ref: &str,
-) -> Result<bool> {
-	crate::backup::staleness::open_group_issue_active(db, group_id, r#ref).await
 }
 
 /// Raw snapshot row: `(server_id, type, latest_snapshot_at, observed_at)`.

--- a/crates/database/src/backup/refs.rs
+++ b/crates/database/src/backup/refs.rs
@@ -32,6 +32,12 @@ pub const RECONCILE_REPORT_GAP: &str = "backup-reconcile-report-gap";
 /// non-zero). Server-scoped, `Warning` (non-paging on its own).
 pub const RECONCILE_SIZE_MISMATCH: &str = "backup-reconcile-size-mismatch";
 
+/// A run reported success but no matching repo snapshot landed (the device
+/// lied or the upload didn't persist). Server-scoped, `Error`. Detecting it
+/// takes the group's repo inventory, but the finding is about the one server
+/// whose report didn't hold up, so it is filed against that server.
+pub const RECONCILE_MISSING: &str = "backup-reconcile-missing";
+
 // --- group-level (page regardless of any member's is_monitored) ---
 
 /// A group whose last successful maintenance run is older than the
@@ -43,10 +49,6 @@ pub const MAINTENANCE_STALE: &str = "backup-maintenance-stale";
 /// when maintenance is running but erroring. Group-scoped, `Error`. Clears
 /// when a newer run finishes successfully.
 pub const MAINTENANCE_ERROR: &str = "backup-maintenance-error";
-
-/// A run reported success but no matching repo snapshot landed (the device
-/// lied or the upload didn't persist). Group-scoped, `Error`.
-pub const RECONCILE_MISSING: &str = "backup-reconcile-missing";
 
 /// Repo corruption / poisoning detected by the inspection Job. Group-scoped,
 /// registers as an escalating failure. Raised by the inspection-Job component
@@ -73,9 +75,9 @@ pub const PREFLIGHT_ASSUME: &str = "preflight-assume";
 /// absent, or retention < 30 days). Group-scoped, `Critical`.
 pub const PREFLIGHT_OBJECT_LOCK: &str = "preflight-object-lock";
 
-/// Restore-verification (later/additive): PGRO reported a failed/stale
-/// restorability check. Group-scoped, `Error`. Routed through the same
-/// group-level helper.
+/// PGRO reported a failed/stale restorability check for one replica.
+/// Server-scoped, `Error`; the ref carries the `(type, intent)` dimension so
+/// each replica of a server recovers independently.
 pub const RESTORE_VERIFICATION: &str = "restore-verification";
 pub const MIGRATION_TEST: &str = "migration-test";
 

--- a/crates/database/src/backup/staleness.rs
+++ b/crates/database/src/backup/staleness.rs
@@ -612,7 +612,12 @@ pub(crate) async fn open_group_issue_active(
 	Ok(n > 0)
 }
 
-fn server_label(server: &Server) -> String {
+/// How an alert message names a server: the name an operator knows it by,
+/// qualified with its host when both are known, falling back to the host
+/// alone and finally to the id. Shared with [`crate::backup::reconcile`] so
+/// every backup alert names servers the same way.
+// spec: BKJ#alerting
+pub(super) fn server_label(server: &Server) -> String {
 	let host = server.host.as_ref().map(|h| h.0.to_string());
 	match (&server.name, host) {
 		(Some(n), Some(h)) if !n.is_empty() => format!("{n} ({h})"),

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -521,7 +521,9 @@ impl NewEvent {
 /// Open (or recover) a **group-scoped** issue, bypassing the per-server
 /// `is_monitored` gate. This is the single entrypoint for control-plane
 /// concerns that are not attributable to any one server — backup corruption,
-/// upstream preflight failures, reconcile-missing, restore-verification.
+/// maintenance failures, upstream preflight failures. A finding that names a
+/// server belongs on that server even when detecting it took group-wide
+/// state; scope is not the lever for making something page.
 ///
 /// Mirrors [`NewEvent::save`] but keys the issue on
 /// `(server_group_id, source, ref)` instead of `(server_id, …)`:

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -465,7 +465,7 @@ impl RestoreConsumerCapability {
 	}
 }
 
-/// The stable group-level alert ref for one replica's restore-health. Per
+/// The stable alert ref for one replica's restore-health. Per
 /// `(server, type, intent)` so each replica recovers independently (one
 /// intent's healthy report must not clear another's failure on the same
 /// server).

--- a/crates/database/tests/it/backup_detection.rs
+++ b/crates/database/tests/it/backup_detection.rs
@@ -233,6 +233,31 @@ async fn server_issue(
 	.ok()
 }
 
+#[derive(QueryableByName, Debug)]
+struct MessageRow {
+	#[diesel(sql_type = sql_types::Text)]
+	message: String,
+}
+
+/// The alert text of a server-scoped issue, for asserting on how it reads.
+async fn issue_message(
+	conn: &mut AsyncPgConnection,
+	server_id: Uuid,
+	r#ref: &str,
+) -> Option<String> {
+	sql_query(
+		"SELECT message FROM issues \
+		 WHERE server_id = $1 AND source = $2 AND \"ref\" = $3",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(refs::CANOPY_SOURCE)
+	.bind::<sql_types::Text, _>(r#ref)
+	.get_result::<MessageRow>(conn)
+	.await
+	.ok()
+	.map(|r| r.message)
+}
+
 async fn group_issue(
 	conn: &mut AsyncPgConnection,
 	group_id: Uuid,
@@ -718,16 +743,20 @@ async fn reconcile_files_missing_when_report_fresh_but_no_snapshot() {
 			.expect("reconcile sweep");
 
 		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
-		let issue = group_issue(&mut conn, group_id, &mref)
+		let issue = server_issue(&mut conn, server_id, &mref)
 			.await
-			.expect("reconcile-missing issue filed (group-scoped)");
+			.expect("reconcile-missing issue filed against the server it concerns");
 		assert_eq!(issue.effective_result.as_deref(), Some("failed"));
 		assert!(issue.active);
-		// Group-level Error opens an incident.
+		assert!(
+			group_issue(&mut conn, group_id, &mref).await.is_none(),
+			"the finding is about one server, not the group",
+		);
+		// A per-server Error on a monitored server still opens an incident.
 		assert_eq!(
-			group_issue_open_links(&mut conn, group_id, &mref).await,
+			server_issue_open_links(&mut conn, server_id, &mref).await,
 			1,
-			"reconcile-missing is group-level and opens an incident",
+			"reconcile-missing opens an incident",
 		);
 	})
 	.await;
@@ -783,11 +812,152 @@ async fn reconcile_files_missing_when_report_fresh_and_the_pair_has_no_snapshot_
 			.expect("reconcile sweep");
 
 		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
-		let issue = group_issue(&mut conn, group_id, &mref)
+		let issue = server_issue(&mut conn, server_id, &mref)
 			.await
 			.expect("reconcile-missing issue filed for the pair with no snapshot");
 		assert_eq!(issue.effective_result.as_deref(), Some("failed"));
 		assert!(issue.active);
+	})
+	.await;
+}
+
+/// Two servers in one group failing the same check hold two separate alerts.
+/// While this was group-scoped they collided on one row, so whichever server
+/// the sweep reached last owned the message — and the healthy one's recovery
+/// filed a `Passed` that cleared the broken one's alert.
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_missing_is_per_server_not_shared_across_the_group() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let interval = SignedDuration::from_hours(12);
+		let group_id = insert_group(&mut conn, "g").await;
+		let broken_id = insert_server(&mut conn, group_id, true).await;
+		let healthy_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, broken_id, &pg).await;
+		enable_capability(&mut conn, healthy_id, &pg).await;
+
+		// Both report success recently.
+		for sid in [broken_id, healthy_id] {
+			insert_backup_success_aged(
+				&mut conn,
+				device_id,
+				group_id,
+				sid,
+				&pg,
+				SignedDuration::from_hours(2),
+			)
+			.await;
+		}
+		// Only the healthy server's report is backed by a fresh snapshot; the
+		// broken one's snapshot is three days old.
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{healthy_id}:/data"),
+			Some(healthy_id),
+			Some(&pg),
+			Some(Timestamp::now() - SignedDuration::from_hours(2)),
+		)
+		.await
+		.expect("upsert healthy snapshot");
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{broken_id}:/data"),
+			Some(broken_id),
+			Some(&pg),
+			Some(Timestamp::now() - SignedDuration::from_hours(72)),
+		)
+		.await
+		.expect("upsert broken snapshot");
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("reconcile sweep");
+
+		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
+		let broken = server_issue(&mut conn, broken_id, &mref)
+			.await
+			.expect("the server whose snapshot is missing holds the alert");
+		assert_eq!(broken.effective_result.as_deref(), Some("failed"));
+		assert!(
+			broken.active,
+			"the healthy server in the same group must not clear it",
+		);
+		assert!(
+			server_issue(&mut conn, healthy_id, &mref).await.is_none(),
+			"the healthy server has no reconcile-missing alert of its own",
+		);
+	})
+	.await;
+}
+
+/// Alert text names the server the way an operator knows it, not by id.
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_missing_names_the_server_rather_than_its_id() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let interval = SignedDuration::from_hours(12);
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		sql_query("UPDATE servers SET name = 'kotare-central' WHERE id = $1")
+			.bind::<sql_types::Uuid, _>(server_id)
+			.execute(&mut conn)
+			.await
+			.expect("name the server");
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+
+		insert_backup_success_aged(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(2),
+		)
+		.await;
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{server_id}:/data"),
+			Some(server_id),
+			Some(&pg),
+			Some(Timestamp::now() - SignedDuration::from_hours(72)),
+		)
+		.await
+		.expect("upsert stale snapshot");
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("reconcile sweep");
+
+		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
+		let message = issue_message(&mut conn, server_id, &mref)
+			.await
+			.expect("reconcile-missing issue filed");
+		assert!(
+			message.contains("kotare-central"),
+			"message names the server: {message}",
+		);
+		assert!(
+			!message.contains(&server_id.to_string()),
+			"message does not fall back to the id: {message}",
+		);
 	})
 	.await;
 }

--- a/crates/database/tests/it/incident_list_status.rs
+++ b/crates/database/tests/it/incident_list_status.rs
@@ -81,7 +81,7 @@ async fn the_status_filter_selects_the_right_incidents() {
 		.expect("seed incidents");
 
 		let since = Timestamp::now() - SignedDuration::from_hours(7 * 24);
-		let mut ids = async |conn: &mut _, status| -> Vec<Uuid> {
+		let ids = async |conn: &mut _, status| -> Vec<Uuid> {
 			Incident::list_open_since(conn, since, None, status, 100)
 				.await
 				.expect("list")

--- a/migrations/2026-08-03-233339-0000_fold_reconcile_missing_to_server_scope/down.sql
+++ b/migrations/2026-08-03-233339-0000_fold_reconcile_missing_to_server_scope/down.sql
@@ -1,0 +1,4 @@
+-- Irreversible: the folded rows can be pushed back to their group, but which
+-- rows were group-scoped to begin with isn't recorded, and the incidents
+-- closed in step 3 can't be told apart from ones closed normally. Nothing to
+-- restore.

--- a/migrations/2026-08-03-233339-0000_fold_reconcile_missing_to_server_scope/up.sql
+++ b/migrations/2026-08-03-233339-0000_fold_reconcile_missing_to_server_scope/up.sql
@@ -1,0 +1,90 @@
+-- backup-reconcile-missing was filed group-scoped, on the reasoning that it
+-- should page regardless of a member's monitoring state. But the finding is
+-- about one server: every server in a group collided on the single
+-- (server_group_id, source, 'backup-reconcile-missing:<type>') row, so one
+-- server's failure overwrote another's, and a healthy server's recovery
+-- cleared a broken server's alert. It is now an ordinary server-scoped check
+-- with the same ref, subject to the monitoring gate like the other
+-- per-server backup signals.
+--
+-- The ref is unchanged, so stored silences and the catalog rows carry over
+-- untouched. The server a row was last about is recoverable from its check
+-- detail, and for rows predating detail-carrying filings, from the message
+-- text (which has always led with "Server <uuid> ").
+--
+-- Alerts the collision hid are not recoverable and are not recreated here:
+-- the next sweep files them fresh against their own servers.
+
+-- 1. Fold rows whose server still exists onto server scope. A server belongs
+--    to one group and this ref was never filed server-scoped before, so
+--    there is no issues_server_id_source_ref_key collision. The row keeps
+--    its incident membership and its history; the next sweep rewrites its
+--    message to name the server.
+UPDATE issues AS i
+SET
+	server_id = a.server_id,
+	server_group_id = NULL
+FROM (
+	SELECT
+		id,
+		COALESCE(
+			NULLIF(detail ->> 'server_id', ''),
+			substring(message FROM '^Server ([0-9a-fA-F-]{36}) ')
+		)::uuid AS server_id
+	FROM issues
+	WHERE source = 'canopy'
+		AND server_group_id IS NOT NULL
+		AND ref LIKE 'backup-reconcile-missing:%'
+		AND COALESCE(
+			NULLIF(detail ->> 'server_id', ''),
+			substring(message FROM '^Server ([0-9a-fA-F-]{36}) ')
+		) ~ '^[0-9a-fA-F-]{36}$'
+) AS a
+WHERE i.id = a.id
+	AND EXISTS (SELECT 1 FROM servers s WHERE s.id = a.server_id);
+
+-- 2. Anything still group-scoped has no server to attribute it to: the
+--    server was deleted, or the row predates both attribution paths. No code
+--    path can reach such a row now, so it would hold its incident open
+--    forever. Release it and resolve it.
+CREATE TEMP TABLE orphaned_reconcile_missing ON COMMIT DROP AS
+SELECT id FROM issues
+WHERE source = 'canopy'
+	AND server_group_id IS NOT NULL
+	AND ref LIKE 'backup-reconcile-missing:%';
+
+UPDATE incident_issues
+SET left_at = now()
+WHERE left_at IS NULL
+	AND issue_id IN (SELECT id FROM orphaned_reconcile_missing);
+
+UPDATE issues
+SET
+	active = false,
+	resolved_at = now(),
+	resolved_by = 'migration',
+	resolved_reason = 'group-scoped reconcile-missing folded to server scope; no server to fold this row onto'
+WHERE id IN (SELECT id FROM orphaned_reconcile_missing);
+
+-- 3. Close any incident those releases emptied. Mirrors the leave path in
+--    re_evaluate_incident_membership: an incident is held open by its
+--    currently-failing contributors, so one with none left retires. No Slack
+--    resolve is enqueued — a migration is not an event the fleet should be
+--    paged about, and these incidents are about servers that no longer
+--    exist.
+UPDATE incidents AS inc
+SET closed_at = now()
+WHERE inc.closed_at IS NULL
+	AND EXISTS (
+		SELECT 1 FROM incident_issues il
+		WHERE il.incident_id = inc.id
+			AND il.issue_id IN (SELECT id FROM orphaned_reconcile_missing)
+	)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM incident_issues il
+		JOIN issues i ON i.id = il.issue_id
+		WHERE il.incident_id = inc.id
+			AND il.left_at IS NULL
+			AND i.effective_result = 'failed'
+	);


### PR DESCRIPTION
🤖 A group-wide `backup-reconcile-missing` alert that names a single server — by uuid — turned out to be two visible symptoms of one mistake, plus a third defect neither symptom exposed.

## The mistake

`backup-reconcile-missing` was filed at `Scope::Group`, on the reasoning that a device lying about a successful backup should page regardless of the server's monitoring state. Scope was the wrong lever for that.

Group issues key on `(server_group_id, source, ref)`, and the ref folds in only the backup *type* — not the server. So every server in a group collided on one issue row:

- the message was whichever server the sweep reached last;
- the recovery arm checked whether the *group* issue was active, so a healthy server in the group filed the `Passed` that cleared a broken server's alert — and the next sweep re-raised it. Order-dependent flapping.

The spec justified group scope for signals "that belong to no single server", but this one names a server in its own message. `restore-verification` had the same tension and was already resolved the other way: a fleet-stable ref carrying the extra dimensions, filed at server scope.

## Changes

`backup-reconcile-missing` becomes an ordinary server-scoped check with the same ref. Stored silences carry over untouched — the ref is unchanged, and `CheckPolicy::apply_scoped` consults the server's group as well as the server, so an existing group-level silence still matches.

All three reconcile messages now use `server_label()` (shared out of `staleness.rs`), resolved in one batched query for the whole scan rather than per finding. Report-gap and size-mismatch were the worse offenders: both fetched the `Server` and then interpolated `server.id` anyway.

Spec: missing-snapshot reconciliation moves to the per-server bullet, and `restore-verification` is dropped from the group-level list where it was already stale. Two servers failing the same check now hold separate alerts, and alert text names servers the way an operator knows them. Stale doc comments in `refs.rs`, `restore.rs`, and `issues.rs` corrected to match.

## Behaviour change

Reconcile-missing now respects the monitoring gate. The alternative was an `always_page` flag on `CheckFiling` to decouple "always pages" from "is a group fact", but `backup-staleness` and `backup-never` are equally data-safety signals and are already gated — a server whose backups you have deliberately stopped monitoring should not page on any of them.

## Migration

`2026-08-03-233339-0000_fold_reconcile_missing_to_server_scope` folds live group-scoped rows onto the server recorded in their check detail, falling back to the uuid in the message text for rows predating detail-carrying filings. Incident membership survives, so an open incident stays continuous and the next sweep rewrites its message with the server's name.

Rows with no server to fold onto (the server was deleted) can no longer be reached by any code path, so they would hold their incident open forever. Those are released from the incident and resolved, and an incident left with no failing contributors is closed — mirroring the leave path in `re_evaluate_incident_membership`, without enqueueing a Slack resolve for servers that no longer exist.

Alerts the collision hid are not recoverable and are not recreated; the next sweep files them fresh against their own servers.

Verified against a populated database in a rolled-back transaction: rows folded via both attribution paths, orphan released and resolved.

## Incidental

A one-line `unused_mut` warning fix in `tests/it/incident_list_status.rs`, already present on main, rode along in the same commit.
