### PR TITLE
feat(upgrades): say when a plan has nothing to test it

### DIFF
--- a/.workhorse/specs/private-server/upgrade-plans.md
+++ b/.workhorse/specs/private-server/upgrade-plans.md
@@ -75,6 +75,7 @@ Canopy presents planned upgrades across the fleet in one view, so the question "
 For each group with an open plan it shows the target version, the version the group is on now, the planned date and hour where there are ones, and the pre-upgrade verdict for that target, so an operator sees both the intent and whether the deployment's data survives it.
 The hour carries its zone, abbreviated: whose midnight it is is the whole question a reader has.
 Where an attempt is under way it shows that too, since a restore takes hours and a verdict of not-yet-tested otherwise looks the same whether the pipeline is working or has stopped.
+Where nothing is declared to migrate the group's data it says so in place of the verdict, since a plan on a deployment with no such declaration is never dispatched and a reader would otherwise wait on a result that cannot arrive.
 Groups with no plan are shown too, behind a disclosure that counts them: an unplanned deployment several minors behind is what this view exists to surface, and the count surfaces it without the list crowding out what is moving.
 
 A plan whose date has passed without being met is presented as late, judged on the day alone rather than the hour.

--- a/crates/database/src/restore.rs
+++ b/crates/database/src/restore.rs
@@ -445,6 +445,28 @@ impl RestoreConsumerCapability {
 	}
 }
 
+/// Whether any enabled declaration on `group_id` migrates what it restores.
+///
+/// The consumer's advertised `migrate` semantic decides, whatever the intent is
+/// named: only a migrating intent is dispatched a target version.
+// spec: RST#verdicts
+pub async fn group_migrates(db: &mut AsyncPgConnection, group_id: Uuid) -> Result<bool> {
+	for replica in RestoreReplica::list_for_group(db, group_id).await? {
+		if !replica.enabled {
+			continue;
+		}
+		let advertised =
+			RestoreConsumerCapability::list_for_consumer(db, replica.consumer_device_id).await?;
+		if advertised
+			.iter()
+			.any(|d| d.intent == replica.intent && d.has_semantic(semantics::MIGRATE))
+		{
+			return Ok(true);
+		}
+	}
+	Ok(false)
+}
+
 /// Why a server a redacting declaration covers can't be redacted.
 ///
 /// Each of these withholds the server's worklist entry: a replica that

--- a/crates/private-server/src/fns/upgrade_plans.rs
+++ b/crates/private-server/src/fns/upgrade_plans.rs
@@ -52,6 +52,11 @@ pub struct PlannedUpgrade {
 	/// than folded into it: a restore takes hours, so a group mid-test would
 	/// otherwise read as untested for the whole window.
 	pub attempt: Option<crate::fns::migration_tests::AttemptState>,
+	/// Whether anything is declared to migrate this group's data. A plan on a
+	/// group with nothing declared is never dispatched, so its verdict would sit
+	/// at "not tested" indefinitely with nothing on its way. `null` without a
+	/// plan.
+	pub testable: Option<bool>,
 }
 
 /// Planned upgrades across the fleet.
@@ -109,11 +114,18 @@ pub async fn fleet(
 			}
 		};
 
-		let attempt = match &plan {
+		let testable = match &plan {
 			None => None,
-			Some(_) => {
+			Some(_) => Some(database::restore::group_migrates(&mut conn, group.id).await?),
+		};
+
+		// Issuances carry no intent, so another intent's restore traffic would
+		// read as a test under way.
+		let attempt = match testable {
+			Some(true) => {
 				crate::fns::migration_tests::attempt_state(&mut conn, group.id, now_ts).await?
 			}
+			_ => None,
 		};
 
 		out.push(PlannedUpgrade {
@@ -125,6 +137,7 @@ pub async fn fleet(
 			late,
 			verdict,
 			attempt,
+			testable,
 		});
 	}
 

--- a/crates/private-server/tests/it/upgrade_plans.rs
+++ b/crates/private-server/tests/it/upgrade_plans.rs
@@ -88,6 +88,82 @@ async fn a_target_behind_the_group_is_refused() {
 	.await;
 }
 
+/// A plan on a group with nothing declared to migrate its data is never
+/// dispatched, so the view says so rather than reporting it as merely untested.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_plan_nothing_will_test_says_so() {
+	commons_tests::server::run(async |mut conn, _, private| {
+		conn.batch_execute(
+			"INSERT INTO versions (id, major, minor, patch, changelog, status) VALUES
+				('cccccccc-0000-0000-0000-0000000000f1', 2, 61, 0, 'x', 'published');
+			INSERT INTO server_groups (id, name, effective_version) VALUES
+				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');
+			INSERT INTO devices (id, role) VALUES
+				('cccccccc-0000-0000-0000-0000000000d0', 'backup-restore');
+			INSERT INTO restore_consumer_capabilities
+				(consumer_device_id, intent, semantics)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0', 'analytics',
+				'[\"check\", \"url\"]');
+			INSERT INTO restore_replicas
+				(consumer_device_id, group_id, type, intent, name)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'analytics',
+				'kamaka-analytics');
+			INSERT INTO upgrade_plans (group_id, target_version_id) VALUES
+				('cccccccc-0000-0000-0000-000000000001',
+				 'cccccccc-0000-0000-0000-0000000000f1');
+			INSERT INTO backup_credential_issuances
+				(device_id, group_id, type, purpose, issued_at, expires_at,
+				 sts_assumed_role, bucket, prefix)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'restore',
+				NOW() - INTERVAL '20 minutes', NOW() + INTERVAL '40 minutes',
+				'arn:aws:iam::1:role/r', 'b', '')",
+		)
+		.await
+		.unwrap();
+
+		let fleet: Vec<Value> = private
+			.post("/api/upgrade_plans/fleet")
+			.json(&json!({}))
+			.await
+			.json();
+		let row = fleet.iter().find(|r| r["group_id"] == GROUP).unwrap();
+		assert_eq!(
+			row["testable"], false,
+			"an intent that does not migrate tests nothing"
+		);
+		assert!(
+			row["attempt"].is_null(),
+			"and its restores are not a migration test under way"
+		);
+
+		// A declaration on a migrating intent is what turns the plan into work.
+		conn.batch_execute(
+			"INSERT INTO restore_consumer_capabilities
+				(consumer_device_id, intent, semantics)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0', 'upgrade', '[\"migrate\"]');
+			INSERT INTO restore_replicas
+				(consumer_device_id, group_id, type, intent, name)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'upgrade',
+				'kamaka-upgrade');",
+		)
+		.await
+		.unwrap();
+
+		let fleet: Vec<Value> = private
+			.post("/api/upgrade_plans/fleet")
+			.json(&json!({}))
+			.await
+			.json();
+		let row = fleet.iter().find(|r| r["group_id"] == GROUP).unwrap();
+		assert_eq!(row["testable"], true);
+		assert_eq!(row["attempt"], "in_flight");
+	})
+	.await;
+}
+
 /// A restore takes hours, so a group mid-test must not read as untested: an
 /// issuance with no report yet is an attempt in flight.
 #[tokio::test(flavor = "multi_thread")]
@@ -100,6 +176,14 @@ async fn an_attempt_in_flight_shows_beside_the_verdict() {
 				('cccccccc-0000-0000-0000-000000000001', 'kamaka', '2.60.0');
 			INSERT INTO devices (id, role) VALUES
 				('cccccccc-0000-0000-0000-0000000000d0', 'backup-restore');
+			INSERT INTO restore_consumer_capabilities
+				(consumer_device_id, intent, semantics)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0', 'upgrade', '[\"migrate\"]');
+			INSERT INTO restore_replicas
+				(consumer_device_id, group_id, type, intent, name)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'upgrade',
+				'kamaka-upgrade');
 			INSERT INTO upgrade_plans (group_id, target_version_id) VALUES
 				('cccccccc-0000-0000-0000-000000000001',
 				 'cccccccc-0000-0000-0000-0000000000f1');",
@@ -165,6 +249,14 @@ async fn a_member_servers_own_restore_is_not_an_attempt() {
 				 'https://clone.example.com', 'central',
 				 'cccccccc-0000-0000-0000-000000000001',
 				 'cccccccc-0000-0000-0000-0000000000d1');
+			INSERT INTO restore_consumer_capabilities
+				(consumer_device_id, intent, semantics)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0', 'upgrade', '[\"migrate\"]');
+			INSERT INTO restore_replicas
+				(consumer_device_id, group_id, type, intent, name)
+			 VALUES ('cccccccc-0000-0000-0000-0000000000d0',
+				'cccccccc-0000-0000-0000-000000000001', 'tamanu-postgres', 'upgrade',
+				'kamaka-upgrade');
 			INSERT INTO upgrade_plans (group_id, target_version_id) VALUES
 				('cccccccc-0000-0000-0000-000000000001',
 				 'cccccccc-0000-0000-0000-0000000000f1');

--- a/private-web/e2e/upgrades.spec.ts
+++ b/private-web/e2e/upgrades.spec.ts
@@ -1,11 +1,33 @@
 import { expect, test } from "./test-fixtures";
 import {
 	resetSeededTables,
+	seedDevice,
+	seedRestoreConsumerCapability,
+	seedRestoreReplica,
 	seedServerGroup,
 	seedUpgradePlan,
 	seedVersion,
 	seedVersionKnownIssue,
 } from "./seed";
+
+/** Declare a replica on an intent that migrates, which is what makes a plan
+ * something the pipeline will act on. */
+async function declareUpgradeReplica(
+	sql: Parameters<typeof seedRestoreReplica>[0],
+	groupId: string,
+): Promise<void> {
+	const consumer = await seedDevice(sql, { role: "backup-restore" });
+	await seedRestoreConsumerCapability(sql, {
+		deviceId: consumer.id,
+		intents: [{ intent: "upgrade", semantics: ["check", "once", "migrate"] }],
+	});
+	await seedRestoreReplica(sql, {
+		consumerDeviceId: consumer.id,
+		groupId,
+		intent: "upgrade",
+		name: "upgrade",
+	});
+}
 
 test.describe("upgrades dashboard", () => {
 	test.beforeEach(async ({ sql }) => {
@@ -35,6 +57,7 @@ test.describe("upgrades dashboard", () => {
 			plannedFor: "2020-01-01",
 			note: "site can absorb 2.61 only",
 		});
+		await declareUpgradeReplica(sql, planned.id);
 
 		await page.goto("/upgrades");
 
@@ -64,6 +87,30 @@ test.describe("upgrades dashboard", () => {
 		await expect(page.getByTestId("unplanned-upgrades")).not.toContainText(
 			"kamaka",
 		);
+	});
+
+	test("says a plan with nothing declared to test it is not set up", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "kamaka" });
+		const target = await seedVersion(sql, { major: 2, minor: 61, patch: 0 });
+		await seedUpgradePlan(sql, {
+			groupId: group.id,
+			targetVersionId: target.id,
+			plannedFor: "2020-01-01",
+		});
+
+		await page.goto("/upgrades");
+
+		// Nothing is declared to migrate this group's data, so no test will ever
+		// run: saying "not yet tested" would leave a reader waiting on a result
+		// that cannot arrive.
+		const row = page
+			.getByTestId("planned-upgrade-row")
+			.filter({ hasText: "kamaka" });
+		await expect(row).toContainText("not set up");
+		await expect(row).not.toContainText("not yet tested");
 	});
 
 	test("says so when nothing is planned", async ({ page, sql }) => {

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -12323,6 +12323,13 @@
             ],
             "description": "The plan's target as semver."
           },
+          "testable": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether anything is declared to migrate this group's data. A plan on a\ngroup with nothing declared is never dispatched, so its verdict would sit\nat \"not tested\" indefinitely with nothing on its way. `null` without a\nplan."
+          },
           "verdict": {
             "type": [
               "string",

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -6823,6 +6823,13 @@ export interface components {
             /** @description The plan's target as semver. */
             target_version?: string | null;
             /**
+             * @description Whether anything is declared to migrate this group's data. A plan on a
+             *     group with nothing declared is never dispatched, so its verdict would sit
+             *     at "not tested" indefinitely with nothing on its way. `null` without a
+             *     plan.
+             */
+            testable?: boolean | null;
+            /**
              * @description Where the group's data stands against the planned version, rolled up from
              *     its servers: any failure makes the group a failure, since one server
              *     whose data breaks is enough to stop the upgrade. `null` without a plan.

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -117,7 +117,10 @@ export default function Upgrades() {
 												spacing={0.5}
 												sx={{ alignItems: "center" }}
 											>
-												<VerdictChip verdict={row.verdict} />
+												<VerdictChip
+													verdict={row.verdict}
+													testable={row.testable}
+												/>
 												<AttemptChip attempt={row.attempt} />
 											</Stack>
 										</TableCell>
@@ -316,7 +319,13 @@ function OutcomeChip({
 
 /// Whether the deployment's own data survives the planned version, rolled up
 /// from its servers. Pairing it with the plan is the point of this view.
-function VerdictChip({ verdict }: { verdict: string | null | undefined }) {
+function VerdictChip({
+	verdict,
+	testable,
+}: {
+	verdict: string | null | undefined;
+	testable: boolean | null | undefined;
+}) {
 	if (verdict === "passed") {
 		return <Chip size="small" color="success" label="passed" />;
 	}
@@ -324,6 +333,18 @@ function VerdictChip({ verdict }: { verdict: string | null | undefined }) {
 		return (
 			<Tooltip title="a server's data broke the migrations; the version is held back">
 				<Chip size="small" color="warning" label="failed" />
+			</Tooltip>
+		);
+	}
+	if (testable === false) {
+		return (
+			<Tooltip title="nothing is declared to migrate this deployment's data, so no test will run: declare a restore replica for it on the group's page">
+				<Chip
+					size="small"
+					color="warning"
+					variant="outlined"
+					label="not set up"
+				/>
 			</Tooltip>
 		);
 	}


### PR DESCRIPTION
No deployment has ever been migration-tested: nothing is declared on a migrating intent, and the page read "not yet tested" as though a result were on its way.

- Rows say "not set up" when nothing is declared to migrate that group's data.
- The "testing" chip stops firing on another intent's restore traffic. Issuances carry no intent, so the declaration is the only thing that separates them.