### PR TITLE
feat(checks): a check name is a category, not an instance

### DIFF
--- a/.workhorse/specs/jobs/backup.md
+++ b/.workhorse/specs/jobs/backup.md
@@ -84,6 +84,11 @@ Backup alerts are raised at one of two scopes:
 A signal about one server is raised against that server, even when the condition it detects is a disagreement between the device's report and the group's repository.
 Two servers in a group failing the same check hold two separate alerts, and one server's recovery never clears another's.
 
+Each signal is one check, whatever the deployment backs up.
+A server backing up its database, its configuration, and its reverse-proxy configuration has one staleness signal, not one per backup type — the types it is stale for are carried in the signal's detail and named in its text, and the signal is graded per type before it settles on the most urgent of them, as any check with instances is (see [CHK](../monitoring/checks.md)).
+So an operator configures staleness once for the fleet and, where a particular type warrants different treatment, writes a rule for that type rather than acquiring another check to configure.
+The same holds for the restore signals, which have both a backup type and a restore intent.
+
 Each signal has a stable key by which operators silence or snooze it and by which the interface and notifications refer to it; the keys are a contract and are not renamed without migrating stored silences.
 Where an alert's text names the server it concerns, it names it the way an operator knows it, falling back to an identifier only when the server has neither a name nor a host.
 A signal recovers when the condition that raised it clears.

--- a/.workhorse/specs/monitoring/checks.md
+++ b/.workhorse/specs/monitoring/checks.md
@@ -43,6 +43,24 @@ Its **ingest mode** governs whether the device API accepts the source's reports 
 
 New sources default to `on` and `allow`. A source that isn't ingested (`ignore` or `deny`) is excluded from reachability regardless of its reachability mode — there is no fresh data to judge it by.
 
+## Names
+
+A check's name is a category, not an instance.
+It names the condition being checked, and it is the unit an operator configures once and then reasons about across the whole fleet.
+
+Anything that varies between instances of the same condition — which backup configuration, which restore intent, which certificate — belongs in the check's detail, and never in its name.
+Detail is where policy rules read from, so an operator can grade or silence one instance differently from the rest without a catalog entry for each.
+A name that encodes a parameter turns one configurable check into as many entries as there are instances, and a catalog that has to be configured that many times has stopped being a way to get your eyes on things efficiently.
+
+### Checks with instances
+
+Where a target has several instances of one condition, Canopy holds one state for the check, as it does for every (target, source, check).
+
+Each instance is graded through policy on its own, against its own detail, so a rule or silence written for one instance applies to only that instance.
+The check's effective result is then the most urgent across the instances that were not skipped, and its detail carries every instance that is not passing, each with its own result, so an operator can see which ones are in trouble without opening anything else.
+Its message names those instances.
+The check recovers when no instance is left degraded.
+
 ## Results
 
 A check's result is one of, in decreasing order of urgency:

--- a/crates/database/src/backup/reconcile.rs
+++ b/crates/database/src/backup/reconcile.rs
@@ -40,8 +40,11 @@ use jiff::{SignedDuration, Timestamp};
 use uuid::Uuid;
 
 use crate::{
-	backup::{refs, staleness::ScanRow},
-	issues::{CheckFiling, Scope, file_check},
+	backup::{
+		refs,
+		staleness::{ScanRow, label_list},
+	},
+	issues::{CheckInstance, InstancedCheckFiling, Scope, file_check_instances},
 	servers::Server,
 };
 
@@ -113,231 +116,234 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 		);
 	}
 
-	let mut filed = 0usize;
+	// One check per server, not one per backup type: group the scan by server
+	// and grade each type as an instance (see the Names section of the CHK
+	// spec).
+	let mut by_server: HashMap<Uuid, Vec<&ScanRow>> = HashMap::new();
+	let mut order: Vec<Uuid> = Vec::new();
 	for row in rows {
-		let grace = row.expected_interval.saturating_mul(2);
-		let report_fresh = row
-			.last_success_at
-			.is_some_and(|t| now.duration_since(t) <= grace);
+		by_server
+			.entry(row.server_id)
+			.or_insert_with(|| {
+				order.push(row.server_id);
+				Vec::new()
+			})
+			.push(row);
+	}
 
-		let snap = snaps.get(&(row.server_id, row.r#type.clone()));
-		let snapshot_fresh = snap
-			.and_then(|s| s.latest_snapshot_at)
-			.is_some_and(|t| now.duration_since(t) <= grace);
-		let inventory_fresh = inspected_at
-			.get(&row.group_id)
-			.is_some_and(|at| now.duration_since(*at) <= INVENTORY_STALE_AFTER);
-
-		let missing_ref = format!("{}:{}", refs::RECONCILE_MISSING, row.r#type);
-		let gap_ref = format!("{}:{}", refs::RECONCILE_REPORT_GAP, row.r#type);
+	let mut filed = 0usize;
+	for server_id in order {
+		let server_rows = &by_server[&server_id];
+		let device_id = server_rows.iter().find_map(|r| r.device_id);
 		// A scanned server always exists (the scan joins servers), so the
 		// fallback is unreachable in practice — it just avoids a panic path.
 		let label = labels
-			.get(&row.server_id)
+			.get(&server_id)
 			.cloned()
-			.unwrap_or_else(|| row.server_id.to_string());
+			.unwrap_or_else(|| server_id.to_string());
 
-		match (report_fresh, snapshot_fresh) {
-			// Report says success but the data didn't land (or its row is
-			// missing). Only conclude this when the repo inventory is fresh
-			// enough.
-			(true, false) if inventory_fresh => {
-				file_check(
-					db,
-					CheckFiling {
-						source: crate::statuses::CANOPY_SOURCE,
-						scope: Scope::Server(row.server_id),
-						device_id: row.device_id,
-						check: &missing_ref,
-						observed: CheckResult::Failed,
-						title: None,
-						message: &format!(
-							"Server {label} reported a successful {} backup but no matching repo snapshot landed",
-							row.r#type,
-						),
-						detail: Some(serde_json::json!({
-							"type": row.r#type.to_string(),
-						})),
-						default_ceiling: CheckResult::Warning,
-						default_escalates: false,
-						documentation: Some(refs::RECONCILE_MISSING_DOC),
-					},
-				)
-				.await?;
-				filed += 1;
-			}
-			// Both agree it's fine → clear any open missing alert.
-			(true, true) => {
-				if crate::backup::staleness::open_server_issue_active(
-					db,
-					row.server_id,
-					&missing_ref,
-				)
-				.await?
-				{
-					file_check(
-						db,
-						CheckFiling {
-							source: crate::statuses::CANOPY_SOURCE,
-							scope: Scope::Server(row.server_id),
-							device_id: row.device_id,
-							check: &missing_ref,
-							observed: CheckResult::Passed,
-							title: None,
-							message: &format!(
-								"Server {label} backup report and repo snapshot agree again"
-							),
-							detail: None,
-							default_ceiling: CheckResult::Warning,
-							default_escalates: false,
-							documentation: Some(refs::RECONCILE_MISSING_DOC),
-						},
-					)
-					.await?;
-					filed += 1;
-				}
-				filed += clear_report_gap(db, row, &label, &gap_ref).await?;
-			}
+		let missing_open = crate::backup::staleness::open_server_issue_active(
+			db,
+			server_id,
+			refs::RECONCILE_MISSING,
+		)
+		.await?;
+		let gap_open = crate::backup::staleness::open_server_issue_active(
+			db,
+			server_id,
+			refs::RECONCILE_REPORT_GAP,
+		)
+		.await?;
+		let size_open = crate::backup::staleness::open_server_issue_active(
+			db,
+			server_id,
+			refs::RECONCILE_SIZE_MISMATCH,
+		)
+		.await?;
+
+		let mut missing_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
+		let mut gap_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
+		let mut size_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
+		let mut any_missing = false;
+		let mut any_decidable = false;
+		let mut any_gap = false;
+		let mut any_size = false;
+
+		for row in server_rows {
+			let grace = row.expected_interval.saturating_mul(2);
+			let report_fresh = row
+				.last_success_at
+				.is_some_and(|t| now.duration_since(t) <= grace);
+			let snap = snaps.get(&(row.server_id, row.r#type.clone()));
+			let snapshot_fresh = snap
+				.and_then(|s| s.latest_snapshot_at)
+				.is_some_and(|t| now.duration_since(t) <= grace);
+			let inventory_fresh = inspected_at
+				.get(&row.group_id)
+				.is_some_and(|at| now.duration_since(*at) <= INVENTORY_STALE_AFTER);
+
+			// Report says success but the data didn't land. Only concluded when
+			// the repo inventory is fresh enough to be trusted; a lagging
+			// inspector must not produce false "report lied" findings, and a
+			// type whose inventory is stale is left out of the check rather
+			// than counted healthy.
+			let missing = report_fresh && !snapshot_fresh && inventory_fresh;
+			let missing_undecidable = report_fresh && !snapshot_fresh && !inventory_fresh;
+			any_missing |= missing;
+			any_decidable |= !missing_undecidable;
+			missing_instances.push(CheckInstance {
+				label: row.r#type.to_string(),
+				observed: if missing {
+					CheckResult::Failed
+				} else if missing_undecidable {
+					CheckResult::Skipped
+				} else {
+					CheckResult::Passed
+				},
+				detail: Some(serde_json::json!({
+					"type": row.r#type.to_string(),
+				})),
+			});
+
 			// Snapshot landed but no recent report → the reporting path is
-			// broken. Per-server warning (non-paging).
-			(false, true) => {
-				file_check(
-					db,
-					CheckFiling {
-						source: crate::statuses::CANOPY_SOURCE,
-						scope: Scope::Server(row.server_id),
-						device_id: row.device_id,
-						check: &gap_ref,
-						observed: CheckResult::Warning,
-						title: None,
-						message: &format!(
-							"A fresh {} repo snapshot exists for {label} but no backup run was reported",
-							row.r#type,
-						),
-						detail: Some(serde_json::json!({
-							"type": row.r#type.to_string(),
-						})),
-						default_ceiling: CheckResult::Warning,
-						default_escalates: false,
-						documentation: Some(refs::RECONCILE_REPORT_GAP_DOC),
-					},
-				)
-				.await?;
-				filed += 1;
+			// broken, not the backup.
+			let gap = !report_fresh && snapshot_fresh;
+			any_gap |= gap;
+			gap_instances.push(CheckInstance {
+				label: row.r#type.to_string(),
+				observed: if gap {
+					CheckResult::Warning
+				} else {
+					CheckResult::Passed
+				},
+				detail: Some(serde_json::json!({
+					"type": row.r#type.to_string(),
+				})),
+			});
+
+			// Size discrepancy: orthogonal to freshness. Compare the latest run
+			// that has both a reported and an observed size.
+			let sizes = sized.get(&(row.server_id, row.r#type.clone()));
+			let mismatch = sizes.is_some_and(|(reported, observed)| reported != observed);
+			any_size |= mismatch;
+			let mut size_detail = serde_json::Map::new();
+			size_detail.insert("type".into(), row.r#type.to_string().into());
+			if let Some(&(reported, observed)) = sizes {
+				size_detail.insert("reported_bytes".into(), reported.into());
+				size_detail.insert("observed_bytes".into(), observed.into());
 			}
-			// Neither fresh → the staleness scan owns it; clear stale reconcile
-			// alerts.
-			(false, false) => {
-				filed += clear_report_gap(db, row, &label, &gap_ref).await?;
-			}
-			// (true, false) but the repo inventory is stale: skip the missing
-			// verdict.
-			(true, false) => {}
+			size_instances.push(CheckInstance {
+				label: row.r#type.to_string(),
+				observed: if mismatch {
+					CheckResult::Warning
+				} else {
+					CheckResult::Passed
+				},
+				detail: Some(serde_json::Value::Object(size_detail)),
+			});
 		}
 
-		// Size discrepancy: orthogonal to freshness. Compare the latest run that
-		// has both a reported and an observed size.
-		let size_ref = format!("{}:{}", refs::RECONCILE_SIZE_MISMATCH, row.r#type);
-		match sized.get(&(row.server_id, row.r#type.clone())) {
-			Some(&(reported, observed)) if reported != observed => {
-				file_check(
-					db,
-					CheckFiling {
-						source: crate::statuses::CANOPY_SOURCE,
-						scope: Scope::Server(row.server_id),
-						device_id: row.device_id,
-						check: &size_ref,
-						observed: CheckResult::Warning,
-						title: None,
-						message: &format!(
-							"Server {label} reported a {} snapshot size of {reported} bytes but the repo holds {observed}",
-							row.r#type,
-						),
-						detail: Some(serde_json::json!({
-							"type": row.r#type.to_string(),
-							"reported_bytes": reported,
-							"observed_bytes": observed,
-						})),
-						default_ceiling: CheckResult::Warning,
-						default_escalates: false,
-						documentation: Some(refs::RECONCILE_SIZE_MISMATCH_DOC),
-					},
-				)
-				.await?;
-				filed += 1;
-			}
-			// Agree, or no comparable run → clear any open mismatch.
-			_ => {
-				filed += clear_size_mismatch(db, row, &label, &size_ref).await?;
-			}
+		// A stale repo inventory makes the missing verdict undecidable, not
+		// resolved: when it is stale for every type there is nothing to
+		// conclude, so leave whatever state is already there rather than
+		// clearing an open finding on the strength of a lagging inspector.
+		if any_missing || (missing_open && any_decidable) {
+			let total = missing_instances.len();
+			file_check_instances(
+				db,
+				InstancedCheckFiling {
+					source: crate::statuses::CANOPY_SOURCE,
+					scope: Scope::Server(server_id),
+					device_id,
+					check: refs::RECONCILE_MISSING,
+					title: None,
+					instances: missing_instances,
+					default_ceiling: CheckResult::Warning,
+					default_escalates: false,
+					documentation: Some(refs::RECONCILE_MISSING_DOC),
+				},
+				&|degraded| match degraded {
+					[] => format!("Server {label} backup reports and repo snapshots agree again"),
+					[one] => format!(
+						"Server {label} reported a successful {} backup but no matching repo snapshot landed",
+						one.label
+					),
+					many => format!(
+						"Server {label} reported {} of its {total} backups successful with no matching repo snapshot: {}",
+						many.len(),
+						label_list(many),
+					),
+				},
+			)
+			.await?;
+			filed += 1;
+		}
+
+		if any_gap || gap_open {
+			let total = gap_instances.len();
+			file_check_instances(
+				db,
+				InstancedCheckFiling {
+					source: crate::statuses::CANOPY_SOURCE,
+					scope: Scope::Server(server_id),
+					device_id,
+					check: refs::RECONCILE_REPORT_GAP,
+					title: None,
+					instances: gap_instances,
+					default_ceiling: CheckResult::Warning,
+					default_escalates: false,
+					documentation: Some(refs::RECONCILE_REPORT_GAP_DOC),
+				},
+				&|degraded| match degraded {
+					[] => format!("Backup reporting for {label} recovered"),
+					[one] => format!(
+						"A fresh {} repo snapshot exists for {label} but no backup run was reported",
+						one.label
+					),
+					many => format!(
+						"Fresh repo snapshots exist for {} of {label}'s {total} types with no backup run reported: {}",
+						many.len(),
+						label_list(many),
+					),
+				},
+			)
+			.await?;
+			filed += 1;
+		}
+
+		if any_size || size_open {
+			let total = size_instances.len();
+			file_check_instances(
+				db,
+				InstancedCheckFiling {
+					source: crate::statuses::CANOPY_SOURCE,
+					scope: Scope::Server(server_id),
+					device_id,
+					check: refs::RECONCILE_SIZE_MISMATCH,
+					title: None,
+					instances: size_instances,
+					default_ceiling: CheckResult::Warning,
+					default_escalates: false,
+					documentation: Some(refs::RECONCILE_SIZE_MISMATCH_DOC),
+				},
+				&|degraded| match degraded {
+					[] => format!("Reported and repo snapshot sizes for {label} agree again"),
+					[one] => format!(
+						"Server {label} reported a {} snapshot size that disagrees with the repo",
+						one.label
+					),
+					many => format!(
+						"Server {label} reported snapshot sizes disagreeing with the repo for {} of its {total} types: {}",
+						many.len(),
+						label_list(many),
+					),
+				},
+			)
+			.await?;
+			filed += 1;
 		}
 	}
 	Ok(filed)
-}
-
-/// Clear an open per-server size-mismatch issue when the sizes agree again (or
-/// there's no longer a comparable run to disagree).
-async fn clear_size_mismatch(
-	db: &mut AsyncPgConnection,
-	row: &ScanRow,
-	label: &str,
-	size_ref: &str,
-) -> Result<usize> {
-	if !crate::backup::staleness::open_server_issue_active(db, row.server_id, size_ref).await? {
-		return Ok(0);
-	}
-	file_check(
-		db,
-		CheckFiling {
-			source: crate::statuses::CANOPY_SOURCE,
-			scope: Scope::Server(row.server_id),
-			device_id: row.device_id,
-			check: size_ref,
-			observed: CheckResult::Passed,
-			title: None,
-			message: &format!(
-				"Reported and repo {} snapshot sizes for {label} agree again",
-				row.r#type
-			),
-			detail: None,
-			default_ceiling: CheckResult::Warning,
-			default_escalates: false,
-			documentation: Some(refs::RECONCILE_SIZE_MISMATCH_DOC),
-		},
-	)
-	.await?;
-	Ok(1)
-}
-
-/// Clear an open per-server report-gap issue when the report path is healthy
-/// again (or the pair is genuinely stale and the staleness scan owns it).
-async fn clear_report_gap(
-	db: &mut AsyncPgConnection,
-	row: &ScanRow,
-	label: &str,
-	gap_ref: &str,
-) -> Result<usize> {
-	if !crate::backup::staleness::open_server_issue_active(db, row.server_id, gap_ref).await? {
-		return Ok(0);
-	}
-	file_check(
-		db,
-		CheckFiling {
-			source: crate::statuses::CANOPY_SOURCE,
-			scope: Scope::Server(row.server_id),
-			device_id: row.device_id,
-			check: gap_ref,
-			observed: CheckResult::Passed,
-			title: None,
-			message: &format!("Backup reporting for {label} ({}) recovered", row.r#type),
-			detail: None,
-			default_ceiling: CheckResult::Warning,
-			default_escalates: false,
-			documentation: Some(refs::RECONCILE_REPORT_GAP_DOC),
-		},
-	)
-	.await?;
-	Ok(1)
 }
 
 /// Raw snapshot row: `(server_id, type, latest_snapshot_at, observed_at)`.

--- a/crates/database/src/backup/staleness.rs
+++ b/crates/database/src/backup/staleness.rs
@@ -27,7 +27,10 @@ use uuid::Uuid;
 
 use crate::{
 	backup::refs,
-	issues::{CheckFiling, Scope, file_check},
+	issues::{
+		CheckFiling, CheckInstance, GradedInstance, InstancedCheckFiling, Scope, file_check,
+		file_check_instances,
+	},
 	servers::Server,
 };
 
@@ -276,151 +279,179 @@ pub async fn scan_rows(db: &mut AsyncPgConnection) -> Result<Vec<ScanRow>> {
 		.collect())
 }
 
-fn type_suffix(ty: &BackupType) -> String {
-	format!(":{ty}")
+/// Read an instance's `last_success_at` back out of its detail for the
+/// message. The detail is the one place the specifics live now that the
+/// message summarises across types.
+fn last_success_of(instance: &GradedInstance) -> String {
+	instance
+		.detail
+		.as_ref()
+		.and_then(|d| d.get("last_success_at"))
+		.and_then(|v| v.as_str())
+		.unwrap_or("never")
+		.to_owned()
 }
 
-/// Run the full staleness sweep over a pre-computed scan: classify
-/// every scanned `(server, type)` and file/clear the per-server
-/// `backup-staleness` / `backup-never` issues, then the group-level
-/// `backup-maintenance-stale`. Returns the number of events filed.
+/// Join instance labels for a message, in the order they were graded (most
+/// urgent first). Shared with [`crate::backup::reconcile`] so every backup
+/// check names its degraded instances the same way.
+pub(super) fn label_list(instances: &[GradedInstance]) -> String {
+	instances
+		.iter()
+		.map(|i| i.label.as_str())
+		.collect::<Vec<_>>()
+		.join(", ")
+}
+
+/// Run the full staleness sweep over a pre-computed scan: classify every
+/// scanned `(server, type)`, then file one `backup-staleness` and one
+/// `backup-never` check *per server* with the types as instances, and the
+/// group-level `backup-maintenance-stale`. Returns the number of events
+/// filed.
+///
+/// A server backing up four things has one staleness check, not four: the
+/// types it is stale for are instances of that check (see the Names section
+/// of the CHK spec), so an operator configures staleness once and writes a
+/// rule on `check.type` where a particular type warrants different handling.
 pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize> {
 	let now = Timestamp::now();
 	let mut filed = 0usize;
 
+	// Group the scan by server, preserving first-seen order so the sweep stays
+	// deterministic.
+	let mut by_server: HashMap<Uuid, Vec<&ScanRow>> = HashMap::new();
+	let mut order: Vec<Uuid> = Vec::new();
 	for row in rows {
-		// The ref is per-(server, type): the (server_id, source, ref) issue key
-		// must distinguish types, so the type is folded into the ref suffix.
-		let staleness_ref = format!("{}{}", refs::STALENESS, type_suffix(&row.r#type));
-		let never_ref = format!("{}{}", refs::NEVER, type_suffix(&row.r#type));
+		by_server
+			.entry(row.server_id)
+			.or_insert_with(|| {
+				order.push(row.server_id);
+				Vec::new()
+			})
+			.push(row);
+	}
 
-		let was_active = open_server_issue_active(db, row.server_id, &staleness_ref).await?;
-		let verdict = row.classify(now, was_active);
-
-		let server = Server::get_by_id(db, row.server_id).await?;
+	for server_id in order {
+		let server_rows = &by_server[&server_id];
+		let device_id = server_rows.iter().find_map(|r| r.device_id);
+		let server = Server::get_by_id(db, server_id).await?;
 		let label = server_label(&server);
 
-		match verdict {
-			StalenessVerdict::Stale => {
-				let grace = row.grace();
-				file_check(
-					db,
-					CheckFiling {
-						source: crate::statuses::CANOPY_SOURCE,
-						scope: Scope::Server(row.server_id),
-						device_id: row.device_id,
-						check: &staleness_ref,
-						observed: CheckResult::Failed,
-						title: None,
-						message: &format!(
-							"Server {label} has no successful {} backup newer than {} (last success {})",
-							row.r#type,
-							fmt_dur(grace),
-							row.last_success_at
-								.map(|t| t.to_string())
-								.unwrap_or_else(|| "never".into()),
-						),
-						detail: Some(serde_json::json!({
-							"type": row.r#type.to_string(),
-							"grace_secs": grace.as_secs(),
-							"last_success_at": row.last_success_at.map(|t| t.to_string()),
-						})),
-						default_ceiling: CheckResult::Warning,
-						default_escalates: false,
-						documentation: Some(refs::STALENESS_DOC),
-					},
-				)
-				.await?;
-				filed += 1;
-			}
-			StalenessVerdict::Recovered => {
-				file_check(
-					db,
-					CheckFiling {
-						source: crate::statuses::CANOPY_SOURCE,
-						scope: Scope::Server(row.server_id),
-						device_id: row.device_id,
-						check: &staleness_ref,
-						observed: CheckResult::Passed,
-						title: None,
-						message: &format!(
-							"Server {label} reported a successful {} backup again",
-							row.r#type
-						),
-						detail: None,
-						default_ceiling: CheckResult::Warning,
-						default_escalates: false,
-						documentation: Some(refs::STALENESS_DOC),
-					},
-				)
-				.await?;
-				filed += 1;
-			}
-			StalenessVerdict::Never => {
-				// `backup-never` clears on first success (it transitions to OK,
-				// not Recovered — there's no recovery message for it). Only file
-				// while it's still never-backed-up.
-				//
-				// Warning, not failure: a server that has *never* backed up
-				// (freshly set up, or blocked by an upstream issue) shouldn't
-				// open an incident. A *missed* backup — a server that was
-				// backing up and stopped (`Stale`, above) — is the failure
-				// that pages.
-				file_check(
-					db,
-					CheckFiling {
-						source: crate::statuses::CANOPY_SOURCE,
-						scope: Scope::Server(row.server_id),
-						device_id: row.device_id,
-						check: &never_ref,
-						observed: CheckResult::Warning,
-						title: None,
-						message: &format!(
-							"Server {label} has never reported a successful {} backup (expected since {})",
-							row.r#type,
-							row.anchor(),
-						),
-						detail: Some(serde_json::json!({
-							"type": row.r#type.to_string(),
-							"expected_since": row.anchor().to_string(),
-						})),
-						default_ceiling: CheckResult::Warning,
-						default_escalates: false,
-						documentation: Some(refs::NEVER_DOC),
-					},
-				)
-				.await?;
-				filed += 1;
-			}
-			StalenessVerdict::Ok => {
-				// If a `backup-never` is open but the server has now backed up,
-				// clear it.
-				if row.last_success_at.is_some()
-					&& open_server_issue_active(db, row.server_id, &never_ref).await?
-				{
-					file_check(
-						db,
-						CheckFiling {
-							source: crate::statuses::CANOPY_SOURCE,
-							scope: Scope::Server(row.server_id),
-							device_id: row.device_id,
-							check: &never_ref,
-							observed: CheckResult::Passed,
-							title: None,
-							message: &format!(
-								"Server {label} reported its first successful {} backup",
-								row.r#type
-							),
-							detail: None,
-							default_ceiling: CheckResult::Warning,
-							default_escalates: false,
-							documentation: Some(refs::NEVER_DOC),
-						},
-					)
-					.await?;
-					filed += 1;
-				}
-			}
+		// Both flags are per-server now that the check is: whether this
+		// server's staleness (or never) check is currently degraded at all.
+		let stale_open = open_server_issue_active(db, server_id, refs::STALENESS).await?;
+		let never_open = open_server_issue_active(db, server_id, refs::NEVER).await?;
+
+		let mut stale_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
+		let mut never_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
+		let mut any_stale = false;
+		let mut any_never = false;
+
+		for row in server_rows {
+			let verdict = row.classify(now, stale_open);
+			let grace = row.grace();
+
+			let stale = verdict == StalenessVerdict::Stale;
+			any_stale |= stale;
+			stale_instances.push(CheckInstance {
+				label: row.r#type.to_string(),
+				observed: if stale {
+					CheckResult::Failed
+				} else {
+					CheckResult::Passed
+				},
+				detail: Some(serde_json::json!({
+					"type": row.r#type.to_string(),
+					"grace_secs": grace.as_secs(),
+					"last_success_at": row.last_success_at.map(|t| t.to_string()),
+				})),
+			});
+
+			// A server that has *never* backed up (freshly set up, or blocked
+			// upstream) is a different condition from one that was backing up
+			// and stopped, so it is its own check rather than an instance of
+			// staleness.
+			let never = verdict == StalenessVerdict::Never;
+			any_never |= never;
+			never_instances.push(CheckInstance {
+				label: row.r#type.to_string(),
+				observed: if never {
+					CheckResult::Warning
+				} else {
+					CheckResult::Passed
+				},
+				detail: Some(serde_json::json!({
+					"type": row.r#type.to_string(),
+					"expected_since": row.anchor().to_string(),
+				})),
+			});
+		}
+
+		// File when something is degraded, or when the check is open and needs
+		// clearing. A healthy server with nothing open has nothing to say.
+		if any_stale || stale_open {
+			let total = stale_instances.len();
+			file_check_instances(
+				db,
+				InstancedCheckFiling {
+					source: crate::statuses::CANOPY_SOURCE,
+					scope: Scope::Server(server_id),
+					device_id,
+					check: refs::STALENESS,
+					title: None,
+					instances: stale_instances,
+					default_ceiling: CheckResult::Warning,
+					default_escalates: false,
+					documentation: Some(refs::STALENESS_DOC),
+				},
+				&|degraded| match degraded {
+					[] => format!("Server {label} is backing up on schedule again"),
+					[one] => format!(
+						"Server {label} has no recent {} backup (last success {})",
+						one.label,
+						last_success_of(one),
+					),
+					many => format!(
+						"Server {label} has no recent backup for {} of its {total} types: {}",
+						many.len(),
+						label_list(many),
+					),
+				},
+			)
+			.await?;
+			filed += 1;
+		}
+
+		if any_never || never_open {
+			let total = never_instances.len();
+			file_check_instances(
+				db,
+				InstancedCheckFiling {
+					source: crate::statuses::CANOPY_SOURCE,
+					scope: Scope::Server(server_id),
+					device_id,
+					check: refs::NEVER,
+					title: None,
+					instances: never_instances,
+					default_ceiling: CheckResult::Warning,
+					default_escalates: false,
+					documentation: Some(refs::NEVER_DOC),
+				},
+				&|degraded| match degraded {
+					[] => format!("Server {label} has now backed up everything expected of it"),
+					[one] => format!(
+						"Server {label} has never reported a successful {} backup",
+						one.label
+					),
+					many => format!(
+						"Server {label} has never backed up {} of its {total} types: {}",
+						many.len(),
+						label_list(many),
+					),
+				},
+			)
+			.await?;
+			filed += 1;
 		}
 	}
 

--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -396,6 +396,26 @@ impl CheckPolicy {
 		observed: CheckResult,
 		ctx: &EvaluationContext<'_>,
 	) -> Result<GradedResult> {
+		let entry = Self::fleet_grading(db, source, check_name).await?;
+		Ok(Self::grade(
+			entry.as_ref(),
+			source,
+			check_name,
+			observed,
+			ctx,
+		))
+	}
+
+	/// One check's catalog entry, in the form [`Self::grade`] takes. `None`
+	/// means the check has no catalog row yet. Load this once when grading
+	/// several instances of the same check (see
+	/// [`crate::issues::file_check_instances`]) so the catalog is read once
+	/// rather than once per instance.
+	pub async fn fleet_grading(
+		db: &mut AsyncPgConnection,
+		source: &str,
+		check_name: &str,
+	) -> Result<Option<FleetGrading>> {
 		use crate::schema::check_policies::dsl;
 		let row: Option<(String, bool, Option<JsonValue>, bool)> = dsl::check_policies
 			.select((
@@ -408,14 +428,7 @@ impl CheckPolicy {
 			.first(db)
 			.await
 			.optional()?;
-		let entry = row.map(FleetGrading::from_row);
-		Ok(Self::grade(
-			entry.as_ref(),
-			source,
-			check_name,
-			observed,
-			ctx,
-		))
+		Ok(row.map(FleetGrading::from_row))
 	}
 
 	/// The pure half of [`Self::apply`]: grade `observed` through an

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -899,12 +899,105 @@ pub struct CheckFiling<'a> {
 /// error (critical when the policy escalates), warning/broken →
 /// warning; passed and skipped record healthy state and close.
 pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -> Result<Issue> {
-	use crate::check_policies::{CheckPolicy, EvaluationContext};
+	let instance = CheckInstance {
+		label: String::new(),
+		observed: filing.observed,
+		detail: filing.detail.clone(),
+	};
+	let message = filing.message;
+	file_check_instances(
+		conn,
+		InstancedCheckFiling {
+			source: filing.source,
+			scope: filing.scope,
+			device_id: filing.device_id,
+			check: filing.check,
+			title: filing.title,
+			default_ceiling: filing.default_ceiling,
+			default_escalates: filing.default_escalates,
+			documentation: filing.documentation,
+			instances: vec![instance],
+		},
+		&|_| message.to_string(),
+	)
+	.await
+}
+
+/// One instance of a check the target has several of: one of a server's
+/// backup types, one of its restore intents.
+///
+/// Instances exist so a check can stay a single named category — see the
+/// Names section of the CHK spec. Never spell an instance into the check
+/// name.
+#[derive(Debug, Clone)]
+pub struct CheckInstance {
+	/// How this instance is named in the check's message, e.g. the backup
+	/// type. Not read by policy — the fields policy matches on live in
+	/// `detail`.
+	pub label: String,
+	/// What this instance observed this pass.
+	pub observed: CheckResult,
+	/// This instance's own fields. Policy rules reach them as `check.*`, so
+	/// whatever identifies the instance (`type`, `intent`, …) must be in
+	/// here for an operator to be able to grade or silence it on its own.
+	pub detail: Option<serde_json::Value>,
+}
+
+/// What grading an instance produced, for building the check's message.
+#[derive(Debug, Clone)]
+pub struct GradedInstance {
+	pub label: String,
+	pub observed: CheckResult,
+	pub effective: CheckResult,
+	pub detail: Option<serde_json::Value>,
+}
+
+/// A check filed from several instances. Everything except the per-instance
+/// fields is shared, because there is one check and one catalog entry
+/// however many instances the target has.
+pub struct InstancedCheckFiling<'a> {
+	pub source: &'a str,
+	pub scope: Scope,
+	pub device_id: Option<Uuid>,
+	pub check: &'a str,
+	pub title: Option<&'a str>,
+	pub instances: Vec<CheckInstance>,
+	pub default_ceiling: CheckResult,
+	pub default_escalates: bool,
+	pub documentation: Option<&'a str>,
+}
+
+/// File one check from several instances of its condition, grading each
+/// instance on its own and settling on the most urgent of them.
+///
+/// This is what keeps a check a category instead of a name per instance: one
+/// catalog entry, one state, one thing for an operator to configure, however
+/// many backup types or restore intents the target has. Because each instance
+/// is graded separately against its own detail, a rule or silence written for
+/// one instance still applies to only that instance.
+///
+/// Skipped instances (a silence matched) drop out of the aggregate entirely
+/// rather than counting as healthy. If every instance is skipped, so is the
+/// check.
+///
+/// `message` is called with the instances that are not passing, most urgent
+/// first, and is what the operator reads; it gets an empty slice when
+/// everything is healthy, which is the recovery message.
+pub async fn file_check_instances(
+	conn: &mut AsyncPgConnection,
+	filing: InstancedCheckFiling<'_>,
+	message: &(dyn Fn(&[GradedInstance]) -> String + Sync),
+) -> Result<Issue> {
+	use crate::check_policies::{CheckPolicy, EvaluationContext, ScopedCheckPolicy};
 
 	let source = filing.source;
 	debug_assert!(
 		matches!(filing.scope, Scope::Server(_)) || source == crate::statuses::CANOPY_SOURCE,
 		"group- and canopy-wide filings are canopy's own",
+	);
+	debug_assert!(
+		!filing.instances.is_empty(),
+		"a filing with no instances says nothing; skip the call instead",
 	);
 	CheckPolicy::register(
 		conn,
@@ -916,22 +1009,6 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 	)
 	.await?;
 
-	// Rule-evaluation context: the check's detail (with the normalised
-	// result injected, mirroring status ingestion), no report-wide
-	// extras, and the server's tags where there is a server. Filings
-	// whose observation policy shouldn't touch (an operator explicitly
-	// raising a manual condition) still flow through so the catalog row
-	// and stamps exist, but manual entries register at a failed ceiling
-	// so the operator's chosen result passes through ungraded by default.
-	let mut check_extra = filing
-		.detail
-		.as_ref()
-		.and_then(|d| d.as_object().cloned())
-		.unwrap_or_default();
-	check_extra.insert(
-		"result".into(),
-		serde_json::Value::String(filing.observed.to_string()),
-	);
 	let status_extra = serde_json::Map::new();
 	let (tags, scope_server, scope_group): (
 		std::collections::HashMap<String, serde_json::Value>,
@@ -953,33 +1030,107 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 		Scope::Group(group_id) => (Default::default(), None, Some(group_id)),
 		Scope::Global => (Default::default(), None, None),
 	};
-	let ctx = EvaluationContext {
-		status_extra: &status_extra,
-		check_extra: &check_extra,
-		tags: &tags,
-	};
-	let graded = CheckPolicy::apply_scoped(
-		conn,
-		source,
-		filing.check,
-		filing.observed,
-		&ctx,
-		scope_server,
-		scope_group,
-	)
-	.await?;
+
+	// The catalog entry and the scoped chain are properties of the check, not
+	// of any one instance: read them once and grade purely from there, so a
+	// server with a dozen backup types still costs two queries.
+	let fleet = CheckPolicy::fleet_grading(conn, source, filing.check).await?;
+	let chain =
+		ScopedCheckPolicy::chain_for(conn, source, filing.check, scope_server, scope_group).await?;
+
+	let mut graded_instances: Vec<GradedInstance> = Vec::with_capacity(filing.instances.len());
+	let mut escalates = false;
+	for instance in &filing.instances {
+		// Rule-evaluation context: the instance's detail (with the normalised
+		// result injected, mirroring status ingestion), no report-wide extras,
+		// and the server's tags where there is a server.
+		let mut check_extra = instance
+			.detail
+			.as_ref()
+			.and_then(|d| d.as_object().cloned())
+			.unwrap_or_default();
+		check_extra.insert(
+			"result".into(),
+			serde_json::Value::String(instance.observed.to_string()),
+		);
+		let ctx = EvaluationContext {
+			status_extra: &status_extra,
+			check_extra: &check_extra,
+			tags: &tags,
+		};
+		let fleet_graded = CheckPolicy::grade(
+			fleet.as_ref(),
+			source,
+			filing.check,
+			instance.observed,
+			&ctx,
+		);
+		let graded = CheckPolicy::chain_scoped(fleet_graded, &chain, &ctx);
+		escalates |= graded.escalates;
+		graded_instances.push(GradedInstance {
+			label: instance.label.clone(),
+			observed: instance.observed,
+			effective: graded.effective,
+			detail: instance.detail.clone(),
+		});
+	}
+
+	// The check settles on its most urgent instance. A skipped instance is
+	// silenced, not healthy, so it neither drags the check down nor props it
+	// up; a check whose instances are all skipped is itself skipped.
+	let considered: Vec<&GradedInstance> = graded_instances
+		.iter()
+		.filter(|i| i.effective != CheckResult::Skipped)
+		.collect();
+	let effective = considered
+		.iter()
+		.map(|i| i.effective)
+		.min_by_key(|r| r.urgency_rank())
+		.unwrap_or(CheckResult::Skipped);
+
+	// The observed result is always recorded as observed, so it spans every
+	// instance including the silenced ones: silencing a check changes what
+	// Canopy acts on, never what it saw.
+	let observed = graded_instances
+		.iter()
+		.map(|i| i.observed)
+		.min_by_key(|r| r.urgency_rank())
+		.unwrap_or(CheckResult::Skipped);
+
+	let mut degraded: Vec<GradedInstance> = considered
+		.iter()
+		.filter(|i| i.effective != CheckResult::Passed)
+		.map(|i| (*i).clone())
+		.collect();
+	degraded.sort_by_key(|i| i.effective.urgency_rank());
+
+	let detail = instance_detail(&graded_instances, &degraded);
+	let rendered = message(&degraded);
 
 	let active = matches!(
-		graded.effective,
+		effective,
 		CheckResult::Failed | CheckResult::Warning | CheckResult::Broken
 	);
 	let description = if active { filing.title } else { None };
 	let stamp = CheckStateStamp {
 		check: filing.check.to_string(),
-		observed: filing.observed,
-		effective: graded.effective,
-		escalates: graded.escalates,
-		detail: filing.detail.clone(),
+		observed,
+		effective,
+		escalates,
+		detail: detail.clone(),
+	};
+	let filing = CheckFiling {
+		source,
+		scope: filing.scope,
+		device_id: filing.device_id,
+		check: filing.check,
+		observed,
+		title: filing.title,
+		message: &rendered,
+		detail,
+		default_ceiling: filing.default_ceiling,
+		default_escalates: filing.default_escalates,
+		documentation: filing.documentation,
 	};
 
 	match filing.scope {
@@ -1019,6 +1170,49 @@ pub async fn file_check(conn: &mut AsyncPgConnection, filing: CheckFiling<'_>) -
 			.await
 		}
 	}
+}
+
+/// The detail an instanced check stores: every instance that is not passing,
+/// each with its own result, plus how many there were in total. That is what
+/// lets an operator see which backup types a server is stale for without
+/// opening anything else — the thing a check name per type used to convey.
+///
+/// A single unlabelled instance is an ordinary check filed through this path,
+/// so its detail passes straight through unchanged.
+fn instance_detail(
+	all: &[GradedInstance],
+	degraded: &[GradedInstance],
+) -> Option<serde_json::Value> {
+	if let [only] = all
+		&& only.label.is_empty()
+	{
+		return only.detail.clone();
+	}
+	if degraded.is_empty() {
+		return None;
+	}
+	let instances: Vec<serde_json::Value> = degraded
+		.iter()
+		.map(|i| {
+			let mut obj = i
+				.detail
+				.as_ref()
+				.and_then(|d| d.as_object().cloned())
+				.unwrap_or_default();
+			obj.insert(
+				"result".into(),
+				serde_json::Value::String(i.effective.to_string()),
+			);
+			obj.entry("instance")
+				.or_insert_with(|| serde_json::Value::String(i.label.clone()));
+			serde_json::Value::Object(obj)
+		})
+		.collect();
+	Some(serde_json::json!({
+		"instances": instances,
+		"degraded": degraded.len(),
+		"total": all.len(),
+	}))
 }
 
 /// One rollup input row: `(server_id, source, check_name, effective_result)`.

--- a/crates/database/tests/it/backup_detection.rs
+++ b/crates/database/tests/it/backup_detection.rs
@@ -265,6 +265,76 @@ async fn issue_message(
 	.map(|r| r.message)
 }
 
+#[derive(QueryableByName, Debug)]
+struct NameRow {
+	#[diesel(sql_type = sql_types::Text)]
+	name: String,
+}
+
+/// Every canopy issue ref on a server matching a LIKE pattern. Used to assert
+/// a check has exactly one entry rather than one per instance.
+async fn issues_matching(
+	conn: &mut AsyncPgConnection,
+	server_id: Uuid,
+	pattern: &str,
+) -> Vec<String> {
+	sql_query(
+		"SELECT \"ref\" AS name FROM issues \
+		 WHERE server_id = $1 AND source = $2 AND \"ref\" LIKE $3 ORDER BY \"ref\"",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(refs::CANOPY_SOURCE)
+	.bind::<sql_types::Text, _>(pattern)
+	.load::<NameRow>(conn)
+	.await
+	.expect("load issue refs")
+	.into_iter()
+	.map(|r| r.name)
+	.collect()
+}
+
+/// Every catalog entry matching a LIKE pattern — what an operator would have
+/// to configure.
+async fn catalog_names(conn: &mut AsyncPgConnection, pattern: &str) -> Vec<String> {
+	sql_query(
+		"SELECT check_name AS name FROM check_policies \
+		 WHERE source = $1 AND check_name LIKE $2 ORDER BY check_name",
+	)
+	.bind::<sql_types::Text, _>(refs::CANOPY_SOURCE)
+	.bind::<sql_types::Text, _>(pattern)
+	.load::<NameRow>(conn)
+	.await
+	.expect("load catalog names")
+	.into_iter()
+	.map(|r| r.name)
+	.collect()
+}
+
+#[derive(QueryableByName, Debug)]
+struct DetailRow {
+	#[diesel(sql_type = sql_types::Nullable<sql_types::Jsonb>)]
+	detail: Option<serde_json::Value>,
+}
+
+/// A check's stored detail, which is where the per-instance results live.
+async fn issue_detail(
+	conn: &mut AsyncPgConnection,
+	server_id: Uuid,
+	r#ref: &str,
+) -> Option<serde_json::Value> {
+	sql_query(
+		"SELECT detail FROM issues \
+		 WHERE server_id = $1 AND source = $2 AND \"ref\" = $3",
+	)
+	.bind::<sql_types::Uuid, _>(server_id)
+	.bind::<sql_types::Text, _>(refs::CANOPY_SOURCE)
+	.bind::<sql_types::Text, _>(r#ref)
+	.get_result::<DetailRow>(conn)
+	.await
+	.ok()
+	.and_then(|r| r.detail)
+}
+
 async fn group_issue(
 	conn: &mut AsyncPgConnection,
 	group_id: Uuid,
@@ -327,10 +397,6 @@ async fn group_issue_open_links(conn: &mut AsyncPgConnection, group_id: Uuid, r#
 
 // The per-(server,type) ref suffix that `sweep` folds onto STALENESS/NEVER and
 // reconcile folds onto its refs (`:{type}`).
-fn typed_ref(base: &str, ty: &BackupType) -> String {
-	format!("{base}:{ty}")
-}
-
 // ===========================================================================
 // Case 1 — `classify` boundaries (pure, no DB)
 // ===========================================================================
@@ -540,8 +606,8 @@ async fn sweep_files_staleness_for_monitored_server_with_old_success() {
 			.await
 			.expect("sweep");
 
-		let sref = typed_ref(refs::STALENESS, &pg);
-		let issue = server_issue(&mut conn, server_id, &sref)
+		let sref = refs::STALENESS;
+		let issue = server_issue(&mut conn, server_id, sref)
 			.await
 			.expect("staleness issue filed");
 		// The sweep still observes a failure; the shipped ceiling is what caps
@@ -556,7 +622,7 @@ async fn sweep_files_staleness_for_monitored_server_with_old_success() {
 		assert!(!issue.escalates);
 		assert!(issue.active, "staleness issue is active");
 		assert_eq!(
-			server_issue_open_links(&mut conn, server_id, &sref).await,
+			server_issue_open_links(&mut conn, server_id, sref).await,
 			0,
 			"a warning does not open an incident on its own",
 		);
@@ -584,8 +650,8 @@ async fn sweep_files_never_for_server_that_never_succeeded() {
 			.await
 			.expect("sweep");
 
-		let nref = typed_ref(refs::NEVER, &pg);
-		let issue = server_issue(&mut conn, server_id, &nref)
+		let nref = refs::NEVER;
+		let issue = server_issue(&mut conn, server_id, nref)
 			.await
 			.expect("never issue filed");
 		// Never-reported is a warning (so first-time setup doesn't open an
@@ -594,7 +660,7 @@ async fn sweep_files_never_for_server_that_never_succeeded() {
 		assert!(issue.active);
 		// Staleness ref must NOT be filed when there's never been a success.
 		assert!(
-			server_issue(&mut conn, server_id, &typed_ref(refs::STALENESS, &pg))
+			server_issue(&mut conn, server_id, refs::STALENESS)
 				.await
 				.is_none(),
 			"never path does not also file backup-staleness",
@@ -637,15 +703,15 @@ async fn unmonitored_staleness_records_issue_but_no_incident_link() {
 			.await
 			.expect("sweep");
 
-		let sref = typed_ref(refs::STALENESS, &pg);
+		let sref = refs::STALENESS;
 		// Issue/event is still recorded unconditionally.
-		let issue = server_issue(&mut conn, server_id, &sref)
+		let issue = server_issue(&mut conn, server_id, sref)
 			.await
 			.expect("issue still recorded for unmonitored server");
 		assert!(issue.active);
 		// ...but it must NOT contribute to any incident (is_monitored gate).
 		assert_eq!(
-			server_issue_open_links(&mut conn, server_id, &sref).await,
+			server_issue_open_links(&mut conn, server_id, sref).await,
 			0,
 			"unmonitored staleness must not open/join an incident",
 		);
@@ -691,8 +757,8 @@ async fn reconcile_files_report_gap_when_snapshot_fresh_but_no_report() {
 			.await
 			.expect("reconcile sweep");
 
-		let gref = typed_ref(refs::RECONCILE_REPORT_GAP, &pg);
-		let issue = server_issue(&mut conn, server_id, &gref)
+		let gref = refs::RECONCILE_REPORT_GAP;
+		let issue = server_issue(&mut conn, server_id, gref)
 			.await
 			.expect("report-gap issue filed");
 		assert_eq!(
@@ -703,7 +769,7 @@ async fn reconcile_files_report_gap_when_snapshot_fresh_but_no_report() {
 		assert!(issue.active);
 		// Warning never opens an incident on its own.
 		assert_eq!(
-			server_issue_open_links(&mut conn, server_id, &gref).await,
+			server_issue_open_links(&mut conn, server_id, gref).await,
 			0,
 			"Warning report-gap does not open an incident by itself",
 		);
@@ -757,8 +823,8 @@ async fn reconcile_files_missing_when_report_fresh_but_no_snapshot() {
 			.await
 			.expect("reconcile sweep");
 
-		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
-		let issue = server_issue(&mut conn, server_id, &mref)
+		let mref = refs::RECONCILE_MISSING;
+		let issue = server_issue(&mut conn, server_id, mref)
 			.await
 			.expect("reconcile-missing issue filed against the server it concerns");
 		assert_eq!(issue.observed_result.as_deref(), Some("failed"));
@@ -769,11 +835,11 @@ async fn reconcile_files_missing_when_report_fresh_but_no_snapshot() {
 		);
 		assert!(issue.active);
 		assert!(
-			group_issue(&mut conn, group_id, &mref).await.is_none(),
+			group_issue(&mut conn, group_id, mref).await.is_none(),
 			"the finding is about one server, not the group",
 		);
 		assert_eq!(
-			server_issue_open_links(&mut conn, server_id, &mref).await,
+			server_issue_open_links(&mut conn, server_id, mref).await,
 			0,
 			"a warning does not open an incident on its own",
 		);
@@ -830,8 +896,8 @@ async fn reconcile_files_missing_when_report_fresh_and_the_pair_has_no_snapshot_
 			.await
 			.expect("reconcile sweep");
 
-		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
-		let issue = server_issue(&mut conn, server_id, &mref)
+		let mref = refs::RECONCILE_MISSING;
+		let issue = server_issue(&mut conn, server_id, mref)
 			.await
 			.expect("reconcile-missing issue filed for the pair with no snapshot");
 		assert_eq!(issue.observed_result.as_deref(), Some("failed"));
@@ -902,8 +968,8 @@ async fn reconcile_missing_is_per_server_not_shared_across_the_group() {
 			.await
 			.expect("reconcile sweep");
 
-		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
-		let broken = server_issue(&mut conn, broken_id, &mref)
+		let mref = refs::RECONCILE_MISSING;
+		let broken = server_issue(&mut conn, broken_id, mref)
 			.await
 			.expect("the server whose snapshot is missing holds the alert");
 		assert_eq!(broken.observed_result.as_deref(), Some("failed"));
@@ -913,7 +979,7 @@ async fn reconcile_missing_is_per_server_not_shared_across_the_group() {
 			"the healthy server in the same group must not clear it",
 		);
 		assert!(
-			server_issue(&mut conn, healthy_id, &mref).await.is_none(),
+			server_issue(&mut conn, healthy_id, mref).await.is_none(),
 			"the healthy server has no reconcile-missing alert of its own",
 		);
 	})
@@ -967,8 +1033,8 @@ async fn reconcile_missing_names_the_server_rather_than_its_id() {
 			.await
 			.expect("reconcile sweep");
 
-		let mref = typed_ref(refs::RECONCILE_MISSING, &pg);
-		let message = issue_message(&mut conn, server_id, &mref)
+		let mref = refs::RECONCILE_MISSING;
+		let message = issue_message(&mut conn, server_id, mref)
 			.await
 			.expect("reconcile-missing issue filed");
 		assert!(
@@ -1017,14 +1083,92 @@ async fn reconcile_skips_missing_when_the_group_was_never_inspected() {
 			.expect("reconcile sweep");
 
 		assert!(
-			group_issue(
-				&mut conn,
-				group_id,
-				&typed_ref(refs::RECONCILE_MISSING, &pg)
-			)
-			.await
-			.is_none(),
+			group_issue(&mut conn, group_id, refs::RECONCILE_MISSING)
+				.await
+				.is_none(),
 			"an uninspected group must not be accused of losing backups",
+		);
+		assert!(
+			server_issue(&mut conn, server_id, refs::RECONCILE_MISSING)
+				.await
+				.is_none(),
+			"and no per-server finding either",
+		);
+	})
+	.await;
+}
+
+/// A stale repo inventory makes the missing verdict undecidable, not resolved.
+/// With every type undecidable there is nothing to conclude, so an already-open
+/// finding stays open rather than being cleared on the strength of a lagging
+/// inspector.
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_leaves_an_open_missing_alone_when_the_inventory_goes_stale() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let interval = SignedDuration::from_hours(12);
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+		insert_backup_success_aged(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(2),
+		)
+		.await;
+
+		// Fresh inventory, stale snapshot → the finding is raised.
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{server_id}:/data"),
+			Some(server_id),
+			Some(&pg),
+			Some(Timestamp::now() - SignedDuration::from_hours(72)),
+		)
+		.await
+		.expect("upsert stale snapshot");
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("first sweep");
+		assert!(
+			server_issue(&mut conn, server_id, refs::RECONCILE_MISSING)
+				.await
+				.expect("finding raised")
+				.active,
+		);
+
+		// Now the inspector falls behind: back-date every observation past the
+		// inventory-staleness bound.
+		sql_query(
+			"UPDATE backup_repo_snapshots SET observed_at = NOW() - INTERVAL '30 days' \
+			 WHERE group_id = $1",
+		)
+		.bind::<sql_types::Uuid, _>(group_id)
+		.execute(&mut conn)
+		.await
+		.expect("age the inventory");
+
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("second sweep");
+		assert!(
+			server_issue(&mut conn, server_id, refs::RECONCILE_MISSING)
+				.await
+				.expect("finding still present")
+				.active,
+			"a lagging inspector must not clear an open finding",
 		);
 	})
 	.await;
@@ -1063,9 +1207,9 @@ async fn reconcile_clears_report_gap_when_report_and_snapshot_agree() {
 		database::backup::reconcile::sweep(&mut conn, &rows)
 			.await
 			.expect("first reconcile");
-		let gref = typed_ref(refs::RECONCILE_REPORT_GAP, &pg);
+		let gref = refs::RECONCILE_REPORT_GAP;
 		assert!(
-			server_issue(&mut conn, server_id, &gref)
+			server_issue(&mut conn, server_id, gref)
 				.await
 				.expect("report-gap open")
 				.active,
@@ -1089,7 +1233,7 @@ async fn reconcile_clears_report_gap_when_report_and_snapshot_agree() {
 			.await
 			.expect("second reconcile");
 
-		let issue = server_issue(&mut conn, server_id, &gref)
+		let issue = server_issue(&mut conn, server_id, gref)
 			.await
 			.expect("report-gap still present (now cleared)");
 		assert!(
@@ -1140,8 +1284,8 @@ async fn reconcile_files_size_mismatch_when_reported_size_differs_from_repo() {
 			.await
 			.expect("reconcile sweep");
 
-		let sref = typed_ref(refs::RECONCILE_SIZE_MISMATCH, &pg);
-		let issue = server_issue(&mut conn, server_id, &sref)
+		let sref = refs::RECONCILE_SIZE_MISMATCH;
+		let issue = server_issue(&mut conn, server_id, sref)
 			.await
 			.expect("size-mismatch issue filed");
 		assert_eq!(
@@ -1151,7 +1295,7 @@ async fn reconcile_files_size_mismatch_when_reported_size_differs_from_repo() {
 		);
 		assert!(issue.active);
 		assert_eq!(
-			server_issue_open_links(&mut conn, server_id, &sref).await,
+			server_issue_open_links(&mut conn, server_id, sref).await,
 			0,
 			"Warning size-mismatch does not open an incident by itself",
 		);
@@ -1195,9 +1339,9 @@ async fn reconcile_clears_size_mismatch_when_latest_sizes_agree() {
 		database::backup::reconcile::sweep(&mut conn, &rows)
 			.await
 			.expect("first reconcile");
-		let sref = typed_ref(refs::RECONCILE_SIZE_MISMATCH, &pg);
+		let sref = refs::RECONCILE_SIZE_MISMATCH;
 		assert!(
-			server_issue(&mut conn, server_id, &sref)
+			server_issue(&mut conn, server_id, sref)
 				.await
 				.expect("size-mismatch open")
 				.active,
@@ -1230,7 +1374,7 @@ async fn reconcile_clears_size_mismatch_when_latest_sizes_agree() {
 			.await
 			.expect("second reconcile");
 
-		let issue = server_issue(&mut conn, server_id, &sref)
+		let issue = server_issue(&mut conn, server_id, sref)
 			.await
 			.expect("size-mismatch still present (now cleared)");
 		assert!(
@@ -1577,6 +1721,124 @@ async fn backup_sweeps_seed_no_check_that_defaults_to_a_failure() {
 				row.check_name,
 			);
 		}
+	})
+	.await;
+}
+
+/// One check per server, whatever it backs up. A server stale on three of its
+/// four types holds a single `backup-staleness` check naming all three, not
+/// three checks — and the catalog has one entry to configure, not three.
+// spec: CHK#names
+#[tokio::test(flavor = "multi_thread")]
+async fn staleness_is_one_check_per_server_with_the_types_as_instances() {
+	TestDb::run(|mut conn, _url| async move {
+		let interval = SignedDuration::from_hours(12);
+		let stale_types = [
+			BackupType::TamanuPostgres,
+			BackupType::Custom("tamanu-config".into()),
+			BackupType::Custom("caddy-config".into()),
+		];
+		let fresh_type = BackupType::Custom("postgres-config".into());
+
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+
+		for ty in stale_types.iter().chain(std::iter::once(&fresh_type)) {
+			insert_schedule(&mut conn, group_id, ty, interval).await;
+			enable_capability(&mut conn, server_id, ty).await;
+		}
+		// Three types last succeeded three days ago (stale), one an hour ago.
+		for ty in &stale_types {
+			insert_backup_success_aged(
+				&mut conn,
+				device_id,
+				group_id,
+				server_id,
+				ty,
+				SignedDuration::from_hours(72),
+			)
+			.await;
+		}
+		insert_backup_success_aged(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&fresh_type,
+			SignedDuration::from_hours(1),
+		)
+		.await;
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		assert_eq!(rows.len(), 4, "four scanned (server, type) pairs");
+		database::backup::staleness::sweep(&mut conn, &rows)
+			.await
+			.expect("sweep");
+
+		// Exactly one staleness issue for the server, and no parameterised
+		// variants alongside it.
+		let issues = issues_matching(&mut conn, server_id, "backup-staleness%").await;
+		assert_eq!(
+			issues,
+			vec![refs::STALENESS.to_string()],
+			"one staleness check per server, named for the condition only",
+		);
+
+		let issue = server_issue(&mut conn, server_id, refs::STALENESS)
+			.await
+			.expect("staleness issue filed");
+		assert_eq!(issue.observed_result.as_deref(), Some("failed"));
+		assert_eq!(issue.effective_result.as_deref(), Some("warning"));
+
+		// The message names the types it is stale for, and the detail carries
+		// them with their own results — the thing a name per type used to say.
+		let message = issue_message(&mut conn, server_id, refs::STALENESS)
+			.await
+			.expect("message");
+		for ty in &stale_types {
+			assert!(
+				message.contains(&ty.to_string()),
+				"message names {ty}: {message}",
+			);
+		}
+		assert!(
+			!message.contains(&fresh_type.to_string()),
+			"the fresh type is not named: {message}",
+		);
+
+		let detail = issue_detail(&mut conn, server_id, refs::STALENESS)
+			.await
+			.expect("detail");
+		assert_eq!(detail["total"], 4, "four instances were considered");
+		assert_eq!(detail["degraded"], 3, "three of them are stale");
+		let listed: Vec<&str> = detail["instances"]
+			.as_array()
+			.expect("instances array")
+			.iter()
+			.map(|i| i["type"].as_str().expect("type"))
+			.collect();
+		for ty in &stale_types {
+			assert!(
+				listed.contains(&ty.to_string().as_str()),
+				"detail lists {ty}"
+			);
+		}
+		assert!(
+			!listed.contains(&fresh_type.to_string().as_str()),
+			"detail omits the healthy type",
+		);
+
+		// And the catalog gained one entry, not one per type.
+		let catalog = catalog_names(&mut conn, "backup-staleness%").await;
+		assert_eq!(
+			catalog,
+			vec![refs::STALENESS.to_string()],
+			"one catalog entry to configure, not one per backup type",
+		);
 	})
 	.await;
 }

--- a/migrations/2026-08-04-022520-0000_collapse_backup_check_names/down.sql
+++ b/migrations/2026-08-04-022520-0000_collapse_backup_check_names/down.sql
@@ -1,0 +1,3 @@
+-- Irreversible: the per-type rows that lost the collapse are deleted, and
+-- which type each survivor came from isn't recoverable from the collapsed name.
+-- Nothing to restore.

--- a/migrations/2026-08-04-022520-0000_collapse_backup_check_names/up.sql
+++ b/migrations/2026-08-04-022520-0000_collapse_backup_check_names/up.sql
@@ -1,0 +1,188 @@
+-- The backup sweeps spelled the backup type into the check name:
+-- backup-staleness:tamanu-postgres, backup-staleness:caddy-config, and so on.
+-- A deployment backing up four things therefore produced four separate checks
+-- to configure, four catalog rows, and four entries in every listing — for one
+-- condition. A check name is a category an operator configures once; anything
+-- that varies per instance belongs in the detail, where policy rules read it as
+-- check.<field>. See the Names section of the CHK spec.
+--
+-- Each of these five checks is now filed once per server with the types as
+-- instances, graded per type and settling on the most urgent. Collapse the
+-- stored state to match.
+
+-- 1. Issues. Several per-type rows collapse onto one per (target, source, ref),
+--    so pick a survivor per target and drop the rest rather than letting the
+--    uniqueness constraints reject the rename. The survivor is the most urgent
+--    row, then the most recently seen: that keeps the row an operator is most
+--    likely already looking at, with its incident membership and history.
+--
+--    The survivor's per-type detail is left as it is. It describes one type
+--    where the new shape carries every degraded instance, and the next sweep
+--    overwrites it with the aggregate — within a minute, since these sweeps run
+--    on the reachability tick.
+CREATE TEMP TABLE backup_check_renames ON COMMIT DROP AS
+SELECT
+	id,
+	base,
+	row_number() OVER (
+		PARTITION BY source, base, server_id, server_group_id
+		ORDER BY
+			CASE effective_result
+				WHEN 'failed' THEN 0
+				WHEN 'warning' THEN 1
+				WHEN 'broken' THEN 2
+				WHEN 'passed' THEN 3
+				ELSE 4
+			END,
+			last_seen DESC,
+			id
+	) AS rank
+FROM (
+	SELECT i.*, split_part(i.ref, ':', 1) AS base
+	FROM issues i
+	WHERE i.source = 'canopy'
+		AND i.ref LIKE '%:%'
+		AND split_part(i.ref, ':', 1) IN (
+			'backup-staleness',
+			'backup-never',
+			'backup-reconcile-missing',
+			'backup-reconcile-report-gap',
+			'backup-reconcile-size-mismatch'
+		)
+) AS parameterised;
+
+-- Which incidents the departing rows were contributing to, captured before the
+-- rows go so the emptied ones can be retired afterwards.
+CREATE TEMP TABLE touched_incidents ON COMMIT DROP AS
+SELECT DISTINCT il.incident_id
+FROM incident_issues il
+WHERE il.left_at IS NULL
+	AND il.issue_id IN (SELECT id FROM backup_check_renames WHERE rank > 1);
+
+UPDATE incident_issues
+SET left_at = now()
+WHERE left_at IS NULL
+	AND issue_id IN (SELECT id FROM backup_check_renames WHERE rank > 1);
+
+DELETE FROM issues
+WHERE id IN (SELECT id FROM backup_check_renames WHERE rank > 1);
+
+UPDATE issues AS i
+SET ref = r.base, check_name = r.base
+FROM backup_check_renames r
+WHERE i.id = r.id AND r.rank = 1;
+
+-- Retire incidents the departures emptied of failing contributors. Mirrors the
+-- leave path in re_evaluate_incident_membership: an incident is held open by
+-- its currently-failing contributors. No Slack resolve is enqueued — the
+-- condition didn't change, only how many rows describe it.
+UPDATE incidents AS inc
+SET closed_at = now()
+WHERE inc.closed_at IS NULL
+	AND inc.id IN (SELECT incident_id FROM touched_incidents)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM incident_issues il
+		JOIN issues i ON i.id = il.issue_id
+		WHERE il.incident_id = inc.id
+			AND il.left_at IS NULL
+			AND i.effective_result = 'failed'
+	);
+
+-- 2. Scoped policies, which is where silences live. A silence on
+--    backup-staleness:tamanu-postgres meant "silence staleness for this one
+--    type". Under one check name the equivalent is a rule that skips the
+--    instance whose check.type matches, which is exactly what per-instance
+--    grading is for. Rewrite them so operators keep the suppression they set
+--    up, instead of it silently widening to every type or being dropped.
+--
+--    The rules column is an if-ladder: {"if": [condition, result, …]} (see
+--    check_policies::IfLadder, and Condition's JsonLogic encoding). A
+--    ceiling-only silence becomes a single-branch ladder and gives up its
+--    ceiling; a row that already carried rules keeps them, with the type guard
+--    prepended so the guard wins.
+UPDATE scoped_check_policies
+SET
+	check_name = split_part(check_name, ':', 1),
+	ceiling = NULL,
+	rules = jsonb_build_object(
+		'if',
+		jsonb_build_array(
+			jsonb_build_object(
+				'==',
+				jsonb_build_array(
+					jsonb_build_object('var', 'check.type'),
+					split_part(check_name, ':', 2)
+				)
+			),
+			COALESCE(ceiling, 'skipped')
+		) || COALESCE(rules -> 'if', '[]'::jsonb)
+	)
+WHERE source = 'canopy'
+	AND check_name LIKE '%:%'
+	AND split_part(check_name, ':', 1) IN (
+		'backup-staleness',
+		'backup-never',
+		'backup-reconcile-missing',
+		'backup-reconcile-report-gap',
+		'backup-reconcile-size-mismatch'
+	);
+
+-- 3. Catalog rows: the thing that made an operator configure one condition
+--    once per type. Keep the most deliberately-set row's policy for the
+--    collapsed name — an operator-reviewed row beats a canopy-seeded one, and
+--    among equals the most urgent ceiling wins — and drop the rest. If nothing
+--    survives, the next filing re-registers the collapsed name with its
+--    shipped defaults.
+CREATE TEMP TABLE backup_policy_renames ON COMMIT DROP AS
+SELECT
+	source,
+	check_name,
+	base,
+	row_number() OVER (
+		PARTITION BY source, base
+		ORDER BY
+			CASE WHEN reviewed_by IS DISTINCT FROM 'canopy' THEN 0 ELSE 1 END,
+			CASE ceiling
+				WHEN 'failed' THEN 0
+				WHEN 'warning' THEN 1
+				WHEN 'broken' THEN 2
+				WHEN 'passed' THEN 3
+				ELSE 4
+			END,
+			check_name
+	) AS rank
+FROM (
+	SELECT p.*, split_part(p.check_name, ':', 1) AS base
+	FROM check_policies p
+	WHERE p.source = 'canopy'
+		AND p.check_name LIKE '%:%'
+		AND split_part(p.check_name, ':', 1) IN (
+			'backup-staleness',
+			'backup-never',
+			'backup-reconcile-missing',
+			'backup-reconcile-report-gap',
+			'backup-reconcile-size-mismatch'
+		)
+) AS parameterised;
+
+DELETE FROM check_policies p
+USING backup_policy_renames r
+WHERE p.source = r.source AND p.check_name = r.check_name AND r.rank > 1;
+
+-- A bare collapsed row already existing wins outright; the parameterised one
+-- goes rather than colliding on the rename.
+DELETE FROM check_policies p
+USING backup_policy_renames r
+WHERE p.source = r.source
+	AND p.check_name = r.check_name
+	AND r.rank = 1
+	AND EXISTS (
+		SELECT 1 FROM check_policies q
+		WHERE q.source = r.source AND q.check_name = r.base
+	);
+
+UPDATE check_policies p
+SET check_name = r.base
+FROM backup_policy_renames r
+WHERE p.source = r.source AND p.check_name = r.check_name AND r.rank = 1;


### PR DESCRIPTION
🤖 Stacked on #479 — review that first; this branch is based on it because both touch the same files.

## Why

Backup checks spelled the backup type into the name: `backup-staleness:tamanu-postgres`, `backup-staleness:caddy-config`, `backup-staleness:tamanu-config`, `backup-staleness:postgres-config`. A deployment backing up four things produced four checks to configure, four catalog rows, and four entries in every listing — for one condition. That defeats the point of a catalog you configure once and then use to get your eyes on things quickly.

## The rule

A check name is a **category**. Anything that varies between instances of the same condition — which backup configuration, which restore intent — goes in the check's detail, where policy rules already read it as `check.<field>`.

New normative sections: `CHK#names` (a name is a category, instances go in detail, and how an instanced check aggregates), its application in `BKJ`, and the `AGENTS.md` bullet that landed with #479.

## How it aggregates

The five backup sweeps — staleness, never, reconcile-missing, report-gap, size-mismatch — now file one check per server with the types as instances:

- each instance is graded through policy **on its own**, against its own detail, so a rule or silence written for one backup type still affects only that type. That was the whole reason the type was in the name.
- the check settles on its most urgent instance;
- its detail carries every degraded instance with that instance's own result, and its message names them.

So an operator configures staleness once for the fleet, and where a particular type warrants different treatment, writes `check.type == '…'` rather than acquiring another check.

New in `issues.rs`: `file_check_instances`, with `file_check` reduced to its one-instance case so nothing else changes behaviour. The catalog entry and scoped chain are read once per check rather than once per instance, so a server with a dozen backup types still costs two queries.

## Two details worth a look

**Silences.** A skipped instance leaves the aggregate rather than counting as healthy, and a check whose instances are all skipped is itself skipped. But the *observed* result still spans every instance including the silenced ones — silencing changes what canopy acts on, never what it saw, which `CHK` requires. Getting this wrong initially broke `scoped_check_policies::server_silence_grades_filings_to_skipped`, which is a good test.

**Undecidable is not resolved.** A stale repo inventory makes the missing verdict undecidable. Where it is stale for every type there is nothing to conclude, so an already-open finding is left alone instead of being cleared on the strength of a lagging inspector. That is easy to lose in a refactor, so there is a test for it.

## Migration

Collapses the stored state three ways:

- **issues** — per-type rows onto one per target. The survivor is the most urgent, then the most recently seen, so it keeps the row an operator is most likely already looking at along with its incident membership and history; losers leave their incidents first, and incidents left with no failing contributor retire.
- **silences** (scoped policies) — a silence on `backup-staleness:tamanu-postgres` becomes a rule guard on `check.type`, so operators keep exactly the suppression they configured instead of it widening to every type or being dropped. Verified to produce the correct if-ladder: `{"if": [{"==": [{"var": "check.type"}, "tamanu-postgres"]}, "skipped"]}`, with pre-existing rules preserved behind the guard.
- **catalog** — per-type rows onto one, preferring an operator-reviewed policy over a canopy-seeded one.

All three verified against synthetic data in a rolled-back transaction.

## Deliberately not in scope

`restore-verification`, `redaction`, and `migration-test` still carry `(type, intent)` in their names. A follow-up is in progress.