### PR TITLE
feat(monitoring): A1: declare maintenance to suspend incidents

### DIFF
--- a/.workhorse/plans/a1/plan.md
+++ b/.workhorse/plans/a1/plan.md
@@ -1,0 +1,22 @@
+# A1 — Declare server maintenance to suspend incidents
+
+Spec: [MNT](../../specs/monitoring/maintenance.md). The window is a target-scoped, time-bounded ceiling of `skipped` over every check, so it rides the existing policy chain rather than adding a parallel suppression path.
+
+## Build
+
+- [x] Migration + `schema.rs` entry for `maintenance_windows` (server xor group, `expected_end`, `note`, `declared_by/at`, `ended_at/by`, `settled_at`). Partial unique index on the open row per target.
+- [x] `database::maintenance_windows`: declare (amends an open window), lift, list open, list for target, `suspends()` and its batch form, expiry and settle sweeps.
+- [x] Grading: `ScopedCheckPolicy::chain_for`/`chains_for_scope` append a synthetic skipped ceiling while a covering window suspends. Every grading path picks it up with no call-site change.
+- [x] `re_evaluate_incident_membership`: maintenance joins snoozed/silenced/unmonitored as a leave reason.
+- [x] Declare, amend, and lift re-evaluate the target's open issues, as a silence does.
+- [x] Sweeps in `monitor.rs`: end a window at its expected end, and re-evaluate the target once its settle period elapses.
+- [x] Slack: `maintenance_declared` and `maintenance_ended` outbox kinds. Webhooks optional, so an unconfigured deployment records without posting.
+- [x] Private-server `/api/maintenance` (declare, amend, lift, list, for-target) and regenerated OpenAPI.
+- [x] UI: declare/amend/lift on server and group, the fleet view of open windows, maintenance marking on health and status dots, declare from an open incident, declare from an upgrade plan.
+- [x] Tests: database integration cases, then Playwright for the surfaces.
+
+## Decisions
+
+- Suspension is `now() < COALESCE(ended_at, expected_end) + settle`, so grading is right even when a sweep is late, and settling needs no second state.
+- The settle period is a fleet-wide constant, per the spec's "same for every window".
+- Maintenance is not written into `scoped_check_policies`: silences are per (source, check) and operator-owned, and a window is neither.

--- a/.workhorse/specs/monitoring/checks.md
+++ b/.workhorse/specs/monitoring/checks.md
@@ -96,9 +96,11 @@ Canopy's own checks register already reviewed, with the policy their condition w
 Beyond the fleet catalog, a transform can be scoped to a target: per server, per group, or Canopy-wide.
 Transforms apply in order — fleet catalog, then group, then server — each acting on the previous effective result, so the most specific scope has the last word.
 
-The operator interface presents one scoped policy: the **silence**, a scoped ceiling of `skipped`, recording who silenced and when.
+The operator interface presents two scoped policies.
+The **silence** is a scoped ceiling of `skipped` on one check, recording who silenced and when.
 A silenced check keeps recording its observed results; its effective result is skipped, so it raises nothing and counts nowhere.
-The model admits arbitrary scoped transforms; surfaces beyond the silence are deliberately not offered yet.
+The **maintenance window** is the same ceiling applied to every check on a target for a bounded time, so that work an operator is doing raises nothing while it runs (see [MNT](maintenance.md)).
+The model admits arbitrary scoped transforms; surfaces beyond these two are deliberately not offered yet.
 
 ## Documentation
 

--- a/.workhorse/specs/monitoring/incidents.md
+++ b/.workhorse/specs/monitoring/incidents.md
@@ -23,7 +23,7 @@ Warnings never hold an incident open.
 When the last effective failure leaves because its result recovered, the incident does not close immediately: it **lingers** for its target's linger window, remaining the target's open incident.
 A check whose effective result becomes failed during the window — a fresh failure or the same one returning — ends the lingering and the incident continues.
 An incident whose linger window elapses without an effective failure closes, recording the close as of when its last effective failure left.
-Lingering damps reporter flapping, not operator action: a last failure leaving through resolution, snooze, silence, or its server's monitoring being turned off closes the incident immediately.
+Lingering damps reporter flapping, not operator action: a last failure leaving through resolution, snooze, silence, a maintenance window declared over its target (see [MNT](maintenance.md)), or its server's monitoring being turned off closes the incident immediately.
 
 The membership history — which issues joined and left, and when — is kept and presented as the incident's timeline.
 An issue can leave and rejoin the same incident.

--- a/.workhorse/specs/monitoring/maintenance.md
+++ b/.workhorse/specs/monitoring/maintenance.md
@@ -1,0 +1,103 @@
+---
+id: MNT
+---
+
+# Maintenance windows
+
+A maintenance window is an operator's declaration that a server or a group is being worked on, so what Canopy observes while the work runs raises nothing.
+A window is bounded in time, ends itself, and records who declared it and what for, so a quiet part of the fleet is always attributable to a decision someone made.
+
+## Scope
+
+This spec covers declaring a window, what it suspends, how it ends, and how it is presented.
+How results are graded is the check-state model (see [CHK](checks.md)), and what a suspended check stops contributing to is the incident spec (see [INC](incidents.md)).
+
+It does not cover planned upgrades (see [UPG](../private-server/upgrade-plans.md)).
+A plan records where a deployment is going and when it expects to move; a window declares that work is happening now.
+
+## Why it exists
+
+An upgrade looks exactly like a deployment falling over: the server stops reporting, its checks go stale, and the group opens an incident someone then has to read before recognising it as the work they are already doing.
+Alerting through planned work costs an operator the trust they place in the next alert.
+
+Neither existing control answers this.
+A silence is one check held down until an operator removes it, so covering an upgrade means writing several and remembering to clear every one afterwards.
+Turning a server's monitoring off is per-server and unbounded, and a switch with nothing to turn it back on is one that stays off.
+
+## Declaring
+
+An operator declares a window over one server or one group, giving the time it is expected to end and, optionally, a note saying what is being done.
+Canopy records the operator who declared it and when, alongside the expected end and the note.
+Declaring, amending, and lifting are administrative actions and are audited (see [ADM](../private-server/admin-access.md)).
+
+A group's window covers the group's own checks and the checks of every server in it, including servers that join the group while it holds.
+A server can be covered by its own window and by its group's at the same time, and stays suspended until the last window covering it has ended.
+
+A target has at most one open window.
+Declaring over a target that already has one amends that window rather than opening a second, and the amendment records who made it and when.
+
+Canopy never opens a window by itself.
+A group with an open upgrade plan is offered the declaration from that plan, prefilled with the plan's window and note, so declaring is one action at the moment the work starts.
+The plan supplies the prefill and triggers nothing: an hour someone typed in advance is not evidence that work began.
+
+## What a window suspends
+
+While a window holds over a target, every check on that target has an effective result of skipped, whatever it was observed as (see [CHK](checks.md), "Policy").
+It is the transform a silence applies, applied to the target's every check for as long as the window holds rather than to one check until an operator intervenes.
+
+Observed results continue to be recorded throughout, so what a server said during the work is readable afterwards, and a window never costs Canopy the record of what happened while it held.
+A window changes how Canopy grades what it observes and nothing else: sources are expected to report as they always were, and are told to run their checks as they always were.
+
+A skipped check is not an issue, so a target under a window contributes nothing to incidents and raises no notification.
+An issue that was part of an open incident leaves it when the window is declared.
+An incident whose last effective failure leaves this way closes immediately, as it does for any other operator action (see [INC](incidents.md), "Membership").
+Where that close is notified, the notice says the incident closed because maintenance was declared, so a reader does not take it as the problem having gone away.
+
+Canopy-wide checks are Canopy monitoring its own operation and are never suspended by a window over a server or a group (see [SELF](../private-server/self-alerts.md)).
+
+## Ending
+
+A window ends when its expected end passes, or when an operator lifts it earlier.
+Canopy ends a window at its expected end without asking anyone, so a window left forgotten does not leave a deployment unwatched indefinitely.
+An operator whose work is running long extends the window by amending its end before it passes; once a window has ended it is history, and resuming suspension is a fresh declaration.
+
+Canopy records how each window ended: the expected end passing, or the operator who lifted it and when.
+Ended windows are retained as the target's maintenance history, so what was being done the last time a deployment went quiet is readable against it.
+
+## Settling
+
+A window's suspension persists for a settle period after the window ends.
+
+A server is back before the sources on it have reported again, and a server whose every source is stale is unreachable (see [CHK](checks.md), "Reachability").
+Ending suspension at the instant the work finishes would therefore report as failed the deployment that has just come back, for as long as the work took.
+Suspension outlasting the window by a settle period gives the reporters on a server time to be heard from before Canopy judges them.
+
+Checks are suspended and observed results are recorded during settling exactly as during the window itself.
+When the settle period elapses, every check on the target is graded normally again, and anything still degraded contributes from that point as it would have all along.
+The settle period is the same for every window.
+
+## Notification
+
+Canopy notifies operators over the target's notification channel when a window is declared and again when its suspension ends (see [INC](incidents.md), "Notification").
+The declaration names the target, the operator, the expected end, and the note.
+The ending names the target, says whether an operator lifted the window or its expected end passed, and says when watching resumes.
+A target with no notification channel notifies nowhere.
+
+## Presentation
+
+A target under a window is presented as under maintenance wherever its health or reachability is presented as it currently stands, in the manner an unmonitored server is marked (see [CHK](checks.md), "Monitoring gate").
+Its health is muted and carries an indicator naming the window and when it ends, so a failing server under maintenance is never read as a failing server nobody has noticed, and never read as an unmonitored one either.
+The status legend names the mark.
+
+Canopy presents every open window across the fleet in one view: what each covers, who declared it, when it ends, and its note.
+The view answers "what are we not watching right now" without reading each group.
+
+A target's own surface presents its open window with the actions to amend or lift it, and presents its ended windows as history.
+A check whose effective result is skipped because a window holds says so where its result is presented, rather than leaving the skip unexplained.
+
+## Out of scope
+
+- Performing, scheduling, or triggering the maintenance itself.
+- Declaring a window to begin at a future time. A window says work is happening now; an intended window is what a plan records (see [UPG](../private-server/upgrade-plans.md)).
+- Suspending Canopy's own self-monitoring.
+- Exempting a check from suspension so it still alerts while a window holds.

--- a/.workhorse/specs/monitoring/maintenance.md
+++ b/.workhorse/specs/monitoring/maintenance.md
@@ -7,99 +7,79 @@ id: MNT
 A maintenance window is an operator's declaration that a server or a group is being worked on, so what Canopy observes while the work runs raises nothing.
 A window is bounded in time, ends itself, and records who declared it and what for, so a quiet part of the fleet is always attributable to a decision someone made.
 
-## Scope
-
-This spec covers declaring a window, what it suspends, how it ends, and how it is presented.
-How results are graded is the check-state model (see [CHK](checks.md)), and what a suspended check stops contributing to is the incident spec (see [INC](incidents.md)).
-
-It does not cover planned upgrades (see [UPG](../private-server/upgrade-plans.md)).
-A plan records where a deployment is going and when it expects to move; a window declares that work is happening now.
-
 ## Why it exists
 
-An upgrade looks exactly like a deployment falling over: the server stops reporting, its checks go stale, and the group opens an incident someone then has to read before recognising it as the work they are already doing.
+An upgrade looks exactly like a deployment falling over: the server stops reporting, its checks go stale, and the group opens an incident someone has to read before recognising it as work already under way.
 Alerting through planned work costs an operator the trust they place in the next alert.
 
-Neither existing control answers this.
-A silence is one check held down until an operator removes it, so covering an upgrade means writing several and remembering to clear every one afterwards.
-Turning a server's monitoring off is per-server and unbounded, and a switch with nothing to turn it back on is one that stays off.
+Neither existing control covers it.
+A silence is one check held down until someone removes it, so covering an upgrade means writing several and remembering to clear every one.
+Turning a server's monitoring off is unbounded, and a switch with nothing to turn it back on stays off.
 
 ## Declaring
 
 An operator declares a window over one server or one group, giving the time it is expected to end and, optionally, a note saying what is being done.
-Canopy records the operator who declared it and when, alongside the expected end and the note.
+Canopy records who declared it and when, alongside the expected end and the note.
 Declaring, amending, and lifting are administrative actions and are audited (see [ADM](../private-server/admin-access.md)).
 
-A group's window covers the group's own checks and the checks of every server in it, including servers that join the group while it holds.
-A server can be covered by its own window and by its group's at the same time, and stays suspended until the last window covering it has ended.
+A group's window covers the group's own checks and those of every server in it, including servers that join while it holds.
+A server covered by its own window and by its group's stays suspended until the last of them has ended.
 
-A target has at most one open window.
-Declaring over a target that already has one amends that window rather than opening a second, and the amendment records who made it and when.
+A target has at most one open window: declaring over one that already has a window amends it, recording who amended and when.
 
 Canopy never opens a window by itself.
-A group with an open upgrade plan is offered the declaration from that plan, prefilled with the plan's window and note, so declaring is one action at the moment the work starts.
-The plan supplies the prefill and triggers nothing: an hour someone typed in advance is not evidence that work began.
-
-An open incident offers the declaration over its target as well, so an operator who recognises an alert as the work they are already doing declares from where they are reading it, and the incident closes as its issues leave.
+A group with an open upgrade plan is offered the declaration from that plan, prefilled with its window and note, so declaring is one action at the moment the work starts (see [UPG](../private-server/upgrade-plans.md)).
+An hour someone typed in advance is not evidence that work began, so a planned window suspends nothing on its own.
+An open incident offers the declaration over its target too, so an operator who recognises an alert as their own work declares from where they are reading it.
 
 ## What a window suspends
 
-While a window holds over a target, every check on that target has an effective result of skipped, whatever it was observed as (see [CHK](checks.md), "Policy").
-It is the transform a silence applies, applied to the target's every check for as long as the window holds rather than to one check until an operator intervenes.
-
-Observed results continue to be recorded throughout, so what a server said during the work is readable afterwards, and a window never costs Canopy the record of what happened while it held.
-A window changes how Canopy grades what it observes and nothing else: sources are expected to report as they always were, and are told to run their checks as they always were.
+While a window holds over a target, every check on that target has an effective result of skipped, whatever it was observed as: the transform a silence applies to one check, applied to all of them for as long as the window holds (see [CHK](checks.md), "Policy").
+Observed results are recorded throughout, and sources are expected to report and told to run their checks exactly as they were before, so a window changes how Canopy grades what it sees and nothing else.
 
 A skipped check is not an issue, so a target under a window contributes nothing to incidents and raises no notification.
-An issue that was part of an open incident leaves it when the window is declared.
-An incident whose last effective failure leaves this way closes immediately, as it does for any other operator action (see [INC](incidents.md), "Membership").
-Where that close is notified, the notice says the incident closed because maintenance was declared, so a reader does not take it as the problem having gone away.
+An issue in an open incident leaves it when the window is declared, and an incident whose last effective failure leaves this way closes immediately, as it does for any operator action (see [INC](incidents.md), "Membership").
+Where that close is notified, the notice says maintenance was declared, so a reader does not take it as the problem having gone away.
 
-Canopy-wide checks are Canopy monitoring its own operation and are never suspended by a window over a server or a group (see [SELF](../private-server/self-alerts.md)).
+Canopy-wide checks are Canopy monitoring its own operation, and are never suspended by a window over a server or a group (see [SELF](../private-server/self-alerts.md)).
 
 ## Ending
 
-A window ends when its expected end passes, or when an operator lifts it earlier.
-Canopy ends a window at its expected end without asking anyone, so a window left forgotten does not leave a deployment unwatched indefinitely.
-An operator whose work is running long extends the window by amending its end before it passes; once a window has ended it is history, and resuming suspension is a fresh declaration.
+A window ends when an operator lifts it or when its expected end passes, and Canopy records which, with the operator and the time.
+Ending at the expected end without asking anyone is what keeps a forgotten window from leaving a deployment unwatched.
+Work running long extends the window by amending its end before it passes; a window that has ended is history, and suspending again is a fresh declaration.
 
-Canopy records how each window ended: the expected end passing, or the operator who lifted it and when.
 Ended windows are retained as the target's maintenance history, so what was being done the last time a deployment went quiet is readable against it.
 
 ## Settling
 
-A window's suspension persists for a settle period after the window ends.
+Suspension persists for a settle period after the window ends, unchanged in every respect from the window itself.
 
-A server is back before the sources on it have reported again, and a server whose every source is stale is unreachable (see [CHK](checks.md), "Reachability").
-Ending suspension at the instant the work finishes would therefore report as failed the deployment that has just come back, for as long as the work took.
-Suspension outlasting the window by a settle period gives the reporters on a server time to be heard from before Canopy judges them.
-
-Checks are suspended and observed results are recorded during settling exactly as during the window itself.
-When the settle period elapses, every check on the target is graded normally again, and anything still degraded contributes from that point as it would have all along.
+A server is back before the sources on it have reported again, and a server whose every source is stale is unreachable (see [CHK](checks.md), "Reachability"), so ending suspension the instant the work finishes would report a deployment that has just come back as failed for as long as the work took.
 The settle period is the same for every window.
+When it elapses, every check on the target is graded normally again, and anything still degraded contributes from then on.
 
 ## Notification
 
-Canopy notifies operators over the target's notification channel when a window is declared and again when its suspension ends (see [INC](incidents.md), "Notification").
+Canopy notifies operators when a window is declared and again when its suspension ends, over the channel that carries the target's incidents, which for a server is its group's (see [INC](incidents.md), "Notification").
 The declaration names the target, the operator, the expected end, and the note.
-The ending names the target, says whether an operator lifted the window or its expected end passed, and says when watching resumes.
-A target with no notification channel notifies nowhere.
+The ending says whether an operator lifted the window or its expected end passed, and when watching resumes.
 
 ## Presentation
 
-A target under a window is presented as under maintenance wherever its health or reachability is presented as it currently stands, in the manner an unmonitored server is marked (see [CHK](checks.md), "Monitoring gate").
-Its health is muted and carries an indicator naming the window and when it ends, so a failing server under maintenance is never read as a failing server nobody has noticed, and never read as an unmonitored one either.
+A target under a window presents as under maintenance wherever its health or reachability is presented as it currently stands, marked in the manner an unmonitored server is and distinguishable from one (see [CHK](checks.md), "Monitoring gate").
+Its health is muted and carries the window and when it ends, so a failing server under maintenance is not read as one nobody has noticed.
 The status legend names the mark.
 
 Canopy presents every open window across the fleet in one view: what each covers, who declared it, when it ends, and its note.
 The view answers "what are we not watching right now" without reading each group.
 
-A target's own surface presents its open window with the actions to amend or lift it, and presents its ended windows as history.
-A check whose effective result is skipped because a window holds says so where its result is presented, rather than leaving the skip unexplained.
+A target's own surface presents its open window with the actions to amend or lift it, and its ended windows as history.
+A check skipped because a window holds says so where its result is presented.
 
 ## Out of scope
 
 - Performing, scheduling, or triggering the maintenance itself.
-- Declaring a window to begin at a future time. A window says work is happening now; an intended window is what a plan records (see [UPG](../private-server/upgrade-plans.md)).
+- Declaring a window to begin at a future time: a window says work is happening now, and an intended one is what a plan records (see [UPG](../private-server/upgrade-plans.md)).
 - Suspending Canopy's own self-monitoring.
 - Exempting a check from suspension so it still alerts while a window holds.

--- a/.workhorse/specs/monitoring/maintenance.md
+++ b/.workhorse/specs/monitoring/maintenance.md
@@ -40,6 +40,8 @@ Canopy never opens a window by itself.
 A group with an open upgrade plan is offered the declaration from that plan, prefilled with the plan's window and note, so declaring is one action at the moment the work starts.
 The plan supplies the prefill and triggers nothing: an hour someone typed in advance is not evidence that work began.
 
+An open incident offers the declaration over its target as well, so an operator who recognises an alert as the work they are already doing declares from where they are reading it, and the incident closes as its issues leave.
+
 ## What a window suspends
 
 While a window holds over a target, every check on that target has an effective result of skipped, whatever it was observed as (see [CHK](checks.md), "Policy").

--- a/.workhorse/specs/private-server/upgrade-plans.md
+++ b/.workhorse/specs/private-server/upgrade-plans.md
@@ -74,6 +74,9 @@ Recording a plan is what asks for the testing, and no restore is spent on a vers
 
 A plan changes what is tested, so changing one invalidates nothing already recorded: earlier verdicts stand against the versions they named, and the new target simply becomes the one that has not been tested yet.
 
+Declaring maintenance reads the open plan for its prefill: an operator starting the work is offered a window carrying the plan's window and note (see [MNT](../monitoring/maintenance.md)).
+The plan is read at the moment someone declares, so a planned hour arriving suspends nothing on its own.
+
 ## The dashboard
 
 Canopy presents planned upgrades across the fleet in one view, so the question "what is moving, and when" is answered without reading each group.

--- a/crates/database/src/check_policies.rs
+++ b/crates/database/src/check_policies.rs
@@ -17,6 +17,7 @@
 //! endpoints.
 
 use crate::issues::Scope;
+use crate::maintenance_windows::MaintenanceWindow;
 use commons_errors::{AppError, Result};
 use commons_types::status::CheckResult;
 use diesel::dsl::{AsSelect, SqlTypeOf};
@@ -876,6 +877,9 @@ impl ScopedCheckPolicy {
 			.filter(dsl::source.eq(source).and(dsl::check_name.eq(check_name)));
 		let mut rows: Vec<Self> = query.load(db).await.map_err(AppError::from)?;
 		Self::order_chain(&mut rows);
+		if MaintenanceWindow::suspends(db, server_id, group_id).await? {
+			rows.push(Self::maintenance(server_id, group_id));
+		}
 		Ok(rows)
 	}
 
@@ -901,6 +905,11 @@ impl ScopedCheckPolicy {
 		}
 		for chain in chains.values_mut() {
 			Self::order_chain(chain);
+		}
+		if MaintenanceWindow::suspends(db, server_id, group_id).await? {
+			for chain in chains.values_mut() {
+				chain.push(Self::maintenance(server_id, group_id));
+			}
 		}
 		Ok(chains)
 	}
@@ -932,6 +941,32 @@ impl ScopedCheckPolicy {
 						.is_not_distinct_from(group)
 						.and(dsl::server_group_id.is_not_null())),
 			),
+		}
+	}
+
+	/// The transform a maintenance window contributes: a skipped ceiling
+	/// over every check on the target, for as long as the window suspends
+	/// it (see [`crate::maintenance_windows`]). It rides the chain rather
+	/// than gating each grading call site, so a path that grades a check
+	/// cannot forget to honour a window.
+	///
+	/// Not a stored row: windows cover a target, while
+	/// `scoped_check_policies` holds operator-owned transforms on one
+	/// (source, check). A ceiling only narrows, so where it sits in the
+	/// chain makes no difference.
+	fn maintenance(server_id: Option<Uuid>, group_id: Option<Uuid>) -> Self {
+		let now = Timestamp::now();
+		Self {
+			id: Uuid::nil(),
+			created_at: now,
+			updated_at: now,
+			source: String::new(),
+			check_name: String::new(),
+			server_id,
+			server_group_id: group_id,
+			ceiling: Some(CheckResult::Skipped.to_string()),
+			rules: None,
+			created_by: None,
 		}
 	}
 

--- a/crates/database/src/issues.rs
+++ b/crates/database/src/issues.rs
@@ -1656,13 +1656,15 @@ pub async fn get_global_issue(conn: &mut AsyncPgConnection, r#ref: &str) -> Resu
 /// Compute whether the issue *should* currently be contributing to an
 /// open incident, and apply join/leave accordingly. The rules:
 ///
-/// - **Leave**: `!active || resolved || snoozed || silenced || !monitored`.
+/// - **Leave**: `!active || resolved || snoozed || silenced || maintained ||
+///   !monitored`.
 ///   A result downgrade alone does *not* remove an issue — once
 ///   contributing, it stays until it's actually gone or explicitly
 ///   suppressed. Flipping the server to unmonitored *does* remove it: the
 ///   operator has said they're not watching this server, so its issues
 ///   stop counting. The same applies if the check is silenced at server
-///   or group scope — see [`crate::silenced_refs`].
+///   or group scope — see [`crate::silenced_refs`] — or if a maintenance
+///   window suspends the target, see [`crate::maintenance_windows`].
 /// - **Join**: not leaving, AND one of:
 ///   - the state opens incidents on its own — an effective failure (see
 ///     [`Issue::opens_incident`]); or
@@ -1678,8 +1680,8 @@ pub async fn get_global_issue(conn: &mut AsyncPgConnection, r#ref: &str) -> Resu
 ///   The linger sweep ([`sweep_lingering_incidents`]) closes it once the
 ///   window elapses, backdating the close to when the failure left. Only a
 ///   leave caused by the check actually recovering lingers: resolution,
-///   snooze, silence, and monitoring-off are explicit operator actions,
-///   not flaps, and close immediately — as does a zero linger window.
+///   snooze, silence, maintenance, and monitoring-off are explicit operator
+///   actions, not flaps, and close immediately — as does a zero linger window.
 ///   Lesser contributors that joined because
 ///   the target had an open incident stay attached (so the audit trail and
 ///   Slack thread retain them) but **do not** hold the incident open (or
@@ -1721,6 +1723,14 @@ async fn re_evaluate_incident_membership(
 		&issue.r#ref,
 	)
 	.await?;
+	// A maintenance window over the target suspends everything on it, so its
+	// issues leave exactly as a silenced one does.
+	let maintained = crate::maintenance_windows::MaintenanceWindow::suspends(
+		conn,
+		issue.server_id,
+		target.group_id(),
+	)
+	.await?;
 	// Lock the target before reading whether it has an open incident: for a
 	// sub-Error issue, that read is the entire justification for joining, and
 	// a concurrent close landing between here and `find_or_open_incident`
@@ -1729,10 +1739,15 @@ async fn re_evaluate_incident_membership(
 	lock_target(conn, target).await?;
 	let target_open = target_has_open_incident(conn, target).await?;
 
-	let should_leave =
-		!issue.active || issue.resolved_at.is_some() || snoozed || silenced || !monitored;
+	let should_leave = !issue.active
+		|| issue.resolved_at.is_some()
+		|| snoozed
+		|| silenced
+		|| maintained
+		|| !monitored;
 	let should_join = monitored
 		&& !silenced
+		&& !maintained
 		&& issue.active
 		&& issue.resolved_at.is_none()
 		&& !snoozed
@@ -2232,6 +2247,76 @@ pub async fn reevaluate_open_issues_for_group_ref(
 			None,
 		)
 		.await?;
+	}
+	Ok(())
+}
+
+/// Re-evaluate every currently-open issue on a scope against incident
+/// membership: one server's, or a whole group's plus the group's own. Used
+/// when something about the target changes what counts, rather than
+/// something about one check — currently a maintenance window being
+/// declared over it (see [`crate::maintenance_windows`]).
+///
+/// `by` attributes an incident that closes as a result, so the notice says
+/// what happened instead of reading as the trouble having passed.
+pub async fn reevaluate_open_issues_for_scope(
+	db: &mut AsyncPgConnection,
+	scope: Scope,
+	by: Option<&str>,
+) -> Result<()> {
+	use crate::schema::{issues, servers};
+
+	let (gid, server_ids, include_group_scoped) = match scope {
+		Scope::Server(sid) => {
+			let server = Server::get_by_id(db, sid).await?;
+			let Some(gid) = server.group_id else {
+				return Ok(());
+			};
+			(gid, vec![sid], false)
+		}
+		Scope::Group(gid) => {
+			let ids: Vec<Uuid> = servers::table
+				.select(servers::id)
+				.filter(servers::group_id.eq(gid))
+				.load(db)
+				.await?;
+			(gid, ids, true)
+		}
+		Scope::Global => return Ok(()),
+	};
+
+	let mut query = issues::table
+		.select(Issue::as_select())
+		.filter(issues::active.eq(true))
+		.filter(issues::resolved_at.is_null())
+		.into_boxed();
+	query = if include_group_scoped {
+		query.filter(
+			issues::server_id
+				.eq_any(server_ids.clone())
+				.or(issues::server_group_id.eq(gid)),
+		)
+	} else {
+		query.filter(issues::server_id.eq_any(server_ids.clone()))
+	};
+	let open_issues: Vec<Issue> = query.load(db).await?;
+
+	let mut monitored_by_server: std::collections::HashMap<Uuid, bool> =
+		std::collections::HashMap::new();
+	for sid in &server_ids {
+		let server = Server::get_by_id(db, *sid).await?;
+		monitored_by_server.insert(*sid, server.is_monitored);
+	}
+
+	let now = Timestamp::now();
+	for issue in open_issues {
+		// A group-scoped issue answers to no server's monitoring gate.
+		let monitored = match issue.server_id {
+			Some(sid) => monitored_by_server.get(&sid).copied().unwrap_or(true),
+			None => true,
+		};
+		re_evaluate_incident_membership(db, &issue, IncidentTarget::Group(gid), monitored, now, by)
+			.await?;
 	}
 	Ok(())
 }
@@ -2781,7 +2866,7 @@ async fn enqueue_slack_resolve_inner(
 	Ok(())
 }
 
-fn format_group_label(group: &ServerGroup, server: Option<&Server>) -> String {
+pub(crate) fn format_group_label(group: &ServerGroup, server: Option<&Server>) -> String {
 	if let Some(server) = server {
 		let host = server.host.as_ref().map(|h| h.0.to_string());
 		let server_part = match (&server.name, host) {

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -15,6 +15,7 @@ pub mod check_policies;
 pub mod chrome_releases;
 pub mod devices;
 pub mod issues;
+pub mod maintenance_windows;
 pub mod mcp_tokens;
 pub mod migration_tests;
 pub mod notes;

--- a/crates/database/src/maintenance_windows.rs
+++ b/crates/database/src/maintenance_windows.rs
@@ -1,0 +1,458 @@
+//! Operator declarations that a server or a group is being worked on.
+//!
+//! While a window suspends a target, every check on it grades to skipped
+//! (the transform a silence applies to one check, applied to all of them:
+//! see [`crate::check_policies::ScopedCheckPolicy::chain_for`]), so nothing
+//! on the target opens or joins an incident and nothing notifies.
+//!
+//! Suspension outlasts the window itself by [`SETTLE`]. A server is back
+//! before the sources on it have reported again, and a server whose every
+//! source is stale is unreachable, so ending suspension the instant the
+//! work finishes would report a deployment that has just come back as
+//! failed for as long as the work took.
+
+use std::collections::HashSet;
+
+use commons_errors::{AppError, Result};
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use jiff::{SignedDuration, Timestamp};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::issues::Scope;
+use crate::server_groups::ServerGroup;
+use crate::servers::Server;
+use crate::slack_outbox::{KIND_MAINTENANCE_DECLARED, KIND_MAINTENANCE_ENDED, SlackOutbox, vars};
+
+/// How long suspension outlasts the window, giving the reporters on a
+/// server time to be heard from before Canopy judges them. The same for
+/// every window.
+pub const SETTLE: SignedDuration = SignedDuration::from_mins(10);
+
+/// A declaration that a server or a group is being worked on.
+#[derive(Clone, Debug, Serialize, Deserialize, Queryable, Selectable, utoipa::ToSchema)]
+#[diesel(table_name = crate::schema::maintenance_windows)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct MaintenanceWindow {
+	/// Unique identifier of this window.
+	pub id: Uuid,
+	/// Set for a window over one server.
+	pub server_id: Option<Uuid>,
+	/// Set for a window over a group, covering the group's own checks and
+	/// those of every server in it.
+	pub server_group_id: Option<Uuid>,
+	/// When the operator expects the work to finish. A window reaching it
+	/// ends itself.
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub expected_end: Timestamp,
+	/// What is being done, where the operator said.
+	pub note: Option<String>,
+	/// The operator who declared the window. `None` if not recorded.
+	pub declared_by: Option<String>,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	/// When the window was declared.
+	pub declared_at: Timestamp,
+	/// The operator who last amended the window, where one has.
+	pub amended_by: Option<String>,
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	/// When the window was last amended.
+	pub amended_at: Option<Timestamp>,
+	/// When the window stopped holding. `None` while it holds.
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	pub ended_at: Option<Timestamp>,
+	/// The operator who lifted the window. `None` where its expected end
+	/// passed instead.
+	pub ended_by: Option<String>,
+	/// Stamped once the settle period has elapsed and the target's issues
+	/// have been re-evaluated.
+	#[diesel(deserialize_as = jiff_diesel::NullableTimestamp, serialize_as = jiff_diesel::NullableTimestamp)]
+	pub settled_at: Option<Timestamp>,
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	/// When this record was created.
+	pub created_at: Timestamp,
+	/// When this record was last modified.
+	#[diesel(deserialize_as = jiff_diesel::Timestamp, serialize_as = jiff_diesel::Timestamp)]
+	pub updated_at: Timestamp,
+}
+
+impl MaintenanceWindow {
+	/// The target this window covers.
+	pub fn scope(&self) -> Scope {
+		Scope::from_columns(self.server_id, self.server_group_id)
+	}
+
+	/// When the window itself ended, or is due to: an operator's lift where
+	/// there was one, the expected end otherwise.
+	pub fn window_end(&self) -> Timestamp {
+		self.ended_at.unwrap_or(self.expected_end)
+	}
+
+	/// When suspension over the target ends.
+	pub fn suspension_end(&self) -> Timestamp {
+		self.window_end() + SETTLE
+	}
+
+	/// Is the window still holding, as opposed to settling or over?
+	pub fn holds_at(&self, now: Timestamp) -> bool {
+		self.ended_at.is_none() && now < self.expected_end
+	}
+
+	/// Is the target still suspended, whether the window holds or is
+	/// settling?
+	pub fn suspends_at(&self, now: Timestamp) -> bool {
+		now < self.suspension_end()
+	}
+
+	/// Declare a window over `scope`, or amend the open one if the target
+	/// already has it: a target has at most one open window.
+	pub async fn declare(
+		db: &mut AsyncPgConnection,
+		scope: Scope,
+		expected_end: Timestamp,
+		note: Option<&str>,
+		by: Option<&str>,
+	) -> Result<Self> {
+		use crate::schema::maintenance_windows::dsl;
+		let Some((server, group)) = fleet_columns(scope) else {
+			return Err(AppError::BadRequest(
+				"a maintenance window covers a server or a group".into(),
+			));
+		};
+		if expected_end <= Timestamp::now() {
+			return Err(AppError::BadRequest(
+				"a maintenance window ends in the future".into(),
+			));
+		}
+
+		if let Some(open) = Self::open_for(db, scope).await? {
+			return diesel::update(dsl::maintenance_windows.filter(dsl::id.eq(open.id)))
+				.set((
+					dsl::expected_end.eq(jiff_diesel::Timestamp::from(expected_end)),
+					dsl::note.eq(note),
+					dsl::amended_by.eq(by),
+					dsl::amended_at.eq(jiff_diesel::Timestamp::from(Timestamp::now())),
+					dsl::updated_at.eq(jiff_diesel::Timestamp::from(Timestamp::now())),
+				))
+				.returning(Self::as_select())
+				.get_result(db)
+				.await
+				.map_err(AppError::from);
+		}
+
+		let window: Self = diesel::insert_into(dsl::maintenance_windows)
+			.values((
+				dsl::server_id.eq(server),
+				dsl::server_group_id.eq(group),
+				dsl::expected_end.eq(jiff_diesel::Timestamp::from(expected_end)),
+				dsl::note.eq(note),
+				dsl::declared_by.eq(by),
+			))
+			.returning(Self::as_select())
+			.get_result(db)
+			.await
+			.map_err(AppError::from)?;
+
+		let label = target_label(db, scope).await?;
+		SlackOutbox::enqueue(
+			db,
+			KIND_MAINTENANCE_DECLARED,
+			None,
+			None,
+			None,
+			vars::maintenance_declared(&label, by, &format_when(expected_end), note),
+			Timestamp::now(),
+		)
+		.await?;
+
+		// The target's issues leave their incident now, rather than waiting
+		// for each check to be re-graded on its next report.
+		let closed_because = match by {
+			Some(login) => format!("maintenance declared by {login}"),
+			None => "maintenance being declared".to_string(),
+		};
+		crate::issues::reevaluate_open_issues_for_scope(db, scope, Some(&closed_because)).await?;
+
+		Ok(window)
+	}
+
+	/// Lift a window before its expected end. A window already ended is
+	/// returned untouched, so a double lift is idempotent.
+	pub async fn lift(db: &mut AsyncPgConnection, id: Uuid, by: Option<&str>) -> Result<Self> {
+		use crate::schema::maintenance_windows::dsl;
+		let now = Timestamp::now();
+		let lifted: Option<Self> = diesel::update(
+			dsl::maintenance_windows
+				.filter(dsl::id.eq(id))
+				.filter(dsl::ended_at.is_null()),
+		)
+		.set((
+			dsl::ended_at.eq(jiff_diesel::Timestamp::from(now)),
+			dsl::ended_by.eq(by),
+			dsl::updated_at.eq(jiff_diesel::Timestamp::from(now)),
+		))
+		.returning(Self::as_select())
+		.get_result(db)
+		.await
+		.optional()
+		.map_err(AppError::from)?;
+		match lifted {
+			Some(window) => {
+				window.announce_ended(db).await?;
+				Ok(window)
+			}
+			None => Self::get(db, id).await,
+		}
+	}
+
+	/// Tell operators the target is being watched again from the end of its
+	/// settle period. Whether an operator lifted the window or its expected
+	/// end passed is what `ended_by` records.
+	async fn announce_ended(&self, db: &mut AsyncPgConnection) -> Result<()> {
+		let label = target_label(db, self.scope()).await?;
+		SlackOutbox::enqueue(
+			db,
+			KIND_MAINTENANCE_ENDED,
+			None,
+			None,
+			None,
+			vars::maintenance_ended(
+				&label,
+				self.ended_by.as_deref(),
+				&format_when(self.suspension_end()),
+			),
+			Timestamp::now(),
+		)
+		.await?;
+		Ok(())
+	}
+
+	pub async fn get(db: &mut AsyncPgConnection, id: Uuid) -> Result<Self> {
+		use crate::schema::maintenance_windows::dsl;
+		dsl::maintenance_windows
+			.select(Self::as_select())
+			.filter(dsl::id.eq(id))
+			.first(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// The target's window while it holds. A settling window is over as far
+	/// as declaring goes: a fresh declaration opens a new one.
+	pub async fn open_for(db: &mut AsyncPgConnection, scope: Scope) -> Result<Option<Self>> {
+		use crate::schema::maintenance_windows::dsl;
+		let Some((server, group)) = fleet_columns(scope) else {
+			return Ok(None);
+		};
+		dsl::maintenance_windows
+			.select(Self::as_select())
+			.filter(
+				dsl::ended_at
+					.is_null()
+					.and(dsl::server_id.is_not_distinct_from(server))
+					.and(dsl::server_group_id.is_not_distinct_from(group)),
+			)
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)
+	}
+
+	/// Every window still holding, most recently declared first.
+	pub async fn list_open(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::maintenance_windows::dsl;
+		dsl::maintenance_windows
+			.select(Self::as_select())
+			.filter(dsl::ended_at.is_null())
+			.order(dsl::declared_at.desc())
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// The target's windows, open and ended, most recently declared first.
+	pub async fn list_for_scope(
+		db: &mut AsyncPgConnection,
+		scope: Scope,
+		limit: i64,
+	) -> Result<Vec<Self>> {
+		use crate::schema::maintenance_windows::dsl;
+		let Some((server, group)) = fleet_columns(scope) else {
+			return Ok(Vec::new());
+		};
+		dsl::maintenance_windows
+			.select(Self::as_select())
+			.filter(
+				dsl::server_id
+					.is_not_distinct_from(server)
+					.and(dsl::server_group_id.is_not_distinct_from(group)),
+			)
+			.order(dsl::declared_at.desc())
+			.limit(limit)
+			.load(db)
+			.await
+			.map_err(AppError::from)
+	}
+
+	/// Is a check filed against `(server_id, group_id)` suspended? A server
+	/// is covered by its own window and by its group's, and stays suspended
+	/// until the last of them has settled.
+	pub async fn suspends(
+		db: &mut AsyncPgConnection,
+		server_id: Option<Uuid>,
+		group_id: Option<Uuid>,
+	) -> Result<bool> {
+		use crate::schema::maintenance_windows::dsl;
+		if server_id.is_none() && group_id.is_none() {
+			return Ok(false);
+		}
+		let cutoff = jiff_diesel::Timestamp::from(Timestamp::now() - SETTLE);
+		let found: Option<Uuid> = dsl::maintenance_windows
+			.select(dsl::id)
+			.filter(
+				dsl::server_id
+					.eq(server_id)
+					.or(dsl::server_group_id.eq(group_id)),
+			)
+			.filter(
+				dsl::ended_at
+					.is_null()
+					.and(dsl::expected_end.gt(cutoff))
+					.or(dsl::ended_at.gt(cutoff)),
+			)
+			.first(db)
+			.await
+			.optional()
+			.map_err(AppError::from)?;
+		Ok(found.is_some())
+	}
+
+	/// The servers and groups currently suspended, for callers judging many
+	/// targets in one pass.
+	pub async fn suspended_targets(
+		db: &mut AsyncPgConnection,
+	) -> Result<(HashSet<Uuid>, HashSet<Uuid>)> {
+		use crate::schema::maintenance_windows::dsl;
+		let cutoff = jiff_diesel::Timestamp::from(Timestamp::now() - SETTLE);
+		let rows: Vec<(Option<Uuid>, Option<Uuid>)> = dsl::maintenance_windows
+			.select((dsl::server_id, dsl::server_group_id))
+			.filter(
+				dsl::ended_at
+					.is_null()
+					.and(dsl::expected_end.gt(cutoff))
+					.or(dsl::ended_at.gt(cutoff)),
+			)
+			.load(db)
+			.await
+			.map_err(AppError::from)?;
+		let mut servers = HashSet::new();
+		let mut groups = HashSet::new();
+		for (server, group) in rows {
+			if let Some(id) = server {
+				servers.insert(id);
+			}
+			if let Some(id) = group {
+				groups.insert(id);
+			}
+		}
+		Ok((servers, groups))
+	}
+
+	/// End every window whose expected end has passed, stamping the end at
+	/// that expected end rather than at now: the window was over then, and
+	/// backdating keeps the settle period honest however late this runs.
+	/// Returns what it ended, for notification.
+	pub async fn sweep_expired(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::maintenance_windows::dsl;
+		let now = jiff_diesel::Timestamp::from(Timestamp::now());
+		let expired: Vec<Self> = diesel::update(
+			dsl::maintenance_windows
+				.filter(dsl::ended_at.is_null())
+				.filter(dsl::expected_end.le(now)),
+		)
+		.set((
+			dsl::ended_at.eq(dsl::expected_end.nullable()),
+			dsl::updated_at.eq(now),
+		))
+		.returning(Self::as_select())
+		.get_results(db)
+		.await
+		.map_err(AppError::from)?;
+		for window in &expired {
+			window.announce_ended(db).await?;
+		}
+		Ok(expired)
+	}
+
+	/// End windows that have reached their expected end, then re-evaluate
+	/// the targets whose settle period has since elapsed, so anything still
+	/// degraded contributes again. Returns how many of each.
+	///
+	/// A target still covered by another window is unaffected by the second
+	/// pass: membership re-evaluation consults the windows over it, so the
+	/// last one to end is the one that lets its issues back in.
+	pub async fn sweep(db: &mut AsyncPgConnection) -> Result<(usize, usize)> {
+		let ended = Self::sweep_expired(db).await?;
+		let settled = Self::claim_settled(db).await?;
+		for window in &settled {
+			crate::issues::reevaluate_open_issues_for_scope(db, window.scope(), None).await?;
+		}
+		Ok((ended.len(), settled.len()))
+	}
+
+	/// Claim the ended windows whose settle period has elapsed, so their
+	/// targets can be re-evaluated once each.
+	pub async fn claim_settled(db: &mut AsyncPgConnection) -> Result<Vec<Self>> {
+		use crate::schema::maintenance_windows::dsl;
+		let now = Timestamp::now();
+		let cutoff = jiff_diesel::Timestamp::from(now - SETTLE);
+		diesel::update(
+			dsl::maintenance_windows
+				.filter(dsl::settled_at.is_null())
+				.filter(dsl::ended_at.is_not_null())
+				.filter(dsl::ended_at.le(cutoff)),
+		)
+		.set(dsl::settled_at.eq(jiff_diesel::Timestamp::from(now)))
+		.returning(Self::as_select())
+		.get_results(db)
+		.await
+		.map_err(AppError::from)
+	}
+}
+
+/// How a window's target reads in a notification.
+pub async fn target_label(db: &mut AsyncPgConnection, scope: Scope) -> Result<String> {
+	match scope {
+		Scope::Server(sid) => {
+			let server = Server::get_by_id(db, sid).await?;
+			match server.group_id {
+				Some(gid) => {
+					let group = ServerGroup::get_by_id(db, gid).await?;
+					Ok(crate::issues::format_group_label(&group, Some(&server)))
+				}
+				None => Ok(server
+					.name
+					.clone()
+					.or_else(|| server.host.as_ref().map(|h| h.0.to_string()))
+					.unwrap_or_else(|| server.id.to_string())),
+			}
+		}
+		Scope::Group(gid) => Ok(ServerGroup::get_by_id(db, gid).await?.name),
+		Scope::Global => Ok("Canopy".to_string()),
+	}
+}
+
+fn format_when(at: Timestamp) -> String {
+	at.strftime("%Y-%m-%d %H:%M UTC").to_string()
+}
+
+/// The storage columns for a window's scope. Canopy-wide is not a target a
+/// window covers: Canopy's own checks are its self-monitoring, and fleet
+/// work never suspends them.
+fn fleet_columns(scope: Scope) -> Option<(Option<Uuid>, Option<Uuid>)> {
+	match scope {
+		Scope::Server(id) => Some((Some(id), None)),
+		Scope::Group(id) => Some((None, Some(id))),
+		Scope::Global => None,
+	}
+}

--- a/crates/database/src/schema.rs
+++ b/crates/database/src/schema.rs
@@ -401,6 +401,25 @@ diesel::table! {
 }
 
 diesel::table! {
+	maintenance_windows (id) {
+		id -> Uuid,
+		server_id -> Nullable<Uuid>,
+		server_group_id -> Nullable<Uuid>,
+		expected_end -> Timestamptz,
+		note -> Nullable<Text>,
+		declared_by -> Nullable<Text>,
+		declared_at -> Timestamptz,
+		amended_by -> Nullable<Text>,
+		amended_at -> Nullable<Timestamptz>,
+		ended_at -> Nullable<Timestamptz>,
+		ended_by -> Nullable<Text>,
+		settled_at -> Nullable<Timestamptz>,
+		created_at -> Timestamptz,
+		updated_at -> Timestamptz,
+	}
+}
+
+diesel::table! {
 	mcp_tokens (id) {
 		id -> Uuid,
 		name -> Text,
@@ -820,6 +839,8 @@ diesel::joinable!(restore_consumer_capabilities -> devices (consumer_device_id))
 diesel::joinable!(restore_replicas -> devices (consumer_device_id));
 diesel::joinable!(restore_replicas -> server_groups (group_id));
 diesel::joinable!(restore_replicas -> servers (server_id));
+diesel::joinable!(maintenance_windows -> server_groups (server_group_id));
+diesel::joinable!(maintenance_windows -> servers (server_id));
 diesel::joinable!(scoped_check_policies -> server_groups (server_group_id));
 diesel::joinable!(scoped_check_policies -> servers (server_id));
 diesel::joinable!(server_backup_capabilities -> servers (server_id));
@@ -873,6 +894,7 @@ diesel::allow_tables_to_appear_in_same_query!(
 	incidents,
 	issue_notes,
 	issues,
+	maintenance_windows,
 	mcp_tokens,
 	migration_tests,
 	migration_timings,

--- a/crates/database/src/slack_outbox/mod.rs
+++ b/crates/database/src/slack_outbox/mod.rs
@@ -40,6 +40,11 @@ pub const KIND_INCIDENT_RESOLVE: &str = "incident_resolve";
 /// Legacy: direct self-alert notices, from before self-alerts flowed
 /// through canopy-wide incidents. Nothing enqueues these anymore; the
 /// constants remain so the drainer can drain straggler rows harmlessly.
+/// A maintenance window declared over a server or a group.
+pub const KIND_MAINTENANCE_DECLARED: &str = "maintenance_declared";
+/// A maintenance window ended, whether an operator lifted it or its
+/// expected end passed.
+pub const KIND_MAINTENANCE_ENDED: &str = "maintenance_ended";
 pub const KIND_SELF_ALERT_OPEN: &str = "self_alert_open";
 /// Legacy: see [`KIND_SELF_ALERT_OPEN`].
 pub const KIND_SELF_ALERT_RESOLVE: &str = "self_alert_resolve";

--- a/crates/database/src/slack_outbox/vars.rs
+++ b/crates/database/src/slack_outbox/vars.rs
@@ -74,6 +74,32 @@ pub fn incident_resolve(server_label: &str, by: Option<&str>) -> Value {
 	})
 }
 
+/// `maintenance_declared`: variables `target`, `by`, `until`, `note`.
+pub fn maintenance_declared(
+	target: &str,
+	by: Option<&str>,
+	until: &str,
+	note: Option<&str>,
+) -> Value {
+	json!({
+		"target": target,
+		"by": by.unwrap_or("an operator"),
+		"until": until,
+		"note": truncate(note.unwrap_or(""), MAX_MESSAGE_LEN),
+	})
+}
+
+/// `maintenance_ended`: variables `target`, `by`, `watching_from`. `by` is
+/// the operator who lifted the window, or the event where its expected end
+/// passed instead.
+pub fn maintenance_ended(target: &str, by: Option<&str>, watching_from: &str) -> Value {
+	json!({
+		"target": target,
+		"by": by.unwrap_or("its expected end passing"),
+		"watching_from": watching_from,
+	})
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/database/tests/it/main.rs
+++ b/crates/database/tests/it/main.rs
@@ -28,6 +28,7 @@ mod incident_result_semantics;
 mod incident_stats;
 mod incident_stranded_membership;
 mod issue_list_filters;
+mod maintenance_windows;
 mod mcp_tokens;
 mod migration_test_candidates;
 mod migration_test_reports;

--- a/crates/database/tests/it/maintenance_windows.rs
+++ b/crates/database/tests/it/maintenance_windows.rs
@@ -1,0 +1,423 @@
+//! Maintenance windows: an operator's declaration that a target is being
+//! worked on. While one suspends a target every check on it grades to
+//! skipped, its issues leave their incident, and suspension outlasts the
+//! window by the settle period so a server that is back but has not
+//! reported yet is not called unreachable.
+
+use commons_types::status::CheckResult;
+use database::{
+	issues::{CheckFiling, Issue, Scope, file_check},
+	maintenance_windows::{MaintenanceWindow, SETTLE},
+	statuses::CANOPY_SOURCE,
+};
+use diesel::{QueryableByName, sql_query, sql_types};
+use diesel_async::RunQueryDsl;
+use jiff::{SignedDuration, Timestamp};
+use uuid::Uuid;
+
+#[derive(QueryableByName)]
+struct RowId {
+	#[diesel(sql_type = sql_types::Uuid)]
+	id: Uuid,
+}
+
+#[derive(QueryableByName)]
+struct Count {
+	#[diesel(sql_type = sql_types::BigInt)]
+	count: i64,
+}
+
+async fn insert_group(conn: &mut diesel_async::AsyncPgConnection) -> Uuid {
+	let row: RowId = sql_query("INSERT INTO server_groups (name) VALUES ('g') RETURNING id")
+		.get_result(conn)
+		.await
+		.expect("insert group");
+	row.id
+}
+
+async fn insert_server(conn: &mut diesel_async::AsyncPgConnection, group_id: Option<Uuid>) -> Uuid {
+	let row: RowId = sql_query(
+		"INSERT INTO servers (host, group_id) VALUES ('http://maint.invalid/', $1) RETURNING id",
+	)
+	.bind::<sql_types::Nullable<sql_types::Uuid>, _>(group_id)
+	.get_result(conn)
+	.await
+	.expect("insert server");
+	row.id
+}
+
+fn filing(server_id: Uuid, check: &str, observed: CheckResult) -> CheckFiling<'_> {
+	CheckFiling {
+		source: CANOPY_SOURCE,
+		scope: Scope::Server(server_id),
+		device_id: None,
+		check,
+		observed,
+		title: Some("Maintenance test"),
+		message: "maintenance test filing",
+		detail: None,
+		default_ceiling: CheckResult::Failed,
+		default_escalates: false,
+		documentation: None,
+	}
+}
+
+async fn state_for(
+	conn: &mut diesel_async::AsyncPgConnection,
+	server_id: Uuid,
+	check: &str,
+) -> Issue {
+	Issue::list_by_source_ref(conn, CANOPY_SOURCE, check, &[server_id])
+		.await
+		.expect("list")
+		.into_iter()
+		.next()
+		.expect("state row filed")
+}
+
+/// Incidents on the group that are still open.
+async fn open_incidents(conn: &mut diesel_async::AsyncPgConnection, group_id: Uuid) -> i64 {
+	let row: Count = sql_query(
+		"SELECT COUNT(*) AS count FROM incidents \
+		 WHERE server_group_id = $1 AND closed_at IS NULL",
+	)
+	.bind::<sql_types::Uuid, _>(group_id)
+	.get_result(conn)
+	.await
+	.expect("count open incidents");
+	row.count
+}
+
+/// Issues currently attached to an incident on the group.
+async fn live_members(conn: &mut diesel_async::AsyncPgConnection, group_id: Uuid) -> i64 {
+	let row: Count = sql_query(
+		"SELECT COUNT(*) AS count FROM incident_issues ii \
+		 JOIN incidents i ON i.id = ii.incident_id \
+		 WHERE i.server_group_id = $1 AND ii.left_at IS NULL",
+	)
+	.bind::<sql_types::Uuid, _>(group_id)
+	.get_result(conn)
+	.await
+	.expect("count live members");
+	row.count
+}
+
+async fn backdate_expected_end(
+	conn: &mut diesel_async::AsyncPgConnection,
+	id: Uuid,
+	ago: SignedDuration,
+) {
+	sql_query("UPDATE maintenance_windows SET expected_end = $2 WHERE id = $1")
+		.bind::<sql_types::Uuid, _>(id)
+		.bind::<sql_types::Timestamptz, _>(jiff_diesel::Timestamp::from(Timestamp::now() - ago))
+		.execute(conn)
+		.await
+		.expect("backdate");
+}
+
+fn in_an_hour() -> Timestamp {
+	Timestamp::now() + SignedDuration::from_hours(1)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_window_grades_every_check_on_its_target_to_skipped() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, None).await;
+		MaintenanceWindow::declare(
+			&mut conn,
+			Scope::Server(server_id),
+			in_an_hour(),
+			Some("upgrading"),
+			Some("op"),
+		)
+		.await
+		.expect("declare");
+
+		file_check(
+			&mut conn,
+			filing(server_id, "reachability", CheckResult::Failed),
+		)
+		.await
+		.expect("file");
+
+		let state = state_for(&mut conn, server_id, "reachability").await;
+		assert_eq!(
+			state.observed_result,
+			Some(CheckResult::Failed),
+			"the observation is recorded through the window"
+		);
+		assert_eq!(
+			state.effective_result,
+			Some(CheckResult::Skipped),
+			"a window grades the check to skipped, as a silence does"
+		);
+		assert!(!state.active);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn declaring_takes_the_target_out_of_its_open_incident() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let group_id = insert_group(&mut conn).await;
+		let server_id = insert_server(&mut conn, Some(group_id)).await;
+
+		file_check(
+			&mut conn,
+			filing(server_id, "reachability", CheckResult::Failed),
+		)
+		.await
+		.expect("file");
+		assert_eq!(
+			open_incidents(&mut conn, group_id).await,
+			1,
+			"a failure with no window opens an incident"
+		);
+
+		MaintenanceWindow::declare(
+			&mut conn,
+			Scope::Server(server_id),
+			in_an_hour(),
+			None,
+			Some("op"),
+		)
+		.await
+		.expect("declare");
+
+		assert_eq!(
+			live_members(&mut conn, group_id).await,
+			0,
+			"the issue leaves the incident when the window is declared"
+		);
+		assert_eq!(
+			open_incidents(&mut conn, group_id).await,
+			0,
+			"nothing else holds the incident open, so it closes immediately"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_group_window_covers_its_servers_and_the_group_itself() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let group_id = insert_group(&mut conn).await;
+		let server_id = insert_server(&mut conn, Some(group_id)).await;
+		MaintenanceWindow::declare(
+			&mut conn,
+			Scope::Group(group_id),
+			in_an_hour(),
+			None,
+			Some("op"),
+		)
+		.await
+		.expect("declare");
+
+		file_check(
+			&mut conn,
+			filing(server_id, "reachability", CheckResult::Failed),
+		)
+		.await
+		.expect("file server check");
+		assert_eq!(
+			state_for(&mut conn, server_id, "reachability")
+				.await
+				.effective_result,
+			Some(CheckResult::Skipped),
+			"a group's window covers the checks of every server in it"
+		);
+
+		let mut group_filing = filing(server_id, "backup-staleness", CheckResult::Failed);
+		group_filing.scope = Scope::Group(group_id);
+		file_check(&mut conn, group_filing)
+			.await
+			.expect("file group check");
+		assert_eq!(
+			open_incidents(&mut conn, group_id).await,
+			0,
+			"the group's own checks are covered too, so nothing opens"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn the_window_ends_at_its_expected_end_and_suspension_outlasts_it() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, None).await;
+		let window = MaintenanceWindow::declare(
+			&mut conn,
+			Scope::Server(server_id),
+			in_an_hour(),
+			None,
+			Some("op"),
+		)
+		.await
+		.expect("declare");
+
+		// A minute past its expected end: the sweep ends it, stamping the
+		// end at the expected end rather than at now.
+		backdate_expected_end(&mut conn, window.id, SignedDuration::from_mins(1)).await;
+		let (ended, settled) = MaintenanceWindow::sweep(&mut conn).await.expect("sweep");
+		assert_eq!((ended, settled), (1, 0), "ended, and not yet settled");
+
+		let ended = MaintenanceWindow::get(&mut conn, window.id)
+			.await
+			.expect("get");
+		assert!(ended.ended_at.is_some(), "the expected end ends the window");
+		assert_eq!(
+			ended.ended_by, None,
+			"nobody lifted it; its expected end passed"
+		);
+		assert!(
+			MaintenanceWindow::suspends(&mut conn, Some(server_id), None)
+				.await
+				.expect("suspends"),
+			"suspension runs on through the settle period"
+		);
+
+		// Past the settle period now.
+		backdate_expected_end(&mut conn, window.id, SETTLE + SignedDuration::from_mins(1)).await;
+		sql_query("UPDATE maintenance_windows SET ended_at = expected_end WHERE id = $1")
+			.bind::<sql_types::Uuid, _>(window.id)
+			.execute(&mut conn)
+			.await
+			.expect("backdate end");
+		assert!(
+			!MaintenanceWindow::suspends(&mut conn, Some(server_id), None)
+				.await
+				.expect("suspends"),
+			"the settle period has elapsed, so the target is watched again"
+		);
+
+		let (_, settled) = MaintenanceWindow::sweep(&mut conn).await.expect("sweep");
+		assert_eq!(settled, 1, "the settled window is claimed exactly once");
+		let (_, again) = MaintenanceWindow::sweep(&mut conn).await.expect("sweep");
+		assert_eq!(again, 0, "and not claimed twice");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failure_after_the_settle_period_opens_an_incident_again() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let group_id = insert_group(&mut conn).await;
+		let server_id = insert_server(&mut conn, Some(group_id)).await;
+		let window = MaintenanceWindow::declare(
+			&mut conn,
+			Scope::Server(server_id),
+			in_an_hour(),
+			None,
+			Some("op"),
+		)
+		.await
+		.expect("declare");
+
+		file_check(
+			&mut conn,
+			filing(server_id, "reachability", CheckResult::Failed),
+		)
+		.await
+		.expect("file during the window");
+		assert_eq!(open_incidents(&mut conn, group_id).await, 0);
+
+		backdate_expected_end(&mut conn, window.id, SETTLE + SignedDuration::from_mins(1)).await;
+		MaintenanceWindow::sweep(&mut conn).await.expect("sweep");
+
+		file_check(
+			&mut conn,
+			filing(server_id, "reachability", CheckResult::Failed),
+		)
+		.await
+		.expect("file after settling");
+		assert_eq!(
+			state_for(&mut conn, server_id, "reachability")
+				.await
+				.effective_result,
+			Some(CheckResult::Failed),
+			"grading is normal again once the settle period has elapsed"
+		);
+		assert_eq!(
+			open_incidents(&mut conn, group_id).await,
+			1,
+			"anything still failing contributes from then on"
+		);
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn declaring_over_an_open_window_amends_it() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, None).await;
+		let first = MaintenanceWindow::declare(
+			&mut conn,
+			Scope::Server(server_id),
+			in_an_hour(),
+			Some("upgrading"),
+			Some("op"),
+		)
+		.await
+		.expect("declare");
+
+		let later = Timestamp::now() + SignedDuration::from_hours(3);
+		let second = MaintenanceWindow::declare(
+			&mut conn,
+			Scope::Server(server_id),
+			later,
+			Some("still upgrading"),
+			Some("other"),
+		)
+		.await
+		.expect("amend");
+
+		assert_eq!(second.id, first.id, "a target has at most one open window");
+		assert_eq!(second.declared_by.as_deref(), Some("op"));
+		assert_eq!(
+			second.amended_by.as_deref(),
+			Some("other"),
+			"the amendment records who made it"
+		);
+		assert!(second.amended_at.is_some());
+		assert!(second.expected_end > first.expected_end);
+
+		let windows = MaintenanceWindow::list_for_scope(&mut conn, Scope::Server(server_id), 10)
+			.await
+			.expect("list");
+		assert_eq!(windows.len(), 1, "and not a second window");
+	})
+	.await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lifting_records_the_operator_and_is_idempotent() {
+	commons_tests::db::TestDb::run(async |mut conn, _| {
+		let server_id = insert_server(&mut conn, None).await;
+		let window = MaintenanceWindow::declare(
+			&mut conn,
+			Scope::Server(server_id),
+			in_an_hour(),
+			None,
+			Some("op"),
+		)
+		.await
+		.expect("declare");
+
+		let lifted = MaintenanceWindow::lift(&mut conn, window.id, Some("other"))
+			.await
+			.expect("lift");
+		assert_eq!(lifted.ended_by.as_deref(), Some("other"));
+		let ended_at = lifted.ended_at.expect("ended");
+
+		let again = MaintenanceWindow::lift(&mut conn, window.id, Some("third"))
+			.await
+			.expect("lift again");
+		assert_eq!(
+			again.ended_at,
+			Some(ended_at),
+			"a window already ended is left as it was"
+		);
+		assert_eq!(again.ended_by.as_deref(), Some("other"));
+	})
+	.await
+}

--- a/crates/jobs/src/bin/monitor.rs
+++ b/crates/jobs/src/bin/monitor.rs
@@ -243,6 +243,16 @@ pub fn spawn() -> JoinHandle<()> {
 				Err(err) => error!("incident linger sweep failed: {err}"),
 			}
 
+			// Maintenance windows that have reached their expected end, and
+			// targets whose settle period has elapsed and are watched again.
+			match database::maintenance_windows::MaintenanceWindow::sweep(&mut db).await {
+				Ok((0, 0)) => {}
+				Ok((ended, settled)) => {
+					debug!("maintenance: ended {ended} window(s), settled {settled}")
+				}
+				Err(err) => error!("maintenance window sweep failed: {err}"),
+			}
+
 			// Backstop drain of the incident-reeval queue in case the dedicated
 			// worker task above has died. Safe to run concurrently with it:
 			// `process_incident_reeval_queue` claims rows `FOR UPDATE SKIP

--- a/crates/jobs/src/bin/slacker_outbox.rs
+++ b/crates/jobs/src/bin/slacker_outbox.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 use clap::Parser;
 use commons_types::status::CheckResult;
 use database::slack_outbox::{
-	KIND_INCIDENT_OPEN, KIND_INCIDENT_RESOLVE, KIND_SELF_ALERT_OPEN, KIND_SELF_ALERT_RESOLVE,
-	SlackOutbox,
+	KIND_INCIDENT_OPEN, KIND_INCIDENT_RESOLVE, KIND_MAINTENANCE_DECLARED, KIND_MAINTENANCE_ENDED,
+	KIND_SELF_ALERT_OPEN, KIND_SELF_ALERT_RESOLVE, SlackOutbox,
 };
 use diesel_async::AsyncConnection;
 use lloggs::{LoggingArgs, PreArgs};
@@ -63,6 +63,11 @@ const WATCHDOG_CHECK_EVERY: Duration = Duration::from_secs(30);
 struct Config {
 	open: Option<String>,
 	resolve: Option<String>,
+	/// Maintenance hooks are optional independently of the incident ones: a
+	/// deployment that hasn't built the workflows still records its windows
+	/// and suspends on them, it just doesn't announce them.
+	maintenance_declared: Option<String>,
+	maintenance_ended: Option<String>,
 	private_url: Option<String>,
 }
 
@@ -71,6 +76,8 @@ impl Config {
 		Self::build(
 			std::env::var("SLACK_WEBHOOK_OPEN_URL").ok(),
 			std::env::var("SLACK_WEBHOOK_RESOLVE_URL").ok(),
+			std::env::var("SLACK_WEBHOOK_MAINTENANCE_DECLARED_URL").ok(),
+			std::env::var("SLACK_WEBHOOK_MAINTENANCE_ENDED_URL").ok(),
 			std::env::var("PRIVATE_URL").ok(),
 		)
 	}
@@ -78,6 +85,8 @@ impl Config {
 	fn build(
 		open: Option<String>,
 		resolve: Option<String>,
+		maintenance_declared: Option<String>,
+		maintenance_ended: Option<String>,
 		private_url: Option<String>,
 	) -> miette::Result<Self> {
 		let inputs: [(&str, &Option<String>); 2] = [
@@ -111,6 +120,8 @@ impl Config {
 		Ok(Self {
 			open,
 			resolve,
+			maintenance_declared,
+			maintenance_ended,
 			private_url: Some(private_url),
 		})
 	}
@@ -125,6 +136,8 @@ impl Config {
 		match kind {
 			KIND_INCIDENT_OPEN => Ok(self.open.as_deref()),
 			KIND_INCIDENT_RESOLVE => Ok(self.resolve.as_deref()),
+			KIND_MAINTENANCE_DECLARED => Ok(self.maintenance_declared.as_deref()),
+			KIND_MAINTENANCE_ENDED => Ok(self.maintenance_ended.as_deref()),
 			// Legacy: nothing enqueues self-alert rows anymore; stragglers
 			// from before an upgrade drain as delivered without posting.
 			KIND_SELF_ALERT_OPEN | KIND_SELF_ALERT_RESOLVE => Ok(None),
@@ -387,6 +400,12 @@ async fn deliver(
 			debug!(id = %row.id, kind = %row.kind, "legacy self-alert row; marked delivered without posting");
 			return Ok(String::new());
 		}
+		// A deployment with no maintenance workflow records its windows
+		// without announcing them, rather than failing every row forever.
+		Ok(None) if row.kind == KIND_MAINTENANCE_DECLARED || row.kind == KIND_MAINTENANCE_ENDED => {
+			debug!(id = %row.id, kind = %row.kind, "no maintenance webhook configured; marked delivered without posting");
+			return Ok(String::new());
+		}
 		Ok(None) => {
 			return Err(DeliveryError {
 				msg: format!("no webhook url configured for kind {:?}", row.kind),
@@ -500,6 +519,8 @@ mod tests {
 		let err = Config::build(
 			Some("http://example/open".into()),
 			None,
+			None,
+			None,
 			Some("https://canopy.test".into()),
 		)
 		.expect_err("must require every incident SLACK_WEBHOOK_*_URL when any is set");
@@ -515,6 +536,8 @@ mod tests {
 			Some("http://example/open".into()),
 			Some("http://example/resolve".into()),
 			None,
+			None,
+			None,
 		)
 		.expect_err("must require PRIVATE_URL");
 		assert!(err.to_string().contains("PRIVATE_URL"));
@@ -522,7 +545,7 @@ mod tests {
 
 	#[test]
 	fn config_ok_when_no_hooks_set_even_without_private_url() {
-		let cfg = Config::build(None, None, None).expect("no-op mode is fine");
+		let cfg = Config::build(None, None, None, None, None).expect("no-op mode is fine");
 		assert!(!cfg.any_hook());
 	}
 
@@ -531,6 +554,8 @@ mod tests {
 		let cfg = Config::build(
 			Some("http://example/open".into()),
 			Some("http://example/resolve".into()),
+			None,
+			None,
 			Some("https://canopy.test".into()),
 		)
 		.expect("complete config is fine");
@@ -543,6 +568,8 @@ mod tests {
 			cfg.url_for(KIND_INCIDENT_RESOLVE),
 			Ok(Some("http://example/resolve"))
 		);
+		assert_eq!(cfg.url_for(KIND_MAINTENANCE_DECLARED), Ok(None));
+		assert_eq!(cfg.url_for(KIND_MAINTENANCE_ENDED), Ok(None));
 		assert_eq!(cfg.url_for(KIND_SELF_ALERT_OPEN), Ok(None));
 		assert_eq!(cfg.url_for(KIND_SELF_ALERT_RESOLVE), Ok(None));
 		assert_eq!(cfg.url_for("mystery"), Err(()));
@@ -564,6 +591,7 @@ mod tests {
 			open: Some(url),
 			resolve: None,
 			private_url: Some("https://canopy.example.ts.net".into()),
+			..Default::default()
 		};
 		let mut r = row(
 			KIND_INCIDENT_OPEN,
@@ -609,6 +637,7 @@ mod tests {
 			open: Some(url),
 			resolve: None,
 			private_url: Some("https://new.example/".into()),
+			..Default::default()
 		};
 		let mut r = row(
 			KIND_INCIDENT_OPEN,
@@ -648,6 +677,7 @@ mod tests {
 			open: Some("http://127.0.0.1:1/open-should-not-be-hit".into()),
 			resolve: Some(resolve_url),
 			private_url: Some("https://canopy.test".into()),
+			..Default::default()
 		};
 		let r = row(
 			KIND_INCIDENT_RESOLVE,
@@ -677,6 +707,7 @@ mod tests {
 			open: Some(url),
 			resolve: None,
 			private_url: Some("https://canopy.test".into()),
+			..Default::default()
 		};
 		let r = row(KIND_INCIDENT_OPEN, serde_json::json!({}));
 		let err = deliver(&reqwest::Client::new(), &cfg, &r)
@@ -700,6 +731,7 @@ mod tests {
 			open: Some("http://127.0.0.1:1/should-not-be-hit".into()),
 			resolve: Some("http://127.0.0.1:1/should-not-be-hit".into()),
 			private_url: Some("https://canopy.test".into()),
+			..Default::default()
 		};
 		let r = row("bogus_kind", serde_json::json!({}));
 		let err = deliver(&reqwest::Client::new(), &cfg, &r)
@@ -720,6 +752,7 @@ mod tests {
 			open: Some("http://127.0.0.1:1/should-not-be-hit".into()),
 			resolve: Some("http://127.0.0.1:1/should-not-be-hit".into()),
 			private_url: Some("https://canopy.test".into()),
+			..Default::default()
 		};
 		let mut r = row(KIND_SELF_ALERT_OPEN, serde_json::json!({}));
 		r.incident_id = None;

--- a/crates/private-server/src/fns.rs
+++ b/crates/private-server/src/fns.rs
@@ -11,6 +11,7 @@ pub mod domains;
 pub mod healthchecks;
 pub mod incidents;
 pub mod issues;
+pub mod maintenance;
 pub mod mcp_tokens;
 pub mod migration_tests;
 pub mod restore_replicas;
@@ -70,6 +71,7 @@ pub fn routes() -> OpenApiRouter<crate::state::AppState> {
 			.nest("/self_alerts", self_alerts::routes())
 			.nest("/server_groups", server_groups::routes())
 			.nest("/servers", servers::routes())
+			.nest("/maintenance", maintenance::routes())
 			.nest("/silenced_refs", silenced_refs::routes())
 			.nest("/sql", sql::routes())
 			.nest("/statuses", statuses::routes())

--- a/crates/private-server/src/fns/maintenance.rs
+++ b/crates/private-server/src/fns/maintenance.rs
@@ -1,0 +1,197 @@
+use axum::Json;
+use axum::extract::State;
+use canopy_utoipa_axum::{router::OpenApiRouter, routes};
+use commons_errors::{AppError, ProblemDetailsSchema, Result};
+use commons_servers::tailscale_auth::{TailscaleAdmin, TailscaleUser};
+use commons_types::Uuid;
+use database::issues::Scope;
+use database::maintenance_windows::MaintenanceWindow;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::state::AppState;
+
+/// How many of a target's ended windows its history returns.
+const HISTORY_LIMIT: i64 = 20;
+
+pub fn routes() -> OpenApiRouter<AppState> {
+	OpenApiRouter::new()
+		.routes(routes!(list_open))
+		.routes(routes!(for_target))
+		.routes(routes!(declare))
+		.routes(routes!(lift))
+}
+
+/// The target a window covers: exactly one of the two is set.
+#[derive(Deserialize, ToSchema)]
+pub struct TargetArgs {
+	/// The server, for a window over one server.
+	pub server_id: Option<Uuid>,
+	/// The group, for a window over a whole group.
+	pub server_group_id: Option<Uuid>,
+}
+
+impl TargetArgs {
+	fn scope(&self) -> Result<Scope> {
+		match (self.server_id, self.server_group_id) {
+			(Some(id), None) => Ok(Scope::Server(id)),
+			(None, Some(id)) => Ok(Scope::Group(id)),
+			_ => Err(AppError::BadRequest(
+				"a maintenance window covers one server or one group".into(),
+			)),
+		}
+	}
+}
+
+/// Declare a window over a target, or amend the one it already has.
+#[derive(Deserialize, ToSchema)]
+pub struct DeclareArgs {
+	/// The server, for a window over one server.
+	pub server_id: Option<Uuid>,
+	/// The group, for a window over a whole group.
+	pub server_group_id: Option<Uuid>,
+	/// When the work is expected to finish. The window ends itself then.
+	#[schema(value_type = String, format = DateTime)]
+	pub expected_end: Timestamp,
+	/// What is being done.
+	pub note: Option<String>,
+}
+
+/// The window to lift.
+#[derive(Deserialize, ToSchema)]
+pub struct LiftArgs {
+	/// The window, as returned when it was declared or listed.
+	pub id: Uuid,
+}
+
+/// An open window with the target it covers, named so a fleet-wide view
+/// reads without a lookup per row.
+#[derive(Serialize, ToSchema)]
+pub struct OpenWindow {
+	/// The window itself.
+	pub window: MaintenanceWindow,
+	/// The target as it reads to an operator.
+	pub target: String,
+}
+
+/// Every maintenance window currently holding, across the fleet.
+///
+/// Most recently declared first. A window that has ended is history and
+/// belongs to its target, so it is not listed here even while its settle
+/// period runs.
+#[utoipa::path(
+	post,
+	path = "/list_open",
+	tag = "maintenance",
+	security(("tailscale-user" = [])),
+	responses(
+		(status = 200, body = Vec<OpenWindow>),
+	),
+)]
+pub async fn list_open(
+	State(state): State<AppState>,
+	_user: TailscaleUser,
+	Json(_args): Json<serde_json::Value>,
+) -> Result<Json<Vec<OpenWindow>>> {
+	let mut conn = state.db.get().await?;
+	let windows = MaintenanceWindow::list_open(&mut conn).await?;
+	let mut out = Vec::with_capacity(windows.len());
+	for window in windows {
+		let target = database::maintenance_windows::target_label(&mut conn, window.scope()).await?;
+		out.push(OpenWindow { window, target });
+	}
+	Ok(Json(out))
+}
+
+/// A target's maintenance windows.
+///
+/// Open and ended, most recently declared first, so what was being done the
+/// last time the target went quiet is readable against it.
+#[utoipa::path(
+	post,
+	path = "/for_target",
+	tag = "maintenance",
+	security(("tailscale-user" = [])),
+	request_body = TargetArgs,
+	responses(
+		(status = 200, body = Vec<MaintenanceWindow>),
+		(status = 400, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn for_target(
+	State(state): State<AppState>,
+	_user: TailscaleUser,
+	Json(args): Json<TargetArgs>,
+) -> Result<Json<Vec<MaintenanceWindow>>> {
+	let mut conn = state.db.get().await?;
+	let rows = MaintenanceWindow::list_for_scope(&mut conn, args.scope()?, HISTORY_LIMIT).await?;
+	Ok(Json(rows))
+}
+
+/// Declare that a server or a group is being worked on.
+///
+/// Every check on the target grades to skipped while the window holds and
+/// for a settle period after it ends, so nothing on it opens or joins an
+/// incident. Issues already in an open incident leave it, closing the
+/// incident where nothing else holds it open. A target that already has an
+/// open window has that window amended rather than a second opened.
+/// Requires admin access.
+#[utoipa::path(
+	post,
+	path = "/declare",
+	tag = "maintenance",
+	security(("tailscale-admin" = [])),
+	request_body = DeclareArgs,
+	responses(
+		(status = 200, body = MaintenanceWindow),
+		(status = 400, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn declare(
+	State(state): State<AppState>,
+	admin: TailscaleAdmin,
+	Json(args): Json<DeclareArgs>,
+) -> Result<Json<MaintenanceWindow>> {
+	let mut conn = state.db.get().await?;
+	let scope = TargetArgs {
+		server_id: args.server_id,
+		server_group_id: args.server_group_id,
+	}
+	.scope()?;
+	let window = MaintenanceWindow::declare(
+		&mut conn,
+		scope,
+		args.expected_end,
+		args.note.as_deref(),
+		Some(&admin.0.login),
+	)
+	.await?;
+	Ok(Json(window))
+}
+
+/// Lift a window before its expected end.
+///
+/// Suspension runs on for the settle period, after which the target is
+/// watched again. Lifting a window that has already ended changes nothing.
+/// Requires admin access.
+#[utoipa::path(
+	post,
+	path = "/lift",
+	tag = "maintenance",
+	security(("tailscale-admin" = [])),
+	request_body = LiftArgs,
+	responses(
+		(status = 200, body = MaintenanceWindow),
+		(status = 400, body = ProblemDetailsSchema),
+	),
+)]
+pub async fn lift(
+	State(state): State<AppState>,
+	admin: TailscaleAdmin,
+	Json(args): Json<LiftArgs>,
+) -> Result<Json<MaintenanceWindow>> {
+	let mut conn = state.db.get().await?;
+	let window = MaintenanceWindow::lift(&mut conn, args.id, Some(&admin.0.login)).await?;
+	Ok(Json(window))
+}

--- a/crates/private-server/src/fns/servers.rs
+++ b/crates/private-server/src/fns/servers.rs
@@ -45,6 +45,10 @@ pub struct ServerDetailData {
 	pub up: ShortStatus,
 	/// Current self-reported health, derived from the most recent status report.
 	pub health: HealthState,
+	/// Whether a maintenance window suspends this server, its own or its
+	/// group's: its checks are recorded and shown, and raise nothing.
+	// spec: MNT#presentation
+	pub maintained: bool,
 	/// The server's current checks across every source, graded and
 	/// classified — the live consolidated checks view.
 	pub checks: commons_types::status::ConsolidatedChecks,
@@ -140,6 +144,11 @@ pub struct ServerInfo {
 	/// Whether the server may obtain TLS certificates for names under its
 	/// group's domains.
 	pub may_manage_tls: bool,
+	/// Whether a maintenance window suspends this server, its own or its
+	/// group's. Set alongside `up` and `health` by the endpoints that
+	/// decorate listings; `None` where they aren't.
+	// spec: MNT#presentation
+	pub maintained: Option<bool>,
 }
 
 /// The server's most recently reported status push: version/host info plus
@@ -307,6 +316,7 @@ pub(super) fn server_to_info(s: Server) -> ServerInfo {
 		archived: s.deleted_at.is_some(),
 		up: None,
 		health: None,
+		maintained: None,
 		may_manage_dns: s.may_manage_dns,
 		may_manage_tls: s.may_manage_tls,
 	}
@@ -332,10 +342,18 @@ pub(super) async fn decorate_with_status(
 	let server_groups: Vec<(Uuid, Option<Uuid>)> =
 		infos.iter().map(|i| (i.id, i.group_id)).collect();
 	let health = database::issues::health_from_check_state(conn, &server_groups).await?;
+	let (maintained_servers, maintained_groups) =
+		database::maintenance_windows::MaintenanceWindow::suspended_targets(conn).await?;
 	for info in infos.iter_mut() {
 		let st = by_server.get(&info.id).copied();
 		info.up = Some(st.map(|s| s.short_status()).unwrap_or_default());
 		info.health = Some(health.get(&info.id).copied().unwrap_or_default());
+		info.maintained = Some(
+			maintained_servers.contains(&info.id)
+				|| info
+					.group_id
+					.is_some_and(|gid| maintained_groups.contains(&gid)),
+		);
 	}
 	Ok(())
 }
@@ -755,12 +773,20 @@ pub async fn get_detail(
 	// spec: SVC#munin-link
 	let munin = figures.munin().unwrap_or(false);
 
+	let maintained = database::maintenance_windows::MaintenanceWindow::suspends(
+		&mut conn,
+		Some(args.server_id),
+		server.group_id,
+	)
+	.await?;
+
 	Ok(Json(ServerDetailData {
 		server: server_details,
 		device_info,
 		last_status,
 		up,
 		health,
+		maintained,
 		checks,
 		group,
 		siblings,

--- a/crates/private-server/src/openapi.rs
+++ b/crates/private-server/src/openapi.rs
@@ -26,6 +26,7 @@ use utoipa::{
 		(name = "healthchecks", description = "Healthcheck catalog: severities, conditional rules, and sample data."),
 		(name = "incidents", description = "Operational incidents (groups of issues against a server)."),
 		(name = "issues", description = "Per-server issues raised from device events."),
+		(name = "maintenance", description = "Windows declaring that a server or a group is being worked on."),
 		(name = "mcp_tokens", description = "Bearer tokens for the public MCP mount."),
 		(name = "upgrade_plans", description = "Where each deployment is going: the version a group intends to move to, and when."),
 		(name = "migration_tests", description = "Where each server stands against the version it would take next."),

--- a/migrations/2026-08-25-041711-0000_maintenance_windows/down.sql
+++ b/migrations/2026-08-25-041711-0000_maintenance_windows/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE maintenance_windows;

--- a/migrations/2026-08-25-041711-0000_maintenance_windows/up.sql
+++ b/migrations/2026-08-25-041711-0000_maintenance_windows/up.sql
@@ -1,0 +1,46 @@
+-- An operator's declaration that a server or a group is being worked on. While
+-- a window suspends, every check on the target grades to skipped, so nothing on
+-- it opens or joins an incident.
+CREATE TABLE maintenance_windows (
+	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+	server_id UUID REFERENCES servers (id) ON DELETE CASCADE,
+	server_group_id UUID REFERENCES server_groups (id) ON DELETE CASCADE,
+	-- When the operator expects the work to finish. A window that reaches it
+	-- ends itself, so a forgotten one never leaves a deployment unwatched.
+	expected_end TIMESTAMPTZ NOT NULL,
+	note TEXT,
+	declared_by TEXT,
+	declared_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	amended_by TEXT,
+	amended_at TIMESTAMPTZ,
+	-- Set when the window stops holding: the operator's lift, or the sweep
+	-- stamping the expected end. `ended_by` distinguishes the two.
+	ended_at TIMESTAMPTZ,
+	ended_by TEXT,
+	-- Stamped once the settle period after the end has elapsed and the target's
+	-- issues have been re-evaluated, so that happens exactly once per window.
+	settled_at TIMESTAMPTZ,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	CONSTRAINT maintenance_windows_one_target CHECK (num_nonnulls(server_id, server_group_id) = 1)
+);
+
+-- At most one open window per target. Ended windows are the target's
+-- maintenance history and accumulate freely, hence the partial index.
+CREATE UNIQUE INDEX maintenance_windows_one_open_per_server
+	ON maintenance_windows (server_id)
+	WHERE ended_at IS NULL AND server_id IS NOT NULL;
+CREATE UNIQUE INDEX maintenance_windows_one_open_per_group
+	ON maintenance_windows (server_group_id)
+	WHERE ended_at IS NULL AND server_group_id IS NOT NULL;
+
+-- The two sweeps: windows that have reached their expected end, and ended
+-- windows whose settle period has yet to be accounted for.
+CREATE INDEX maintenance_windows_open
+	ON maintenance_windows (expected_end)
+	WHERE ended_at IS NULL;
+CREATE INDEX maintenance_windows_unsettled
+	ON maintenance_windows (ended_at)
+	WHERE ended_at IS NOT NULL AND settled_at IS NULL;
+CREATE INDEX maintenance_windows_server ON maintenance_windows (server_id, declared_at DESC);
+CREATE INDEX maintenance_windows_group ON maintenance_windows (server_group_id, declared_at DESC);

--- a/private-web/e2e/maintenance.spec.ts
+++ b/private-web/e2e/maintenance.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "./test-fixtures";
+import {
+	resetSeededTables,
+	seedMaintenanceWindow,
+	seedServer,
+	seedServerGroup,
+	seedStatus,
+	type Sql,
+} from "./seed";
+
+async function openWindows(sql: Sql): Promise<number> {
+	const rows = await sql.query<{ n: string }>(
+		"SELECT COUNT(*) AS n FROM maintenance_windows WHERE ended_at IS NULL",
+	);
+	return Number(rows[0]!.n);
+}
+
+// spec: MNT
+test.describe("maintenance windows", () => {
+	test.beforeEach(async ({ sql }) => {
+		await resetSeededTables(sql);
+	});
+
+	test("a server under a window says so, and its health is marked", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "under-the-knife" });
+		const server = await seedServer(sql, {
+			name: "being-upgraded",
+			groupId: group.id,
+		});
+		await seedStatus(sql, { serverId: server.id, healthy: true });
+		await seedMaintenanceWindow(sql, {
+			serverId: server.id,
+			note: "Upgrading to 2.62",
+			declaredBy: "daniel@bes.au",
+		});
+
+		await page.goto(`/servers/${server.id}`);
+		const section = page.getByTestId("maintenance-section");
+		await expect(section).toContainText("Under maintenance until");
+		await expect(section).toContainText("Upgrading to 2.62");
+		await expect(section).toContainText("daniel@bes.au");
+		await expect(page.getByTestId("maintenance-marker")).toBeVisible();
+	});
+
+	test("declaring from the server page opens a window", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "about-to-move" });
+		const server = await seedServer(sql, {
+			name: "going-down",
+			groupId: group.id,
+		});
+		await seedStatus(sql, { serverId: server.id, healthy: true });
+
+		await page.goto(`/servers/${server.id}`);
+		await page.getByRole("button", { name: "Declare maintenance" }).click();
+		await page.getByLabel("What's being done").fill("Swapping the disk");
+		await page.getByRole("button", { name: "Declare", exact: true }).click();
+
+		await expect(
+			page.getByTestId("maintenance-section"),
+		).toContainText("Swapping the disk");
+		expect(await openWindows(sql)).toBe(1);
+	});
+
+	test("lifting ends the window", async ({ page, sql }) => {
+		const group = await seedServerGroup(sql, { name: "back-already" });
+		const server = await seedServer(sql, { name: "done", groupId: group.id });
+		await seedStatus(sql, { serverId: server.id, healthy: true });
+		await seedMaintenanceWindow(sql, { serverId: server.id, note: "Rebooting" });
+
+		await page.goto(`/servers/${server.id}`);
+		await page.getByRole("button", { name: "Lift" }).click();
+
+		await expect(
+			page.getByRole("button", { name: "Declare maintenance" }),
+		).toBeVisible();
+		expect(await openWindows(sql)).toBe(0);
+	});
+
+	test("the maintenance page lists what the fleet is not watching", async ({
+		page,
+		sql,
+	}) => {
+		const group = await seedServerGroup(sql, { name: "whole-deployment" });
+		await seedMaintenanceWindow(sql, {
+			serverGroupId: group.id,
+			note: "Cutting over the database",
+		});
+
+		await page.goto("/maintenance");
+		const row = page.getByRole("row", { name: /whole-deployment/ });
+		await expect(row).toContainText("Cutting over the database");
+		await expect(
+			page.getByRole("link", { name: "whole-deployment" }),
+		).toHaveAttribute("href", `/groups/${group.id}`);
+	});
+
+	test("nothing under maintenance says so", async ({ page }) => {
+		await page.goto("/maintenance");
+		await expect(
+			page.getByText("Nothing is under maintenance"),
+		).toBeVisible();
+	});
+});

--- a/private-web/e2e/seed.ts
+++ b/private-web/e2e/seed.ts
@@ -47,7 +47,7 @@ function randomLabel(prefix: string): string {
  * statement with CASCADE. */
 export async function resetSeededTables(sql: Sql): Promise<void> {
 	await sql.query(
-		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, migration_tests, migration_timings, upgrade_plans, version_known_issues, recovery_vault_writes, server_names, server_certificates, compromised_keys RESTART IDENTITY CASCADE",
+		"TRUNCATE statuses, server_reported_detail, issues, device_keys, servers, server_groups, server_group_domains, devices, versions, tailscale_users, check_policies, scoped_check_policies, source_policies, server_group_backup_config, server_group_backup_schedule, server_backup_capabilities, backup_requests, backup_runs, backup_run_progress, backup_repo_stats, backup_maintenance_runs, backup_credential_issuances, restore_replicas, restore_consumer_capabilities, backup_restore_checks, migration_tests, migration_timings, upgrade_plans, maintenance_windows, version_known_issues, recovery_vault_writes, server_names, server_certificates, compromised_keys RESTART IDENTITY CASCADE",
 	);
 	// The truncate takes the migration-seeded nil "Canopy" server with it;
 	// self-alerts attach to that row, so put it back. `kind = 'canopy'` is the
@@ -1271,6 +1271,38 @@ export async function seedMigrationTest(
 
 /** Record where a group is going. `plannedFor` is `YYYY-MM-DD`; omit for a plan
  * with no date. */
+export interface SeededMaintenanceWindow {
+	id: string;
+}
+
+/** A maintenance window over a server or a group. `endsInHours` places the
+ * expected end, so a negative value seeds one the sweep will end. */
+export async function seedMaintenanceWindow(
+	sql: Sql,
+	opts: {
+		serverId?: string;
+		serverGroupId?: string;
+		endsInHours?: number;
+		note?: string | null;
+		declaredBy?: string | null;
+	},
+): Promise<SeededMaintenanceWindow> {
+	const rows = await sql.query<{ id: string }>(
+		`INSERT INTO maintenance_windows
+		   (server_id, server_group_id, expected_end, note, declared_by)
+		 VALUES ($1, $2, NOW() + make_interval(mins => $3), $4, $5)
+		 RETURNING id`,
+		[
+			opts.serverId ?? null,
+			opts.serverGroupId ?? null,
+			Math.round((opts.endsInHours ?? 2) * 60),
+			opts.note ?? null,
+			opts.declaredBy ?? "seed@bes.au",
+		],
+	);
+	return { id: rows[0]!.id };
+}
+
 export async function seedUpgradePlan(
 	sql: Sql,
 	opts: {

--- a/private-web/e2e/server-reachability-silence.spec.ts
+++ b/private-web/e2e/server-reachability-silence.spec.ts
@@ -58,6 +58,9 @@ test.describe("reachability alerting switch on the server form", () => {
 
 		await page.goto(`/groups/${group.id}/servers/new`);
 		await page.getByLabel(/^Name(\s*\*)?$/i).fill("expected-to-stay");
+		// The switch settling is what says the form is live; clicking before
+		// that lands on markup with no handler attached yet.
+		await expect(page.getByLabel(SWITCH)).toBeChecked();
 		await page.getByRole("button", { name: "Create server" }).click();
 
 		await expect(page).toHaveURL(/\/servers\/[0-9a-f-]{36}$/);

--- a/private-web/openapi.json
+++ b/private-web/openapi.json
@@ -4483,6 +4483,188 @@
         ]
       }
     },
+    "/api/maintenance/declare": {
+      "post": {
+        "tags": [
+          "maintenance"
+        ],
+        "summary": "Declare that a server or a group is being worked on.",
+        "description": "Every check on the target grades to skipped while the window holds and\nfor a settle period after it ends, so nothing on it opens or joins an\nincident. Issues already in an open incident leave it, closing the\nincident where nothing else holds it open. A target that already has an\nopen window has that window amended rather than a second opened.\nRequires admin access.",
+        "operationId": "declare",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeclareArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceWindow"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/maintenance/for_target": {
+      "post": {
+        "tags": [
+          "maintenance"
+        ],
+        "summary": "A target's maintenance windows.",
+        "description": "Open and ended, most recently declared first, so what was being done the\nlast time the target went quiet is readable against it.",
+        "operationId": "for_target",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TargetArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MaintenanceWindow"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
+    "/api/maintenance/lift": {
+      "post": {
+        "tags": [
+          "maintenance"
+        ],
+        "summary": "Lift a window before its expected end.",
+        "description": "Suspension runs on for the settle period, after which the target is\nwatched again. Lifting a window that has already ended changes nothing.\nRequires admin access.",
+        "operationId": "lift",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LiftArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceWindow"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetailsSchema"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-admin": []
+          }
+        ]
+      }
+    },
+    "/api/maintenance/list_open": {
+      "post": {
+        "tags": [
+          "maintenance"
+        ],
+        "summary": "Every maintenance window currently holding, across the fleet.",
+        "description": "Most recently declared first. A window that has ended is history and\nbelongs to its target, so it is not listed here even while its settle\nperiod runs.",
+        "operationId": "list_open",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OpenWindow"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tailscale-user": []
+          }
+        ]
+      }
+    },
     "/api/mcp_tokens/list": {
       "post": {
         "tags": [
@@ -9215,6 +9397,43 @@
           }
         }
       },
+      "DeclareArgs": {
+        "type": "object",
+        "description": "Declare a window over a target, or amend the one it already has.",
+        "required": [
+          "expected_end"
+        ],
+        "properties": {
+          "expected_end": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the work is expected to finish. The window ends itself then."
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "What is being done."
+          },
+          "server_group_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The group, for a window over a whole group."
+          },
+          "server_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The server, for a window over one server."
+          }
+        }
+      },
       "DecommissionArgs": {
         "type": "object",
         "description": "Request body for decommissioning a check.",
@@ -11219,6 +11438,20 @@
           }
         }
       },
+      "LiftArgs": {
+        "type": "object",
+        "description": "The window to lift.",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The window, as returned when it was declared or listed."
+          }
+        }
+      },
       "ListActiveArgs": {
         "type": "object",
         "description": "Filters for listing open incidents.",
@@ -11460,6 +11693,112 @@
           "quick",
           "full"
         ]
+      },
+      "MaintenanceWindow": {
+        "type": "object",
+        "description": "A declaration that a server or a group is being worked on.",
+        "required": [
+          "id",
+          "expected_end",
+          "declared_at",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "amended_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When the window was last amended."
+          },
+          "amended_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The operator who last amended the window, where one has."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this record was created."
+          },
+          "declared_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the window was declared."
+          },
+          "declared_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The operator who declared the window. `None` if not recorded."
+          },
+          "ended_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When the window stopped holding. `None` while it holds."
+          },
+          "ended_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The operator who lifted the window. `None` where its expected end\npassed instead."
+          },
+          "expected_end": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the operator expects the work to finish. A window reaching it\nends itself."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of this window."
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "What is being done, where the operator said."
+          },
+          "server_group_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Set for a window over a group, covering the group's own checks and\nthose of every server in it."
+          },
+          "server_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Set for a window over one server."
+          },
+          "settled_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Stamped once the settle period has elapsed and the target's issues\nhave been re-evaluated."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this record was last modified."
+          }
+        }
       },
       "ManagedZoneView": {
         "type": "object",
@@ -11711,6 +12050,24 @@
               "null"
             ],
             "description": "Apex of the managed zone covering this name, or null where no configured\nzone does — in which case Canopy can publish nothing for it."
+          }
+        }
+      },
+      "OpenWindow": {
+        "type": "object",
+        "description": "An open window with the target it covers, named so a fleet-wide view\nreads without a lookup per row.",
+        "required": [
+          "window",
+          "target"
+        ],
+        "properties": {
+          "target": {
+            "type": "string",
+            "description": "The target as it reads to an operator."
+          },
+          "window": {
+            "$ref": "#/components/schemas/MaintenanceWindow",
+            "description": "The window itself."
           }
         }
       },
@@ -11969,6 +12326,13 @@
                 "kind": {
                   "$ref": "#/components/schemas/ServerKind",
                   "description": "The server's role within its product's topology."
+                },
+                "maintained": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ],
+                  "description": "Whether a maintenance window suspends this server, its own or its\ngroup's. Set alongside `up` and `health` by the endpoints that\ndecorate listings; `None` where they aren't."
                 },
                 "may_manage_dns": {
                   "type": "boolean",
@@ -14271,6 +14635,7 @@
           "server",
           "up",
           "health",
+          "maintained",
           "checks",
           "siblings",
           "billing_labels",
@@ -14324,6 +14689,10 @@
                 "description": "The server's most recently reported status, if it has ever reported one."
               }
             ]
+          },
+          "maintained": {
+            "type": "boolean",
+            "description": "Whether a maintenance window suspends this server, its own or its\ngroup's: its checks are recorded and shown, and raise nothing."
           },
           "munin": {
             "type": "boolean",
@@ -14711,6 +15080,13 @@
           "kind": {
             "$ref": "#/components/schemas/ServerKind",
             "description": "The server's role within its product's topology."
+          },
+          "maintained": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether a maintenance window suspends this server, its own or its\ngroup's. Set alongside `up` and `health` by the endpoints that\ndecorate listings; `None` where they aren't."
           },
           "may_manage_dns": {
             "type": "boolean",
@@ -15834,6 +16210,28 @@
           }
         }
       },
+      "TargetArgs": {
+        "type": "object",
+        "description": "The target a window covers: exactly one of the two is set.",
+        "properties": {
+          "server_group_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The group, for a window over a whole group."
+          },
+          "server_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The server, for a window over one server."
+          }
+        }
+      },
       "Transition": {
         "type": "object",
         "description": "One healthy↔degraded transition: the state became (or was first\nobserved) `degraded`/healthy at `at`.",
@@ -16483,6 +16881,10 @@
     {
       "name": "issues",
       "description": "Per-server issues raised from device events."
+    },
+    {
+      "name": "maintenance",
+      "description": "Windows declaring that a server or a group is being worked on."
     },
     {
       "name": "mcp_tokens",

--- a/private-web/src/App.tsx
+++ b/private-web/src/App.tsx
@@ -40,6 +40,7 @@ import Healthchecks from "./routes/Healthchecks";
 import SourcesSettings from "./routes/SourcesSettings";
 import IncidentDetail from "./routes/IncidentDetail";
 import Incidents from "./routes/Incidents";
+import Maintenance from "./routes/Maintenance";
 import Status from "./routes/Status";
 import ServerCreate from "./routes/ServerCreate";
 import ServerDetail from "./routes/ServerDetail";
@@ -65,6 +66,7 @@ const BASE_NAV: NavItem[] = [
 	{ label: "Fleet", to: "/servers" },
 	{ label: "Versions", to: "/versions" },
 	{ label: "Upgrades", to: "/upgrades" },
+	{ label: "Maintenance", to: "/maintenance" },
 	{ label: "Devices", to: "/devices" },
 	{ label: "Bestool", to: "/bestool" },
 	{ label: "Settings", to: "/settings" },
@@ -196,6 +198,7 @@ export default function App() {
 					<Route path="/incidents/:id" element={<IncidentDetail />} />
 					<Route path="/healthchecks/:source/:check" element={<CheckDetail />} />
 					<Route path="/upgrades" element={<Upgrades />} />
+					<Route path="/maintenance" element={<Maintenance />} />
 					<Route path="/versions" element={<Versions />} />
 					<Route path="/versions/:version" element={<VersionDetail />} />
 					<Route path="/servers" element={<Servers />}>

--- a/private-web/src/api-types.ts
+++ b/private-web/src/api-types.ts
@@ -2278,6 +2278,96 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/maintenance/declare": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Declare that a server or a group is being worked on.
+         * @description Every check on the target grades to skipped while the window holds and
+         *     for a settle period after it ends, so nothing on it opens or joins an
+         *     incident. Issues already in an open incident leave it, closing the
+         *     incident where nothing else holds it open. A target that already has an
+         *     open window has that window amended rather than a second opened.
+         *     Requires admin access.
+         */
+        post: operations["declare"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/maintenance/for_target": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * A target's maintenance windows.
+         * @description Open and ended, most recently declared first, so what was being done the
+         *     last time the target went quiet is readable against it.
+         */
+        post: operations["for_target"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/maintenance/lift": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Lift a window before its expected end.
+         * @description Suspension runs on for the settle period, after which the target is
+         *     watched again. Lifting a window that has already ended changes nothing.
+         *     Requires admin access.
+         */
+        post: operations["lift"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/maintenance/list_open": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Every maintenance window currently holding, across the fleet.
+         * @description Most recently declared first. A window that has ended is history and
+         *     belongs to its target, so it is not listed here even while its settle
+         *     period runs.
+         */
+        post: operations["list_open"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/mcp_tokens/list": {
         parameters: {
             query?: never;
@@ -4920,6 +5010,26 @@ export interface components {
              */
             server_group_id: string;
         };
+        /** @description Declare a window over a target, or amend the one it already has. */
+        DeclareArgs: {
+            /**
+             * Format: date-time
+             * @description When the work is expected to finish. The window ends itself then.
+             */
+            expected_end: string;
+            /** @description What is being done. */
+            note?: string | null;
+            /**
+             * Format: uuid
+             * @description The group, for a window over a whole group.
+             */
+            server_group_id?: string | null;
+            /**
+             * Format: uuid
+             * @description The server, for a window over one server.
+             */
+            server_id?: string | null;
+        };
         /** @description Request body for decommissioning a check. */
         DecommissionArgs: {
             /**
@@ -6193,6 +6303,14 @@ export interface components {
             /** @description Whether the migrations applied. */
             verdict: components["schemas"]["Verdict"];
         };
+        /** @description The window to lift. */
+        LiftArgs: {
+            /**
+             * Format: uuid
+             * @description The window, as returned when it was declared or listed.
+             */
+            id: string;
+        };
         /** @description Filters for listing open incidents. */
         ListActiveArgs: {
             /**
@@ -6356,6 +6474,73 @@ export interface components {
          * @enum {string}
          */
         MaintenanceKind: "quick" | "full";
+        /** @description A declaration that a server or a group is being worked on. */
+        MaintenanceWindow: {
+            /**
+             * Format: date-time
+             * @description When the window was last amended.
+             */
+            amended_at?: string | null;
+            /** @description The operator who last amended the window, where one has. */
+            amended_by?: string | null;
+            /**
+             * Format: date-time
+             * @description When this record was created.
+             */
+            created_at: string;
+            /**
+             * Format: date-time
+             * @description When the window was declared.
+             */
+            declared_at: string;
+            /** @description The operator who declared the window. `None` if not recorded. */
+            declared_by?: string | null;
+            /**
+             * Format: date-time
+             * @description When the window stopped holding. `None` while it holds.
+             */
+            ended_at?: string | null;
+            /**
+             * @description The operator who lifted the window. `None` where its expected end
+             *     passed instead.
+             */
+            ended_by?: string | null;
+            /**
+             * Format: date-time
+             * @description When the operator expects the work to finish. A window reaching it
+             *     ends itself.
+             */
+            expected_end: string;
+            /**
+             * Format: uuid
+             * @description Unique identifier of this window.
+             */
+            id: string;
+            /** @description What is being done, where the operator said. */
+            note?: string | null;
+            /**
+             * Format: uuid
+             * @description Set for a window over a group, covering the group's own checks and
+             *     those of every server in it.
+             */
+            server_group_id?: string | null;
+            /**
+             * Format: uuid
+             * @description Set for a window over one server.
+             */
+            server_id?: string | null;
+            /**
+             * Format: date-time
+             * @description Stamped once the settle period has elapsed and the target's issues
+             *     have been re-evaluated.
+             */
+            settled_at?: string | null;
+            /**
+             * Format: date-time
+             * @description When this record was last modified.
+             */
+            updated_at: string;
+        };
         /**
          * @description A DNS zone Canopy can write records in.
          *
@@ -6526,6 +6711,16 @@ export interface components {
             zone?: string | null;
         };
         /**
+         * @description An open window with the target it covers, named so a fleet-wide view
+         *     reads without a lookup per row.
+         */
+        OpenWindow: {
+            /** @description The target as it reads to an operator. */
+            target: string;
+            /** @description The window itself. */
+            window: components["schemas"]["MaintenanceWindow"];
+        };
+        /**
          * @description One person currently connected to a server, identified by their
          *     Tailscale login.
          *
@@ -6643,6 +6838,12 @@ export interface components {
                 is_monitored: boolean;
                 /** @description The server's role within its product's topology. */
                 kind: components["schemas"]["ServerKind"];
+                /**
+                 * @description Whether a maintenance window suspends this server, its own or its
+                 *     group's. Set alongside `up` and `health` by the endpoints that
+                 *     decorate listings; `None` where they aren't.
+                 */
+                maintained?: boolean | null;
                 /**
                  * @description Whether the server may manage its own DNS records for names under its
                  *     group's domains.
@@ -8148,6 +8349,11 @@ export interface components {
             health: components["schemas"]["HealthState"];
             last_status?: null | components["schemas"]["ServerLastStatusData"];
             /**
+             * @description Whether a maintenance window suspends this server, its own or its
+             *     group's: its checks are recorded and shown, and raise nothing.
+             */
+            maintained: boolean;
+            /**
              * @description Whether the server is known to run Munin, from the most recent source
              *     to report the flag. The UI offers a Munin link only when this is true.
              */
@@ -8390,6 +8596,12 @@ export interface components {
             is_monitored: boolean;
             /** @description The server's role within its product's topology. */
             kind: components["schemas"]["ServerKind"];
+            /**
+             * @description Whether a maintenance window suspends this server, its own or its
+             *     group's. Set alongside `up` and `health` by the endpoints that
+             *     decorate listings; `None` where they aren't.
+             */
+            maintained?: boolean | null;
             /**
              * @description Whether the server may manage its own DNS records for names under its
              *     group's domains.
@@ -9073,6 +9285,19 @@ export interface components {
             tags: string[];
             /** @description The tailnet (Tailscale network) this node belongs to. */
             tailnet: string;
+        };
+        /** @description The target a window covers: exactly one of the two is set. */
+        TargetArgs: {
+            /**
+             * Format: uuid
+             * @description The group, for a window over a whole group.
+             */
+            server_group_id?: string | null;
+            /**
+             * Format: uuid
+             * @description The server, for a window over one server.
+             */
+            server_id?: string | null;
         };
         /**
          * @description One healthy↔degraded transition: the state became (or was first
@@ -12463,6 +12688,122 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["IssueData"];
+                };
+            };
+        };
+    };
+    declare: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeclareArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaintenanceWindow"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    for_target: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TargetArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaintenanceWindow"][];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    lift: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LiftArgs"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MaintenanceWindow"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetailsSchema"];
+                };
+            };
+        };
+    };
+    list_open: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": unknown;
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpenWindow"][];
                 };
             };
         };

--- a/private-web/src/components/DeclareMaintenanceDialog.tsx
+++ b/private-web/src/components/DeclareMaintenanceDialog.tsx
@@ -1,0 +1,149 @@
+import {
+	Alert,
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	DialogTitle,
+	Stack,
+	TextField,
+	ToggleButton,
+	ToggleButtonGroup,
+} from "@mui/material";
+import { useEffect, useState } from "react";
+import { useApiAction } from "../api";
+import type { MaintenanceWindow } from "../types";
+
+const PRESETS = [1, 2, 4, 8];
+
+/** `datetime-local` wants a local wall clock with no zone, which is what
+ * the operator is thinking in when they say "back by six". */
+function toLocalInput(at: Date): string {
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${at.getFullYear()}-${pad(at.getMonth() + 1)}-${pad(at.getDate())}T${pad(at.getHours())}:${pad(at.getMinutes())}`;
+}
+
+function hoursFromNow(hours: number): string {
+	return toLocalInput(new Date(Date.now() + hours * 3600_000));
+}
+
+/** Declare a maintenance window over a server or a group, or amend the one
+ * it already has. Everything on the target grades to skipped while the
+ * window holds, so nothing on it opens or joins an incident. */
+export default function DeclareMaintenanceDialog({
+	open,
+	onClose,
+	scope,
+	id,
+	targetLabel,
+	existing,
+	prefill,
+	onDone,
+}: {
+	open: boolean;
+	onClose: () => void;
+	scope: "server" | "group";
+	id: string;
+	targetLabel?: string;
+	/** The target's open window, when this is an amendment. */
+	existing?: MaintenanceWindow | null;
+	/** Starting values where something else knows them, such as an upgrade
+	 * plan's window and note. */
+	prefill?: { expectedEnd?: string; note?: string };
+	onDone: () => void;
+}) {
+	const declare = useApiAction("maintenance", "declare");
+	const [endsAt, setEndsAt] = useState(() => hoursFromNow(2));
+	const [note, setNote] = useState("");
+
+	useEffect(() => {
+		if (!open) return;
+		const end = existing?.expected_end ?? prefill?.expectedEnd;
+		setEndsAt(end ? toLocalInput(new Date(end)) : hoursFromNow(2));
+		setNote(existing?.note ?? prefill?.note ?? "");
+		declare.reset();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [open, existing?.id]);
+
+	const submit = async () => {
+		const at = new Date(endsAt);
+		if (Number.isNaN(at.getTime())) return;
+		try {
+			await declare.call({
+				...(scope === "server" ? { server_id: id } : { server_group_id: id }),
+				expected_end: at.toISOString(),
+				note: note.trim() === "" ? null : note.trim(),
+			});
+			onDone();
+			onClose();
+		} catch {
+			/* surfaced via declare.error */
+		}
+	};
+
+	const amending = Boolean(existing);
+	return (
+		<Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+			<DialogTitle>
+				{amending ? "Amend maintenance" : "Declare maintenance"}
+				{targetLabel ? ` — ${targetLabel}` : ""}
+			</DialogTitle>
+			<DialogContent>
+				<DialogContentText sx={{ mb: 2 }}>
+					{scope === "group"
+						? "Every check on this group and its servers is suspended: nothing opens or joins an incident, and nothing notifies."
+						: "Every check on this server is suspended: nothing opens or joins an incident, and nothing notifies."}{" "}
+					The window ends itself at the time below, and watching resumes a
+					few minutes later once the reporters have been heard from.
+				</DialogContentText>
+				<Stack spacing={2}>
+					<ToggleButtonGroup
+						size="small"
+						exclusive
+						value={null}
+						onChange={(_, hours: number | null) => {
+							if (hours) setEndsAt(hoursFromNow(hours));
+						}}
+					>
+						{PRESETS.map((hours) => (
+							<ToggleButton key={hours} value={hours}>
+								{hours}h
+							</ToggleButton>
+						))}
+					</ToggleButtonGroup>
+					<TextField
+						size="small"
+						type="datetime-local"
+						label="Expected to end"
+						value={endsAt}
+						onChange={(e) => setEndsAt(e.target.value)}
+						slotProps={{ inputLabel: { shrink: true } }}
+					/>
+					<TextField
+						size="small"
+						label="What's being done"
+						placeholder="Upgrading to 2.62"
+						multiline
+						minRows={2}
+						value={note}
+						onChange={(e) => setNote(e.target.value)}
+					/>
+					{declare.error && (
+						<Alert severity="error">{declare.error.message}</Alert>
+					)}
+				</Stack>
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onClose}>Cancel</Button>
+				<Button
+					variant="contained"
+					onClick={submit}
+					disabled={declare.pending || endsAt === ""}
+				>
+					{amending ? "Amend" : "Declare"}
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+}

--- a/private-web/src/components/HealthChip.tsx
+++ b/private-web/src/components/HealthChip.tsx
@@ -1,12 +1,16 @@
 import { Box, Chip, Stack, Tooltip } from "@mui/material";
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
 import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import type { HealthState } from "../types";
 
 const UNMONITORED_TOOLTIP =
 	"This server is unmonitored — its checks are recorded and shown, but nothing alerts on them.";
+
+const MAINTAINED_TOOLTIP =
+	"A maintenance window is being worked on here — its checks are recorded and shown, and raise nothing until the window ends.";
 
 const LABEL: Record<HealthState, string> = {
 	healthy: "Healthy",
@@ -45,10 +49,15 @@ export default function HealthChip({
 	health,
 	stale = false,
 	monitored = true,
+	maintained = false,
 }: {
 	health: HealthState;
 	stale?: boolean;
 	monitored?: boolean;
+	/** Whether a maintenance window suspends the server: the chip fades and
+	 * takes a maintenance marker, distinct from the unmonitored one. */
+	// spec: MNT#presentation
+	maintained?: boolean;
 }) {
 	const chip = stale ? (
 		<Tooltip title="Server isn't currently reporting status; this reflects its most recent received report.">
@@ -78,17 +87,28 @@ export default function HealthChip({
 			/>
 		</Tooltip>
 	);
-	if (monitored) return chip;
+	if (monitored && !maintained) return chip;
 	return (
 		<Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
 			<Box sx={{ opacity: 0.5, display: "inline-flex" }}>{chip}</Box>
-			<Tooltip title={UNMONITORED_TOOLTIP}>
-				<NotificationsOffIcon
-					fontSize="small"
-					color="info"
-					data-testid="unmonitored-marker"
-				/>
-			</Tooltip>
+			{maintained && (
+				<Tooltip title={MAINTAINED_TOOLTIP}>
+					<BuildOutlinedIcon
+						fontSize="small"
+						color="info"
+						data-testid="maintenance-marker"
+					/>
+				</Tooltip>
+			)}
+			{!monitored && (
+				<Tooltip title={UNMONITORED_TOOLTIP}>
+					<NotificationsOffIcon
+						fontSize="small"
+						color="info"
+						data-testid="unmonitored-marker"
+					/>
+				</Tooltip>
+			)}
 		</Stack>
 	);
 }

--- a/private-web/src/components/Legends.tsx
+++ b/private-web/src/components/Legends.tsx
@@ -58,6 +58,12 @@ export function StatusLegend() {
 					Cut through: unmonitored (state shown, nothing alerts)
 				</Typography>
 			</Stack>
+			<Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+				<StatusDot up="down" maintained />
+				<Typography variant="body2" color="text.secondary">
+					Cut the other way: under maintenance (being worked on)
+				</Typography>
+			</Stack>
 		</Stack>
 	);
 }

--- a/private-web/src/components/MaintenanceSection.tsx
+++ b/private-web/src/components/MaintenanceSection.tsx
@@ -1,0 +1,187 @@
+import {
+	Alert,
+	Box,
+	Button,
+	LinearProgress,
+	Paper,
+	Stack,
+	Typography,
+} from "@mui/material";
+import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
+import { useState } from "react";
+import { useApi, useApiAction } from "../api";
+import { useIsAdmin } from "../hooks/useIsAdmin";
+import type { MaintenanceWindow } from "../types";
+import DeclareMaintenanceDialog from "./DeclareMaintenanceDialog";
+import TimeAgo from "./TimeAgo";
+
+const HISTORY_SHOWN = 5;
+
+/** The target's maintenance: the window holding over it with the actions to
+ * amend or lift it, and the windows that have ended as history. Sits on the
+ * server and group detail pages. */
+// spec: MNT#presentation
+export default function MaintenanceSection({
+	scope,
+	id,
+	targetLabel,
+	onChanged,
+}: {
+	scope: "server" | "group";
+	id: string;
+	targetLabel?: string;
+	/** Called after declaring or lifting, so the page can refresh the
+	 * health and checks that the window changes. */
+	onChanged?: () => void;
+}) {
+	const isAdmin = useIsAdmin() === true;
+	const [tick, setTick] = useState(0);
+	const [dialogOpen, setDialogOpen] = useState(false);
+	const lift = useApiAction("maintenance", "lift");
+
+	const result = useApi(
+		"maintenance",
+		"for_target",
+		scope === "server" ? { server_id: id } : { server_group_id: id },
+		[id, tick],
+	);
+
+	const reload = () => {
+		setTick((t) => t + 1);
+		onChanged?.();
+	};
+
+	if (result.status === "loading" || result.status === "idle") {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<Heading />
+				<LinearProgress />
+			</Paper>
+		);
+	}
+	if (result.status === "error") {
+		return (
+			<Paper variant="outlined" sx={{ p: 2 }}>
+				<Heading />
+				<Alert severity="error">{result.error.message}</Alert>
+			</Paper>
+		);
+	}
+
+	const windows: MaintenanceWindow[] = result.data;
+	const open = windows.find((w) => w.ended_at === null) ?? null;
+	const history = windows.filter((w) => w.ended_at !== null).slice(0, HISTORY_SHOWN);
+
+	if (!open && history.length === 0 && !isAdmin) return null;
+
+	return (
+		<Paper variant="outlined" sx={{ p: 2 }} data-testid="maintenance-section">
+			<Heading />
+			{open ? (
+				<Alert
+					severity="info"
+					icon={<BuildOutlinedIcon fontSize="inherit" />}
+					sx={{ mb: history.length ? 2 : 0 }}
+					action={
+						isAdmin ? (
+							<Stack direction="row" spacing={1}>
+								<Button size="small" onClick={() => setDialogOpen(true)}>
+									Amend
+								</Button>
+								<Button
+									size="small"
+									variant="outlined"
+									disabled={lift.pending}
+									onClick={async () => {
+										try {
+											await lift.call({ id: open.id });
+											reload();
+										} catch {
+											/* surfaced below */
+										}
+									}}
+								>
+									Lift
+								</Button>
+							</Stack>
+						) : undefined
+					}
+				>
+					<Typography variant="body2">
+						Under maintenance until <TimeAgo timestamp={open.expected_end} />
+						{open.declared_by && `, declared by ${open.declared_by}`}.
+						Checks are recorded and shown; nothing on this{" "}
+						{scope === "server" ? "server" : "group"} alerts.
+					</Typography>
+					{open.note && (
+						<Typography variant="body2" sx={{ mt: 0.5, fontStyle: "italic" }}>
+							{open.note}
+						</Typography>
+					)}
+				</Alert>
+			) : (
+				isAdmin && (
+					<Button
+						size="small"
+						variant="outlined"
+						startIcon={<BuildOutlinedIcon />}
+						onClick={() => setDialogOpen(true)}
+						sx={{ mb: history.length ? 2 : 0 }}
+					>
+						Declare maintenance
+					</Button>
+				)
+			)}
+			{lift.error && (
+				<Alert severity="error" sx={{ mt: 1 }}>
+					{lift.error.message}
+				</Alert>
+			)}
+			{history.length > 0 && (
+				<Stack spacing={1}>
+					{history.map((window) => (
+						<Box
+							key={window.id}
+							sx={{ p: 1.5, border: 1, borderColor: "divider", borderRadius: 1 }}
+						>
+							<Stack
+								direction="row"
+								spacing={1}
+								sx={{ alignItems: "center", flexWrap: "wrap" }}
+								useFlexGap
+							>
+								<Typography variant="body2">
+									{window.note ?? "Maintenance"}
+								</Typography>
+								<Box sx={{ flex: 1 }} />
+								<Typography variant="caption" color="text.secondary">
+									ended <TimeAgo timestamp={window.ended_at as string} />
+									{window.ended_by
+										? ` by ${window.ended_by}`
+										: " at its expected end"}
+								</Typography>
+							</Stack>
+						</Box>
+					))}
+				</Stack>
+			)}
+			<DeclareMaintenanceDialog
+				open={dialogOpen}
+				onClose={() => setDialogOpen(false)}
+				scope={scope}
+				id={id}
+				targetLabel={targetLabel}
+				existing={open}
+				onDone={reload}
+			/>
+		</Paper>
+	);
+}
+
+function Heading() {
+	return (
+		<Typography variant="h6" component="h2" gutterBottom>
+			Maintenance
+		</Typography>
+	);
+}

--- a/private-web/src/components/StatusDot.tsx
+++ b/private-web/src/components/StatusDot.tsx
@@ -27,6 +27,11 @@ const REACHABLE: ReadonlySet<ShortStatus> = new Set(["up", "blip"]);
 const UNMONITORED_MASK =
 	"linear-gradient(135deg, #000 0 42%, transparent 42% 58%, #000 58% 100%)";
 
+// A window's cut runs the other way, so a target being worked on is not read
+// as one nobody is watching at all.
+const MAINTAINED_MASK =
+	"linear-gradient(45deg, #000 0 42%, transparent 42% 58%, #000 58% 100%)";
+
 interface StatusDotProps {
 	up: ShortStatus;
 	/** Server's self-reported health from its most recent status push.
@@ -43,6 +48,11 @@ interface StatusDotProps {
 	 * normal but raise nothing. Defaults to monitored. */
 	// spec: CHK#monitoring-gate
 	monitored?: boolean;
+	/** Whether a maintenance window suspends this server. Cut the other way
+	 * from unmonitored: the work is deliberate and temporary, and its checks
+	 * are still recorded and shown. Defaults to not under maintenance. */
+	// spec: MNT#presentation
+	maintained?: boolean;
 }
 
 export default function StatusDot({
@@ -52,7 +62,13 @@ export default function StatusDot({
 	dim,
 	size = "1em",
 	monitored = true,
+	maintained = false,
 }: StatusDotProps) {
+	const mask = maintained
+		? MAINTAINED_MASK
+		: monitored
+			? undefined
+			: UNMONITORED_MASK;
 	const outlineColor =
 		health && REACHABLE.has(up) ? HEALTH_OUTLINE[health] : null;
 	// Errors swap the dot's fill and outline colours instead of stacking a
@@ -79,14 +95,18 @@ export default function StatusDot({
 				outline: outlineColor ? "0.2em solid" : "none",
 				outlineColor,
 				outlineOffset: outlineColor ? "-0.2em" : 0,
-				maskImage: monitored ? undefined : UNMONITORED_MASK,
-				WebkitMaskImage: monitored ? undefined : UNMONITORED_MASK,
+				maskImage: mask,
+				WebkitMaskImage: mask,
 			}}
 		/>
 	);
-	const tooltip = monitored
-		? title
-		: [title, "unmonitored"].filter(Boolean).join(" · ");
+	const tooltip = [
+		title,
+		maintained ? "under maintenance" : null,
+		monitored ? null : "unmonitored",
+	]
+		.filter(Boolean)
+		.join(" · ");
 	if (tooltip) {
 		return <Tooltip title={tooltip}>{dot}</Tooltip>;
 	}

--- a/private-web/src/routes/GroupDetail.tsx
+++ b/private-web/src/routes/GroupDetail.tsx
@@ -19,6 +19,7 @@ import GroupDomainsSection from "../components/GroupDomainsSection";
 import MigrationTestsSection from "../components/MigrationTestsSection";
 import { OperatorAvatar, connectedFor } from "../components/OperatorAvatars";
 import ServerShorty from "../components/ServerShorty";
+import MaintenanceSection from "../components/MaintenanceSection";
 import SilencedRefsSection from "../components/SilencedRefsSection";
 import TimeAgo from "../components/TimeAgo";
 import { useApi, useApiAction } from "../api";
@@ -243,6 +244,11 @@ export default function GroupDetail() {
 
 			<GroupDomainsSection groupId={group.id} />
 
+			<MaintenanceSection
+				scope="group"
+				id={group.id}
+				targetLabel={group.name}
+			/>
 			<SilencedRefsSection scope="group" id={group.id} />
 		</Stack>
 	);

--- a/private-web/src/routes/IncidentDetail.tsx
+++ b/private-web/src/routes/IncidentDetail.tsx
@@ -22,6 +22,8 @@ import { useState } from "react";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
 import IssueRow from "../components/IssueRow";
+import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
+import DeclareMaintenanceDialog from "../components/DeclareMaintenanceDialog";
 import { AddNoteButton } from "../components/NotesList";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { useIsNotificationHeld } from "../hooks/useIsNotificationHeld";
@@ -145,6 +147,7 @@ function Header({
 	const unresolve = useApiAction("incidents", "unresolve");
 
 	const [resolveOpen, setResolveOpen] = useState(false);
+	const [maintenanceOpen, setMaintenanceOpen] = useState(false);
 	const [reason, setReason] = useState<ResolvedReason>("fixed");
 
 	const wrap = async (fn: () => Promise<unknown>) => {
@@ -338,6 +341,29 @@ function Header({
 							parentId={incident.id}
 							onAdded={onChanged}
 							variant="outlined"
+						/>
+					</>
+				)}
+				{/* An operator who recognises this as work they are already
+				    doing declares the window from where they are reading it. */}
+				{/* spec: MNT#declaring */}
+				{isAdmin && incident.server_group_id != null && (
+					<>
+						<Button
+							size="small"
+							variant="outlined"
+							startIcon={<BuildOutlinedIcon />}
+							onClick={() => setMaintenanceOpen(true)}
+						>
+							This is maintenance…
+						</Button>
+						<DeclareMaintenanceDialog
+							open={maintenanceOpen}
+							onClose={() => setMaintenanceOpen(false)}
+							scope="group"
+							id={incident.server_group_id}
+							targetLabel={incident.server_group_name ?? undefined}
+							onDone={onChanged}
 						/>
 					</>
 				)}

--- a/private-web/src/routes/Maintenance.tsx
+++ b/private-web/src/routes/Maintenance.tsx
@@ -1,0 +1,116 @@
+import {
+	Alert,
+	Button,
+	LinearProgress,
+	Paper,
+	Stack,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableRow,
+	Typography,
+} from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { useApi, useApiAction } from "../api";
+import TimeAgo from "../components/TimeAgo";
+import { useIsAdmin } from "../hooks/useIsAdmin";
+import { usePageTitle } from "../hooks/usePageTitle";
+
+/// What the fleet is not being watched on right now: every maintenance
+/// window currently holding, what it covers, and when it ends.
+// spec: MNT#presentation
+export default function Maintenance() {
+	usePageTitle("Maintenance");
+	const isAdmin = useIsAdmin() === true;
+	const list = useApi("maintenance", "list_open");
+	const lift = useApiAction("maintenance", "lift");
+
+	if (list.status === "loading" || list.status === "idle") {
+		return <LinearProgress />;
+	}
+	if (list.status === "error") {
+		return <Alert severity="error">{list.error.message}</Alert>;
+	}
+
+	const rows = list.data;
+
+	return (
+		<Stack spacing={2}>
+			<Typography variant="h5" component="h1">
+				Maintenance
+			</Typography>
+			<Typography variant="body2" color="text.secondary">
+				Targets being worked on. Every check on them is recorded and shown,
+				and raises nothing until the window ends and its settle period has
+				passed.
+			</Typography>
+			{lift.error && <Alert severity="error">{lift.error.message}</Alert>}
+			{rows.length === 0 ? (
+				<Paper variant="outlined" sx={{ p: 3 }}>
+					<Typography color="text.secondary">
+						Nothing is under maintenance. Declare a window from a server or
+						a group.
+					</Typography>
+				</Paper>
+			) : (
+				<Paper variant="outlined">
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell>Target</TableCell>
+								<TableCell>Ends</TableCell>
+								<TableCell>Declared</TableCell>
+								<TableCell>What's being done</TableCell>
+								{isAdmin && <TableCell align="right" />}
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{rows.map(({ window, target }) => (
+								<TableRow key={window.id} hover>
+									<TableCell>
+										<RouterLink
+											to={
+												window.server_id
+													? `/servers/${window.server_id}`
+													: `/groups/${window.server_group_id}`
+											}
+										>
+											{target}
+										</RouterLink>
+									</TableCell>
+									<TableCell>
+										<TimeAgo timestamp={window.expected_end} />
+									</TableCell>
+									<TableCell>
+										<TimeAgo timestamp={window.declared_at} />
+										{window.declared_by && ` by ${window.declared_by}`}
+									</TableCell>
+									<TableCell>{window.note ?? "—"}</TableCell>
+									{isAdmin && (
+										<TableCell align="right">
+											<Button
+												size="small"
+												disabled={lift.pending}
+												onClick={async () => {
+													try {
+														await lift.call({ id: window.id });
+														list.reload();
+													} catch {
+														/* surfaced above */
+													}
+												}}
+											>
+												Lift
+											</Button>
+										</TableCell>
+									)}
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</Paper>
+			)}
+		</Stack>
+	);
+}

--- a/private-web/src/routes/ServerDetail.tsx
+++ b/private-web/src/routes/ServerDetail.tsx
@@ -57,6 +57,7 @@ import IncidentsLink from "../components/IncidentsLink";
 import OperatorAvatars from "../components/OperatorAvatars";
 import ManualEventButton from "../components/ManualEventButton";
 import ServerCertificatesSection from "../components/ServerCertificatesSection";
+import MaintenanceSection from "../components/MaintenanceSection";
 import SilencedRefsSection from "../components/SilencedRefsSection";
 import StatusDot from "../components/StatusDot";
 import TailnetIdentitySection from "../components/TailnetIdentitySection";
@@ -195,6 +196,7 @@ export default function ServerDetail() {
 				checks={data.checks}
 				onSilenced={bumpRefresh}
 				up={data.up}
+				maintained={data.maintained}
 				refreshTick={refreshTick}
 			/>
 			{data.group && (
@@ -228,6 +230,12 @@ export default function ServerDetail() {
 					onEventSubmitted={bumpRefresh}
 				/>
 			)}
+			<MaintenanceSection
+				scope="server"
+				id={data.server.id}
+				targetLabel={data.server.name ?? data.server.display_host}
+				onChanged={() => detail.reload()}
+			/>
 			<SilencedRefsSection
 				scope="server"
 				id={data.server.id}
@@ -765,6 +773,7 @@ function InfoSection({
 	checks,
 	onSilenced,
 	up,
+	maintained,
 	refreshTick,
 }: {
 	server: ServerInfo;
@@ -773,6 +782,7 @@ function InfoSection({
 	checks: ConsolidatedChecks;
 	onSilenced: () => void;
 	up: ShortStatus;
+	maintained: boolean;
 	refreshTick: number;
 }) {
 	return (
@@ -782,6 +792,7 @@ function InfoSection({
 					health={health}
 					up={up}
 					monitored={server.is_monitored !== false}
+					maintained={maintained}
 					operators={status.operators}
 				/>
 			)}
@@ -869,11 +880,13 @@ function HealthIndicator({
 	health,
 	up,
 	monitored,
+	maintained,
 	operators,
 }: {
 	health: HealthState;
 	up: ShortStatus;
 	monitored: boolean;
+	maintained: boolean;
 	operators: OperatorPresence[];
 }) {
 	const reporting = up === "up" || up === "blip";
@@ -884,7 +897,12 @@ function HealthIndicator({
 			useFlexGap
 			sx={{ mb: 1.5, alignItems: "center", flexWrap: "wrap" }}
 		>
-			<HealthChip health={health} stale={!reporting} monitored={monitored} />
+			<HealthChip
+				health={health}
+				stale={!reporting}
+				monitored={monitored}
+				maintained={maintained}
+			/>
 			{reporting && operators.length > 0 && (
 				<Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
 					<OperatorAvatars operators={operators} size={24} />
@@ -1615,6 +1633,7 @@ function SiblingServers({
 										up={sib.up ?? "gone"}
 										health={sib.health ?? undefined}
 										monitored={sib.is_monitored !== false}
+										maintained={sib.maintained === true}
 									/>
 									<MuiLink
 										component={RouterLink}
@@ -2119,6 +2138,7 @@ function SiblingDotStrip({
 							up={(m.entry.up as ShortStatus | undefined) ?? "gone"}
 							health={(m.entry.health as HealthState | undefined) ?? undefined}
 							monitored={m.entry.is_monitored !== false}
+							maintained={m.entry.maintained === true}
 							title={m.entry.name ?? ""}
 							dim={!m.focused}
 							size="0.8em"

--- a/private-web/src/routes/Upgrades.tsx
+++ b/private-web/src/routes/Upgrades.tsx
@@ -1,4 +1,5 @@
 import AddIcon from "@mui/icons-material/Add";
+import BuildOutlinedIcon from "@mui/icons-material/BuildOutlined";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
@@ -46,6 +47,7 @@ import {
 } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import { useApi, useApiAction } from "../api";
+import DeclareMaintenanceDialog from "../components/DeclareMaintenanceDialog";
 import TimeAgo from "../components/TimeAgo";
 import { useIsAdmin } from "../hooks/useIsAdmin";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -184,6 +186,14 @@ export default function Upgrades() {
 													groupName={row.group_name}
 													targetVersion={row.target_version ?? ""}
 													onWithdrawn={() => setTick((t) => t + 1)}
+												/>
+												<DeclareFromPlan
+													groupId={row.group_id}
+													groupName={row.group_name}
+													plannedTime={row.plan?.planned_time ?? null}
+													plannedEnd={row.plan?.planned_end_time ?? null}
+													note={row.plan?.note ?? null}
+													onDeclared={() => setTick((t) => t + 1)}
 												/>
 											</TableCell>
 										)}
@@ -2101,5 +2111,69 @@ function WithdrawPlan({
 		>
 			<DeleteIcon fontSize="small" />
 		</IconButton>
+	);
+}
+
+/** How long the plan says the deployment is down, from its window's two
+ * wall clocks. A close earlier in the day than the open is the following
+ * morning, as the plan reads it. Two hours where the plan names no window,
+ * which is what a declaration otherwise starts from. */
+function plannedHours(time: string | null, end: string | null): number {
+	if (!time || !end) return 2;
+	const minutes = (clock: string) => {
+		const [h, m] = clock.split(":");
+		return Number(h) * 60 + Number(m ?? 0);
+	};
+	const span = minutes(end) - minutes(time);
+	return (span > 0 ? span : span + 24 * 60) / 60;
+}
+
+/** Declare maintenance for a group from its open plan, carrying the plan's
+ * window length and note. The plan supplies the prefill and triggers
+ * nothing: this is an operator saying the work is starting now. */
+// spec: MNT#declaring
+function DeclareFromPlan({
+	groupId,
+	groupName,
+	plannedTime,
+	plannedEnd,
+	note,
+	onDeclared,
+}: {
+	groupId: string;
+	groupName: string;
+	plannedTime: string | null;
+	plannedEnd: string | null;
+	note: string | null;
+	onDeclared: () => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const hours = plannedHours(plannedTime, plannedEnd);
+	return (
+		<>
+			<Tooltip title="Declare maintenance: suspend this group's alerting while the upgrade runs">
+				<IconButton
+					size="small"
+					aria-label={`Declare maintenance for ${groupName}`}
+					onClick={() => setOpen(true)}
+				>
+					<BuildOutlinedIcon fontSize="small" />
+				</IconButton>
+			</Tooltip>
+			<DeclareMaintenanceDialog
+				open={open}
+				onClose={() => setOpen(false)}
+				scope="group"
+				id={groupId}
+				targetLabel={groupName}
+				prefill={{
+					expectedEnd: new Date(
+						Date.now() + hours * 3600_000,
+					).toISOString(),
+					note: note ?? undefined,
+				}}
+				onDone={onDeclared}
+			/>
+		</>
 	);
 }

--- a/private-web/src/types.ts
+++ b/private-web/src/types.ts
@@ -82,6 +82,7 @@ export type ServerRank = Solidify<Schemas["ServerRank"]>;
 export type VersionStatus = Solidify<Schemas["VersionStatus"]>;
 export type DeviceRole = Solidify<Schemas["DeviceRole"]>;
 export type ProvisionedCredential = Solidify<Schemas["ProvisionedCredential"]>;
+export type MaintenanceWindow = Solidify<Schemas["MaintenanceWindow"]>;
 export type ResolvedReason = Solidify<Schemas["ResolvedReason"]>;
 
 export type VersionStr = Solidify<Schemas["VersionStr"]>;


### PR DESCRIPTION
- Upgrades read as outages: the server stops reporting, the group opens an incident, someone reads it before recognising it as the work we are doing.
- A window is a bounded-time ceiling of `skipped` over every check on a target. It rides the scoped-policy chain, so every grading path honours it and the existing leave/close rules cover the incident side.
- Ends itself at the declared time; suspension outlasts that by a settle period so a server that is back but has not reported yet is not called unreachable.
- Slack hooks for declare/end are optional, unlike the incident ones: an unconfigured deployment still records and suspends, it just does not announce.
- No scheduling ahead: an open upgrade plan is prefill only, it triggers nothing.