### PR TITLE
fix(upgrades): an attempt chip that means a migration test

### DIFF
--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -445,6 +445,28 @@ impl RestoreConsumerCapability {
 	}
 }
 
+/// Whether any enabled declaration on `group_id` migrates what it restores.
+///
+/// The consumer's advertised `migrate` semantic decides, whatever the intent is
+/// named: only a migrating intent is dispatched a target version.
+// spec: RST#verdicts
+pub async fn group_migrates(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<bool> {
+	for replica in RestoreReplica::list_for_group(db, group_id).await? {
+		if !replica.enabled {
+			continue;
+		}
+		let advertised =
+			RestoreConsumerCapability::list_for_consumer(db, replica.consumer_device_id).await?;
+		if advertised
+			.iter()
+			.any(|d| d.intent == replica.intent && d.has_semantic(semantics::MIGRATE))
+		{
+			return Ok(true);
+		}
+	}
+	Ok(false)
+}
+
 /// Why a server a redacting declaration covers can't be redacted.
 ///
 /// Each of these withholds the server's worklist entry: a replica that

--- a/crates/private-server/src/fns/migration_tests.rs
+++ b/crates/private-server/src/fns/migration_tests.rs
@@ -80,6 +80,12 @@ pub async fn attempt_state(
 ) -> Result<Option<AttemptState>> {
 	use database::backups::BackupCredentialIssuance;
 
+	// Issuances carry no intent, so another intent's restore traffic would read
+	// as a test under way.
+	if !database::restore::group_migrates(conn, group_id).await? {
+		return Ok(None);
+	}
+
 	let reports =
 		database::restore::BackupRestoreCheck::list_recent_for_group(conn, group_id, 50).await?;
 	// Member-server devices restore for their own purposes (clone refreshes,

--- a/crates/private-server/tests/it/upgrade_plans.rs
+++ b/crates/private-server/tests/it/upgrade_plans.rs
@@ -100,6 +100,14 @@ async fn an_attempt_in_flight_shows_beside_the_verdict() {
 				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');
 			INSERT INTO devices (id, role) VALUES
 				('cccccccc-0000-0000-0000-0000000000d0', 'backup-restore');
+			INSERT INTO restore_consumer_capabilities
+				(consumer_device_id, intent, semantics)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0', 'upgrade', '[\"migrate\"]');
+			INSERT INTO restore_replicas
+				(consumer_device_id, group_id, type, intent, name)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'upgrade',
+				'kamaka-upgrade');
 			INSERT INTO upgrade_plans (group_id, target_version_id) VALUES
 				('cccccccc-0000-0000-0000-000000000001',
 				 'cccccccc-0000-0000-0000-0000000000f1');",
@@ -165,6 +173,14 @@ async fn a_member_servers_own_restore_is_not_an_attempt() {
 				 'https://clone.example.com', 'central',
 				 'cccccccc-0000-0000-0000-000000000001',
 				 'cccccccc-0000-0000-0000-0000000000d1');
+			INSERT INTO restore_consumer_capabilities
+				(consumer_device_id, intent, semantics)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0', 'upgrade', '[\"migrate\"]');
+			INSERT INTO restore_replicas
+				(consumer_device_id, group_id, type, intent, name)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'upgrade',
+				'kamaka-upgrade');
 			INSERT INTO upgrade_plans (group_id, target_version_id) VALUES
 				('cccccccc-0000-0000-0000-000000000001',
 				 'cccccccc-0000-0000-0000-0000000000f1');
@@ -211,6 +227,55 @@ async fn a_member_servers_own_restore_is_not_an_attempt() {
 			.json();
 		let row = fleet.iter().find(|r| r["group_id"] == GROUP).unwrap();
 		assert_eq!(row["attempt"], "ended_without_report");
+	})
+	.await;
+}
+
+/// A group whose only declaration serves another intent restores on its own
+/// cadence, and none of that traffic is a migration test.
+#[tokio::test(flavor = "multi_thread")]
+async fn restores_for_another_intent_are_not_an_attempt() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+				('cccccccc-0000-0000-0000-0000000000f1', 2, 61, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');
+			INSERT INTO devices (id, role) VALUES
+				('cccccccc-0000-0000-0000-0000000000d0', 'backup-restore');
+			INSERT INTO restore_consumer_capabilities
+				(consumer_device_id, intent, semantics)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0', 'analytics',
+				'[\"check\", \"url\"]');
+			INSERT INTO restore_replicas
+				(consumer_device_id, group_id, type, intent, name)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'analytics',
+				'kamaka-analytics');
+			INSERT INTO upgrade_plans (group_id, target_version_id) VALUES
+				('cccccccc-0000-0000-0000-000000000001',
+				 'cccccccc-0000-0000-0000-0000000000f1');
+			INSERT INTO backup_credential_issuances
+				(device_id, group_id, type, purpose, issued_at, expires_at,
+				 sts_assumed_role, bucket, prefix)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'restore',
+				NOW() - INTERVAL '20 minutes', NOW() + INTERVAL '40 minutes',
+				'arn:aws:iam::1:role/r', 'b', '')",
+		)
+		.await
+		.unwrap();
+
+		let fleet: Vec<Value> = private
+			.post("/api/upgrade_plans/fleet")
+			.json(&json!({}))
+			.await
+			.json();
+		let row = fleet.iter().find(|r| r["group_id"] == GROUP).unwrap();
+		assert!(
+			row["attempt"].is_null(),
+			"an unreported analytics restore is not a migration test"
+		);
 	})
 	.await;
 }


### PR DESCRIPTION
The Upgrades page showed "testing" whenever any restore credential was outstanding for a group. Nauru has read that for weeks off analytics traffic, while no migration test has ever run there.

- `attempt_state` returns None unless the group has an enabled declaration on a `migrate` intent.
- Issuances carry no intent, so the declaration is the only thing that tells that traffic apart.