### PR TITLE
fix(backup): reconcile-missing must prove what it claims

### DIFF
--- a/.workhorse/specs/jobs/backup.md
+++ b/.workhorse/specs/jobs/backup.md
@@ -42,7 +42,8 @@ This is the escrow the operator recovery ceremony verifies (see [BKO](../private
 Canopy periodically inspects each group's repo against the storage directly, independent of what devices reported:
 
 - it verifies repo integrity, and a failed verification is repo corruption;
-- it inventories the repo — the latest snapshot per source — as the ground truth a device's report is reconciled against;
+- it inventories the repo as the ground truth a device's report is reconciled against: the latest snapshot per source, and the identity of every snapshot it found, so a run's reported snapshot can be looked up rather than inferred from timestamps.
+  The inventory describes the repository as it stands at that inspection, so a snapshot expired by retention stops being recorded;
 - it records repo size, logical and physical, and the storage cost basis for display;
 - it records each snapshot's logical size and matches it to the device run that produced it by snapshot id, so the repo's own size stands in when a run reported none, and is cross-checked against the size a run did report. A snapshot's recorded size is written once, because a snapshot is immutable.
 
@@ -59,10 +60,15 @@ Pruning is fleet-wide and independent of any group's maintenance, so it never wa
 
 ## Detection
 
-Canopy reconciles three sources — what a device reported, what credentials were issued, and what actually landed in the repo — and alerts on disagreement:
+Canopy reconciles three sources — what a device reported, what credentials were issued, and what actually landed in the repo — and surfaces where they disagree:
 
 - **staleness** — a server with a prior successful backup but none recent, or one that has never backed up though it has been expected long enough. Recency is the age of the *data*, measured from the moment the backup froze what it captured (see [BAK](../public-server/backup.md)), falling back to the run's report time when it reported no such moment. So a backup that took many hours to upload is aged from when it was taken, and a server whose data is a day old is not counted fresh because its upload finished minutes ago. Both which run counts as the latest success and how old that success is use the same measure, so a server's freshness never travels backwards as new runs arrive.
-- **reconcile** — a device reported a successful backup but no matching snapshot landed (the report is false or the upload didn't persist), or a fresh snapshot exists but no recent report (the reporting path is broken). These are measured from report times, not from when data was frozen, because they assert that the reporting path itself is working rather than anything about the age of the data.
+- **reconcile** — a device reported a successful backup naming the snapshot it created and the repository does not hold that snapshot (the report is false or the upload didn't persist), or a fresh snapshot exists but no recent report (the reporting path is broken).
+  These assert that the reporting path itself is working rather than anything about the age of the data.
+  A snapshot's absence is only evidence once someone has looked: no verdict is reached from an inventory older than the run it would contradict, and a run whose snapshot could have been expired by retention since it was reported is not judged at all.
+  Where a verdict cannot be reached the signal is neither passing nor failing, and one that cannot be reached for any of a server's backup types leaves whatever was already raised standing rather than clearing it.
+- **snapshot recency** — the newest snapshot the repository holds for a server's source is older than the moment the device's latest run says it froze its data.
+  Backups and repository inspection run on independent cadences, so this compares two observations that are routinely out of step with nothing wrong; it is recorded and presented for context but never alerts, and it is only reached where the run reported the moment its data was frozen and the source has been inspected since.
 - **size** — a device reported a snapshot size that disagrees with the size the same snapshot occupies in the repo; only compared when both sizes are known and non-zero.
 - **maintenance** — a group whose maintenance is overdue, or whose most recent maintenance failed.
 
@@ -75,6 +81,9 @@ Backup signals therefore default to a warning and do not escalate, and an operat
 
 Three signals are the exception, and default to an escalating failure: repo corruption, a rotation that left the repository openable by neither passphrase, and object-lock protection that is missing or weakened.
 Each of these means the backups are already gone, unrecoverable, or unprotected, rather than merely late.
+
+A signal whose evidence supports only that something looks off, rather than that anything is wrong, ranks below a warning: it is recorded and presented with what it observed, and never alerts.
+Snapshot recency is one, and its wording says what was observed rather than what it implies, so an operator reading it is not told a backup is missing on the strength of two timestamps.
 
 Backup alerts are raised at one of two scopes:
 

--- a/crates/database/src/backup/reconcile.rs
+++ b/crates/database/src/backup/reconcile.rs
@@ -1,17 +1,23 @@
 //! Reconcile device **reports** against repo **inventory**: cross-check what
-//! devices reported (`backup_runs`) against what *actually landed* in the repo
-//! (`backup_repo_snapshots`).
+//! devices reported (`backup_runs`) against what inspection found in the repo
+//! (`backup_repo_observed_snapshots` for the individual snapshots,
+//! `backup_repo_snapshots` for the per-source summary).
 //!
-//! Per scanned `(server, type)`, resolved against the kopia source recorded in
-//! `backup_repo_snapshots`:
+//! Per scanned `(server, type)`:
 //!
-//! - **report success but no recent snapshot** → `backup-reconcile-missing`
-//!   (`Error`, per-server). The case the reports alone cannot catch — a device
-//!   lying about success or data not persisting. Detecting it needs the
-//!   group's repo inventory, but the finding is about the one server whose
+//! - **the reported snapshot is not in the repo** → `backup-reconcile-missing`
+//!   (`Warning`, per-server). The run named the snapshot it created and the
+//!   repository does not hold it: the case reports alone cannot catch, a device
+//!   lying about success or an upload that didn't persist. Detecting it needs
+//!   the group's repo inventory, but the finding is about the one server whose
 //!   report didn't hold up, so it is filed against that server: two servers in
 //!   a group can fail it independently, and one recovering must not clear the
 //!   other.
+//! - **the repo looks behind the report** → `backup-reconcile-recency`
+//!   (recorded only, never alerting). The newest snapshot for the source is
+//!   older than the moment the reported run froze its data. It compares
+//!   timestamps produced by two independent cadences, so it means "something
+//!   looks off" and cannot mean more than that.
 //! - **recent snapshot but no report** → `backup-reconcile-report-gap`
 //!   (`Warning`, per-server, non-paging). The reporting path is broken, not
 //!   the backup.
@@ -25,12 +31,21 @@
 //!   (`Warning`, per-server, non-paging). The device reported a snapshot size
 //!   that doesn't match what the repo holds.
 //!
-//! Freshness guard: if the repo inventory for the group is itself stale (its
-//! `observed_at` older than [`INVENTORY_STALE_AFTER`]), the "missing" verdict
-//! is skipped — a lagging inspector must not produce false "report lied"
-//! alerts.
+//! **Absence is only evidence once someone has looked.** Backups run on one
+//! cadence and inspection on a slower, independent one, so "the repo doesn't
+//! show it" routinely means "nobody has looked since". Every verdict about a
+//! run therefore requires an inspection *newer than that run*; where there
+//! isn't one, the instance is [`CheckResult::Skipped`] — neither passed nor
+//! failed — and a check with nothing decidable is not filed at all, so an
+//! already-open finding is left alone rather than cleared on the strength of a
+//! lagging inspector.
+//!
+//! Two things this cannot see, both because a repository leaves no record of an
+//! inspection that found nothing: a group whose repository inspection finds
+//! entirely empty, and a group whose snapshots have never been itemised.
+//! Corruption and staleness own those.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use commons_errors::Result;
 use commons_types::{backup::BackupType, status::CheckResult};
@@ -48,12 +63,16 @@ use crate::{
 	servers::Server,
 };
 
-/// How old a group's repo snapshot inventory (`observed_at`) may be before
-/// reconciliation refuses to conclude "missing". Tied to the inspection
-/// cadence floor (weekly for manual-only groups) plus a day of grace. If the
-/// inspector hasn't run recently we can't trust "no snapshot landed", so we
-/// defer to the inspection Job's own failure surfacing instead.
-pub const INVENTORY_STALE_AFTER: SignedDuration = SignedDuration::from_hours((7 + 1) * 24);
+/// Slack allowed when comparing a snapshot's recorded time against the moment
+/// the run that produced it says it froze its data.
+///
+/// The two are recorded by the same device from the same clock, and for a
+/// backup with nothing to dump beforehand they are the same instant recorded
+/// twice — so they can land either side of each other by a rounding or a
+/// scheduling hiccup. A real miss is a whole backup interval out, so a few
+/// minutes of slack costs nothing and stops a healthy pair being reported on a
+/// second's difference.
+const RECENCY_TOLERANCE: SignedDuration = SignedDuration::from_mins(5);
 
 /// Snapshot freshness + observed-at for one `(server, type)`, from
 /// `backup_repo_snapshots`.
@@ -67,6 +86,7 @@ struct SnapInfo {
 /// [`ScanRow`]s that [`crate::backup::staleness::scan_rows`] produced (the
 /// caller passes them in so the staleness scan and reconciliation share one
 /// pass). Returns the number of events filed.
+// spec: BKJ#detection
 pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize> {
 	if rows.is_empty() {
 		return Ok(0);
@@ -80,10 +100,11 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 	};
 	let snaps = snapshot_info(db, &group_ids).await?;
 
-	// Inventory freshness is a property of the *group's* inspection, not of any
-	// one pair's snapshot row: the inspection Job only writes a row for sources
-	// it actually finds, so the pair with nothing in the repo — precisely the
-	// one the "missing" verdict exists for — has no row of its own to date.
+	// When the group was last inspected, which is what makes a snapshot's
+	// absence mean anything. It is a property of the *group's* inspection, not
+	// of any one pair's snapshot row: the inspection Job only writes a row for
+	// sources it actually finds, so the pair with nothing in the repo — exactly
+	// the one a "missing" verdict is about — has no row of its own to date.
 	let mut inspected_at: HashMap<Uuid, Timestamp> = HashMap::new();
 	for gid in &group_ids {
 		if let Some(at) =
@@ -91,6 +112,29 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 		{
 			inspected_at.insert(*gid, at);
 		}
+	}
+
+	// The itemised snapshots each group's repo holds, with when they were
+	// observed. Both halves come from the same table so the evidence and its
+	// freshness can never disagree: a group with no rows has no observation to
+	// reason from, whatever the per-source summaries say.
+	let mut observed_snapshots: HashMap<Uuid, (HashSet<String>, Timestamp)> = HashMap::new();
+	for gid in &group_ids {
+		let (ids, at) =
+			crate::backups::BackupRepoObservedSnapshot::observed_ids_for_group(db, *gid).await?;
+		if let Some(at) = at {
+			observed_snapshots.insert(*gid, (ids, at));
+		}
+	}
+
+	// The run behind each pair's `last_success_at`, for the fields the scan
+	// doesn't carry: the snapshot id the device named, when it reported, and
+	// when it froze its data.
+	let mut latest_success: HashMap<(Uuid, BackupType), crate::backups::BackupRun> = HashMap::new();
+	for gid in &group_ids {
+		latest_success.extend(
+			crate::backups::BackupRun::latest_success_by_server_type_for_group(db, *gid).await?,
+		);
 	}
 
 	// How each scanned server is named in alert text, resolved in one query
@@ -160,12 +204,25 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 			refs::RECONCILE_SIZE_MISMATCH,
 		)
 		.await?;
+		// The recency check's ceiling holds its effective result at passed, so
+		// it is never "active" and there is no open finding to key off. What it
+		// leaves behind instead is an observation, which has to be brought up to
+		// date once the repo catches up.
+		let recency_recorded = crate::backup::staleness::server_check_observed_degraded(
+			db,
+			server_id,
+			refs::RECONCILE_RECENCY,
+		)
+		.await?;
 
 		let mut missing_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
+		let mut recency_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
 		let mut gap_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
 		let mut size_instances: Vec<CheckInstance> = Vec::with_capacity(server_rows.len());
 		let mut any_missing = false;
-		let mut any_decidable = false;
+		let mut any_missing_decidable = false;
+		let mut any_recency_decidable = false;
+		let mut any_behind = false;
 		let mut any_gap = false;
 		let mut any_size = false;
 
@@ -178,31 +235,77 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 			let snapshot_fresh = snap
 				.and_then(|s| s.latest_snapshot_at)
 				.is_some_and(|t| now.duration_since(t) <= grace);
-			let inventory_fresh = inspected_at
-				.get(&row.group_id)
-				.is_some_and(|at| now.duration_since(*at) <= INVENTORY_STALE_AFTER);
+			let run = latest_success.get(&(row.server_id, row.r#type.clone()));
 
-			// Report says success but the data didn't land. Only concluded when
-			// the repo inventory is fresh enough to be trusted; a lagging
-			// inspector must not produce false "report lied" findings, and a
-			// type whose inventory is stale is left out of the check rather
-			// than counted healthy.
-			let missing = report_fresh && !snapshot_fresh && inventory_fresh;
-			let missing_undecidable = report_fresh && !snapshot_fresh && !inventory_fresh;
-			any_missing |= missing;
-			any_decidable |= !missing_undecidable;
+			// The device named the snapshot it created and the repo doesn't hold
+			// it. Skipped unless every condition for the absence to *mean*
+			// something holds: the run named a snapshot, it is recent enough
+			// that retention cannot have expired that snapshot since, and the
+			// repo's snapshots were itemised after the run was reported. The
+			// report time is the bound there rather than the moment the data was
+			// frozen, because a snapshot is in the repo by the time its run is
+			// reported, so an inspection after that point would have seen it.
+			//
+			// A type with no reported success is skipped too: there is no claim
+			// to hold the repo to, so the check didn't run. Staleness and
+			// `backup-never` own the server that reports nothing.
+			let missing = match run.and_then(|r| r.snapshot_id.as_deref().map(|id| (r, id))) {
+				Some((run, id)) if report_fresh => observed_snapshots
+					.get(&row.group_id)
+					.filter(|(_, at)| *at > run.reported_at)
+					.map(|(ids, _)| !ids.contains(id)),
+				_ => None,
+			};
+			any_missing |= missing == Some(true);
+			any_missing_decidable |= missing.is_some();
+			let mut missing_detail = serde_json::Map::new();
+			missing_detail.insert("type".into(), row.r#type.to_string().into());
+			if let Some(id) = run.and_then(|r| r.snapshot_id.as_deref()) {
+				missing_detail.insert("snapshot_id".into(), id.into());
+			}
 			missing_instances.push(CheckInstance {
 				label: row.r#type.to_string(),
-				observed: if missing {
-					CheckResult::Failed
-				} else if missing_undecidable {
-					CheckResult::Skipped
-				} else {
-					CheckResult::Passed
+				observed: match missing {
+					Some(true) => CheckResult::Warning,
+					Some(false) => CheckResult::Passed,
+					None => CheckResult::Skipped,
 				},
-				detail: Some(serde_json::json!({
-					"type": row.r#type.to_string(),
-				})),
+				detail: Some(serde_json::Value::Object(missing_detail)),
+			});
+
+			// The repo's newest snapshot for the source is older than the moment
+			// the reported run froze its data. Decidable only where the run
+			// reported that moment and the source was inspected since the run:
+			// the report time is *after* the snapshot was written, so it is no
+			// lower bound on how new the repo's newest snapshot should be, and
+			// judging against it would call every healthy server behind.
+			let behind = run.and_then(|run| {
+				run.snapshot_taken_at
+					.filter(|_| {
+						inspected_at
+							.get(&row.group_id)
+							.is_some_and(|at| *at > run.reported_at)
+					})
+					.map(|taken| {
+						snap.and_then(|s| s.latest_snapshot_at)
+							.is_none_or(|newest| newest < taken - RECENCY_TOLERANCE)
+					})
+			});
+			any_behind |= behind == Some(true);
+			any_recency_decidable |= behind.is_some();
+			let mut recency_detail = serde_json::Map::new();
+			recency_detail.insert("type".into(), row.r#type.to_string().into());
+			if let Some(at) = snap.and_then(|s| s.latest_snapshot_at) {
+				recency_detail.insert("latest_snapshot_at".into(), at.to_string().into());
+			}
+			recency_instances.push(CheckInstance {
+				label: row.r#type.to_string(),
+				observed: match behind {
+					Some(true) => CheckResult::Warning,
+					Some(false) => CheckResult::Passed,
+					None => CheckResult::Skipped,
+				},
+				detail: Some(serde_json::Value::Object(recency_detail)),
 			});
 
 			// Snapshot landed but no recent report → the reporting path is
@@ -243,11 +346,10 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 			});
 		}
 
-		// A stale repo inventory makes the missing verdict undecidable, not
-		// resolved: when it is stale for every type there is nothing to
-		// conclude, so leave whatever state is already there rather than
-		// clearing an open finding on the strength of a lagging inspector.
-		if any_missing || (missing_open && any_decidable) {
+		// Nothing decidable means nothing to conclude: leave whatever state is
+		// already there rather than clearing an open finding on the strength of
+		// an inspection that predates the runs it would be clearing.
+		if any_missing || (missing_open && any_missing_decidable) {
 			let total = missing_instances.len();
 			file_check_instances(
 				db,
@@ -265,11 +367,50 @@ pub async fn sweep(db: &mut AsyncPgConnection, rows: &[ScanRow]) -> Result<usize
 				&|degraded| match degraded {
 					[] => format!("Server {label} backup reports and repo snapshots agree again"),
 					[one] => format!(
-						"Server {label} reported a successful {} backup but no matching repo snapshot landed",
+						"Server {label} reported a successful {} backup but its snapshot is not in the repo",
 						one.label
 					),
 					many => format!(
-						"Server {label} reported {} of its {total} backups successful with no matching repo snapshot: {}",
+						"Server {label} reported {} of its {total} backups successful with snapshots the repo doesn't hold: {}",
+						many.len(),
+						label_list(many),
+					),
+				},
+			)
+			.await?;
+			filed += 1;
+		}
+
+		// Filed when there is something to say, or something already said that
+		// this pass can retract — the same shape as the arms above, keyed on
+		// the last observation rather than on an open finding, because this
+		// check never has one.
+		if any_behind || (recency_recorded && any_recency_decidable) {
+			let total = recency_instances.len();
+			file_check_instances(
+				db,
+				InstancedCheckFiling {
+					source: crate::statuses::CANOPY_SOURCE,
+					scope: Scope::Server(server_id),
+					device_id,
+					check: refs::RECONCILE_RECENCY,
+					title: None,
+					instances: recency_instances,
+					// Recorded and visible, never alerting: this compares
+					// timestamps from two independent cadences, which supports
+					// "the repo looks behind" and not "a backup is missing".
+					default_ceiling: CheckResult::Passed,
+					default_escalates: false,
+					documentation: Some(refs::RECONCILE_RECENCY_DOC),
+				},
+				&|degraded| match degraded {
+					[] => format!("Repo snapshots for {label} are as new as the runs it reported"),
+					[one] => format!(
+						"The repo holds no {} snapshot for {label} as new as the run it reported",
+						one.label
+					),
+					many => format!(
+						"The repo holds no snapshot as new as the reported run for {} of {label}'s {total} backups: {}",
 						many.len(),
 						label_list(many),
 					),

--- a/crates/database/src/backup/refs.rs
+++ b/crates/database/src/backup/refs.rs
@@ -16,6 +16,10 @@
 //! unrecoverable, or unprotected rather than merely late. Operators can
 //! raise any individual check to a failure through its policy; that is
 //! their call to make, not a default to ship.
+//!
+//! A check whose evidence only supports "something looks off" registers lower
+//! still, at a `Passed` ceiling: recorded and visible, never alerting
+//! ([`RECONCILE_RECENCY`]).
 
 /// The event source for every backup alert. Re-exported from
 /// [`crate::statuses::CANOPY_SOURCE`] so both the reachability sweep and the
@@ -43,11 +47,19 @@ pub const RECONCILE_REPORT_GAP: &str = "backup-reconcile-report-gap";
 /// non-zero). Server-scoped, `Warning` (non-paging on its own).
 pub const RECONCILE_SIZE_MISMATCH: &str = "backup-reconcile-size-mismatch";
 
-/// A run reported success but no matching repo snapshot landed (the device
-/// lied or the upload didn't persist). Server-scoped, `Warning`. Detecting it
-/// takes the group's repo inventory, but the finding is about the one server
-/// whose report didn't hold up, so it is filed against that server.
+/// A run reported a snapshot id the group's repository does not hold — the
+/// device claimed a snapshot that isn't there, so either the report was false
+/// or the upload didn't persist. Server-scoped, `Warning`. Detecting it takes
+/// the group's repo inventory, but the finding is about the one server whose
+/// report didn't hold up, so it is filed against that server.
 pub const RECONCILE_MISSING: &str = "backup-reconcile-missing";
+
+/// The repository holds no snapshot for a server's source as new as the run it
+/// reported. Server-scoped, and registered at a `Passed` ceiling: recorded and
+/// visible, never alerting. It compares timestamps across two independent
+/// cadences and so means "something looks off", not "a backup is missing" —
+/// [`RECONCILE_MISSING`] is the one that establishes that.
+pub const RECONCILE_RECENCY: &str = "backup-reconcile-recency";
 
 // --- group-level (page regardless of any member's is_monitored) ---
 
@@ -178,15 +190,35 @@ Read the run's error in the group's backups panel. Common causes: credential exp
 
 pub const RECONCILE_MISSING_DOC: &str = "## Description
 
-A run reported success but no matching snapshot landed in the repository — the device's report and the repo disagree.
+The device reported a run and named the snapshot it created, and that snapshot is not among the ones repository inspection found. The report and the repository disagree about a specific snapshot, not about timing.
+
+Only the latest successful run per backup type is checked, and only while it is recent enough that retention could not have expired its snapshot, and only where the repository was inspected after the run was reported. Any type that fails one of those conditions is skipped rather than guessed at: the check never concludes from an inspection that predates the run it is judging.
 
 ## Results
 
-- **warn** — reported snapshot absent from the repo.
+- **warn** — the snapshot id the device reported is absent from the repository.
+- **skipped** — the device named no snapshot, the run is too old to distinguish absence from retention, or the repository has not been inspected since the run was reported.
 
 ## Solve
 
-Treat the backup as not having happened. Check the device's kopia logs for upload failures after the snapshot was cut, and re-run the backup.";
+Treat the backup as not having happened. Check the device's kopia logs for upload failures after the snapshot was cut, and re-run the backup. The reported snapshot id is in the check's detail, so `kopia snapshot list` for the source confirms it either way.";
+
+pub const RECONCILE_RECENCY_DOC: &str = "## Description
+
+The newest snapshot repository inspection found for this server's source is older than the moment the device's latest run says it froze its data.
+
+This is a comparison of two timestamps, not a lookup: the inventory records when snapshots were taken, not which ones exist, so this can say the repository looks behind and no more. It never alerts. What it is worth is context — a server showing this alongside a staleness or size signal is worth looking at, and one showing it alone usually means an inspection landed mid-upload.
+
+`backup-reconcile-missing` is the check that establishes a reported backup is actually absent.
+
+## Results
+
+- **warn** (recorded only) — the repository holds nothing for the source as new as the reported run.
+- **skipped** — the run reported no moment its data was frozen (which leaves nothing to compare against), or the repository has not been inspected since the run was reported.
+
+## Solve
+
+Nothing on its own. Read it next to the server's other backup signals.";
 
 pub const CORRUPTION_DOC: &str = "## Description
 

--- a/crates/database/src/backup/staleness.rs
+++ b/crates/database/src/backup/staleness.rs
@@ -624,6 +624,31 @@ pub(crate) async fn open_server_issue_active(
 	Ok(n > 0)
 }
 
+/// Whether a server-scoped `(canopy, ref)` check last *observed* something
+/// other than a pass.
+///
+/// The active flag follows the effective result, so a check whose policy holds
+/// it below alerting is never active however degraded its observations. This is
+/// what a sweep asks in its place, to know whether it has a recorded
+/// observation to bring up to date.
+pub(crate) async fn server_check_observed_degraded(
+	db: &mut AsyncPgConnection,
+	server_id: Uuid,
+	r#ref: &str,
+) -> Result<bool> {
+	use crate::schema::issues::dsl;
+	let n: i64 = dsl::issues
+		.filter(dsl::server_id.eq(server_id))
+		.filter(dsl::source.eq(refs::CANOPY_SOURCE))
+		.filter(dsl::ref_.eq(r#ref))
+		.filter(dsl::observed_result.is_not_null())
+		.filter(dsl::observed_result.ne(CheckResult::Passed.to_string()))
+		.count()
+		.get_result(db)
+		.await?;
+	Ok(n > 0)
+}
+
 /// Whether a group-scoped `(canopy, ref)` issue is currently open + active.
 pub(crate) async fn open_group_issue_active(
 	db: &mut AsyncPgConnection,

--- a/crates/database/src/backups.rs
+++ b/crates/database/src/backups.rs
@@ -8,7 +8,7 @@
 //! logic (STS issuance, scheduler loops, operator UI) lives in the
 //! public-server, `jobs`, and private-server components.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use commons_errors::{AppError, Result};
 use commons_types::backup::{
@@ -2189,6 +2189,141 @@ impl BackupRepoSnapshot {
 			.optional()
 			.map_err(AppError::from)?;
 		Ok(row.map(|r| r.observed_at))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backup_repo_observed_snapshots — every snapshot the last inspection saw
+// ---------------------------------------------------------------------------
+
+/// One snapshot found in a group's repository during inspection, identified the
+/// way the device that created it identifies it (`backup_runs.snapshot_id`).
+///
+/// Where [`BackupRepoSnapshot`] summarises a source ("the newest snapshot for
+/// this source is from 04:00"), this is the itemised set behind that summary, so
+/// a run's reported snapshot can be looked up rather than inferred from
+/// timestamps.
+#[derive(Debug, Clone, Queryable, Selectable)]
+#[diesel(table_name = crate::schema::backup_repo_observed_snapshots)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackupRepoObservedSnapshot {
+	/// ID of the server group whose repository holds the snapshot.
+	pub group_id: Uuid,
+	/// The snapshot's own id, unique within the repository, as a device reports
+	/// it on the run that created it.
+	pub snapshot_id: String,
+	/// Raw source identifier the snapshot belongs to, as recorded in the
+	/// repository.
+	pub source: String,
+	/// When the snapshot was taken, if the repository records it.
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	pub snapshot_at: Option<Timestamp>,
+	/// When the inspection that observed this snapshot ran.
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub observed_at: Timestamp,
+}
+
+/// One snapshot an inspection observed, for [`BackupRepoObservedSnapshot::replace_for_group`].
+#[derive(Debug, Clone)]
+pub struct NewObservedSnapshot {
+	pub snapshot_id: String,
+	pub source: String,
+	pub snapshot_at: Option<Timestamp>,
+}
+
+impl BackupRepoObservedSnapshot {
+	/// Replace a group's observed-snapshot set with what an inspection found.
+	///
+	/// The rows describe the repository as it stands, not a history: a snapshot
+	/// retention has expired is gone from the repository and must be gone from
+	/// here too, or reconciliation would keep matching runs against snapshots
+	/// that no longer exist. So everything not in this listing is dropped, which
+	/// also bounds the table at the size of the repository.
+	///
+	/// The whole batch carries one `observed_at`, and rows still holding an
+	/// earlier one are what the listing didn't mention. Callers must pass a
+	/// complete listing.
+	pub async fn replace_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+		observed: &[NewObservedSnapshot],
+	) -> Result<()> {
+		use crate::schema::backup_repo_observed_snapshots::dsl;
+		use diesel::upsert::excluded;
+
+		let stamp = jiff_diesel::Timestamp::from(Timestamp::now());
+
+		// Chunked so a repository with tens of thousands of snapshots doesn't
+		// build one statement past Postgres's bind-parameter limit.
+		for chunk in observed.chunks(500) {
+			let values: Vec<_> = chunk
+				.iter()
+				.map(|s| {
+					(
+						dsl::group_id.eq(group_id),
+						dsl::snapshot_id.eq(&s.snapshot_id),
+						dsl::source.eq(&s.source),
+						dsl::snapshot_at.eq(jiff_diesel::NullableTimestamp::from(s.snapshot_at)),
+						dsl::observed_at.eq(stamp),
+					)
+				})
+				.collect();
+			diesel::insert_into(dsl::backup_repo_observed_snapshots)
+				.values(values)
+				.on_conflict((dsl::group_id, dsl::snapshot_id))
+				.do_update()
+				.set((
+					dsl::source.eq(excluded(dsl::source)),
+					dsl::snapshot_at.eq(excluded(dsl::snapshot_at)),
+					dsl::observed_at.eq(stamp),
+				))
+				.execute(db)
+				.await
+				.map_err(AppError::from)?;
+		}
+
+		diesel::delete(
+			dsl::backup_repo_observed_snapshots
+				.filter(dsl::group_id.eq(group_id))
+				.filter(dsl::observed_at.lt(stamp)),
+		)
+		.execute(db)
+		.await
+		.map_err(AppError::from)?;
+		Ok(())
+	}
+
+	/// The snapshot ids the last inspection observed in a group's repository,
+	/// with when it observed them.
+	///
+	/// The timestamp is what makes the set usable as evidence: an id's absence
+	/// only means something if the observation is newer than the run being
+	/// reconciled. `None` (no rows) means there is no observation to reason
+	/// from — either the group has never been inspected, or an inspection found
+	/// the repository empty, which are indistinguishable here.
+	pub async fn observed_ids_for_group(
+		db: &mut AsyncPgConnection,
+		group_id: Uuid,
+	) -> Result<(HashSet<String>, Option<Timestamp>)> {
+		use crate::schema::backup_repo_observed_snapshots::dsl;
+
+		let rows: Vec<(String, jiff_diesel::Timestamp)> = dsl::backup_repo_observed_snapshots
+			.filter(dsl::group_id.eq(group_id))
+			.select((dsl::snapshot_id, dsl::observed_at))
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+
+		let mut ids = HashSet::with_capacity(rows.len());
+		let mut latest: Option<Timestamp> = None;
+		for (id, observed_at) in rows {
+			let observed_at = Timestamp::from(observed_at);
+			if latest.is_none_or(|l| observed_at > l) {
+				latest = Some(observed_at);
+			}
+			ids.insert(id);
+		}
+		Ok((ids, latest))
 	}
 }
 

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -48,11 +48,12 @@ pub mod views;
 
 pub use backups::{
 	BackupCredentialIssuance, BackupMaintenanceRun, BackupMaintenanceRunFilters,
-	BackupRecoveryVerification, BackupRepoSnapshot, BackupRepoStats, BackupRequest, BackupRun,
-	BackupRunFilters, BackupRunProgress, BackupTypeDefault, MaintenanceOutcomeFilter,
-	NewBackupCredentialIssuance, NewBackupRun, NewBackupRunProgress, NewBackupTypeDefault,
-	NewServerGroupBackupConfig, NewServerGroupBackupSchedule, RetentionPolicy,
-	ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
+	BackupRecoveryVerification, BackupRepoObservedSnapshot, BackupRepoSnapshot, BackupRepoStats,
+	BackupRequest, BackupRun, BackupRunFilters, BackupRunProgress, BackupTypeDefault,
+	MaintenanceOutcomeFilter, NewBackupCredentialIssuance, NewBackupRun, NewBackupRunProgress,
+	NewBackupTypeDefault, NewObservedSnapshot, NewServerGroupBackupConfig,
+	NewServerGroupBackupSchedule, RetentionPolicy, ServerBackupCapability, ServerGroupBackupConfig,
+	ServerGroupBackupSchedule,
 };
 pub use bestool_snippets::{BestoolSnippet, NewBestoolSnippet};
 pub use commons_types::backup::{

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -62,6 +62,16 @@ diesel::table! {
 }
 
 diesel::table! {
+	backup_repo_observed_snapshots (group_id, snapshot_id) {
+		group_id -> Uuid,
+		snapshot_id -> Text,
+		source -> Text,
+		snapshot_at -> Nullable<Timestamptz>,
+		observed_at -> Timestamptz,
+	}
+}
+
+diesel::table! {
 	backup_repo_snapshots (group_id, source) {
 		group_id -> Uuid,
 		source -> Text,
@@ -770,6 +780,7 @@ diesel::joinable!(artifacts -> versions (version_id));
 diesel::joinable!(backup_credential_issuances -> devices (device_id));
 diesel::joinable!(backup_credential_issuances -> server_groups (group_id));
 diesel::joinable!(backup_maintenance_runs -> server_groups (group_id));
+diesel::joinable!(backup_repo_observed_snapshots -> server_groups (group_id));
 diesel::joinable!(backup_repo_snapshots -> server_groups (group_id));
 diesel::joinable!(backup_repo_snapshots -> servers (server_id));
 diesel::joinable!(backup_repo_stats -> server_groups (group_id));
@@ -834,6 +845,7 @@ diesel::allow_tables_to_appear_in_same_query!(
 	backup_credential_issuances,
 	backup_recovery_verifications,
 	backup_maintenance_runs,
+	backup_repo_observed_snapshots,
 	backup_repo_snapshots,
 	backup_repo_stats,
 	backup_requests,

--- a/crates/database/tests/it/backup_detection.rs
+++ b/crates/database/tests/it/backup_detection.rs
@@ -21,9 +21,9 @@ use database::backup::staleness::{ScanRow, StalenessVerdict};
 use database::diesel_async::AsyncPgConnection;
 use database::pg_duration::PgDuration;
 use database::{
-	BackupConfigStatus, BackupPurpose, BackupRepoSnapshot, BackupRun, NewBackupRun,
-	NewServerGroupBackupConfig, NewServerGroupBackupSchedule, RunOutcome, ServerBackupCapability,
-	ServerGroupBackupConfig, ServerGroupBackupSchedule,
+	BackupConfigStatus, BackupPurpose, BackupRepoObservedSnapshot, BackupRepoSnapshot, BackupRun,
+	NewBackupRun, NewObservedSnapshot, NewServerGroupBackupConfig, NewServerGroupBackupSchedule,
+	RunOutcome, ServerBackupCapability, ServerGroupBackupConfig, ServerGroupBackupSchedule,
 };
 use diesel::{QueryableByName, sql_query, sql_types};
 use diesel_async::RunQueryDsl;
@@ -202,6 +202,85 @@ async fn insert_backup_success_aged(
 	.execute(conn)
 	.await
 	.expect("backdate reported_at");
+}
+
+/// Record a `purpose='backup'` success `age` ago that names the snapshot it
+/// created and says when it froze its data — what the reconcile checks need
+/// before they will decide anything.
+async fn insert_backup_success_with_snapshot(
+	conn: &mut AsyncPgConnection,
+	device_id: Uuid,
+	group_id: Uuid,
+	server_id: Uuid,
+	ty: &BackupType,
+	age: SignedDuration,
+	snapshot_id: &str,
+) {
+	let id = Uuid::new_v4();
+	BackupRun::record(
+		conn,
+		NewBackupRun {
+			id,
+			device_id,
+			group_id,
+			server_id: Some(server_id),
+			r#type: ty.clone(),
+			purpose: BackupPurpose::Backup,
+			outcome: RunOutcome::Success,
+			error: None,
+			bytes_uploaded: Some(42),
+			snapshot_id: Some(snapshot_id.into()),
+			s3_sent_raw_bytes: None,
+			s3_sent_payload_bytes: None,
+			s3_received_raw_bytes: None,
+			s3_received_payload_bytes: None,
+			snapshot_taken_at: Some(Timestamp::now() - age),
+		},
+	)
+	.await
+	.expect("record backup run");
+	let secs = age.as_secs();
+	sql_query(
+		"UPDATE backup_runs SET reported_at = NOW() - ($2 || ' seconds')::INTERVAL WHERE id = $1",
+	)
+	.bind::<sql_types::Uuid, _>(id)
+	.bind::<sql_types::Text, _>(secs.to_string())
+	.execute(conn)
+	.await
+	.expect("backdate reported_at");
+}
+
+/// Stand in for an inspection that itemised the group's repo just now and found
+/// exactly these snapshots.
+async fn record_observed_snapshots(
+	conn: &mut AsyncPgConnection,
+	group_id: Uuid,
+	snapshot_ids: &[&str],
+) {
+	let observed: Vec<NewObservedSnapshot> = snapshot_ids
+		.iter()
+		.map(|id| NewObservedSnapshot {
+			snapshot_id: (*id).into(),
+			source: "canopy@repo:/data".into(),
+			snapshot_at: None,
+		})
+		.collect();
+	BackupRepoObservedSnapshot::replace_for_group(conn, group_id, &observed)
+		.await
+		.expect("record observed snapshots");
+}
+
+/// Back-date every observation of a group's snapshots, so the itemised set is
+/// older than the runs being reconciled against it.
+async fn age_observed_snapshots(conn: &mut AsyncPgConnection, group_id: Uuid) {
+	sql_query(
+		"UPDATE backup_repo_observed_snapshots SET observed_at = NOW() - INTERVAL '30 days' \
+		 WHERE group_id = $1",
+	)
+	.bind::<sql_types::Uuid, _>(group_id)
+	.execute(conn)
+	.await
+	.expect("age observed snapshots");
 }
 
 // --- issue / incident assertion helpers -------------------------------------
@@ -777,8 +856,11 @@ async fn reconcile_files_report_gap_when_snapshot_fresh_but_no_report() {
 	.await;
 }
 
+/// The finding the check's name has always claimed: the device named the
+/// snapshot it created and the repository doesn't hold it. Decided by looking
+/// the id up, not by comparing timestamps.
 #[tokio::test(flavor = "multi_thread")]
-async fn reconcile_files_missing_when_report_fresh_but_no_snapshot() {
+async fn reconcile_files_missing_when_the_reported_snapshot_is_absent_from_the_repo() {
 	TestDb::run(|mut conn, _url| async move {
 		let pg = BackupType::TamanuPostgres;
 		let interval = SignedDuration::from_hours(12);
@@ -790,31 +872,20 @@ async fn reconcile_files_missing_when_report_fresh_but_no_snapshot() {
 		insert_schedule(&mut conn, group_id, &pg, interval).await;
 		enable_capability(&mut conn, server_id, &pg).await;
 
-		// Fresh report (2h old, within grace)...
-		insert_backup_success_aged(
+		// A recent run naming the snapshot it cut...
+		insert_backup_success_with_snapshot(
 			&mut conn,
 			device_id,
 			group_id,
 			server_id,
 			&pg,
 			SignedDuration::from_hours(2),
+			"snap-reported",
 		)
 		.await;
-		// ...but the only snapshot row is stale-snapshot/fresh-inventory: a repo
-		// row observed just now (inventory fresh) whose latest_snapshot_at is
-		// old → "report says success but data didn't land".
-		let source = format!("canopy@{server_id}:/data");
-		let old_snap = Timestamp::now() - SignedDuration::from_hours(72);
-		BackupRepoSnapshot::upsert(
-			&mut conn,
-			group_id,
-			&source,
-			Some(server_id),
-			Some(&pg),
-			Some(old_snap),
-		)
-		.await
-		.expect("upsert snapshot");
+		// ...and an inspection since that run which found other snapshots but
+		// not that one.
+		record_observed_snapshots(&mut conn, group_id, &["snap-elsewhere"]).await;
 
 		let rows = database::backup::staleness::scan_rows(&mut conn)
 			.await
@@ -827,7 +898,7 @@ async fn reconcile_files_missing_when_report_fresh_but_no_snapshot() {
 		let issue = server_issue(&mut conn, server_id, mref)
 			.await
 			.expect("reconcile-missing issue filed against the server it concerns");
-		assert_eq!(issue.observed_result.as_deref(), Some("failed"));
+		assert_eq!(issue.observed_result.as_deref(), Some("warning"));
 		assert_eq!(
 			issue.effective_result.as_deref(),
 			Some("warning"),
@@ -843,17 +914,31 @@ async fn reconcile_files_missing_when_report_fresh_but_no_snapshot() {
 			0,
 			"a warning does not open an incident on its own",
 		);
+
+		let message = issue_message(&mut conn, server_id, mref)
+			.await
+			.expect("message recorded");
+		assert!(
+			message.contains("its snapshot is not in the repo"),
+			"the message describes the lookup that was made: {message}",
+		);
+		let detail = issue_detail(&mut conn, server_id, mref)
+			.await
+			.expect("detail recorded");
+		assert_eq!(
+			detail["instances"][0]["snapshot_id"], "snap-reported",
+			"the id looked up is in the detail: {detail}",
+		);
 	})
 	.await;
 }
 
-/// The case the "missing" verdict exists for: a device reports success while
-/// nothing lands in the repo, so the inspection job — which only writes rows
-/// for sources it actually finds — never creates a snapshot row for the pair.
-/// Inventory freshness has to come from the *group's* last inspection, not
-/// from the absent row, or the alert can never fire.
+/// The inspection job only writes a per-source inventory row for sources it
+/// actually finds, so the pair a "missing" verdict is about has no row of its
+/// own. The itemised snapshot set is what decides the case, and it belongs to
+/// the group rather than to any one pair.
 #[tokio::test(flavor = "multi_thread")]
-async fn reconcile_files_missing_when_report_fresh_and_the_pair_has_no_snapshot_row() {
+async fn reconcile_files_missing_when_the_pair_has_no_snapshot_row_at_all() {
 	TestDb::run(|mut conn, _url| async move {
 		let pg = BackupType::TamanuPostgres;
 		let interval = SignedDuration::from_hours(12);
@@ -866,28 +951,29 @@ async fn reconcile_files_missing_when_report_fresh_and_the_pair_has_no_snapshot_
 		insert_schedule(&mut conn, group_id, &pg, interval).await;
 		enable_capability(&mut conn, server_id, &pg).await;
 
-		// Fresh report for our server...
-		insert_backup_success_aged(
+		insert_backup_success_with_snapshot(
 			&mut conn,
 			device_id,
 			group_id,
 			server_id,
 			&pg,
 			SignedDuration::from_hours(2),
+			"snap-reported",
 		)
 		.await;
-		// ...and the inspector ran recently, but only found another server's
-		// source — nothing for ours.
+		// The inspector ran since the report, but only found another server's
+		// source — nothing for ours, so ours has no inventory row.
 		BackupRepoSnapshot::upsert(
 			&mut conn,
 			group_id,
 			&format!("canopy@{other_id}:/data"),
 			Some(other_id),
 			Some(&pg),
-			Some(Timestamp::now() - SignedDuration::from_hours(2)),
+			Some(Timestamp::now() - SignedDuration::from_hours(1)),
 		)
 		.await
 		.expect("upsert other server's snapshot");
+		record_observed_snapshots(&mut conn, group_id, &["snap-of-the-other-server"]).await;
 
 		let rows = database::backup::staleness::scan_rows(&mut conn)
 			.await
@@ -900,9 +986,187 @@ async fn reconcile_files_missing_when_report_fresh_and_the_pair_has_no_snapshot_
 		let issue = server_issue(&mut conn, server_id, mref)
 			.await
 			.expect("reconcile-missing issue filed for the pair with no snapshot");
-		assert_eq!(issue.observed_result.as_deref(), Some("failed"));
+		assert_eq!(issue.observed_result.as_deref(), Some("warning"));
 		assert_eq!(issue.effective_result.as_deref(), Some("warning"));
 		assert!(issue.active);
+	})
+	.await;
+}
+
+/// The regression that motivated splitting this check in two. Inspection runs
+/// on its own, slower cadence, so for a server backing up more often than the
+/// repo is inspected the newest snapshot on record is routinely older than the
+/// last run — with nothing wrong. A verdict measured against `now` instead of
+/// against the run it contradicts turned that into an alert on every healthy
+/// server in the fleet.
+// spec: BKJ#detection
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_leaves_a_healthy_server_alone_when_inspection_lags_the_backup_cadence() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		// Backs up every 6h; the repo is inspected weekly.
+		let interval = SignedDuration::from_hours(6);
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(24 * 30)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+
+		insert_backup_success_with_snapshot(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(2),
+			"snap-two-hours-ago",
+		)
+		.await;
+
+		// The last inspection was three days ago and, of course, found the
+		// snapshot that existed then.
+		let three_days = SignedDuration::from_hours(72);
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{server_id}:/data"),
+			Some(server_id),
+			Some(&pg),
+			Some(Timestamp::now() - three_days),
+		)
+		.await
+		.expect("upsert snapshot");
+		record_observed_snapshots(&mut conn, group_id, &["snap-three-days-ago"]).await;
+		sql_query(
+			"UPDATE backup_repo_snapshots SET observed_at = NOW() - INTERVAL '72 hours' \
+			 WHERE group_id = $1",
+		)
+		.bind::<sql_types::Uuid, _>(group_id)
+		.execute(&mut conn)
+		.await
+		.expect("age the inventory to the last inspection");
+		age_observed_snapshots(&mut conn, group_id).await;
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("reconcile sweep");
+
+		assert!(
+			server_issue(&mut conn, server_id, refs::RECONCILE_MISSING)
+				.await
+				.is_none(),
+			"a slower inspection cadence is not evidence a backup is missing",
+		);
+		assert!(
+			server_issue(&mut conn, server_id, refs::RECONCILE_RECENCY)
+				.await
+				.is_none(),
+			"and nothing is recorded either: no inspection has looked since the run",
+		);
+	})
+	.await;
+}
+
+/// The timestamp comparison is kept for context, and kept from alerting: it is
+/// recorded with what it observed while its effective result stays passed.
+#[tokio::test(flavor = "multi_thread")]
+async fn reconcile_records_the_recency_observation_without_alerting() {
+	TestDb::run(|mut conn, _url| async move {
+		let pg = BackupType::TamanuPostgres;
+		let interval = SignedDuration::from_hours(12);
+		let group_id = insert_group(&mut conn, "g").await;
+		let server_id = insert_server(&mut conn, group_id, true).await;
+		let device_id = insert_device(&mut conn).await;
+
+		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
+		insert_schedule(&mut conn, group_id, &pg, interval).await;
+		enable_capability(&mut conn, server_id, &pg).await;
+
+		insert_backup_success_with_snapshot(
+			&mut conn,
+			device_id,
+			group_id,
+			server_id,
+			&pg,
+			SignedDuration::from_hours(2),
+			"snap-reported",
+		)
+		.await;
+		// Inspected since the run, and holding the reported snapshot — so there
+		// is nothing missing — but the newest snapshot time on record for the
+		// source is older than the run.
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{server_id}:/data"),
+			Some(server_id),
+			Some(&pg),
+			Some(Timestamp::now() - SignedDuration::from_hours(72)),
+		)
+		.await
+		.expect("upsert snapshot");
+		record_observed_snapshots(&mut conn, group_id, &["snap-reported"]).await;
+
+		let rows = database::backup::staleness::scan_rows(&mut conn)
+			.await
+			.expect("scan");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("reconcile sweep");
+
+		let rref = refs::RECONCILE_RECENCY;
+		let issue = server_issue(&mut conn, server_id, rref)
+			.await
+			.expect("the observation is recorded");
+		assert_eq!(
+			issue.observed_result.as_deref(),
+			Some("warning"),
+			"what was seen is recorded as seen",
+		);
+		assert_eq!(
+			issue.effective_result.as_deref(),
+			Some("passed"),
+			"a timestamp comparison never ranks as an alert",
+		);
+		assert!(!issue.active);
+		assert_eq!(server_issue_open_links(&mut conn, server_id, rref).await, 0,);
+
+		assert!(
+			server_issue(&mut conn, server_id, refs::RECONCILE_MISSING)
+				.await
+				.is_none(),
+			"the repo holds the reported snapshot, so nothing is missing",
+		);
+
+		// The next inspection catches up. The observation has to come with it:
+		// this check is never active, so nothing else would ever retract it.
+		BackupRepoSnapshot::upsert(
+			&mut conn,
+			group_id,
+			&format!("canopy@{server_id}:/data"),
+			Some(server_id),
+			Some(&pg),
+			Some(Timestamp::now() - SignedDuration::from_hours(1)),
+		)
+		.await
+		.expect("refresh snapshot");
+		database::backup::reconcile::sweep(&mut conn, &rows)
+			.await
+			.expect("second reconcile sweep");
+		assert_eq!(
+			server_issue(&mut conn, server_id, rref)
+				.await
+				.expect("still recorded")
+				.observed_result
+				.as_deref(),
+			Some("passed"),
+			"the recorded observation is brought up to date once the repo catches up",
+		);
 	})
 	.await;
 }
@@ -926,40 +1190,21 @@ async fn reconcile_missing_is_per_server_not_shared_across_the_group() {
 		enable_capability(&mut conn, broken_id, &pg).await;
 		enable_capability(&mut conn, healthy_id, &pg).await;
 
-		// Both report success recently.
-		for sid in [broken_id, healthy_id] {
-			insert_backup_success_aged(
+		// Both report success recently, each naming its own snapshot.
+		for (sid, snap) in [(broken_id, "snap-broken"), (healthy_id, "snap-healthy")] {
+			insert_backup_success_with_snapshot(
 				&mut conn,
 				device_id,
 				group_id,
 				sid,
 				&pg,
 				SignedDuration::from_hours(2),
+				snap,
 			)
 			.await;
 		}
-		// Only the healthy server's report is backed by a fresh snapshot; the
-		// broken one's snapshot is three days old.
-		BackupRepoSnapshot::upsert(
-			&mut conn,
-			group_id,
-			&format!("canopy@{healthy_id}:/data"),
-			Some(healthy_id),
-			Some(&pg),
-			Some(Timestamp::now() - SignedDuration::from_hours(2)),
-		)
-		.await
-		.expect("upsert healthy snapshot");
-		BackupRepoSnapshot::upsert(
-			&mut conn,
-			group_id,
-			&format!("canopy@{broken_id}:/data"),
-			Some(broken_id),
-			Some(&pg),
-			Some(Timestamp::now() - SignedDuration::from_hours(72)),
-		)
-		.await
-		.expect("upsert broken snapshot");
+		// The repo holds only the healthy server's snapshot.
+		record_observed_snapshots(&mut conn, group_id, &["snap-healthy"]).await;
 
 		let rows = database::backup::staleness::scan_rows(&mut conn)
 			.await
@@ -972,7 +1217,7 @@ async fn reconcile_missing_is_per_server_not_shared_across_the_group() {
 		let broken = server_issue(&mut conn, broken_id, mref)
 			.await
 			.expect("the server whose snapshot is missing holds the alert");
-		assert_eq!(broken.observed_result.as_deref(), Some("failed"));
+		assert_eq!(broken.observed_result.as_deref(), Some("warning"));
 		assert_eq!(broken.effective_result.as_deref(), Some("warning"));
 		assert!(
 			broken.active,
@@ -1006,25 +1251,17 @@ async fn reconcile_missing_names_the_server_rather_than_its_id() {
 		insert_schedule(&mut conn, group_id, &pg, interval).await;
 		enable_capability(&mut conn, server_id, &pg).await;
 
-		insert_backup_success_aged(
+		insert_backup_success_with_snapshot(
 			&mut conn,
 			device_id,
 			group_id,
 			server_id,
 			&pg,
 			SignedDuration::from_hours(2),
+			"snap-reported",
 		)
 		.await;
-		BackupRepoSnapshot::upsert(
-			&mut conn,
-			group_id,
-			&format!("canopy@{server_id}:/data"),
-			Some(server_id),
-			Some(&pg),
-			Some(Timestamp::now() - SignedDuration::from_hours(72)),
-		)
-		.await
-		.expect("upsert stale snapshot");
+		record_observed_snapshots(&mut conn, group_id, &["snap-elsewhere"]).await;
 
 		let rows = database::backup::staleness::scan_rows(&mut conn)
 			.await
@@ -1049,9 +1286,9 @@ async fn reconcile_missing_names_the_server_rather_than_its_id() {
 	.await;
 }
 
-/// The freshness guard still holds: a group the inspector has never run
-/// against has no inventory to conclude "nothing landed" from, so the missing
-/// verdict defers to the inspection job's own failure surfacing.
+/// A group the inspector has never run against has nothing to conclude
+/// "missing" from: absence of a snapshot from an inventory nobody has written
+/// says only that nobody has looked.
 #[tokio::test(flavor = "multi_thread")]
 async fn reconcile_skips_missing_when_the_group_was_never_inspected() {
 	TestDb::run(|mut conn, _url| async move {
@@ -1064,16 +1301,17 @@ async fn reconcile_skips_missing_when_the_group_was_never_inspected() {
 		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
 		insert_schedule(&mut conn, group_id, &pg, interval).await;
 		enable_capability(&mut conn, server_id, &pg).await;
-		insert_backup_success_aged(
+		insert_backup_success_with_snapshot(
 			&mut conn,
 			device_id,
 			group_id,
 			server_id,
 			&pg,
 			SignedDuration::from_hours(2),
+			"snap-reported",
 		)
 		.await;
-		// No `backup_repo_snapshots` rows at all for the group.
+		// No inventory rows of either kind for the group.
 
 		let rows = database::backup::staleness::scan_rows(&mut conn)
 			.await
@@ -1094,14 +1332,20 @@ async fn reconcile_skips_missing_when_the_group_was_never_inspected() {
 				.is_none(),
 			"and no per-server finding either",
 		);
+		assert!(
+			server_issue(&mut conn, server_id, refs::RECONCILE_RECENCY)
+				.await
+				.is_none(),
+			"nor is a recency observation recorded from an inventory that doesn't exist",
+		);
 	})
 	.await;
 }
 
-/// A stale repo inventory makes the missing verdict undecidable, not resolved.
-/// With every type undecidable there is nothing to conclude, so an already-open
-/// finding stays open rather than being cleared on the strength of a lagging
-/// inspector.
+/// An inventory older than the run makes the missing verdict undecidable, not
+/// resolved. With every type undecidable there is nothing to conclude, so an
+/// already-open finding stays open rather than being cleared on the strength of
+/// a lagging inspector.
 #[tokio::test(flavor = "multi_thread")]
 async fn reconcile_leaves_an_open_missing_alone_when_the_inventory_goes_stale() {
 	TestDb::run(|mut conn, _url| async move {
@@ -1114,27 +1358,20 @@ async fn reconcile_leaves_an_open_missing_alone_when_the_inventory_goes_stale() 
 		insert_ready_config(&mut conn, group_id, SignedDuration::from_hours(72)).await;
 		insert_schedule(&mut conn, group_id, &pg, interval).await;
 		enable_capability(&mut conn, server_id, &pg).await;
-		insert_backup_success_aged(
+		insert_backup_success_with_snapshot(
 			&mut conn,
 			device_id,
 			group_id,
 			server_id,
 			&pg,
 			SignedDuration::from_hours(2),
+			"snap-reported",
 		)
 		.await;
 
-		// Fresh inventory, stale snapshot → the finding is raised.
-		BackupRepoSnapshot::upsert(
-			&mut conn,
-			group_id,
-			&format!("canopy@{server_id}:/data"),
-			Some(server_id),
-			Some(&pg),
-			Some(Timestamp::now() - SignedDuration::from_hours(72)),
-		)
-		.await
-		.expect("upsert stale snapshot");
+		// Inspected since the run, and the reported snapshot isn't there → the
+		// finding is raised.
+		record_observed_snapshots(&mut conn, group_id, &["snap-elsewhere"]).await;
 
 		let rows = database::backup::staleness::scan_rows(&mut conn)
 			.await
@@ -1149,16 +1386,9 @@ async fn reconcile_leaves_an_open_missing_alone_when_the_inventory_goes_stale() 
 				.active,
 		);
 
-		// Now the inspector falls behind: back-date every observation past the
-		// inventory-staleness bound.
-		sql_query(
-			"UPDATE backup_repo_snapshots SET observed_at = NOW() - INTERVAL '30 days' \
-			 WHERE group_id = $1",
-		)
-		.bind::<sql_types::Uuid, _>(group_id)
-		.execute(&mut conn)
-		.await
-		.expect("age the inventory");
+		// Now the inspector falls behind: every observation predates the run it
+		// would be judging.
+		age_observed_snapshots(&mut conn, group_id).await;
 
 		database::backup::reconcile::sweep(&mut conn, &rows)
 			.await
@@ -1656,6 +1886,11 @@ async fn backup_sweeps_seed_no_check_that_defaults_to_a_failure() {
 		refs::PREFLIGHT_OBJECT_LOCK,
 	];
 
+	/// Checks that ship lower than a warning, at a ceiling of `passed`:
+	/// recorded and visible, never alerting, because their evidence supports
+	/// "something looks off" and nothing firmer.
+	const RECORDED_ONLY: [&str; 1] = [refs::RECONCILE_RECENCY];
+
 	TestDb::run(|mut conn, _url| async move {
 		let pg = BackupType::TamanuPostgres;
 		let interval = SignedDuration::from_hours(12);
@@ -1713,11 +1948,17 @@ async fn backup_sweeps_seed_no_check_that_defaults_to_a_failure() {
 			catalog.iter().map(|r| &r.check_name).collect::<Vec<_>>(),
 		);
 		for row in covered {
+			let expected = if RECORDED_ONLY.contains(&row.check_name.as_str()) {
+				("passed", false)
+			} else {
+				("warning", false)
+			};
 			assert_eq!(
 				(row.ceiling.as_str(), row.escalates),
-				("warning", false),
-				"{} must ship as a non-escalating warning: a failure means a \
-				 live service is down, and a backup problem is not that",
+				expected,
+				"{} must ship no more urgently than a non-escalating warning: a \
+				 failure means a live service is down, and a backup problem is \
+				 not that",
 				row.check_name,
 			);
 		}

--- a/crates/jobs/src/backup/complete.rs
+++ b/crates/jobs/src/backup/complete.rs
@@ -95,6 +95,26 @@ pub(crate) async fn complete_inspect(
 		.map_err(|err| err.to_string())?;
 	}
 
+	// The itemised set behind those per-source summaries: which snapshots the
+	// repo actually holds, by the ids devices report. Reconciliation looks a
+	// reported snapshot up in here instead of inferring its fate from
+	// timestamps.
+	let observed: Vec<database::NewObservedSnapshot> = outcome
+		.snapshots
+		.iter()
+		.map(|s| database::NewObservedSnapshot {
+			snapshot_id: s.id.clone(),
+			source: s.source.clone(),
+			snapshot_at: s
+				.snapshot_at
+				.as_deref()
+				.and_then(|t| Timestamp::from_str(t).ok()),
+		})
+		.collect();
+	database::BackupRepoObservedSnapshot::replace_for_group(db, group_id, &observed)
+		.await
+		.map_err(|err| err.to_string())?;
+
 	database::backups::BackupRepoStats::upsert_repo_fields(
 		db,
 		group_id,
@@ -108,7 +128,12 @@ pub(crate) async fn complete_inspect(
 
 	// Fill each device run's snapshot size from the repo (write-once, matched by
 	// snapshot id). The size-discrepancy check reads it back off `backup_runs`.
-	database::backups::BackupRun::backfill_snapshot_logical_bytes(db, group_id, &outcome.snapshots)
+	let sizes: Vec<(String, i64)> = outcome
+		.snapshots
+		.iter()
+		.map(|s| (s.id.clone(), s.logical_bytes))
+		.collect();
+	database::backups::BackupRun::backfill_snapshot_logical_bytes(db, group_id, &sizes)
 		.await
 		.map_err(|err| err.to_string())?;
 
@@ -333,6 +358,83 @@ mod tests {
 				assert_eq!(rows[0].effective_result.as_deref(), Some("failed"));
 				assert!(rows[0].escalates);
 				assert!(rows[0].active, "corruption issue is active");
+			})
+			.await;
+		}
+
+		fn inspect_outcome(snapshots: Vec<crate::backup::kopia::SnapshotEntry>) -> InspectOutcome {
+			InspectOutcome {
+				verify_ok: true,
+				snapshot_count: snapshots.len() as i32,
+				source_count: 1,
+				logical_bytes: 0,
+				physical_bytes: None,
+				sources: vec![],
+				snapshots,
+			}
+		}
+
+		fn snapshot(id: &str, at: &str, size: i64) -> crate::backup::kopia::SnapshotEntry {
+			crate::backup::kopia::SnapshotEntry {
+				id: id.into(),
+				source: "canopy@srv:tamanu-postgres".into(),
+				snapshot_at: Some(at.into()),
+				logical_bytes: size,
+			}
+		}
+
+		/// The observed-snapshot set is the repo as it stands: an inspection
+		/// records what it found and drops what it no longer finds, so a
+		/// snapshot retention has expired stops being matchable.
+		#[tokio::test(flavor = "multi_thread")]
+		async fn inspect_records_observed_snapshots_and_drops_departed_ones() {
+			TestDb::run(|mut conn, _url| async move {
+				let group_id = insert_group(&mut conn, "g").await;
+
+				complete_inspect(
+					&mut conn,
+					group_id,
+					&inspect_outcome(vec![
+						snapshot("k1", "2026-06-18T12:00:00Z", 10),
+						snapshot("k2", "2026-06-18T13:00:00Z", 20),
+					]),
+				)
+				.await
+				.expect("first inspect");
+
+				let (ids, observed_at) =
+					database::BackupRepoObservedSnapshot::observed_ids_for_group(
+						&mut conn, group_id,
+					)
+					.await
+					.expect("read observed ids");
+				assert_eq!(ids.len(), 2);
+				assert!(ids.contains("k1") && ids.contains("k2"));
+				assert!(observed_at.is_some(), "the observation is stamped");
+
+				// k1 has since been expired by retention; k3 is new.
+				complete_inspect(
+					&mut conn,
+					group_id,
+					&inspect_outcome(vec![
+						snapshot("k2", "2026-06-18T13:00:00Z", 20),
+						snapshot("k3", "2026-06-19T13:00:00Z", 30),
+					]),
+				)
+				.await
+				.expect("second inspect");
+
+				let (ids, _) = database::BackupRepoObservedSnapshot::observed_ids_for_group(
+					&mut conn, group_id,
+				)
+				.await
+				.expect("read observed ids again");
+				assert_eq!(ids.len(), 2);
+				assert!(
+					!ids.contains("k1"),
+					"a snapshot the repo no longer holds is not still recorded",
+				);
+				assert!(ids.contains("k2") && ids.contains("k3"));
 			})
 			.await;
 		}

--- a/crates/jobs/src/backup/kopia.rs
+++ b/crates/jobs/src/backup/kopia.rs
@@ -269,6 +269,20 @@ pub fn type_from_path(path: &str) -> Option<String> {
 	}
 }
 
+/// One snapshot found in the repo, as the inventory records it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotEntry {
+	/// The snapshot manifest id — what bestool reports as its `snapshot_id`.
+	pub id: String,
+	/// Full kopia source `user@host:path` the snapshot belongs to.
+	pub source: String,
+	/// RFC3339 timestamp of when the snapshot was taken, when the manifest
+	/// carries one.
+	pub snapshot_at: Option<String>,
+	/// Logical size (`rootEntry.summ.size`), the figure a device reports.
+	pub logical_bytes: i64,
+}
+
 /// Reduced view of a snapshot-manifest list, used by the inspect kind.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Inspected {
@@ -276,9 +290,9 @@ pub struct Inspected {
 	pub source_count: i32,
 	pub logical_bytes: i64,
 	pub sources: Vec<SourceEntry>,
-	/// `(snapshot id, logical size)` for every snapshot with a non-empty id,
-	/// for matching back to the device runs that produced them.
-	pub snapshots: Vec<(String, i64)>,
+	/// Every snapshot with a non-empty id, for matching back to the device runs
+	/// that reported creating them.
+	pub snapshots: Vec<SnapshotEntry>,
 }
 
 /// Reduce a parsed snapshot-manifest list to per-source latest entries + counts
@@ -311,7 +325,12 @@ pub fn inspect_manifests(manifests: &[Manifest]) -> Inspected {
 	let snapshots = manifests
 		.iter()
 		.filter(|m| !m.id.is_empty())
-		.map(|m| (m.id.clone(), m.root_entry.summ.size))
+		.map(|m| SnapshotEntry {
+			id: m.id.clone(),
+			source: m.source.full(),
+			snapshot_at: m.start_time.clone(),
+			logical_bytes: m.root_entry.summ.size,
+		})
 		.collect();
 
 	Inspected {
@@ -720,9 +739,9 @@ pub struct InspectOutcome {
 	/// Physical (stored) bytes from `kopia content stats`; `None` if unparseable.
 	pub physical_bytes: Option<i64>,
 	pub sources: Vec<SourceEntry>,
-	/// `(snapshot id, logical size)` for every snapshot, matched back to the
-	/// device runs that produced them by the completion logic.
-	pub snapshots: Vec<(String, i64)>,
+	/// Every snapshot in the repo, recorded as the inventory and matched back to
+	/// the device runs that produced them by the completion logic.
+	pub snapshots: Vec<SnapshotEntry>,
 }
 
 /// Connect, list snapshots, read physical stats, and verify (read-only). A
@@ -860,7 +879,15 @@ mod tests {
 		]"#;
 		let manifests: Vec<Manifest> = serde_json::from_str(json).unwrap();
 		let got = inspect_manifests(&manifests);
-		assert_eq!(got.snapshots, vec![("k9c0ffee".to_string(), 1490)]);
+		assert_eq!(
+			got.snapshots,
+			vec![SnapshotEntry {
+				id: "k9c0ffee".to_string(),
+				source: "canopy@srv-1:tamanu-postgres".to_string(),
+				snapshot_at: Some("2026-06-18T13:00:00Z".to_string()),
+				logical_bytes: 1490,
+			}]
+		);
 	}
 
 	#[test]

--- a/migrations/2026-08-04-032256-0000_add_backup_repo_observed_snapshots/down.sql
+++ b/migrations/2026-08-04-032256-0000_add_backup_repo_observed_snapshots/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE backup_repo_observed_snapshots;

--- a/migrations/2026-08-04-032256-0000_add_backup_repo_observed_snapshots/up.sql
+++ b/migrations/2026-08-04-032256-0000_add_backup_repo_observed_snapshots/up.sql
@@ -1,0 +1,19 @@
+-- The repo inventory recorded only the newest snapshot time per source, so
+-- canopy held the snapshot id a device reported (backup_runs.snapshot_id) with
+-- nothing to match it against: reconciliation could compare timestamps and no
+-- more. This records the identity of every snapshot an inspection observes, so
+-- "the device reported a snapshot the repository does not hold" is a question
+-- canopy can answer rather than infer.
+--
+-- One row per snapshot per group, keyed by the snapshot's own id, which is
+-- unique within a repository. The set is the last inspection's observation, not
+-- a history: each inspection replaces it, so a snapshot that retention has
+-- since expired stops being recorded and the table stays the size of the repo.
+CREATE TABLE backup_repo_observed_snapshots (
+	group_id UUID NOT NULL REFERENCES server_groups (id) ON DELETE CASCADE,
+	snapshot_id TEXT NOT NULL,
+	source TEXT NOT NULL,
+	snapshot_at TIMESTAMPTZ,
+	observed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+	PRIMARY KEY (group_id, snapshot_id)
+);

--- a/migrations/2026-08-04-034025-0000_retire_unfounded_reconcile_missing/down.sql
+++ b/migrations/2026-08-04-034025-0000_retire_unfounded_reconcile_missing/down.sql
@@ -1,0 +1,3 @@
+-- Irreversible: the state these findings held before they were retired isn't
+-- recorded, and reopening them would re-assert a condition nothing established.
+-- Nothing to restore.

--- a/migrations/2026-08-04-034025-0000_retire_unfounded_reconcile_missing/up.sql
+++ b/migrations/2026-08-04-034025-0000_retire_unfounded_reconcile_missing/up.sql
@@ -1,0 +1,55 @@
+-- backup-reconcile-missing said a server "reported a successful backup but no
+-- matching repo snapshot landed". It never looked a snapshot up: it compared
+-- the repo inventory's age against twice the backup interval, and the inventory
+-- can only ever be as fresh as the last inspection, which runs on a slower,
+-- independent cadence. For any server backing up more than twice a day — the
+-- normal case — that comparison was false whenever nobody had looked recently,
+-- and the guard meant to catch that only asked whether an inspection had
+-- happened in the last eight days, not whether one had happened since the run
+-- it was contradicting. So the check fired on healthy servers.
+--
+-- The name now belongs to the finding it always claimed: the snapshot id a run
+-- reported is absent from the snapshots inspection observed. That is decided
+-- per run and per inspection, so it cannot re-raise these rows on its own, and
+-- until each group is next inspected it has nothing to say about them at all.
+-- Retire them rather than leave a fleet of unfounded warnings standing against
+-- server health. Any that are real come back on the next inspection.
+CREATE TEMP TABLE unfounded_reconcile_missing ON COMMIT DROP AS
+SELECT id FROM issues
+WHERE source = 'canopy'
+	AND ref = 'backup-reconcile-missing'
+	AND active;
+
+UPDATE incident_issues
+SET left_at = now()
+WHERE left_at IS NULL
+	AND issue_id IN (SELECT id FROM unfounded_reconcile_missing);
+
+UPDATE issues
+SET
+	active = false,
+	resolved_at = now(),
+	resolved_by = 'migration',
+	resolved_reason = 'raised by a comparison that could not establish a snapshot was missing'
+WHERE id IN (SELECT id FROM unfounded_reconcile_missing);
+
+-- Close any incident those releases emptied. Mirrors the leave path in
+-- re_evaluate_incident_membership: an incident is held open by its
+-- currently-failing contributors, so one with none left retires. No Slack
+-- resolve is enqueued — these incidents should not have been opened.
+UPDATE incidents AS inc
+SET closed_at = now()
+WHERE inc.closed_at IS NULL
+	AND EXISTS (
+		SELECT 1 FROM incident_issues il
+		WHERE il.incident_id = inc.id
+			AND il.issue_id IN (SELECT id FROM unfounded_reconcile_missing)
+	)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM incident_issues il
+		JOIN issues i ON i.id = il.issue_id
+		WHERE il.incident_id = inc.id
+			AND il.left_at IS NULL
+			AND i.effective_result = 'failed'
+	);


### PR DESCRIPTION
🤖 `backup-reconcile-missing` was firing on healthy servers, and its message described a check it could not perform.

## The two defects

**It was structurally too eager.** `snapshot_fresh` judged the repo inventory's age with a yardstick derived from the *backup* cadence, but `latest_snapshot_at` can only ever be as fresh as the last *inspection* — a slower, independent cadence. For any group inspecting less often than twice its backup interval, which is most of them, the condition collapsed to `report_fresh` and every successful backup became an alert. The `INVENTORY_STALE_AFTER` guard asked the wrong question: whether the inspector had run *at all* in 8 days, not whether it had run since the report it was contradicting.

**It claimed a verification it could not do.** "no matching repo snapshot landed" reads as an id lookup. `backup_runs.snapshot_id` exists — the device tells us the kopia id it created — but `backup_repo_snapshots` recorded only `(group, source) → latest_snapshot_at`, no ids at all. So the check compared two timestamps and narrated the result as if it had looked up a specific snapshot and failed to find it.

## What changed

The producer side already had what was needed: kopia's inspection was parsing the manifest `id` for size backfill and simply not recording it. No bestool change required.

**New table `backup_repo_observed_snapshots`** — `(group_id, snapshot_id) → source, snapshot_at, observed_at`. Separate from `backup_repo_snapshots` (keyed `(group, source)`, one summary row per source) because the natural key here is the snapshot's own id, making reconcile's lookup a PK hit and the write idempotent. Written as replace-the-whole-set per inspection: the table describes the repository *as it stands*, so retention-expired snapshots don't linger and get matched against, and it stays bounded at repo size.

**Two checks, because one catalog entry has one ceiling:**

- `backup-reconcile-missing` keeps its name, its `warning` ceiling and any stored silences, and now means what its documentation always said: the run named a snapshot id, the inventory was itemised *after* that run, and the id is absent. Decidable only when the run named a snapshot **and** the report is within 2× the interval (so retention cannot have expired it) **and** the inventory was observed after `reported_at`. Otherwise `Skipped`.
- `backup-reconcile-recency` is new with a ceiling of `passed` — recorded and visible, never alerting. This is the old heuristic, demoted to what it actually is: "the repo looks behind", not "the data didn't land".

Absence is only evidence once someone has looked, so decidability keys on the inventory having been observed after the run's `reported_at`. `INVENTORY_STALE_AFTER` is gone.

Recency deliberately does **not** fall back to `reported_at` when a run doesn't report `snapshot_taken_at`: a snapshot's freeze moment always precedes its report, so that fallback would judge every healthy server behind. Those runs are `Skipped`.

Messages and documentation now describe only what was observed, including the real limitation — the per-source inventory records times, not ids.

## Migration

`retire_unfounded_reconcile_missing` retires the findings the old comparison raised: release incident links, resolve, close emptied incidents. Without it a fleet of false warnings would sit against server health until each group's next inspection, since the new check is undecidable until then.

## Operator-visible

- The false warnings stop, and existing ones are retired on deploy.
- A new catalog entry `backup-reconcile-recency` appears at ceiling `passed`, pre-reviewed — visible when the repo looks behind, contributing to nothing.
- Until each group's next inspection after deploy, `backup-reconcile-missing` is `skipped`: nothing has itemised the snapshots yet.

## Two blind spots left open, deliberately

An inspection finding an entirely empty repository leaves no inventory rows, so neither check can decide; and a group never itemised is likewise undecidable. `backup_repo_stats.observed_at` would close the empty-repo case, but keying off it would re-introduce a fleet-wide false-warning burst in the deploy window. Both are documented in the module doc and the check documentation.

## Tests

The motivating regression — `reconcile_leaves_a_healthy_server_alone_when_inspection_lags_the_backup_cadence` — was verified by restoring the old `reconcile.rs` and confirming it fails against it.

The two tests that encoded the bug (72h-old snapshot vs a 12h interval, asserting the alert fires) are rewritten to the corrected semantics rather than deleted. `reconcile_leaves_an_open_missing_alone_when_the_inventory_goes_stale` is kept and re-based on the id mechanism; its guarantee still holds. `backup_sweeps_seed_no_check_that_defaults_to_a_failure` gains a `RECORDED_ONLY` list so the ceiling-`passed` check is pinned rather than exempted.
